### PR TITLE
fix(ledger): bound Genesis peer header history

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2689,7 +2689,13 @@ Node composition injects an atomic Genesis-mode/window query from
 `ChainSelector` into ledger, so the same resolver automatically returns to
 Praos once the selector exits Genesis mode. Chainsync and ledger retain enough
 per-peer header ancestry for the active slot window while Genesis is active,
-then shrink back to their normal bounded history after exit.
+then shrink back to their normal bounded history after exit. The ledger's
+peer-local ancestry stores compact header CBOR and prev-hash metadata rather
+than retaining decoded header objects, and enforces both the active window's
+entry bound and an 8 MiB per-connection byte budget. If a candidate fork path
+falls outside the retained suffix, recovery fails closed to a fresh
+ChainSync intersection instead of making a density or rollback decision from
+an incomplete path.
 
 The trust problem Genesis solves for **biased fast-sync sources** — e.g. a
 local shallow peer or the Genesis Sync Accelerator (GSA), which serve blocks

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -154,6 +154,16 @@ const (
 	headerMismatchResyncThreshold = 20
 
 	maxPeerHeaderHistoryPerConn = 256
+	// Genesis fork resolution can need more than the normal K-sized history to
+	// compare a candidate's density, but retaining decoded headers for an
+	// entire slot window makes memory proportional to an attacker-controlled
+	// number of blocks. Store wire header bytes lazily and cap each peer's
+	// retained history independently of the configured slot window. The default
+	// Genesis quorum is one fast source plus two corroborators, so this leaves a
+	// bounded 24 MiB wire-history allowance across the three required peers.
+	// A path that does not fit this budget falls back to a fresh intersection.
+	maxPeerHeaderHistoryBytesPerConn = 8 << 20
+	peerHeaderHistoryRecordOverhead  = 512
 
 	// Match ouroboros-consensus' default maximum permissible clock skew. A
 	// header within this window is held until its slot begins; an earlier
@@ -175,13 +185,21 @@ var ErrRollbackExceedsMithrilBoundary = errors.New(
 )
 
 type peerHeaderRecord struct {
-	event    ChainsyncEvent
-	prevHash []byte
+	// event carries only the metadata needed to reconstruct a ChainsyncEvent.
+	// Production records leave BlockHeader nil and decode headerCbor only when
+	// recovery actually needs it. In-package synthetic headers may provide an
+	// event with a header and use that fallback when no CBOR is available.
+	event      ChainsyncEvent
+	headerCbor []byte
+	prevHash   []byte
+	decodeType uint
+	bytes      int
 }
 
 type peerHeaderChain struct {
-	order  []string
-	byHash map[string]peerHeaderRecord
+	order         []string
+	byHash        map[string]peerHeaderRecord
+	retainedBytes int
 }
 
 func (ls *LedgerState) handleEventChainsync(evt event.Event) {
@@ -1044,17 +1062,71 @@ func (ls *LedgerState) recordPeerHeaderHistory(e ChainsyncEvent) {
 	if _, ok := history.byHash[hashKey]; ok {
 		return
 	}
-	history.order = append(history.order, hashKey)
-	history.byHash[hashKey] = peerHeaderRecord{
-		event:    e,
-		prevHash: append([]byte(nil), e.BlockHeader.PrevHash().Bytes()...),
+	headerCbor := append([]byte(nil), e.BlockHeader.Cbor()...)
+	prevHash := append([]byte(nil), e.BlockHeader.PrevHash().Bytes()...)
+	decodeType := e.Type
+	// Musashi carries the Dijkstra header extension under the Conway wire
+	// block type. Preserve the decoder selected by the protocol callback when
+	// the compact record is rehydrated after a fork.
+	if e.BlockHeader.Era().Id == gledger.EraIdDijkstra {
+		decodeType = gledger.BlockTypeDijkstra
 	}
-	limit := ls.peerHeaderHistoryLimit()
-	for len(history.order) > limit {
+	recordBytes := peerHeaderHistoryRecordOverhead +
+		len(headerCbor) + len(prevHash) + len(e.Point.Hash)
+	if recordBytes > maxPeerHeaderHistoryBytesPerConn {
+		return
+	}
+	for len(history.order) > 0 &&
+		(history.retainedBytes+recordBytes > maxPeerHeaderHistoryBytesPerConn ||
+			len(history.order) >= ls.peerHeaderHistoryLimit()) {
 		evictKey := history.order[0]
 		history.order = history.order[1:]
-		delete(history.byHash, evictKey)
+		if evicted, ok := history.byHash[evictKey]; ok {
+			history.retainedBytes -= evicted.bytes
+			delete(history.byHash, evictKey)
+		}
 	}
+	metadata := ChainsyncEvent{
+		ConnectionId: e.ConnectionId,
+		Point: ocommon.Point{
+			Slot: e.Point.Slot,
+			Hash: append([]byte(nil), e.Point.Hash...),
+		},
+		BlockNumber: e.BlockNumber,
+		Type:        e.Type,
+	}
+	if len(headerCbor) == 0 {
+		// Synthetic headers used by some in-package callers do not expose CBOR.
+		// Keep their decoded value, but charge the same conservative record
+		// overhead so this compatibility path cannot bypass the bound.
+		metadata.BlockHeader = e.BlockHeader
+	}
+	record := peerHeaderRecord{
+		event:      metadata,
+		headerCbor: headerCbor,
+		prevHash:   prevHash,
+		decodeType: decodeType,
+		bytes:      recordBytes,
+	}
+	history.order = append(history.order, hashKey)
+	history.byHash[hashKey] = record
+	history.retainedBytes += recordBytes
+}
+
+func (r peerHeaderRecord) chainsyncEvent() (ChainsyncEvent, bool) {
+	if r.event.BlockHeader != nil {
+		return r.event, true
+	}
+	decodeType := r.decodeType
+	if decodeType == 0 {
+		decodeType = r.event.Type
+	}
+	header, err := gledger.NewBlockHeaderFromCbor(decodeType, r.headerCbor)
+	if err != nil {
+		return ChainsyncEvent{}, false
+	}
+	r.event.BlockHeader = header
+	return r.event, true
 }
 
 func (ls *LedgerState) genesisSelectionState() (bool, uint64) {
@@ -1251,11 +1323,18 @@ func (ls *LedgerState) findPeerForkPath(
 		if !ok {
 			return nil, nil, nil
 		}
+		recordEvent, ok := record.chainsyncEvent()
+		if !ok {
+			// A retained header that cannot be reconstructed is treated like a
+			// missing history entry. Re-intersection is safer than comparing or
+			// replaying an incomplete candidate path.
+			return nil, nil, nil
+		}
 		if _, seen := visited[hashKey]; seen {
 			return nil, nil, nil
 		}
 		visited[hashKey] = struct{}{}
-		pathReversed = append(pathReversed, record.event)
+		pathReversed = append(pathReversed, recordEvent)
 		prevHash = append(prevHash[:0], record.prevHash...)
 	}
 	return nil, nil, nil
@@ -2220,11 +2299,15 @@ func (ls *LedgerState) recoverPeerHeaderHistoryFromPointLocked(
 	}
 	for _, v := range slices.Backward(history.order) {
 		record, ok := history.byHash[v]
-		if !ok || record.event.Point.Slot <= point.Slot {
+		if !ok {
+			continue
+		}
+		recordEvent, ok := record.chainsyncEvent()
+		if !ok || recordEvent.Point.Slot <= point.Slot {
 			continue
 		}
 		ancestorPoint, forkPath, err := ls.findPeerForkPath(
-			record.event,
+			recordEvent,
 			record.prevHash,
 		)
 		if err != nil {

--- a/ledger/chainsync_fork_queue_full_test.go
+++ b/ledger/chainsync_fork_queue_full_test.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"testing"
@@ -23,6 +25,9 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -31,6 +36,13 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
+
+type encodedHeader struct {
+	lcommon.BlockHeader
+	cbor []byte
+}
+
+func (h encodedHeader) Cbor() []byte { return h.cbor }
 
 // buildOverflowForkPath constructs a chain of headerCount headers extending
 // directly from the fixture's committed tip and records all but the last
@@ -85,6 +97,104 @@ func buildOverflowForkPath(
 		prevBlockNumber = h.BlockNumber()
 	}
 	return trigger
+}
+
+func TestRecordPeerHeaderHistoryBoundsRetainedBytes(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	fixture.ls.config.GenesisSelectionStateFunc = func() (bool, uint64) {
+		return true, ^uint64(0)
+	}
+	connId := testChainsyncConnId(6201, 3001)
+	const headerCount = 5000
+	for i := range headerCount {
+		hash := testHashBytes(fmt.Sprintf("budget-header-%d", i))
+		prevHash := fixture.currentTip.Point.Hash
+		if i > 0 {
+			prevHash = testHashBytes(fmt.Sprintf("budget-header-%d", i-1))
+		}
+		header := sizedMockHeader{
+			mockHeader: mockHeader{
+				hash:        lcommon.NewBlake2b256(hash),
+				prevHash:    lcommon.NewBlake2b256(prevHash),
+				blockNumber: fixture.currentTip.BlockNumber + uint64(i) + 1,
+				slot:        fixture.currentTip.Point.Slot + uint64(i) + 1,
+			},
+			cbor: bytes.Repeat([]byte{0x01}, 2048),
+		}
+		fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+			ConnectionId: connId,
+			Point:        ocommon.NewPoint(header.SlotNumber(), hash),
+			Type:         7,
+			BlockHeader:  header,
+		})
+	}
+
+	history := fixture.ls.peerHeaderHistory[connIdKey(connId)]
+	require.NotNil(t, history)
+	expectedBytes := peerHeaderHistoryRecordOverhead + 2048 + 32 + 32
+	expectedCount := maxPeerHeaderHistoryBytesPerConn / expectedBytes
+	assert.Equal(t, expectedCount, len(history.order))
+	assert.Equal(
+		t,
+		hex.EncodeToString(testHashBytes(fmt.Sprintf(
+			"budget-header-%d", headerCount-expectedCount,
+		))),
+		history.order[0],
+	)
+	assert.Equal(
+		t,
+		hex.EncodeToString(testHashBytes(fmt.Sprintf(
+			"budget-header-%d", headerCount-1,
+		))),
+		history.order[len(history.order)-1],
+	)
+	retainedBytes := 0
+	for _, record := range history.byHash {
+		retainedBytes += record.bytes
+		assert.Nil(t, record.event.BlockHeader)
+		assert.Len(t, record.headerCbor, 2048)
+	}
+	assert.Equal(t, retainedBytes, history.retainedBytes)
+	assert.LessOrEqual(t, history.retainedBytes, maxPeerHeaderHistoryBytesPerConn)
+}
+
+func TestPeerHeaderHistoryRehydratesWireHeader(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	connId := testChainsyncConnId(6202, 3002)
+	const slot = 500
+	const blockNumber = 42
+	header := &babbage.BabbageBlockHeader{
+		Body: babbage.BabbageBlockHeaderBody{
+			BlockNumber:   blockNumber,
+			Slot:          slot,
+			PrevHash:      lcommon.NewBlake2b256([]byte("parent")),
+			BlockBodyHash: lcommon.NewBlake2b256([]byte("body")),
+			ProtoVersion:  babbage.BabbageProtoVersion{Major: 8},
+		},
+	}
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	header.SetCbor(headerCbor)
+	encoded := encodedHeader{BlockHeader: header, cbor: headerCbor}
+	fixture.ls.recordPeerHeaderHistory(ChainsyncEvent{
+		ConnectionId: connId,
+		Point:        ocommon.NewPoint(slot, header.Hash().Bytes()),
+		BlockNumber:  blockNumber,
+		Type:         gledger.BlockTypeBabbage,
+		BlockHeader:  encoded,
+	})
+
+	history := fixture.ls.peerHeaderHistory[connIdKey(connId)]
+	require.NotNil(t, history)
+	record := history.byHash[hex.EncodeToString(header.Hash().Bytes())]
+	assert.Nil(t, record.event.BlockHeader)
+	rehydrated, ok := record.chainsyncEvent()
+	require.True(t, ok)
+	require.NotNil(t, rehydrated.BlockHeader)
+	assert.Equal(t, header.Hash(), rehydrated.BlockHeader.Hash())
+	assert.Equal(t, header.PrevHash(), rehydrated.BlockHeader.PrevHash())
+	assert.Equal(t, header.BlockNumber(), rehydrated.BlockHeader.BlockNumber())
+	assert.Equal(t, header.SlotNumber(), rehydrated.BlockHeader.SlotNumber())
 }
 
 // TestTryResolveForkExtensionRestartsBlockfetchAfterQueueOverflow pins the

--- a/ledger/chainsync_fork_queue_full_test.go
+++ b/ledger/chainsync_fork_queue_full_test.go
@@ -149,11 +149,15 @@ func TestRecordPeerHeaderHistoryBoundsRetainedBytes(t *testing.T) {
 		history.order[len(history.order)-1],
 	)
 	retainedBytes := 0
+	decodedHeaders := 0
 	for _, record := range history.byHash {
 		retainedBytes += record.bytes
-		assert.Nil(t, record.event.BlockHeader)
+		if record.event.BlockHeader != nil {
+			decodedHeaders++
+		}
 		assert.Len(t, record.headerCbor, 2048)
 	}
+	assert.Zero(t, decodedHeaders)
 	assert.Equal(t, retainedBytes, history.retainedBytes)
 	assert.LessOrEqual(t, history.retainedBytes, maxPeerHeaderHistoryBytesPerConn)
 }

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -58,6 +58,13 @@ type mockHeader struct {
 	slot        uint64
 }
 
+type sizedMockHeader struct {
+	mockHeader
+	cbor []byte
+}
+
+func (m sizedMockHeader) Cbor() []byte { return m.cbor }
+
 func (m mockHeader) Hash() lcommon.Blake2b256     { return m.hash }
 func (m mockHeader) PrevHash() lcommon.Blake2b256 { return m.prevHash }
 func (m mockHeader) BlockNumber() uint64          { return m.blockNumber }


### PR DESCRIPTION
## Summary

- Bound each connection's Genesis header history by both its recovery window and an 8 MiB byte budget.
- Retain compact metadata and wire header bytes, rehydrating headers only for fork recovery.
- Fall back to a fresh ChainSync intersection when retained history cannot reconstruct a complete path.
- Document the retention and recovery contract.

Closes #3486.

## Validation

- Baseline regression retains all 5,000 entries and fails the byte-bound assertion.
- Focused fixed-head regressions pass repeatedly under the race detector.
- Full ledger unit and race tests pass.
- Conformance, import-boundary, documentation-parity, lint, NilAway, modernize, and golines checks pass.
