### PR TITLE
fix(governance): align committee voting set

### DIFF
--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -49,7 +49,7 @@ type ProposalTally struct {
 	CCYesCount     int
 	CCNoCount      int
 	CCAbstainCount int
-	CCTotalCount   int // active, non-resigned members
+	CCTotalCount   int // active, seated, authorized members
 }
 
 // TallyContext carries the inputs needed to tally a proposal.
@@ -78,9 +78,9 @@ type TallyContext struct {
 	DelegatorInactivityOn bool
 }
 
-// CommitteeVotingState is the ratification view of the seated CC:
-// non-expired, non-deleted cold credentials count in the denominator,
-// while only members with a current hot-key authorization may cast votes.
+// CommitteeVotingState is the ratification view of the seated CC. A member
+// counts in the denominator only while its cold credential is seated, its term
+// is current, and it has an active hot-key authorization.
 type CommitteeVotingState struct {
 	ActiveMemberCount     int
 	MemberHotCredentials  []string
@@ -104,14 +104,11 @@ func LoadCommitteeVotingState(
 		return nil, fmt.Errorf("get seated committee members: %w", err)
 	}
 	// Collect non-expired cold credentials so we can batch-check
-	// resignation status. ExpiresEpoch is the first epoch the member
-	// is no longer active; a member with ExpiresEpoch == currentEpoch
-	// has just aged out and must not contribute to the CC denominator
-	// this epoch (matches Cardano-ledger Haskell: active iff
-	// currentEpoch < termEpoch).
+	// resignation status. A member remains active through ExpiresEpoch
+	// (matching Cardano-ledger: currentEpoch <= termEpoch).
 	coldKeys := make([][]byte, 0, len(members))
 	for _, member := range members {
-		if member.ExpiresEpoch <= currentEpoch {
+		if member.ExpiresEpoch < currentEpoch {
 			continue
 		}
 		coldKeys = append(coldKeys, member.ColdCredHash)
@@ -148,7 +145,7 @@ func LoadCommitteeVotingState(
 	}
 
 	return &CommitteeVotingState{
-		ActiveMemberCount:     len(seated),
+		ActiveMemberCount:     len(memberHotCredentials),
 		MemberHotCredentials:  memberHotCredentials,
 		HotCredentialPresence: hotCredentialPresence,
 	}, nil
@@ -510,9 +507,8 @@ func tallySPOVotes(
 	return nil
 }
 
-// tallyCCVotes counts per-member votes restricted to currently active
-// (non-resigned) CC members. CC members vote via their hot credential
-// after key authorization.
+// tallyCCVotes counts per-member votes restricted to currently active,
+// seated, hot-key-authorized CC members.
 func tallyCCVotes(
 	ctx *TallyContext,
 	votes []*models.GovernanceVote,

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -175,7 +175,7 @@ func TestTallyDRepVotesSeparatesSameHashByCredentialTag(t *testing.T) {
 	assert.Equal(t, uint64(0), tally.DRepAbstainStake)
 }
 
-func TestTallyCCVotesRequiresSeatedAuthorizedCommitteeMembers(t *testing.T) {
+func TestTallyProposalRequiresSeatedAuthorizedCommitteeMembers(t *testing.T) {
 	db, store := newTallyTestDB(t)
 	coldA := testBytes(28, 10)
 	hotA := testBytes(28, 11)
@@ -199,32 +199,42 @@ func TestTallyCCVotesRequiresSeatedAuthorizedCommitteeMembers(t *testing.T) {
 		CertificateID:  2,
 		AddedSlot:      1,
 	})
+	proposal := &models.GovernanceProposal{
+		TxHash:        testBytes(32, 15),
+		ActionType:    uint8(lcommon.GovActionTypeInfo),
+		ProposedEpoch: 9,
+		ExpiresEpoch:  20,
+		AnchorHash:    testBytes(32, 16),
+		ReturnAddress: testBytes(29, 17),
+		AddedSlot:     1,
+	}
+	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      proposal.ID,
+		VoterType:       models.VoterTypeCC,
+		VoterCredential: hotA,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
+	require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      proposal.ID,
+		VoterType:       models.VoterTypeCC,
+		VoterCredential: unseatedHot,
+		Vote:            models.VoteYes,
+		AddedSlot:       2,
+	}, nil))
 
-	tally := &ProposalTally{}
-	err := tallyCCVotes(
-		&TallyContext{DB: db, CurrentEpoch: 10},
-		[]*models.GovernanceVote{
-			{
-				VoterType:       models.VoterTypeCC,
-				VoterCredential: hotA,
-				Vote:            models.VoteYes,
-			},
-			{
-				VoterType:       models.VoterTypeCC,
-				VoterCredential: unseatedHot,
-				Vote:            models.VoteYes,
-			},
-		},
-		tally,
+	tally, err := TallyProposal(
+		&TallyContext{DB: db, CurrentEpoch: 10}, proposal,
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, tally.CCTotalCount)
+	assert.Equal(t, 1, tally.CCTotalCount)
 	assert.Equal(t, 1, tally.CCYesCount)
-	assert.Equal(t, big.NewRat(1, 2), tally.CCYesRatio())
+	assert.Equal(t, big.NewRat(1, 1), tally.CCYesRatio())
 }
 
-func TestLoadCommitteeVotingStateCountsSeatedMembersWithoutHotAuth(
+func TestLoadCommitteeVotingStateExcludesSeatedMembersWithoutHotAuth(
 	t *testing.T,
 ) {
 	db, store := newTallyTestDB(t)
@@ -254,7 +264,7 @@ func TestLoadCommitteeVotingStateCountsSeatedMembersWithoutHotAuth(
 	state, err := LoadCommitteeVotingState(db, nil, 10)
 	require.NoError(t, err)
 
-	assert.Equal(t, 2, state.ActiveMemberCount)
+	assert.Equal(t, 1, state.ActiveMemberCount)
 	assert.Equal(t, []string{string(hotA)}, state.MemberHotCredentials)
 	assert.Contains(t, state.HotCredentialPresence, string(hotA))
 	assert.NotContains(t, state.HotCredentialPresence, string(unseatedHot))
@@ -380,6 +390,76 @@ func TestTallyCCVotesExcludesExpiredCommitteeMembers(t *testing.T) {
 
 	assert.Zero(t, tally.CCTotalCount)
 	assert.Zero(t, tally.CCYesCount)
+}
+
+func TestTallyProposalCommitteeTermEpochIsInclusive(t *testing.T) {
+	testCases := []struct {
+		name         string
+		currentEpoch uint64
+		wantActive   bool
+	}{
+		{name: "before term epoch", currentEpoch: 9, wantActive: true},
+		{name: "at term epoch", currentEpoch: 10, wantActive: true},
+		{name: "after term epoch", currentEpoch: 11, wantActive: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, store := newTallyTestDB(t)
+			cold := testBytes(28, 70)
+			hot := testBytes(28, 71)
+
+			require.NoError(t, store.SetCommitteeMembers(
+				[]*models.CommitteeMember{{
+					ColdCredHash: cold,
+					ExpiresEpoch: 10,
+					AddedSlot:    1,
+				}},
+				nil,
+			))
+			seedTallyCommitteeAuth(t, store, models.AuthCommitteeHot{
+				ColdCredential: cold,
+				HotCredential:  hot,
+				CertificateID:  1,
+				AddedSlot:      1,
+			})
+			proposal := &models.GovernanceProposal{
+				TxHash:        testBytes(32, 72),
+				ActionType:    uint8(lcommon.GovActionTypeInfo),
+				ProposedEpoch: 1,
+				ExpiresEpoch:  20,
+				AnchorHash:    testBytes(32, 73),
+				ReturnAddress: testBytes(29, 74),
+				AddedSlot:     1,
+			}
+			require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+			require.NoError(t, db.SetGovernanceVote(
+				&models.GovernanceVote{
+					ProposalID:      proposal.ID,
+					VoterType:       models.VoterTypeCC,
+					VoterCredential: hot,
+					Vote:            models.VoteYes,
+					AddedSlot:       2,
+				},
+				nil,
+			))
+
+			tally, err := TallyProposal(&TallyContext{
+				DB:           db,
+				CurrentEpoch: testCase.currentEpoch,
+			}, proposal)
+			require.NoError(t, err)
+			if testCase.wantActive {
+				assert.Equal(t, 1, tally.CCTotalCount)
+				assert.Equal(t, 1, tally.CCYesCount)
+				assert.Equal(t, big.NewRat(1, 1), tally.CCYesRatio())
+			} else {
+				assert.Zero(t, tally.CCTotalCount)
+				assert.Zero(t, tally.CCYesCount)
+				assert.Zero(t, tally.CCYesRatio().Sign())
+			}
+		})
+	}
 }
 
 // TestTallyCCVotesNonVotingMembersAreNotCountedAsNo guards against the


### PR DESCRIPTION
Closes #3496

## Summary

- count only seated, current, non-resigned committee members with active hot-key authorization
- keep committee membership active through the member's term epoch
- cover authorization and term-boundary behavior through the production tally path

## Validation

- focused tagged race tests, repeated three times
- full tagged `ledger/governance` and `ledger` race suites
- tagged conformance race suite
- DevNet package tests
- vet, golangci-lint, NilAway, and modernize
- import boundaries, documentation parity, and GORM checks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes committee vote tallies by aligning the counted member set with ledger rules. Previously, the denominator included all seated members and treated ExpiresEpoch as exclusive; now it counts only seated, current members with active hot-key authorization and treats the term epoch as inclusive.

- CC totals and ratios may change when seated members lack hot-key auth.
- Votes from unseated or unauthorized hot credentials are ignored.
- Membership remains active through the member’s ExpiresEpoch.
- The production tally path now enforces authorization and term-boundary behavior, with tests covering these cases.

<sup>Written for commit a290bac7154d428910d7a96189302f8c2cf8943c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

