### PR TITLE
fix(ledger): read reward parameters from the performance epoch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1959,6 +1959,19 @@ networks that declare Shelley at genesis, such as preview, run both. Later
 updates use the normal delayed E-3 snapshot, E-2 performance, and E-1 pots
 mapping.
 
+Within that mapping, every protocol-parameter input to the calculation — d,
+rho, tau, and the pool-level parameters — is read from the **performance**
+epoch, not the pots epoch. cardano-ledger's `startStep` binds
+`pr = es ^. prevPParamsEpochStateL` and derives all of them from it, including
+the parameter set it hands to `mkPoolRewardInfo`; `updateRewards` reads the
+protocol version from the same place. `prevPParams` during the epoch that
+computes the update is the set in force over the epoch whose blocks are
+counted, which is the performance epoch. Only the epoch length comes from the
+pots epoch, standing in for the `slotsPerEpoch` the RUPD rule passes for the
+epoch it runs in. The two sources agree whenever the parameters did not change
+across the boundary, so a network that never moves them cannot tell the
+difference.
+
 Both bootstrap rounds resolve against mark snapshot epoch 0, so that row must
 exist even when it is empty. `snapshot.Manager.CaptureGenesisSnapshot` persists
 it on a fresh sync whose genesis registers no pools — preview, whose pools

--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -491,7 +491,7 @@ func (ls *LedgerState) applyStakeRewardApplication(
 		"reward_snapshot_epoch", app.epochs.snapshot,
 		"performance_epoch", app.epochs.performance,
 		"pots_epoch", app.epochs.pots,
-		"pparams_type", fmt.Sprintf("%T", app.pparams),
+		"performance_pparams_type", fmt.Sprintf("%T", app.pparams),
 		"precomputed", app.precomputed,
 		"total_reward_pot", app.totalRewardPot,
 		"available_rewards", app.availableRewards,
@@ -2612,15 +2612,6 @@ func (ls *LedgerState) rewardParameters(
 			performanceEpoch,
 		)
 	}
-	performanceDecentralization, err := rewardDecentralizationFromPParams(
-		performancePParams,
-	)
-	if err != nil {
-		return nil, rewards.Parameters{}, nil, fmt.Errorf(
-			"get decentralization for reward performance epoch %d: %w",
-			performanceEpoch, err,
-		)
-	}
 	calculationEpochRow, err := ls.db.Metadata().GetEpoch(
 		calculationEpoch,
 		txn.Metadata(),
@@ -2638,33 +2629,27 @@ func (ls *LedgerState) rewardParameters(
 			calculationEpoch,
 		)
 	}
-	eraDesc, ok := ls.eraById(calculationEpochRow.EraId)
-	if !ok || eraDesc == nil {
-		return nil, rewards.Parameters{}, nil, fmt.Errorf(
-			"unknown era ID %d for reward calculation epoch %d",
-			calculationEpochRow.EraId, calculationEpoch,
-		)
-	}
-	pparams, err := ls.db.GetPParams(
-		calculationEpoch,
-		eraDesc.Id,
-		eraDesc.DecodePParamsFunc,
-		txn,
-	)
-	if err != nil {
-		return nil, rewards.Parameters{}, nil, fmt.Errorf(
-			"get pparams for reward calculation epoch %d: %w",
-			calculationEpoch, err,
-		)
-	}
-	if pparams == nil {
-		return nil, rewards.Parameters{}, nil, fmt.Errorf(
-			"missing pparams for reward calculation epoch %d",
-			calculationEpoch,
-		)
-	}
+	// Every protocol-parameter input to the reward calculation comes from the
+	// performance epoch, not the calculation epoch. cardano-ledger's startStep
+	// (LedgerState/PulsingReward.hs) binds `pr = es ^. prevPParamsEpochStateL`
+	// and reads d, rho and tau from it, then hands that same `pr` to
+	// mkPoolRewardInfo for the pool-level parameters; updateRewards reads the
+	// protocol version from it too. `prevPParams` during the epoch that
+	// computes the update is the parameter set in force over the epoch whose
+	// blocks are being counted, which is exactly this round's performance
+	// epoch.
+	//
+	// Only the epoch length is the calculation epoch's, matching the
+	// slotsPerEpoch the RUPD rule passes for the epoch it runs in.
+	//
+	// The two agree whenever the parameters did not change across the
+	// boundary, which is why reading the calculation epoch's went unnoticed.
+	// They diverge on preview at the 2->3 round: d is 1 at the performance
+	// epoch (1) and 0 at the calculation epoch (2), and taking 0 dropped the
+	// d >= 0.8 short circuit, leaving eta at 0 and suppressing that epoch's
+	// entire monetary expansion (dingo #3481).
 	params, err := rewardParametersFromPParams(
-		pparams,
+		performancePParams,
 		ls.config.CardanoNodeConfig,
 		uint64(calculationEpochRow.LengthInSlots),
 	)
