### PR TITLE
perf(database): bound hot-cache updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1681,7 +1681,7 @@ CBOR Data Request
 Tier 1: Hot Cache (in-memory)
   - UTxO entries: configurable count (HotUtxoEntries)
   - Transaction entries: configurable count + byte limit
-  - O(1) access, LRU eviction
+  - Sharded O(1) access, approximate LFU eviction
        | miss
        v
 Tier 2: Block LRU Cache
@@ -1700,7 +1700,37 @@ Tier 3: Cold Extraction
   - Extract CBOR at stored offset
 ```
 
-Tier 1 (`HotCache`, `database/hot_cache.go`) is a lock-free, copy-on-write cache: writers build a new snapshot and `CompareAndSwap` it in without ever taking a mutex. There are two CAS loops — `Put` and probabilistic access-count tracking — each bounded (`maxCASAttempts`, default 16) with yield-then-jittered-backoff between retries; a writer that exhausts its budget under sustained contention drops the update rather than spinning or falling back to a lock — the cache is strictly best-effort, so a dropped write only costs a future miss recomputed from Tier 2/3. LFU eviction is not a separate, third CAS loop: it is folded into `Put`'s own CAS attempt (`evictToFit`) whenever an insert would push the cache over `maxSize`/`maxBytes`, so a size-limit trim is atomic with the insert that triggered it. A standalone eviction pass tried this after Put previously succeeded, but could then lose its own CAS race indefinitely to concurrent access-count updates from `Get` — since only `Put` ever grows the cache, a dropped eviction had no later Put to retry it, leaving the cache permanently over its configured limit. The running byte total is likewise stored inside the same CAS-protected snapshot (`hotCacheData.totalBytes`) rather than in a separately-updated atomic: a byte counter updated only *after* the entries CAS succeeds can be read by a concurrent `Put` after the entries change has landed but before the counter catches up, silently undercounting and skipping byte-limit eviction it should have performed. Contention is observable via `HotCache.CASStats()` and, when a `Config.PromRegistry` is set, the `dingo_hot_cache_cas_attempts_total`, `dingo_hot_cache_writers_aborted_after_budget_total`, `dingo_hot_cache_successful_commits_after_backoff_total`, and `dingo_hot_cache_successful_commit_backoff_seconds_total` metrics (labeled `cache="utxo"|"tx"`); a configured logger also gets a rate-limited warning (at most one per second) when writes are dropped, with the underlying counters remaining authoritative regardless.
+Tier 1 (`HotCache`, `database/hot_cache.go`) uses 64 mutable shards. `Get`
+locks only the shard selected by the key, copies the cached value for caller
+isolation, and records access counts on one in four hits. A sampled count update
+uses a bounded non-blocking shard-lock loop, so LFU accuracy remains
+best-effort under contention without turning reads into cardinality-sized map
+copies.
+
+`Put` uses a bounded non-blocking update-lock loop. Routine insertion or
+replacement changes only the selected shard; the update lock serializes every
+membership change and the exact entry/byte counters. If an insert would cross
+either configured limit, `Put`
+examines at most 64 candidates from insertion/replacement order and evicts the
+least frequently used entries in that fixed window. The insert is admitted
+only when those bounded candidates restore both limits; otherwise the existing
+cache is left intact and the best-effort insert is dropped. A failed window is
+rotated behind the remaining entries so a later bounded attempt can inspect
+different candidates instead of freezing admission behind one undersized
+sample. Admission therefore never copies or sorts the full cache, and both its
+synchronous work and its temporary allocation remain independent of configured
+cardinality. Exhausting the update-lock retry budget also drops the cache
+update; either outcome only causes a later miss to be recomputed from Tier 2/3.
+
+Contention remains observable through the compatibility API
+`HotCache.CASStats()` and the existing
+`dingo_hot_cache_cas_attempts_total`,
+`dingo_hot_cache_writers_aborted_after_budget_total`,
+`dingo_hot_cache_successful_commits_after_backoff_total`, and
+`dingo_hot_cache_successful_commit_backoff_seconds_total` metrics, labeled
+`cache="utxo"|"tx"`. Their historical CAS names are retained for dashboard
+compatibility; they now count non-blocking update-lock attempts. A configured
+logger also receives rate-limited warnings when an update is dropped.
 
 ### CborOffset Structure
 

--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -730,16 +730,16 @@ func (c *TieredCborCache) Metrics() *CacheMetrics {
 	return c.metrics
 }
 
-// SetLogger wires a logger into both hot caches for CAS-retry-budget
+// SetLogger wires a logger into both hot caches for update-retry-budget
 // diagnostics (see HotCache.SetLogger). A nil logger disables this logging.
 func (c *TieredCborCache) SetLogger(logger *slog.Logger) {
 	c.hotUtxo.SetLogger(logger, "utxo")
 	c.hotTx.SetLogger(logger, "tx")
 }
 
-// RegisterCASMetrics exposes both hot caches' copy-on-write contention
-// counters on the given Prometheus registry (see HotCache.RegisterCASMetrics).
-// If registry is nil, this is a no-op.
+// RegisterCASMetrics exposes both hot caches' update-contention counters on
+// the given Prometheus registry (see HotCache.RegisterCASMetrics). The name is
+// retained for compatibility. If registry is nil, this is a no-op.
 func (c *TieredCborCache) RegisterCASMetrics(
 	registry prometheus.Registerer,
 ) error {

--- a/database/cbor_cache_bench_test.go
+++ b/database/cbor_cache_bench_test.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -98,6 +99,55 @@ func BenchmarkHotCacheParallelGet(b *testing.B) {
 			i++
 		}
 	})
+}
+
+// BenchmarkHotCacheCardinality verifies that routine hit and replacement
+// costs stay flat as configured cache cardinality grows. Population happens
+// before the timer so the benchmark reports only steady-state operations.
+func BenchmarkHotCacheCardinality(b *testing.B) {
+	for _, cardinality := range []int{1000, 10000, 50000} {
+		b.Run(fmt.Sprintf("Get/%d", cardinality), func(b *testing.B) {
+			cache, key := populatedHotCache(cardinality)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				cache.Get(key)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Put/%d", cardinality), func(b *testing.B) {
+			cache, key := populatedHotCache(cardinality)
+			value := []byte("replacement-value")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				cache.Put(key, value)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Churn/%d", cardinality), func(b *testing.B) {
+			cache, _ := populatedHotCache(cardinality)
+			value := []byte("replacement-value")
+			key := make([]byte, 0, 32)
+			nextKey := cardinality
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				key = fmt.Appendf(key[:0], "key-%08d", nextKey)
+				cache.Put(key, value)
+				nextKey++
+			}
+		})
+	}
+}
+
+func populatedHotCache(cardinality int) (*HotCache, []byte) {
+	cache := NewHotCache(cardinality, 0)
+	value := []byte("cached-value")
+	for i := range cardinality {
+		cache.Put(fmt.Appendf(nil, "key-%08d", i), value)
+	}
+	return cache, []byte("key-00000000")
 }
 
 // BenchmarkBlockLRUCacheGet measures block LRU cache hit performance

--- a/database/hot_cache.go
+++ b/database/hot_cache.go
@@ -15,30 +15,27 @@
 package database
 
 import (
+	"container/list"
 	"errors"
 	"log/slog"
-	"maps"
 	"runtime"
-	"slices"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// hotCacheData holds entries, access counts, and their total byte size
-// together for atomic updates. Keeping totalBytes here rather than in a
-// separately-updated atomic ensures a reader of one CAS-protected snapshot
-// always sees a byte total that is exactly consistent with that snapshot's
-// entries -- a byte total tracked outside this struct could be read after a
-// concurrent writer's entries CAS had already landed but before that
-// writer's own byte-total update ran, making the byte-limit check
-// undercount and silently skip eviction it should have performed.
-type hotCacheData struct {
-	entries    map[string][]byte
-	accessCnt  map[string]uint64
-	totalBytes int64 // sum of len(key)+len(value) across entries; only meaningful when maxBytes > 0
+type hotCacheEntry struct {
+	value        []byte
+	accessCnt    uint64
+	orderElement *list.Element
+}
+
+type hotCacheShard struct {
+	mu      sync.RWMutex
+	entries map[string]hotCacheEntry
 }
 
 // accessSampleRate controls how often access counts are updated on Get().
@@ -46,17 +43,37 @@ type hotCacheData struct {
 // This trades LFU accuracy for performance by avoiding map copies on every read.
 const accessSampleRate = 4
 
+// hotCacheShardCount spreads readers and sampled-access updates across
+// independent locks. It is fixed so routine operation cost does not grow with
+// configured cache cardinality.
+const hotCacheShardCount = 64
+
+// hotCacheEvictionSampleSize bounds the number of entries inspected by an
+// overflowing Put. Eviction is approximate LFU: the least-used entries from
+// this fixed candidate window are removed until the pending value fits. The
+// fixed window keeps admission CPU and temporary memory independent of total
+// cache cardinality.
+const hotCacheEvictionSampleSize = 64
+
+type hotCacheEvictionCandidate struct {
+	key          string
+	accessCnt    uint64
+	size         int64
+	order        int
+	orderElement *list.Element
+}
+
 const (
-	// defaultMaxCASAttempts bounds the work spent on one best-effort
-	// copy-on-write update (Put, which folds in eviction, or access-count
-	// tracking).
+	// defaultMaxCASAttempts bounds the work spent acquiring an update lock for
+	// one best-effort Put or access-count update. The name is retained for
+	// compatibility with the existing stats and metrics API.
 	defaultMaxCASAttempts = 16
-	// casYieldThreshold is the retry count after which a CAS loop starts
+	// casYieldThreshold is the retry count after which an update loop starts
 	// sleeping a small, randomized amount instead of just yielding the
 	// processor, so contending writers desynchronize instead of retrying
 	// in lockstep.
 	casYieldThreshold = 2
-	// maxCASBackoff caps the randomized sleep between CAS retries.
+	// maxCASBackoff caps the randomized sleep between update retries.
 	maxCASBackoff = 64 * time.Microsecond
 	// abortLogInterval rate-limits the writer-aborted warning log so that
 	// sustained contention produces bounded log/IO traffic instead of one
@@ -66,13 +83,14 @@ const (
 	abortLogInterval = time.Second
 )
 
-// HotCacheCASStats describes contention in HotCache's copy-on-write update
-// path. Values are cumulative for the lifetime of the cache.
+// HotCacheCASStats describes contention in HotCache's update path. The type
+// and field names predate the sharded implementation and remain stable for
+// API and metrics compatibility. Values are cumulative for the cache's life.
 type HotCacheCASStats struct {
-	// Attempts is the total number of CompareAndSwap attempts across Put
-	// (which folds in eviction, see evictToFit) and access-count tracking.
+	// Attempts is the total number of non-blocking lock attempts across Put
+	// and access-count tracking.
 	Attempts uint64
-	// WritersAbortedAfterBudget is the number of copy-on-write updates that
+	// WritersAbortedAfterBudget is the number of best-effort updates that
 	// exhausted their retry budget and were dropped as best-effort.
 	WritersAbortedAfterBudget uint64
 	// SuccessfulCommitsAfterBackoff is the number of updates that succeeded
@@ -84,15 +102,20 @@ type HotCacheCASStats struct {
 	SuccessfulCommitBackoffTime time.Duration
 }
 
-// HotCache provides a lock-free cache for frequently accessed CBOR data.
-// It uses copy-on-write semantics for thread-safe concurrent access without locks.
-// Eviction follows a Least-Frequently-Used (LFU) policy with probabilistic counting.
+// HotCache provides a sharded cache for frequently accessed CBOR data. Reads
+// take a shard read lock, while writes are serialized only long enough to keep
+// global size and byte accounting exact. Eviction follows an approximate
+// Least-Frequently-Used (LFU) policy with probabilistic counting.
 type HotCache struct {
-	data                atomic.Pointer[hotCacheData] // combined entries + access counts + total bytes
-	maxSize             int                          // max number of entries (0 = unlimited)
-	maxBytes            int64                        // max memory in bytes (0 = unlimited)
-	sampleCnt           atomic.Uint64                // counter for probabilistic access tracking
-	casSequence         atomic.Uint64                // gives contending writers asymmetric jitter
+	shards              [hotCacheShardCount]hotCacheShard
+	updateMu            sync.Mutex
+	evictionOrder       list.List
+	size                int
+	totalBytes          int64
+	maxSize             int           // max number of entries (0 = unlimited)
+	maxBytes            int64         // max memory in bytes (0 = unlimited)
+	sampleCnt           atomic.Uint64 // counter for probabilistic access tracking
+	casSequence         atomic.Uint64 // gives contending updates asymmetric jitter
 	casAttempts         atomic.Uint64
 	writersAborted      atomic.Uint64 // updates dropped after exhausting the budget
 	commitsAfterBackoff atomic.Uint64
@@ -108,8 +131,8 @@ type HotCache struct {
 }
 
 // SetLogger wires an optional logger into the cache for diagnostics: it logs
-// a warning whenever a copy-on-write update is dropped after exhausting the
-// CAS retry budget (see HotCacheCASStats.WritersAbortedAfterBudget). name
+// a warning whenever an update is dropped after exhausting the retry budget
+// (see HotCacheCASStats.WritersAbortedAfterBudget). name
 // identifies this cache instance in the log fields (e.g. "utxo", "tx"). A
 // nil logger disables this logging, which is the default.
 func (c *HotCache) SetLogger(logger *slog.Logger, name string) {
@@ -124,7 +147,7 @@ func (c *HotCache) SetLogger(logger *slog.Logger, name string) {
 // per second, trading CPU churn for log/IO churn. writersAborted itself is
 // unaffected and always incremented by the caller, so it remains an
 // authoritative count even while logging is suppressed. op identifies which
-// CAS loop gave up (put or increment_access).
+// update path gave up (put or increment_access).
 func (c *HotCache) logWriterAborted(op string) {
 	if c.logger == nil {
 		return
@@ -140,7 +163,7 @@ func (c *HotCache) logWriterAborted(op string) {
 		return
 	}
 	c.logger.Warn(
-		"hot cache dropped a best-effort update after exhausting its CAS retry budget",
+		"hot cache dropped a best-effort update after exhausting its retry budget",
 		"cache",
 		c.cacheName,
 		"op",
@@ -152,12 +175,11 @@ func (c *HotCache) logWriterAborted(op string) {
 	)
 }
 
-// RegisterCASMetrics exposes this cache's copy-on-write contention counters
-// (see HotCacheCASStats) on the given Prometheus registry, labeled by
-// cacheName (e.g. "utxo", "tx"). If registry is nil, this is a no-op. This
-// method is safe to call more than once with the same registry; a duplicate
-// registration is ignored since the collectors read from this cache's own
-// counters regardless of which registration call installed them.
+// RegisterCASMetrics exposes this cache's update-contention counters (see
+// HotCacheCASStats) on the given Prometheus registry, labeled by cacheName
+// (e.g. "utxo", "tx"). The method and metric names retain their historical
+// CAS terminology for compatibility. If registry is nil, this is a no-op.
+// This method is safe to call more than once with the same registry.
 func (c *HotCache) RegisterCASMetrics(
 	registry prometheus.Registerer,
 	cacheName string,
@@ -169,17 +191,17 @@ func (c *HotCache) RegisterCASMetrics(
 	collectors := []prometheus.Collector{
 		prometheus.NewCounterFunc(prometheus.CounterOpts{
 			Name:        "dingo_hot_cache_cas_attempts_total",
-			Help:        "Total CompareAndSwap attempts across Put (including eviction) and access tracking",
+			Help:        "Total non-blocking update attempts across Put and access tracking",
 			ConstLabels: labels,
 		}, func() float64 { return float64(c.casAttempts.Load()) }),
 		prometheus.NewCounterFunc(prometheus.CounterOpts{
 			Name:        "dingo_hot_cache_writers_aborted_after_budget_total",
-			Help:        "Total copy-on-write updates dropped after exhausting the CAS retry budget",
+			Help:        "Total best-effort updates dropped after exhausting the retry budget",
 			ConstLabels: labels,
 		}, func() float64 { return float64(c.writersAborted.Load()) }),
 		prometheus.NewCounterFunc(prometheus.CounterOpts{
 			Name:        "dingo_hot_cache_successful_commits_after_backoff_total",
-			Help:        "Total copy-on-write updates that succeeded only after backing off at least once",
+			Help:        "Total updates that succeeded only after backing off at least once",
 			ConstLabels: labels,
 		}, func() float64 { return float64(c.commitsAfterBackoff.Load()) }),
 		prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -198,8 +220,8 @@ func (c *HotCache) RegisterCASMetrics(
 	return nil
 }
 
-// CASStats returns a snapshot of copy-on-write contention counters, suitable
-// for diagnostics or metrics export.
+// CASStats returns a snapshot of update-contention counters, suitable for
+// diagnostics or metrics export. Its name is retained for compatibility.
 func (c *HotCache) CASStats() HotCacheCASStats {
 	return HotCacheCASStats{
 		Attempts:                      c.casAttempts.Load(),
@@ -211,9 +233,9 @@ func (c *HotCache) CASStats() HotCacheCASStats {
 	}
 }
 
-// recordSuccessfulCommit records a copy-on-write update that committed after
-// a timed backoff. Keeping this accounting in one place ensures every CAS path
-// uses the same metric semantics.
+// recordSuccessfulCommit records an update that committed after
+// a timed backoff. Keeping this accounting in one place ensures every update
+// path uses the same metric semantics.
 func (c *HotCache) recordSuccessfulCommit(backoffTime time.Duration) {
 	if backoffTime <= 0 {
 		return
@@ -222,7 +244,7 @@ func (c *HotCache) recordSuccessfulCommit(backoffTime time.Duration) {
 	c.commitBackoffNanos.Add(uint64(backoffTime))
 }
 
-// backoff waits between CAS retries: an immediate scheduler yield for the
+// backoff waits between update retries: an immediate scheduler yield for the
 // first couple of attempts, then a small randomized sleep whose window
 // grows with the attempt count. casSequence lets concurrent callers land on
 // different delays without a shared RNG or lock. Returns the duration
@@ -254,52 +276,71 @@ func NewHotCache(maxSize int, maxBytes int64) *HotCache {
 		maxCASAttempts: defaultMaxCASAttempts,
 	}
 
-	// Initialize combined data structure (totalBytes defaults to 0, correct
-	// for an empty cache)
-	data := &hotCacheData{
-		entries:   make(map[string][]byte),
-		accessCnt: make(map[string]uint64),
+	for i := range cache.shards {
+		cache.shards[i].entries = make(map[string]hotCacheEntry)
 	}
-	cache.data.Store(data)
 
 	return cache
 }
 
+func hotCacheShardIndexBytes(key []byte) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	hash := uint64(offset64)
+	for _, value := range key {
+		hash ^= uint64(value)
+		hash *= prime64
+	}
+	return hash % hotCacheShardCount
+}
+
+func hotCacheShardIndexString(key string) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	hash := uint64(offset64)
+	for i := range len(key) {
+		hash ^= uint64(key[i])
+		hash *= prime64
+	}
+	return hash % hotCacheShardCount
+}
+
 // Get retrieves a value from the cache by key.
 // Returns the value and true if found, nil and false otherwise.
-// This operation is lock-free and safe for concurrent use.
+// This operation is safe for concurrent use and locks only one shard.
 // Access counts are updated probabilistically (1 in accessSampleRate calls)
 // to reduce overhead while maintaining approximate LFU behavior.
 func (c *HotCache) Get(key []byte) ([]byte, bool) {
-	data := c.data.Load()
-	if data == nil {
-		return nil, false
-	}
-
-	value, ok := data.entries[string(key)]
+	shard := &c.shards[hotCacheShardIndexBytes(key)]
+	shard.mu.RLock()
+	entry, ok := shard.entries[string(key)]
 	if ok {
+		// Copy while holding the read lock so a replacement cannot recycle the
+		// backing array before the caller receives an isolated value.
+		value := append([]byte(nil), entry.value...)
+		shard.mu.RUnlock()
 		// Probabilistic counting: only update access count 1 in accessSampleRate times
-		// This avoids expensive map copies on every read while maintaining approximate LFU
+		// This keeps write-lock traffic low while maintaining approximate LFU.
 		if c.sampleCnt.Add(1)%accessSampleRate == 0 {
 			c.incrementAccess(key)
 		}
-		// Return a copy to prevent callers from mutating cached data
-		return append([]byte(nil), value...), true
+		return value, true
 	}
+	shard.mu.RUnlock()
 	return nil, false
 }
 
 // Put adds or updates a value in the cache.
 // If maxBytes > 0 and the entry size exceeds maxBytes/10, the entry is skipped.
-// This operation uses copy-on-write semantics for thread safety. If the
-// insert pushes the cache over its configured maxSize/maxBytes, eviction is
-// folded into this same CAS attempt (see evictToFit) rather than run as a
-// separate follow-up operation: a standalone eviction pass would have to win
-// its own CAS race against concurrent access-count updates from Get, and
-// could lose that race indefinitely under sustained read contention with no
-// later Put to retry it, leaving the cache permanently over its limit.
+// This operation uses a bounded, non-blocking attempt to enter the serialized
+// update path. If the insert pushes the cache over maxSize/maxBytes, eviction
+// is completed before the update lock is released, so the cache cannot remain
+// over its configured limits after Put returns.
 func (c *HotCache) Put(key []byte, cbor []byte) {
-	keyStr := string(key)
 	entrySize := int64(len(key) + len(cbor))
 
 	// Skip entries that are too large (> 10% of max memory)
@@ -307,200 +348,220 @@ func (c *HotCache) Put(key []byte, cbor []byte) {
 		return
 	}
 
-	// Copy-on-write: create new combined data with the update
-	var backoffTime time.Duration
-	for attempt := 0; attempt < c.maxCASAttempts; attempt++ {
-		oldData := c.data.Load()
+	backoffTime, ok := c.beginUpdate()
+	if !ok {
+		c.writersAborted.Add(1)
+		c.logWriterAborted("put")
+		return
+	}
+	defer c.updateMu.Unlock()
 
-		newEntries := make(map[string][]byte, len(oldData.entries)+1)
-		maps.Copy(newEntries, oldData.entries)
+	keyStr := string(key)
+	shard := &c.shards[hotCacheShardIndexBytes(key)]
 
-		// Track memory change
-		var memDelta int64
-		if oldValue, exists := newEntries[keyStr]; exists {
-			memDelta = entrySize - int64(len(keyStr)+len(oldValue))
-		} else {
-			memDelta = entrySize
-		}
+	shard.mu.RLock()
+	oldEntry, exists := shard.entries[keyStr]
+	shard.mu.RUnlock()
 
-		// Copy the value to prevent callers from mutating cached data
-		cborCopy := make([]byte, len(cbor))
-		copy(cborCopy, cbor)
-		newEntries[keyStr] = cborCopy
-
-		// Also update access count map
-		newAccessCnt := make(map[string]uint64, len(oldData.accessCnt)+1)
-		maps.Copy(newAccessCnt, oldData.accessCnt)
-		newAccessCnt[keyStr]++ // increment on put
-
-		// Trim to the configured limits as part of this same snapshot, using
-		// oldData's own totalBytes -- not a separately-updated atomic -- as
-		// the byte-usage baseline. Deriving the estimate from the exact
-		// snapshot memDelta is itself computed against means there is no
-		// window in which this read can be stale relative to the entries
-		// it's paired with; needs no per-Put O(n) resummation either.
-		estimatedBytes := oldData.totalBytes + memDelta
-		trimmedEntries, trimmedAccessCnt, bytesEvicted := c.evictToFit(
-			newEntries, newAccessCnt, estimatedBytes,
-		)
-
-		newData := &hotCacheData{
-			entries:    trimmedEntries,
-			accessCnt:  trimmedAccessCnt,
-			totalBytes: estimatedBytes - bytesEvicted,
-		}
-
-		// Try to atomically update both maps together
-		c.casAttempts.Add(1)
-		if c.data.CompareAndSwap(oldData, newData) {
-			c.recordSuccessfulCommit(backoffTime)
-			return
-		}
-		// CAS failed. The bounded loop plus backoff below prevents this from
-		// spinning forever or staying synchronized with other contenders.
-		backoffTime += c.backoff(attempt)
+	projectedSize := c.size
+	projectedBytes := c.totalBytes + entrySize
+	if exists {
+		projectedBytes -= int64(len(keyStr) + len(oldEntry.value))
+	} else {
+		projectedSize++
 	}
 
-	// Cache population is strictly best-effort. Dropping the write keeps
-	// contention out of the caller's critical path; a later miss recomputes it.
-	c.writersAborted.Add(1)
-	c.logWriterAborted("put")
+	victims, fits := c.selectEvictionVictimsLocked(
+		keyStr,
+		projectedSize,
+		projectedBytes,
+	)
+	if !fits {
+		// Cache population is best-effort. If a bounded candidate window
+		// cannot free enough room, preserve the current entries and advance
+		// the window so later bounded attempts can inspect other candidates
+		// rather than dropping every future admission behind the same prefix.
+		c.rotateEvictionCandidatesLocked(victims)
+		return
+	}
+	for _, victim := range victims {
+		c.removeEntryLocked(victim.key)
+	}
+
+	// Copy only after admission succeeds so a dropped best-effort update does
+	// not allocate a value it will never retain.
+	cborCopy := append([]byte(nil), cbor...)
+	shard.mu.Lock()
+	oldEntry, exists = shard.entries[keyStr]
+	accessCnt := uint64(1)
+	var orderElement *list.Element
+	if exists {
+		accessCnt = oldEntry.accessCnt + 1
+		orderElement = oldEntry.orderElement
+		c.evictionOrder.MoveToBack(orderElement)
+		c.totalBytes -= int64(len(keyStr) + len(oldEntry.value))
+	} else {
+		orderElement = c.evictionOrder.PushBack(keyStr)
+		c.size++
+	}
+	shard.entries[keyStr] = hotCacheEntry{
+		value:        cborCopy,
+		accessCnt:    accessCnt,
+		orderElement: orderElement,
+	}
+	c.totalBytes += entrySize
+	shard.mu.Unlock()
+	c.recordSuccessfulCommit(backoffTime)
+}
+
+// beginUpdate makes update admission best-effort and bounded while keeping
+// the global size and byte counters serialized. The historical CAS counters
+// now report these non-blocking lock attempts so existing dashboards retain
+// their contention signal.
+func (c *HotCache) beginUpdate() (time.Duration, bool) {
+	var backoffTime time.Duration
+	for attempt := 0; attempt < c.maxCASAttempts; attempt++ {
+		c.casAttempts.Add(1)
+		if c.updateMu.TryLock() {
+			return backoffTime, true
+		}
+		backoffTime += c.backoff(attempt)
+	}
+	return backoffTime, false
 }
 
 // incrementAccess increments the access counter for a key.
-// Uses copy-on-write semantics for thread safety.
-// Only increments if the key still exists in entries to prevent orphan access counts.
+// The update takes only the owning shard's lock and remains best-effort. It
+// only increments if the key still exists to prevent orphan access counts.
 func (c *HotCache) incrementAccess(key []byte) {
 	keyStr := string(key)
+	shard := &c.shards[hotCacheShardIndexBytes(key)]
 
 	var backoffTime time.Duration
 	for attempt := 0; attempt < c.maxCASAttempts; attempt++ {
-		oldData := c.data.Load()
-		if oldData == nil {
-			return
-		}
-
-		// Check if key still exists in entries (may have been evicted)
-		if _, exists := oldData.entries[keyStr]; !exists {
-			return
-		}
-
-		// Copy and update access counts only - entries are unchanged so reuse them
-		newAccessCnt := make(map[string]uint64, len(oldData.accessCnt))
-		maps.Copy(newAccessCnt, oldData.accessCnt)
-		newAccessCnt[keyStr]++
-
-		newData := &hotCacheData{
-			entries:    oldData.entries, // reuse immutable entries map
-			accessCnt:  newAccessCnt,
-			totalBytes: oldData.totalBytes, // unchanged: no entries added or removed
-		}
-
 		c.casAttempts.Add(1)
-		if c.data.CompareAndSwap(oldData, newData) {
+		if shard.mu.TryLock() {
+			entry, exists := shard.entries[keyStr]
+			if !exists {
+				shard.mu.Unlock()
+				return
+			}
+			entry.accessCnt++
+			shard.entries[keyStr] = entry
+			shard.mu.Unlock()
 			c.recordSuccessfulCommit(backoffTime)
 			return
 		}
-		// CAS failed. This is a probabilistic, best-effort access-count
-		// update (see accessSampleRate), so dropping it under sustained
-		// contention only costs a little LFU accuracy.
 		backoffTime += c.backoff(attempt)
 	}
 	c.writersAborted.Add(1)
 	c.logWriterAborted("increment_access")
 }
 
-// evictToFit trims entries (least-frequently-used first) so the result
-// satisfies maxSize/maxBytes, given a pending insert already folded into
-// entries/accessCnt and an estimate of the resulting byte usage. It returns
-// the input maps unchanged (same references) if no trimming is needed, or
-// new maps with the LFU entries removed, plus the bytes removed.
-//
-// This is called from within Put's own CAS-attempt loop rather than as a
-// separate operation: eviction has no correctness value if it can be
-// starved indefinitely by concurrent access-count updates from Get, since
-// only Put ever grows the cache and there may be no later Put to retry a
-// dropped eviction. Folding it into the same atomic snapshot as the insert
-// makes limit enforcement a property of that single CAS instead of a
-// separate, losable race.
-func (c *HotCache) evictToFit(
-	entries map[string][]byte,
-	accessCnt map[string]uint64,
-	estimatedBytes int64,
-) (map[string][]byte, map[string]uint64, int64) {
-	needEvictBySize := c.maxSize > 0 && len(entries) > c.maxSize
-	needEvictByBytes := c.maxBytes > 0 && estimatedBytes > c.maxBytes
-	if !needEvictBySize && !needEvictByBytes {
-		return entries, accessCnt, 0
+// selectEvictionVictimsLocked requires updateMu. It inspects at most a fixed
+// number of entries from the front of the insertion/replacement order and
+// chooses the least frequently used candidates from that window. It returns
+// false with the attempted candidates when the bounded sample cannot restore
+// all configured limits. The caller may rotate that failed window without
+// changing membership so later bounded attempts can make progress.
+func (c *HotCache) selectEvictionVictimsLocked(
+	excludeKey string,
+	projectedSize int,
+	projectedBytes int64,
+) ([]hotCacheEvictionCandidate, bool) {
+	entriesNeeded := 0
+	if c.maxSize > 0 && projectedSize > c.maxSize {
+		entriesNeeded = projectedSize - c.maxSize
+	}
+	bytesNeeded := int64(0)
+	if c.maxBytes > 0 && projectedBytes > c.maxBytes {
+		bytesNeeded = projectedBytes - c.maxBytes
+	}
+	if entriesNeeded == 0 && bytesNeeded == 0 {
+		return nil, true
 	}
 
-	// Calculate target size (evict ~25%, but keep at least 1 entry)
-	// Only computed when maxSize > 0; otherwise size-based eviction is disabled
-	var targetSize int
-	if c.maxSize > 0 {
-		targetSize = max(1, c.maxSize*3/4)
-	}
-
-	var targetBytes int64
-	if c.maxBytes > 0 {
-		targetBytes = c.maxBytes * 3 / 4
-	}
-
-	// Build list of entries sorted by access count (ascending = least frequent first)
-	type entry struct {
-		key   string
-		count uint64
-		size  int64
-	}
-
-	entriesList := make([]entry, 0, len(entries))
-	for k, v := range entries {
-		entriesList = append(entriesList, entry{
-			key:   k,
-			count: accessCnt[k],
-			size:  int64(len(k) + len(v)),
-		})
-	}
-
-	// Sort by access count ascending (least frequently used first)
-	sort.Slice(entriesList, func(i, j int) bool {
-		return entriesList[i].count < entriesList[j].count
-	})
-
-	// Determine which entries to keep
-	keysToRemove := make(map[string]bool)
-	keptSize := 0
-	var keptBytes int64
-
-	for _, e := range slices.Backward(entriesList) {
-		wouldExceedSize := c.maxSize > 0 && keptSize >= targetSize
-		wouldExceedBytes := c.maxBytes > 0 && keptBytes+e.size > targetBytes
-
-		if wouldExceedSize || wouldExceedBytes {
-			keysToRemove[e.key] = true
-		} else {
-			keptSize++
-			keptBytes += e.size
-		}
-	}
-
-	if len(keysToRemove) == 0 {
-		return entries, accessCnt, 0
-	}
-
-	// Create new maps without evicted entries
-	newEntries := make(map[string][]byte, len(entries)-len(keysToRemove))
-	newAccessCnt := make(map[string]uint64, len(entries)-len(keysToRemove))
-	var bytesRemoved int64
-
-	for k, v := range entries {
-		if keysToRemove[k] {
-			bytesRemoved += int64(len(k) + len(v))
+	candidates := make(
+		[]hotCacheEvictionCandidate,
+		0,
+		min(c.evictionOrder.Len(), hotCacheEvictionSampleSize),
+	)
+	order := 0
+	for element := c.evictionOrder.Front(); element != nil && len(candidates) < hotCacheEvictionSampleSize; element = element.Next() {
+		key := element.Value.(string)
+		if key == excludeKey {
 			continue
 		}
-		newEntries[k] = v
-		newAccessCnt[k] = accessCnt[k]
+		shard := &c.shards[hotCacheShardIndexString(key)]
+		shard.mu.RLock()
+		entry, exists := shard.entries[key]
+		shard.mu.RUnlock()
+		if !exists {
+			continue
+		}
+		candidates = append(candidates, hotCacheEvictionCandidate{
+			key:          key,
+			accessCnt:    entry.accessCnt,
+			size:         int64(len(key) + len(entry.value)),
+			order:        order,
+			orderElement: entry.orderElement,
+		})
+		order++
 	}
 
-	return newEntries, newAccessCnt, bytesRemoved
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].accessCnt != candidates[j].accessCnt {
+			return candidates[i].accessCnt < candidates[j].accessCnt
+		}
+		if candidates[i].size != candidates[j].size {
+			return candidates[i].size > candidates[j].size
+		}
+		return candidates[i].order < candidates[j].order
+	})
+
+	victims := make([]hotCacheEvictionCandidate, 0, len(candidates))
+	var bytesFreed int64
+	for _, candidate := range candidates {
+		if len(victims) >= entriesNeeded && bytesFreed >= bytesNeeded {
+			break
+		}
+		victims = append(victims, candidate)
+		bytesFreed += candidate.size
+	}
+	if len(victims) < entriesNeeded || bytesFreed < bytesNeeded {
+		return victims, false
+	}
+	return victims, true
+}
+
+// rotateEvictionCandidatesLocked requires updateMu. It moves a failed bounded
+// sample to the back of the scan order without evicting it. The next admission
+// can therefore inspect a different fixed-size window while every individual
+// Put remains independent of total cache cardinality.
+func (c *HotCache) rotateEvictionCandidatesLocked(
+	candidates []hotCacheEvictionCandidate,
+) {
+	// selectEvictionVictimsLocked sorts by LFU preference. Restore the original
+	// scan order before moving the window so its relative order stays stable.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].order < candidates[j].order
+	})
+	for _, candidate := range candidates {
+		c.evictionOrder.MoveToBack(candidate.orderElement)
+	}
+}
+
+// removeEntryLocked requires updateMu and removes one selected victim while
+// keeping membership, byte accounting, and eviction order consistent.
+func (c *HotCache) removeEntryLocked(key string) {
+	shard := &c.shards[hotCacheShardIndexString(key)]
+	shard.mu.Lock()
+	entry, exists := shard.entries[key]
+	if exists {
+		delete(shard.entries, key)
+		c.size--
+		c.totalBytes -= int64(len(key) + len(entry.value))
+		c.evictionOrder.Remove(entry.orderElement)
+	}
+	shard.mu.Unlock()
 }

--- a/database/hot_cache_test.go
+++ b/database/hot_cache_test.go
@@ -28,6 +28,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type hotCacheSnapshot struct {
+	entries    map[string][]byte
+	totalBytes int64
+}
+
+func snapshotHotCache(cache *HotCache) *hotCacheSnapshot {
+	cache.updateMu.Lock()
+	defer cache.updateMu.Unlock()
+	data := &hotCacheSnapshot{
+		entries:    make(map[string][]byte, cache.size),
+		totalBytes: cache.totalBytes,
+	}
+	for i := range cache.shards {
+		shard := &cache.shards[i]
+		shard.mu.RLock()
+		for key, entry := range shard.entries {
+			data.entries[key] = entry.value
+		}
+		shard.mu.RUnlock()
+	}
+	return data
+}
+
 func TestHotCacheGetPut(t *testing.T) {
 	cache := NewHotCache(100, 0)
 
@@ -68,6 +91,24 @@ func TestHotCacheGetPut(t *testing.T) {
 		require.True(t, ok, "expected key%d to be found", i)
 		assert.Equal(t, expectedValue, got, "expected value%d to match", i)
 	}
+}
+
+func TestHotCacheMutationIsolation(t *testing.T) {
+	cache := NewHotCache(10, 0)
+	key := []byte("key")
+	value := []byte("original")
+	cache.Put(key, value)
+
+	key[0] = 'X'
+	value[0] = 'X'
+	got, ok := cache.Get([]byte("key"))
+	require.True(t, ok)
+	require.Equal(t, []byte("original"), got)
+
+	got[0] = 'X'
+	gotAgain, ok := cache.Get([]byte("key"))
+	require.True(t, ok)
+	require.Equal(t, []byte("original"), gotAgain)
 }
 
 func TestHotCacheConcurrent(t *testing.T) {
@@ -156,13 +197,13 @@ func TestHotCacheEviction(t *testing.T) {
 		)
 	}
 
-	// Verify cache size is controlled (may be slightly over due to concurrent ops)
-	data := cache.data.Load()
+	// Verify cache size is controlled exactly after Put returns.
+	data := snapshotHotCache(cache)
 	assert.LessOrEqual(
 		t,
 		len(data.entries),
-		maxSize+5,
-		"cache should be close to maxSize after eviction",
+		maxSize,
+		"cache should not exceed maxSize after eviction",
 	)
 }
 
@@ -171,7 +212,7 @@ func TestHotCacheMemoryLimit(t *testing.T) {
 	cache := NewHotCache(1000, maxBytes)
 
 	// Add entries that together exceed maxBytes
-	valueSize := 100
+	valueSize := 90
 	for i := range 20 {
 		key := fmt.Appendf(nil, "key%d", i)
 		value := make([]byte, valueSize)
@@ -184,9 +225,9 @@ func TestHotCacheMemoryLimit(t *testing.T) {
 	// Memory usage should be controlled
 	assert.LessOrEqual(
 		t,
-		cache.data.Load().totalBytes,
-		maxBytes+int64(valueSize*3),
-		"memory should be close to maxBytes after eviction",
+		snapshotHotCache(cache).totalBytes,
+		maxBytes,
+		"memory should not exceed maxBytes after eviction",
 	)
 
 	// Test that oversized entries are rejected
@@ -238,8 +279,119 @@ func TestHotCacheLFUEviction(t *testing.T) {
 	assert.True(t, ok, "moderately accessed key should survive eviction")
 }
 
+// TestHotCacheOperationsHaveBoundedAllocations guards against cache
+// cardinality leaking into replacement, unique-admission, and sampled-access
+// paths. Each operation may allocate for its key/value and fixed eviction
+// sample, but never for a copy of every retained entry.
+func TestHotCacheOperationsHaveBoundedAllocations(t *testing.T) {
+	const cardinality = 1000
+	cache := NewHotCache(cardinality, 0)
+	for i := range cardinality {
+		cache.Put(
+			fmt.Appendf(nil, "key-%04d", i),
+			[]byte("cached-value"),
+		)
+	}
+
+	key := []byte("key-0000")
+	putAllocs := testing.AllocsPerRun(10, func() {
+		cache.Put(key, []byte("replacement"))
+	})
+	assert.LessOrEqual(
+		t,
+		putAllocs,
+		float64(8),
+		"Put must not allocate in proportion to cache cardinality",
+	)
+
+	churnIndex := 0
+	churnAllocs := testing.AllocsPerRun(10, func() {
+		cache.Put(
+			fmt.Appendf(nil, "churn-key-%04d", churnIndex),
+			[]byte("replacement"),
+		)
+		churnIndex++
+	})
+	assert.LessOrEqual(
+		t,
+		churnAllocs,
+		float64(12),
+		"overflow admission must allocate only for a bounded eviction sample",
+	)
+
+	accessAllocs := testing.AllocsPerRun(10, func() {
+		cache.incrementAccess(key)
+	})
+	assert.LessOrEqual(
+		t,
+		accessAllocs,
+		float64(1),
+		"sampled access tracking must not allocate in proportion to cache cardinality",
+	)
+}
+
+func TestHotCacheOperationBytesDoNotScaleWithCardinality(t *testing.T) {
+	const (
+		smallCardinality = 128
+		largeCardinality = 4096
+	)
+
+	for _, operation := range []struct {
+		name  string
+		churn bool
+	}{
+		{name: "replacement"},
+		{name: "unique admission churn", churn: true},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			smallBytes := benchmarkHotCachePutBytes(
+				smallCardinality,
+				operation.churn,
+			)
+			largeBytes := benchmarkHotCachePutBytes(
+				largeCardinality,
+				operation.churn,
+			)
+
+			// Runtime and allocator bookkeeping can add small fixed noise. A
+			// two-times-plus-1 KiB allowance is deliberately generous to that
+			// noise, but still rejects copying a retained map whose allocation
+			// grows linearly from 128 to 4096 entries.
+			assert.LessOrEqual(
+				t,
+				largeBytes,
+				smallBytes*2+1024,
+				"bytes per operation must remain independent of retained cardinality: small=%d large=%d",
+				smallBytes,
+				largeBytes,
+			)
+		})
+	}
+}
+
+func benchmarkHotCachePutBytes(cardinality int, churn bool) int64 {
+	result := testing.Benchmark(func(b *testing.B) {
+		cache, replacementKey := populatedHotCache(cardinality)
+		value := []byte("replacement-value")
+		nextKey := cardinality
+		key := make([]byte, 0, 32)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			if churn {
+				key = fmt.Appendf(key[:0], "churn-%08d", nextKey)
+				nextKey++
+			} else {
+				key = replacementKey
+			}
+			cache.Put(key, value)
+		}
+	})
+	return result.AllocedBytesPerOp()
+}
+
 // TestHotCacheConcurrentPutsCompleteUnderHighContention drives many more
-// concurrent writers (and readers, to exercise incrementAccess's CAS path
+// concurrent writers (and readers, to exercise incrementAccess's update path
 // too) against a small, heavily-contended cache than TestHotCacheConcurrent
 // and asserts every call returns within a bounded time. This validates the
 // acceptance criteria that cache insertion cannot spin indefinitely under
@@ -264,9 +416,9 @@ func TestHotCacheConcurrentPutsCompleteUnderHighContention(t *testing.T) {
 				}
 			}(i)
 		}
-		// Readers exercise incrementAccess's CAS path (see accessSampleRate)
+		// Readers exercise incrementAccess's update path (see accessSampleRate)
 		// concurrently with the writers above, so stats.Attempts genuinely
-		// reflects contention across both CAS paths it claims to cover.
+		// reflects contention across both update paths it claims to cover.
 		for i := range numGoroutines {
 			go func(id int) {
 				defer wg.Done()
@@ -290,21 +442,6 @@ func TestHotCacheConcurrentPutsCompleteUnderHighContention(t *testing.T) {
 
 	stats := cache.CASStats()
 	assert.Positive(t, stats.Attempts, "writers should attempt cache commits")
-	// SuccessfulCommitsAfterBackoff/SuccessfulCommitBackoffTime only count
-	// commits that needed a *sleeping* backoff (attempt >= casYieldThreshold);
-	// a writer that wins after just one or two zero-duration yields
-	// contributes to neither, so asserting either is positive is flaky on a
-	// lightly-loaded or single-core runner. Attempts exceeding the total
-	// number of Put calls is a threshold-independent proof that contention
-	// forced at least one writer to retry rather than succeed on its first
-	// CAS attempt every time.
-	assert.Greater(
-		t,
-		stats.Attempts,
-		uint64(numGoroutines*numOperations),
-		"heavy contention should force at least one writer to retry, "+
-			"not succeed on the first CAS attempt every time",
-	)
 
 	_, ok := cache.Get([]byte("key-0"))
 	assert.True(
@@ -314,47 +451,35 @@ func TestHotCacheConcurrentPutsCompleteUnderHighContention(t *testing.T) {
 	)
 }
 
-// TestHotCacheRetryBudgetFallback deterministically exercises the CAS
-// retry-budget fallback by allowing one CAS attempt and hammering a shared
-// cache with concurrent writers, then asserts the cache degrades gracefully
-// (no panic, no hang) and reports writers that drop their best-effort update.
+// TestHotCacheRetryBudgetFallback deterministically holds the update lock
+// while a one-attempt Put runs, then asserts the cache degrades gracefully
+// and remains usable after dropping the best-effort update.
 func TestHotCacheRetryBudgetFallback(t *testing.T) {
 	cache := NewHotCache(50, 0)
 	cache.maxCASAttempts = 1
 
-	const numGoroutines = 100
-	const numOperations = 100
-
+	cache.updateMu.Lock()
 	done := make(chan struct{})
 	go func() {
-		var wg sync.WaitGroup
-		wg.Add(numGoroutines)
-		for i := range numGoroutines {
-			go func(id int) {
-				defer wg.Done()
-				for j := range numOperations {
-					key := fmt.Appendf(nil, "key-%d", j%10)
-					value := fmt.Appendf(nil, "value-%d-%d", id, j)
-					cache.Put(key, value)
-				}
-			}(i)
-		}
-		wg.Wait()
+		cache.Put([]byte("blocked"), []byte("dropped"))
 		close(done)
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
+		cache.updateMu.Unlock()
 		t.Fatal(
 			"Put calls did not complete within timeout under a tiny retry budget",
 		)
 	}
+	cache.updateMu.Unlock()
 
-	assert.Positive(
+	assert.Equal(
 		t,
+		uint64(1),
 		cache.CASStats().WritersAbortedAfterBudget,
-		"expected at least one writer to exhaust a one-attempt budget under contention",
+		"the blocked writer should exhaust its one-attempt budget",
 	)
 
 	// Cache must remain usable after the fallback triggers.
@@ -370,7 +495,7 @@ func TestHotCacheRetryBudgetFallback(t *testing.T) {
 
 // TestHotCacheLogsWriterAbortedOnBudgetExhaustion deterministically forces
 // the writer-aborted-after-budget path (by setting maxCASAttempts to 0, so
-// the CAS loop body never runs) and asserts a configured logger reports it,
+// the update loop body never runs) and asserts a configured logger reports it,
 // with no reliance on real contention or goroutine timing.
 func TestHotCacheLogsWriterAbortedOnBudgetExhaustion(t *testing.T) {
 	cache := NewHotCache(10, 0)
@@ -385,7 +510,7 @@ func TestHotCacheLogsWriterAbortedOnBudgetExhaustion(t *testing.T) {
 	assert.Contains(
 		t,
 		logOutput,
-		"hot cache dropped a best-effort update after exhausting its CAS retry budget",
+		"hot cache dropped a best-effort update after exhausting its retry budget",
 	)
 	assert.Contains(t, logOutput, "cache=test-cache")
 	assert.Contains(t, logOutput, "op=put")
@@ -443,10 +568,9 @@ func TestHotCacheNilLoggerDoesNotPanic(t *testing.T) {
 	assert.Equal(t, uint64(1), cache.CASStats().WritersAbortedAfterBudget)
 }
 
-// TestHotCacheRegisterCASMetrics verifies that RegisterCASMetrics exposes
-// live CAS contention counters on a Prometheus registry, that the counters
-// reflect this cache's actual state, and that registering twice on the same
-// registry is a safe no-op rather than an error or duplicate series.
+// TestHotCacheRegisterCASMetrics verifies that the compatibility metrics
+// expose live update contention on a Prometheus registry, reflect this
+// cache's actual state, and safely tolerate duplicate registration.
 func TestHotCacheRegisterCASMetrics(t *testing.T) {
 	cache := NewHotCache(10, 0)
 	registry := prometheus.NewRegistry()
@@ -521,7 +645,7 @@ func TestHotCacheZeroMaxSize(t *testing.T) {
 
 	// All entries should be present (limited only by bytes)
 	count := 0
-	data := cache.data.Load()
+	data := snapshotHotCache(cache)
 	if data != nil {
 		count = len(data.entries)
 	}
@@ -542,7 +666,7 @@ func TestHotCacheSmallMaxSize(t *testing.T) {
 	cache.Put([]byte("key2"), []byte("value2"))
 
 	// At least one entry should exist (either key1 or key2)
-	data := cache.data.Load()
+	data := snapshotHotCache(cache)
 	assert.NotNil(t, data)
 	assert.GreaterOrEqual(
 		t,
@@ -550,23 +674,15 @@ func TestHotCacheSmallMaxSize(t *testing.T) {
 		1,
 		"cache with maxSize=1 should keep at least 1 entry",
 	)
-	assert.LessOrEqual(
-		t,
-		len(data.entries),
-		2,
-		"cache with maxSize=1 should have at most 2 entries",
-	)
+	assert.LessOrEqual(t, len(data.entries), 1)
 }
 
 // TestHotCachePutNeverPermanentlyExceedsMaxSizeUnderGetContention reproduces
 // the reported regression: eviction run as a separate operation after Put
 // could lose its own CAS race against concurrent access-count updates from
-// Get, and since only Put retries eviction, a cache that never received
-// another Put stayed oversized forever. Each round fills a small cache,
-// races heavy Get-driven incrementAccess contention against a single
-// overflow Put, and asserts the final state never exceeds maxSize. Because
-// eviction is now folded into the overflowing Put's own CAS attempt (see
-// HotCache.evictToFit), this must hold on every round, not just on average.
+// Get, leaving a cache oversized when no later Put retried eviction. The
+// sharded implementation keeps membership and limit enforcement under the
+// same update lock, so this must hold on every round.
 func TestHotCachePutNeverPermanentlyExceedsMaxSizeUnderGetContention(
 	t *testing.T,
 ) {
@@ -587,7 +703,7 @@ func TestHotCachePutNeverPermanentlyExceedsMaxSizeUnderGetContention(
 		wg.Add(numReaders + 1)
 
 		// Concurrent readers hammer Get() on existing keys, forcing
-		// incrementAccess CAS contention against the overflow Put below.
+		// incrementAccess contention against the overflow Put below.
 		for r := range numReaders {
 			go func(id int) {
 				defer wg.Done()
@@ -607,7 +723,7 @@ func TestHotCachePutNeverPermanentlyExceedsMaxSizeUnderGetContention(
 
 		wg.Wait()
 
-		data := cache.data.Load()
+		data := snapshotHotCache(cache)
 		require.NotNil(t, data)
 		assert.LessOrEqual(
 			t,
@@ -620,115 +736,83 @@ func TestHotCachePutNeverPermanentlyExceedsMaxSizeUnderGetContention(
 	}
 }
 
-// TestEvictToFitNoEvictionWhenWithinLimits verifies evictToFit is a no-op
-// (returns the inputs and zero bytes removed) when neither maxSize nor
-// maxBytes is exceeded.
-func TestEvictToFitNoEvictionWhenWithinLimits(t *testing.T) {
-	cache := NewHotCache(10, 100)
-	entries := map[string][]byte{"a": []byte("1"), "b": []byte("2")}
-	accessCnt := map[string]uint64{"a": 5, "b": 3}
+func TestHotCacheCombinedLimitsUnderChurn(t *testing.T) {
+	testCases := []struct {
+		name      string
+		maxSize   int
+		maxBytes  int64
+		valueSize int
+	}{
+		{
+			name:      "entry count is tighter",
+			maxSize:   5,
+			maxBytes:  1000,
+			valueSize: 80,
+		},
+		{
+			name:      "byte count is tighter",
+			maxSize:   50,
+			maxBytes:  1000,
+			valueSize: 85,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cache := NewHotCache(testCase.maxSize, testCase.maxBytes)
+			for i := range 200 {
+				cache.Put(
+					fmt.Appendf(nil, "key-%03d", i),
+					make([]byte, testCase.valueSize),
+				)
+			}
 
-	gotEntries, gotAccessCnt, bytesRemoved := cache.evictToFit(
-		entries,
-		accessCnt,
-		4,
-	)
-
-	assert.Equal(t, entries, gotEntries)
-	assert.Equal(t, accessCnt, gotAccessCnt)
-	assert.Zero(t, bytesRemoved)
+			data := snapshotHotCache(cache)
+			var actualBytes int64
+			for key, value := range data.entries {
+				actualBytes += int64(len(key) + len(value))
+			}
+			require.Equal(t, actualBytes, data.totalBytes)
+			assert.NotEmpty(t, data.entries)
+			assert.LessOrEqual(t, len(data.entries), testCase.maxSize)
+			assert.LessOrEqual(t, actualBytes, testCase.maxBytes)
+		})
+	}
 }
 
-// TestEvictToFitRemovesLeastFrequentlyUsedFirstBySize verifies size-based
-// eviction trims down to the target size and keeps the most frequently
-// accessed entries, removing the least frequently accessed ones first.
-func TestEvictToFitRemovesLeastFrequentlyUsedFirstBySize(t *testing.T) {
-	cache := NewHotCache(4, 0)
-	entries := map[string][]byte{
-		"most":     []byte("v"),
-		"more":     []byte("v"),
-		"less":     []byte("v"),
-		"least":    []byte("v"),
-		"overflow": []byte("v"),
+func TestHotCacheBoundedAdmissionDropPreservesExistingEntries(t *testing.T) {
+	const maxBytes = int64(1000)
+	cache := NewHotCache(0, maxBytes)
+	for i := range hotCacheEvictionSampleSize {
+		cache.Put([]byte{byte(i)}, nil)
 	}
-	accessCnt := map[string]uint64{
-		"most":     100,
-		"more":     50,
-		"less":     10,
-		"least":    1,
-		"overflow": 1,
+	for i := range 10 {
+		cache.Put([]byte{0xff, byte(i)}, make([]byte, 90))
 	}
+	before := snapshotHotCache(cache)
+	require.Equal(t, int64(984), before.totalBytes)
 
-	gotEntries, gotAccessCnt, bytesRemoved := cache.evictToFit(
-		entries,
-		accessCnt,
-		0,
-	)
+	// The pending 100-byte entry needs 84 bytes of space, while the fixed
+	// candidate window contains 64 one-byte entries. Admission must drop the
+	// pending value without partially evicting that window.
+	pendingKey := []byte{0xfe}
+	cache.Put(pendingKey, make([]byte, 99))
 
-	// target size = max(1, 4*3/4) = 3
-	assert.LessOrEqual(t, len(gotEntries), 3)
-	assert.Contains(
-		t,
-		gotEntries,
-		"most",
-		"highest access count must survive eviction",
-	)
-	assert.Contains(
-		t,
-		gotEntries,
-		"more",
-		"second highest access count must survive eviction",
-	)
-	assert.NotContains(
-		t,
-		gotEntries,
-		"least",
-		"lowest access count should be evicted first",
-	)
-	assert.Equal(t, len(gotEntries), len(gotAccessCnt))
-	assert.Positive(t, bytesRemoved)
-}
+	after := snapshotHotCache(cache)
+	assert.Equal(t, before.totalBytes, after.totalBytes)
+	assert.Equal(t, before.entries, after.entries)
+	_, ok := cache.Get(pendingKey)
+	assert.False(t, ok)
 
-// TestEvictToFitByBytes verifies byte-based eviction trims down to the
-// target byte budget, again preferring to keep the most frequently accessed
-// entries.
-func TestEvictToFitByBytes(t *testing.T) {
-	cache := NewHotCache(0, 100) // maxBytes=100, maxSize unlimited
-	entries := map[string][]byte{
-		"a": make([]byte, 40),
-		"b": make([]byte, 40),
-		"c": make([]byte, 40),
-	}
-	accessCnt := map[string]uint64{"a": 10, "b": 5, "c": 1}
-
-	var estimatedBytes int64
-	for k, v := range entries {
-		estimatedBytes += int64(len(k) + len(v))
-	}
-
-	gotEntries, _, bytesRemoved := cache.evictToFit(
-		entries,
-		accessCnt,
-		estimatedBytes,
-	)
-
-	// Each entry is 1 (key) + 40 (value) = 41 bytes; target = 100*3/4 = 75,
-	// so only the highest-count entry ("a") fits.
-	assert.Equal(t, int64(82), bytesRemoved)
-	assert.Equal(t, map[string][]byte{"a": entries["a"]}, gotEntries)
-}
-
-// TestEvictToFitKeepsAtLeastOneEntryWhenMaxSizeIsOne is the size=1 edge
-// case: eviction must never trim a non-empty cache down to zero entries.
-func TestEvictToFitKeepsAtLeastOneEntryWhenMaxSizeIsOne(t *testing.T) {
-	cache := NewHotCache(1, 0)
-	entries := map[string][]byte{"a": []byte("1"), "b": []byte("2")}
-	accessCnt := map[string]uint64{"a": 5, "b": 1}
-
-	gotEntries, _, _ := cache.evictToFit(entries, accessCnt, 0)
-
-	assert.GreaterOrEqual(t, len(gotEntries), 1)
-	assert.LessOrEqual(t, len(gotEntries), 2)
+	// The failed bounded sample advances instead of permanently freezing
+	// admission behind the same undersized candidates. A retry can inspect the
+	// larger entries that follow and admit the pending value within the same
+	// fixed work bound.
+	cache.Put(pendingKey, make([]byte, 99))
+	afterRetry := snapshotHotCache(cache)
+	assert.LessOrEqual(t, afterRetry.totalBytes, maxBytes)
+	value, ok := cache.Get(pendingKey)
+	require.True(t, ok)
+	assert.Len(t, value, 99)
 }
 
 // TestHotCacheTotalBytesStaysAccurateAcrossEvictions replaces an earlier
@@ -736,12 +820,9 @@ func TestEvictToFitKeepsAtLeastOneEntryWhenMaxSizeIsOne(t *testing.T) {
 // separate curBytes atomic (cache.curBytes.Store(0)) to simulate a delayed
 // concurrent writer, then showing Put trusted the stale value and let the
 // cache grow over maxBytes. That attack is no longer expressible at all:
-// totalBytes now lives inside hotCacheData itself, so every read of it is
-// tied to the exact entries snapshot it describes -- there is no separate
-// counter left to desync. This test instead verifies the new invariant
-// directly: after many sequential Puts (some of which force eviction),
-// data.totalBytes must always equal the real, independently-computed sum of
-// entry sizes, and must never exceed maxBytes.
+// totalBytes is now serialized with membership updates, so there is no
+// separately committed entries snapshot and byte counter to desynchronize.
+// This test verifies the invariant directly after repeated evictions.
 func TestHotCacheTotalBytesStaysAccurateAcrossEvictions(t *testing.T) {
 	const maxBytes = 1000             // per-entry cutoff = maxBytes/10 = 100
 	cache := NewHotCache(0, maxBytes) // maxSize unlimited: purely byte-driven
@@ -753,7 +834,7 @@ func TestHotCacheTotalBytesStaysAccurateAcrossEvictions(t *testing.T) {
 		) // 95 bytes each; forces repeated eviction
 	}
 
-	data := cache.data.Load()
+	data := snapshotHotCache(cache)
 	require.NotNil(t, data)
 	var actualBytes int64
 	for k, v := range data.entries {
@@ -780,8 +861,8 @@ func TestHotCacheTotalBytesStaysAccurateAcrossEvictions(t *testing.T) {
 // instructions wide -- narrow enough that a direct probe with 300 concurrent
 // writers over 50 rounds reproduced zero failures even on the buggy code
 // (see TestHotCacheTotalBytesStaysAccurateAcrossEvictions for how that gap
-// was proven instead). Now that the byte total lives inside hotCacheData
-// itself, this test holds deterministically, every round, by construction.
+// was proven instead). The sharded implementation serializes membership and
+// byte accounting, so this test holds deterministically every round.
 func TestHotCachePutNeverPermanentlyExceedsMaxBytesUnderPutContention(
 	t *testing.T,
 ) {
@@ -807,7 +888,7 @@ func TestHotCachePutNeverPermanentlyExceedsMaxBytesUnderPutContention(
 		}
 		wg.Wait()
 
-		data := cache.data.Load()
+		data := snapshotHotCache(cache)
 		require.NotNil(t, data)
 		var actualBytes int64
 		for k, v := range data.entries {


### PR DESCRIPTION
## Summary

- replace full-cache copy-on-write updates with sharded bounded operations
- enforce exact count and byte limits with fixed-size LFU candidate windows
- preserve APIs and metrics while adding mutation, bounds, and cardinality coverage

## Validation

- `go test -race -tags dingo_extra_plugins -timeout 20m ./database/...`
- focused HotCache and tiered-cache race coverage
- `go vet ./database/...`
- golangci-lint
- NilAway
- modernize
- benchmarks at 1,000, 10,000, and 50,000 entries

Closes #1897


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `HotCache` updates by replacing the copy-on-write map with 64 sharded locks and fixed-size LFU eviction windows. The old behavior could temporarily stay over `maxSize`/`maxBytes` under contention; the new behavior enforces limits exactly after each `Put` while keeping per-op cost independent of cache cardinality. Metrics and APIs are preserved; the “CAS” counters now reflect non-blocking update-lock attempts.

- Refactors
  - Shards `HotCache` with per-shard `RWMutex` and a global update lock for exact size/byte accounting.
  - Admits entries only if a bounded 64-entry LFU candidate window can free enough space; otherwise drops the insert and rotates the window.
  - Samples access-count updates on `Get` (1-in-4) with bounded, non-blocking shard updates.
  - Keeps metric names (`dingo_hot_cache_cas_attempts_total`, etc.) and `CASStats()` while changing their meaning to update-lock attempts.
  - Updates `ARCHITECTURE.md`, adds cardinality-invariant benchmarks, and expands tests for limit enforcement, isolation, contention, and metrics.

- Bug Fixes
  - Prevents the cache from remaining over `maxSize`/`maxBytes` when eviction previously lost CAS races to access-count updates.
  - Serializes membership and byte accounting so `totalBytes` can’t desynchronize from entries.

<sup>Written for commit 1d02d751bacbcdba078f3ef34c293aecd4c8db8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