@@ -2690,7 +2675,7 @@ func (ls *LedgerState) rewardParameters(
 			params.MaxLovelaceSupply,
 		)
 	}
-	return pparams, params, performanceDecentralization, nil
+	return performancePParams, params, params.Decentralization, nil
 }
 
 // applyFullPotConfig copies the CIP-0163 full-pot feature gate from the ledger
@@ -3571,45 +3556,6 @@ func rewardParametersFromPParams(
 		return rewards.Parameters{}, err
 	}
 	return params, nil
-}
-
-func rewardDecentralizationFromPParams(
-	pparams lcommon.ProtocolParameters,
-) (*big.Rat, error) {
-	var decentralization *big.Rat
-	switch pp := pparams.(type) {
-	case *shelley.ShelleyProtocolParameters:
-		decentralization = cloneCBORRat(pp.Decentralization)
-	case *mary.MaryProtocolParameters:
-		decentralization = cloneCBORRat(pp.Decentralization)
-	case *alonzo.AlonzoProtocolParameters:
-		decentralization = cloneCBORRat(pp.Decentralization)
-	case *babbage.BabbageProtocolParameters,
-		*conway.ConwayProtocolParameters,
-		*dijkstra.DijkstraProtocolParameters:
-		decentralization = new(big.Rat)
-	default:
-		return nil, fmt.Errorf("unsupported reward pparams type %T", pparams)
-	}
-	if decentralization == nil {
-		return nil, fmt.Errorf(
-			"%w: missing decentralization",
-			rewards.ErrInvalidParameters,
-		)
-	}
-	if decentralization.Sign() < 0 {
-		return nil, fmt.Errorf(
-			"%w: negative decentralization",
-			rewards.ErrInvalidParameters,
-		)
-	}
-	if decentralization.Cmp(big.NewRat(1, 1)) > 0 {
-		return nil, fmt.Errorf(
-			"%w: decentralization greater than one",
-			rewards.ErrInvalidParameters,
-		)
-	}
-	return decentralization, nil
 }
 
 func rewardEpochFees(

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -4715,7 +4715,20 @@ func TestStakeRewardEpochsForNewEpochMatchDelayedUpdate(t *testing.T) {
 	}, epochs)
 }
 
-func TestRewardParametersUseRUPDCalculationEpochLength(t *testing.T) {
+// TestRewardParametersSplitCalculationAndPerformanceEpochInputs pins where
+// each reward parameter is read from when the two epochs disagree.
+//
+// The epoch length is the calculation epoch's: it stands in for the
+// slotsPerEpoch the RUPD rule passes for the epoch it runs in. Every
+// protocol-parameter value is the performance epoch's, because
+// cardano-ledger's startStep binds `pr = es ^. prevPParamsEpochStateL` and
+// derives d, rho, tau and the pool-level parameters it passes to
+// mkPoolRewardInfo from that. Reading tau or d from the calculation epoch
+// instead silently changes reward amounts on any network where the parameters
+// move across the boundary (dingo #3481).
+func TestRewardParametersSplitCalculationAndPerformanceEpochInputs(
+	t *testing.T,
+) {
 	ls, db := newRewardCalculationTestLedger(t)
 	meta := db.Metadata()
 
@@ -4794,10 +4807,31 @@ func TestRewardParametersUseRUPDCalculationEpochLength(t *testing.T) {
 		&models.RewardAdaPots{Reserves: 100_000_000},
 	)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1_000), params.EpochLength)
-	require.Equal(t, big.NewRat(1, 5), params.TreasuryExpansion)
-	require.Equal(t, big.NewRat(0, 1), params.Decentralization)
-	require.Equal(t, big.NewRat(1, 2), performanceDecentralization)
+	require.Equal(
+		t,
+		uint64(1_000),
+		params.EpochLength,
+		"epoch length comes from the calculation epoch",
+	)
+	require.Equal(
+		t,
+		big.NewRat(0, 1),
+		params.TreasuryExpansion,
+		"tau comes from the performance epoch",
+	)
+	require.Equal(
+		t,
+		big.NewRat(1, 2),
+		params.Decentralization,
+		"d comes from the performance epoch",
+	)
+	require.Equal(
+		t,
+		params.Decentralization,
+		performanceDecentralization,
+		"the block-count decentralization is the same value the "+
+			"calculation uses",
+	)
 }
 
 func TestRewardParametersBabbageDefaultsDecentralizationAndForgoesPrefilter(

--- a/ledger/reward_preview_pots_test.go
+++ b/ledger/reward_preview_pots_test.go
@@ -52,6 +52,15 @@ const (
 	previewEpoch2Treasury = uint64(17_994_600_087_558)
 	previewEpoch2Reserves = uint64(14_982_005_400_350_235)
 
+	// Epoch 1 collected 206597 lovelace in fees, which the 2->3 boundary
+	// folds into the reward pot. Preview's decentralisation is 1 at epochs 0
+	// and 1 and 0 from epoch 2 onward, so the 2->3 round -- whose parameters
+	// come from performance epoch 1 -- still takes the d >= 0.8 short circuit
+	// and expands by the full rho * reserves.
+	previewEpoch2Fees     = uint64(206_597)
+	previewEpoch3Treasury = uint64(26_983_803_369_087)
+	previewEpoch3Reserves = uint64(14_973_016_197_275_303)
+
 	previewEpochLength = uint64(86_400)
 )
 
@@ -100,8 +109,19 @@ func newPreviewRewardPotsTestLedger(
 	pparamsCbor, err := cbor.Encode(pparams)
 	require.NoError(t, err)
 
+	// Preview's decentralisation drops from 1 to 0 at epoch 2, so each epoch
+	// is seeded with its own protocol parameters.
+	decentralizedPParams := *pparams
+	decentralizedPParams.Decentralization = rewardCalcRat(0, 1)
+	decentralizedCbor, err := cbor.Encode(&decentralizedPParams)
+	require.NoError(t, err)
+
 	meta := db.Metadata()
-	for _, epoch := range []uint64{0, 1} {
+	for _, epoch := range []uint64{0, 1, 2} {
+		epochPParamsCbor := pparamsCbor
+		if epoch >= 2 {
+			epochPParamsCbor = decentralizedCbor
+		}
 		startSlot := epoch * previewEpochLength
 		require.NoError(t, meta.SetEpoch(
 			startSlot,
@@ -116,7 +136,7 @@ func newPreviewRewardPotsTestLedger(
 			nil,
 		))
 		require.NoError(t, db.SetPParams(
-			pparamsCbor,
+			epochPParamsCbor,
 			startSlot,
 			epoch,
 			eras.AlonzoEraDesc.Id,
@@ -267,4 +287,45 @@ INSERT INTO "transaction" (
 	require.NotNil(t, state)
 	require.Equal(t, previewEpoch2Treasury, uint64(state.Treasury))
 	require.Equal(t, previewEpoch2Reserves, uint64(state.Reserves))
+}
+
+// TestApplyStakeRewardsPreviewEpoch3Pots pins the 2->3 boundary, where
+// preview's decentralisation differs between the round's performance epoch (1,
+// d = 1) and its calculation epoch (2, d = 0).
+//
+// cardano-ledger's startStep builds the whole reward update from
+// prevPParams -- the parameters in force during the epoch whose blocks are
+// counted, which is dingo's performance epoch -- so d is 1 here and eta takes
+// the d >= 0.8 short circuit. Reading d from the calculation epoch instead
+// gives d = 0, no short circuit, and an eta of zero against an empty epoch-0
+// mark snapshot, which drops the monetary expansion entirely and moves only
+// the fee pot (dingo #3481).
+func TestApplyStakeRewardsPreviewEpoch3Pots(t *testing.T) {
+	ls, db := newPreviewRewardPotsTestLedger(t)
+	meta := db.Metadata()
+
+	require.NoError(t, meta.SetNetworkState(
+		previewEpoch2Treasury,
+		previewEpoch2Reserves,
+		2*previewEpochLength,
+		nil,
+	))
+	require.NoError(t, meta.SaveRewardAdaPots(&models.RewardAdaPots{
+		Epoch:        2,
+		Treasury:     types.Uint64(previewEpoch2Treasury),
+		Reserves:     types.Uint64(previewEpoch2Reserves),
+		Fees:         types.Uint64(previewEpoch2Fees),
+		CapturedSlot: 2 * previewEpochLength,
+	}, nil))
+
+	txn := db.Transaction(true)
+	require.NoError(t, txn.Do(func(txn *database.Txn) error {
+		return ls.applyStakeRewards(txn, 3, 3*previewEpochLength)
+	}))
+
+	state, err := meta.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, previewEpoch3Treasury, uint64(state.Treasury))
+	require.Equal(t, previewEpoch3Reserves, uint64(state.Reserves))
 }


### PR DESCRIPTION
Fixes #3481. Stacked on #3478 — retarget to `main` once that merges.

## Problem

`rewards.Calculate` derived `d`, `rho`, `tau` and the pool-level parameters from the **calculation epoch**'s protocol parameters (`newEpoch-1`).

cardano-ledger's `startStep` ([`LedgerState/PulsingReward.hs`](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs)) binds `pr = es ^. prevPParamsEpochStateL` and reads all of them from it:

```haskell
pr = es ^. prevPParamsEpochStateL
deltaR1 = rationalToCoinViaFloor $ min 1 eta * unboundRational (pr ^. ppRhoL) * fromIntegral reserves
d = unboundRational (pr ^. ppDG)
expectedBlocks = floor $ (1 - d) * unboundRational (activeSlotVal asc) * fromIntegral (unEpochSize slotsPerEpoch)
eta | d >= 0.8 = 1
    | otherwise = blocksMade % expectedBlocks
deltaT1 = floor $ unboundRational (pr ^. ppTauL) * fromIntegral rPot
mkPoolRewardInfoCurry = mkPoolRewardInfo pr _R b ...
```

`prevPParams` during the epoch that computes the update is the set in force over the epoch whose blocks are counted — Dingo's **performance epoch** (`newEpoch-2`). `updateRewards` reads the protocol version from the same place.

The two sources agree whenever the parameters did not change across the boundary, so a network that never moves them cannot tell the difference. That is why this went unnoticed.

## Observed on Preview

Preview's `decentralisation` is 1 at epochs 0–1 and 0 from epoch 2 onward. At the 2→3 boundary Dingo used the calculation epoch's `d = 0`, so `rewardEfficiency` skipped its `d >= 0.8` short circuit and computed `totalBlocks / expectedBlocks` instead. `totalBlocks` is 0 — mark snapshot epoch 0 is empty, and every epoch-1 block was an overlay/OBFT block anyway — so eta was 0 and the entire monetary expansion was dropped. Only the fee pot moved:

```
applied stake rewards: reward_snapshot_epoch=0 performance_epoch=1 pots_epoch=2
  total_reward_pot=206597 available_rewards=165278 undistributed_rewards=165278
```

| epoch 3 field | before | after / Koios |
| --- | ---: | ---: |
| `totals_treasury` | `17994600128877` | `26983803369087` |
| `totals_reserves` | `14982005400515513` | `14973016197275303` |

## Change

- `rewardParameters` builds `rewards.Parameters` from the performance epoch's protocol parameters.
- The epoch length still comes from the calculation epoch, standing in for the `slotsPerEpoch` the RUPD rule passes for the epoch it runs in.
- `rewardDecentralizationFromPParams` is removed: the decentralization passed to `rewardBlockCounts` for overlay-slot exclusion is now the same value the calculation itself uses, so there is one source rather than two.
- The `applied stake rewards` log field is renamed `performance_pparams_type`, since that is now what it reports.
- `ARCHITECTURE.md` documents the split.

## Validation: live Preview genesis replay

```
dingo serve --network preview --data-dir <dir> --storage-mode api \
  --socket-path /tmp/dg/n.socket \
  --port 3421 --private-port 3422 --metrics-port 12821 --debug-port 0 \
  --koios-parity-enabled --koios-parity-strict --koios-parity-accounts=false
```

Before: strict observer fails at epoch 3 with the two mismatches above.

After: epochs 0 through 6 all validate and the run reaches slot 707032. Treasury and reserves match Koios `/totals` exactly at every epoch through 7:

| epoch | treasury | reserves |
| ---: | ---: | ---: |
| 3 | `26983803369087` | `14973016197275303` |
| 4 | `35967613128648` | `14964032387721723` |
| 5 | `45195372193123` | `14954804628961481` |
| 6 | `54434502740001` | `14945565498414603` |
| 7 | `63689264884685` | `14936310736269919` |

The run now stops at epoch 7 on a `pool_presence` mismatch — two pools present in Dingo's reward pool inputs that Koios has no history for. That is a pool-set question, not pot accounting, and is filed separately as #3483.

## Tests

Both fail on the parent branch and pass here, verified by reverting `ledger/reward_calculation.go` and re-running:

- `TestApplyStakeRewardsPreviewEpoch3Pots` — the 2→3 boundary with `d = 1` at the performance epoch and `d = 0` at the calculation epoch, pinned to the Koios reference.
- `TestRewardParametersSplitCalculationAndPerformanceEpochInputs` — renamed from `TestRewardParametersUseRUPDCalculationEpochLength`, which already seeded divergent pparams but asserted `tau` and `d` came from the calculation epoch. It now pins the whole contract: epoch length from the calculation epoch, protocol parameters from the performance epoch.

The existing epoch-1 and epoch-2 Preview tests pass unchanged in both directions — Preview's `d` is 1 at both epochs 0 and 1, so those rounds cannot distinguish the two sources.

## Checks

- `make test` (race): pass
- `go test -race ./ledger/`: pass
- `go test ./internal/test/conformance/`: pass
- `golangci-lint run ./...`: 0 issues; `nilaway`: clean
- `modernize`: 5 findings, all pre-existing on an `origin/main` baseline in untouched files
- `make import-boundaries`, `make docs-parity`, `make golines`: pass
- Live Preview genesis replay with the strict in-process Koios observer, as above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads reward parameters from the performance epoch to match cardano-ledger, fixing dropped monetary expansion on Preview at the 2→3 boundary. Previously `d`, `rho`, `tau`, and pool params came from the calculation epoch; now they come from the performance epoch, while epoch length still comes from the calculation epoch.

- Uses the performance epoch's protocol parameters for `d`, `rho`, `tau`, and pool-level inputs; keeps calculation epoch's `EpochLength`.
- Removes `rewardDecentralizationFromPParams`; decentralization used for overlay-slot exclusion now equals `params.Decentralization`.
- Renames log field `pparams_type` to `performance_pparams_type`.
- Validated by Preview genesis replay: treasury and reserves match Koios `/totals` through epoch 7; adds tests pinning the 2→3 pots and input split.

<sup>Written for commit 2e603a0e814aa3608f0a2cd779153eeab549d2eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

