### PR TITLE
fix(node): configure load replay security parameter

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7463,10 +7463,13 @@ finishing "successfully".
 
 Before installing those hooks, starting the ledger, or replaying a trusted
 batch, `LoadWithDB` configures the `ChainManager` security parameter from the
-constructed load ledger. This matches normal serve and live-reinitialization
-composition and ensures replay recovery can validate and apply bounded primary-
-chain rollbacks. A non-positive parameter fails load startup with load-specific
-context instead of leaving recovery to fail later as unconfigured.
+validated raw genesis values used to construct the load ledger. A configuration
+that declares Shelley at epoch zero uses Shelley K even when experimental fork
+overrides are disabled; a configuration with a Byron prefix uses Byron K. This
+ensures replay recovery can validate and apply bounded primary-chain rollbacks.
+A non-positive parameter for any era replay can reach fails load startup with
+load-specific context instead of leaving recovery to fail later as
+unconfigured.
 
 Because the capture is staged inside the still-open rollover transaction, its
 success metrics (`capture_success_total`, `last_successful_epoch`, and the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7461,6 +7461,13 @@ after replay completes, returns it — failing the load loudly so the operator
 knows the resulting database is incomplete and must be re-imported, rather than
 finishing "successfully".
 
+Before installing those hooks, starting the ledger, or replaying a trusted
+batch, `LoadWithDB` configures the `ChainManager` security parameter from the
+constructed load ledger. This matches normal serve and live-reinitialization
+composition and ensures replay recovery can validate and apply bounded primary-
+chain rollbacks. A non-positive parameter fails load startup with load-specific
+context instead of leaving recovery to fail later as unconfigured.
+
 Because the capture is staged inside the still-open rollover transaction, its
 success metrics (`capture_success_total`, `last_successful_epoch`, and the
 latest-snapshot pool/stake gauges) are published through `database.Txn.AfterCommit`

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -55,17 +55,76 @@ const (
 // be verified without replaying a full ImmutableDB fixture.
 var newLedgerStateForLoad = ledger.NewLedgerState
 
+type loadSecurityParam int
+
+func (k loadSecurityParam) SecurityParam() int {
+	return int(k)
+}
+
 func configureLoadChainSecurityParam(
 	cm *chain.ChainManager,
-	ledgerState interface{ SecurityParam() int },
+	nodeCfg *cardano.CardanoNodeConfig,
 ) error {
-	if err := cm.SetLedger(ledgerState); err != nil {
+	k, err := loadSecurityParamForConfig(nodeCfg)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to configure chain security parameter for load: %w",
+			err,
+		)
+	}
+	if err := cm.SetLedger(loadSecurityParam(k)); err != nil {
 		return fmt.Errorf(
 			"failed to configure chain security parameter for load: %w",
 			err,
 		)
 	}
 	return nil
+}
+
+// loadSecurityParamForConfig validates the raw genesis K values that replay
+// can reach and returns the one for the era where replay starts. It must not
+// use LedgerState.SecurityParam: before Start that method samples the
+// zero-value Byron era and intentionally substitutes its runtime fallback for
+// unavailable or invalid values.
+func loadSecurityParamForConfig(nodeCfg *cardano.CardanoNodeConfig) (int, error) {
+	if nodeCfg == nil {
+		return 0, fmt.Errorf(
+			"%w: cardano node config is required",
+			chain.ErrInvalidSecurityParam,
+		)
+	}
+
+	shelleyGenesis := nodeCfg.ShelleyGenesis()
+	if shelleyGenesis == nil {
+		return 0, fmt.Errorf(
+			"%w: Shelley genesis is required",
+			chain.ErrInvalidSecurityParam,
+		)
+	}
+	if shelleyGenesis.SecurityParam <= 0 {
+		return 0, fmt.Errorf(
+			"%w: Shelley security parameter K must be positive: got %d",
+			chain.ErrInvalidSecurityParam,
+			shelleyGenesis.SecurityParam,
+		)
+	}
+
+	shelleyAtGenesis := false
+	if epoch, declared := nodeCfg.HardForkEpoch("shelley"); declared {
+		shelleyAtGenesis = epoch == 0
+	}
+	byronGenesis := nodeCfg.ByronGenesis()
+	if byronGenesis == nil || shelleyAtGenesis {
+		return shelleyGenesis.SecurityParam, nil
+	}
+	if byronGenesis.ProtocolConsts.K <= 0 {
+		return 0, fmt.Errorf(
+			"%w: Byron security parameter K must be positive: got %d",
+			chain.ErrInvalidSecurityParam,
+			byronGenesis.ProtocolConsts.K,
+		)
+	}
+	return byronGenesis.ProtocolConsts.K, nil
 }
 
 // installEpochBoundarySnapshotHookForLoad is replaceable in tests so load-mode
@@ -499,7 +558,7 @@ func LoadWithDB(
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
-	if err := configureLoadChainSecurityParam(cm, ls); err != nil {
+	if err := configureLoadChainSecurityParam(cm, nodeCfg); err != nil {
 		return err
 	}
 	captureFailures := &loadCaptureFailureTracker{}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -55,6 +55,19 @@ const (
 // be verified without replaying a full ImmutableDB fixture.
 var newLedgerStateForLoad = ledger.NewLedgerState
 
+func configureLoadChainSecurityParam(
+	cm *chain.ChainManager,
+	ledgerState interface{ SecurityParam() int },
+) error {
+	if err := cm.SetLedger(ledgerState); err != nil {
+		return fmt.Errorf(
+			"failed to configure chain security parameter for load: %w",
+			err,
+		)
+	}
+	return nil
+}
+
 // installEpochBoundarySnapshotHookForLoad is replaceable in tests so load-mode
 // composition can verify the hook is installed without starting ledger workers.
 var installEpochBoundarySnapshotHookForLoad = func(
@@ -485,6 +498,9 @@ func LoadWithDB(
 	)
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
+	}
+	if err := configureLoadChainSecurityParam(cm, ls); err != nil {
+		return err
 	}
 	captureFailures := &loadCaptureFailureTracker{}
 	// SNAP-point stake read: runs after MIR and before POOLREAP/enactment so the

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -110,7 +110,7 @@ func loadSecurityParamForConfig(nodeCfg *cardano.CardanoNodeConfig) (int, error)
 	}
 
 	shelleyAtGenesis := false
-	if epoch, declared := nodeCfg.HardForkEpoch("shelley"); declared {
+	if epoch, declared := nodeCfg.DeclaredHardForkEpoch("shelley"); declared {
 		shelleyAtGenesis = epoch == 0
 	}
 	byronGenesis := nodeCfg.ByronGenesis()

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -505,93 +505,102 @@ func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
 	require.True(t, captured.ManualBlockProcessing)
 }
 
-func TestLoadWithDBConfiguresChainSecurityParamBeforeReplay(t *testing.T) {
-	db := newTestDB(t)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
+func TestLoadWithDBConfiguresRawChainSecurityParamBeforeHooks(t *testing.T) {
 	stopAfterRollbackValidation := errors.New(
 		"stop after load rollback validation",
 	)
-	var loadConfig ledger.LedgerStateConfig
-	var rollbackErr error
-	oldNewLedgerStateForLoad := newLedgerStateForLoad
-	oldInstallHook := installEpochBoundarySnapshotHookForLoad
-	newLedgerStateForLoad = func(
-		cfg ledger.LedgerStateConfig,
-	) (*ledger.LedgerState, error) {
-		loadConfig = cfg
-		state, err := ledger.NewLedgerState(cfg)
-		if state != nil {
-			t.Cleanup(func() {
-				require.NoError(t, state.Close())
-			})
-		}
-		return state, err
-	}
-	installEpochBoundarySnapshotHookForLoad = func(
-		_ *ledger.LedgerState,
-		_ func(*database.Txn, event.EpochTransitionEvent) error,
-	) error {
-		rollbackErr = loadConfig.ChainManager.PrimaryChain().ValidateRollback(
-			ocommon.NewPoint(0, nil),
-		)
-		return stopAfterRollbackValidation
-	}
-	t.Cleanup(func() {
-		newLedgerStateForLoad = oldNewLedgerStateForLoad
-		installEpochBoundarySnapshotHookForLoad = oldInstallHook
-	})
-
-	err := LoadWithDB(
-		context.Background(),
-		&config.Config{Network: "preview"},
-		logger,
-		"unused",
-		db,
-	)
-	require.ErrorIs(t, err, stopAfterRollbackValidation)
-	require.False(
-		t,
-		errors.Is(rollbackErr, chain.ErrSecurityParamNotConfigured),
-		"load replay reached rollback validation without configuring K: %v",
-		rollbackErr,
-	)
-	require.NoError(t, rollbackErr)
-}
-
-type loadSecurityParamLedger struct {
-	securityParam int
-}
-
-func (l loadSecurityParamLedger) SecurityParam() int {
-	return l.securityParam
-}
-
-func TestConfigureLoadChainSecurityParamRejectsNonPositiveK(t *testing.T) {
-	t.Parallel()
 
 	for _, test := range []struct {
-		name          string
-		securityParam int
+		name             string
+		mutate           func(*cardano.CardanoNodeConfig)
+		wantErr          string
+		wantHook         bool
+		wantRollbackOkay bool
 	}{
-		{name: "zero", securityParam: 0},
-		{name: "negative", securityParam: -1},
+		{
+			name:             "valid control",
+			wantHook:         true,
+			wantRollbackOkay: true,
+		},
+		{
+			name: "zero Byron K before Shelley",
+			mutate: func(nodeCfg *cardano.CardanoNodeConfig) {
+				epoch := uint64(1)
+				nodeCfg.TestShelleyHardForkAtEpoch = &epoch
+				nodeCfg.ByronGenesis().ProtocolConsts.K = 0
+			},
+			wantErr: "Byron security parameter K must be positive: got 0",
+		},
+		{
+			name: "negative Shelley K at genesis",
+			mutate: func(nodeCfg *cardano.CardanoNodeConfig) {
+				nodeCfg.ShelleyGenesis().SecurityParam = -1
+			},
+			wantErr: "Shelley security parameter K must be positive: got -1",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			cm, err := chain.NewManager(nil, nil)
-			require.NoError(t, err)
+			db := newTestDB(t)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			var loadConfig ledger.LedgerStateConfig
+			var rollbackErr error
+			hookCalled := false
+			oldNewLedgerStateForLoad := newLedgerStateForLoad
+			oldInstallHook := installEpochBoundarySnapshotHookForLoad
+			newLedgerStateForLoad = func(
+				cfg ledger.LedgerStateConfig,
+			) (*ledger.LedgerState, error) {
+				loadConfig = cfg
+				state, err := ledger.NewLedgerState(cfg)
+				if state != nil {
+					t.Cleanup(func() {
+						require.NoError(t, state.Close())
+					})
+				}
+				if err == nil && test.mutate != nil {
+					test.mutate(cfg.CardanoNodeConfig)
+				}
+				return state, err
+			}
+			installEpochBoundarySnapshotHookForLoad = func(
+				_ *ledger.LedgerState,
+				_ func(*database.Txn, event.EpochTransitionEvent) error,
+			) error {
+				hookCalled = true
+				rollbackErr = loadConfig.ChainManager.PrimaryChain().ValidateRollback(
+					ocommon.NewPoint(0, nil),
+				)
+				return stopAfterRollbackValidation
+			}
+			t.Cleanup(func() {
+				newLedgerStateForLoad = oldNewLedgerStateForLoad
+				installEpochBoundarySnapshotHookForLoad = oldInstallHook
+			})
 
-			err = configureLoadChainSecurityParam(
-				cm,
-				loadSecurityParamLedger{securityParam: test.securityParam},
+			err := LoadWithDB(
+				context.Background(),
+				&config.Config{Network: "preview"},
+				logger,
+				"unused",
+				db,
 			)
-			require.ErrorIs(t, err, chain.ErrInvalidSecurityParam)
-			require.ErrorContains(
-				t,
-				err,
-				"failed to configure chain security parameter for load",
-			)
+			if test.wantErr != "" {
+				require.ErrorIs(t, err, chain.ErrInvalidSecurityParam)
+				require.ErrorContains(t, err, test.wantErr)
+				require.False(t, hookCalled, "invalid K reached load hooks")
+				return
+			}
+			require.ErrorIs(t, err, stopAfterRollbackValidation)
+			require.Equal(t, test.wantHook, hookCalled)
+			if test.wantRollbackOkay {
+				require.False(
+					t,
+					errors.Is(rollbackErr, chain.ErrSecurityParamNotConfigured),
+					"load replay reached rollback validation without configuring K: %v",
+					rollbackErr,
+				)
+				require.NoError(t, rollbackErr)
+			}
 		})
 	}
 }

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -470,7 +470,13 @@ func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
 		cfg ledger.LedgerStateConfig,
 	) (*ledger.LedgerState, error) {
 		captured = cfg
-		return &ledger.LedgerState{}, nil
+		state, err := ledger.NewLedgerState(cfg)
+		if state != nil {
+			t.Cleanup(func() {
+				require.NoError(t, state.Close())
+			})
+		}
+		return state, err
 	}
 	installEpochBoundarySnapshotHookForLoad = func(
 		_ *ledger.LedgerState,
@@ -497,6 +503,97 @@ func TestLoadWithDBWiresEpochBoundarySnapshotHook(t *testing.T) {
 	require.NotNil(t, capturedHook)
 	require.True(t, captured.TrustedReplay)
 	require.True(t, captured.ManualBlockProcessing)
+}
+
+func TestLoadWithDBConfiguresChainSecurityParamBeforeReplay(t *testing.T) {
+	db := newTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	stopAfterRollbackValidation := errors.New(
+		"stop after load rollback validation",
+	)
+	var loadConfig ledger.LedgerStateConfig
+	var rollbackErr error
+	oldNewLedgerStateForLoad := newLedgerStateForLoad
+	oldInstallHook := installEpochBoundarySnapshotHookForLoad
+	newLedgerStateForLoad = func(
+		cfg ledger.LedgerStateConfig,
+	) (*ledger.LedgerState, error) {
+		loadConfig = cfg
+		state, err := ledger.NewLedgerState(cfg)
+		if state != nil {
+			t.Cleanup(func() {
+				require.NoError(t, state.Close())
+			})
+		}
+		return state, err
+	}
+	installEpochBoundarySnapshotHookForLoad = func(
+		_ *ledger.LedgerState,
+		_ func(*database.Txn, event.EpochTransitionEvent) error,
+	) error {
+		rollbackErr = loadConfig.ChainManager.PrimaryChain().ValidateRollback(
+			ocommon.NewPoint(0, nil),
+		)
+		return stopAfterRollbackValidation
+	}
+	t.Cleanup(func() {
+		newLedgerStateForLoad = oldNewLedgerStateForLoad
+		installEpochBoundarySnapshotHookForLoad = oldInstallHook
+	})
+
+	err := LoadWithDB(
+		context.Background(),
+		&config.Config{Network: "preview"},
+		logger,
+		"unused",
+		db,
+	)
+	require.ErrorIs(t, err, stopAfterRollbackValidation)
+	require.False(
+		t,
+		errors.Is(rollbackErr, chain.ErrSecurityParamNotConfigured),
+		"load replay reached rollback validation without configuring K: %v",
+		rollbackErr,
+	)
+	require.NoError(t, rollbackErr)
+}
+
+type loadSecurityParamLedger struct {
+	securityParam int
+}
+
+func (l loadSecurityParamLedger) SecurityParam() int {
+	return l.securityParam
+}
+
+func TestConfigureLoadChainSecurityParamRejectsNonPositiveK(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name          string
+		securityParam int
+	}{
+		{name: "zero", securityParam: 0},
+		{name: "negative", securityParam: -1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cm, err := chain.NewManager(nil, nil)
+			require.NoError(t, err)
+
+			err = configureLoadChainSecurityParam(
+				cm,
+				loadSecurityParamLedger{securityParam: test.securityParam},
+			)
+			require.ErrorIs(t, err, chain.ErrInvalidSecurityParam)
+			require.ErrorContains(
+				t,
+				err,
+				"failed to configure chain security parameter for load",
+			)
+		})
+	}
 }
 
 // TestLoadWithDBPropagatesFullPotRewards verifies that the CIP-0163 full-pot

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -511,16 +511,40 @@ func TestLoadWithDBConfiguresRawChainSecurityParamBeforeHooks(t *testing.T) {
 	)
 
 	for _, test := range []struct {
-		name             string
-		mutate           func(*cardano.CardanoNodeConfig)
-		wantErr          string
-		wantHook         bool
-		wantRollbackOkay bool
+		name              string
+		mutate            func(*cardano.CardanoNodeConfig)
+		wantErr           string
+		wantHook          bool
+		wantRollbackOkay  bool
+		wantSecurityParam int
 	}{
 		{
-			name:             "valid control",
-			wantHook:         true,
-			wantRollbackOkay: true,
+			name: "Shelley at genesis uses Shelley K",
+			mutate: func(nodeCfg *cardano.CardanoNodeConfig) {
+				enabled := false
+				epoch := uint64(0)
+				nodeCfg.ExperimentalHardForksEnabled = &enabled
+				nodeCfg.TestShelleyHardForkAtEpoch = &epoch
+				nodeCfg.ByronGenesis().ProtocolConsts.K = 2160
+				nodeCfg.ShelleyGenesis().SecurityParam = 432
+			},
+			wantHook:          true,
+			wantRollbackOkay:  true,
+			wantSecurityParam: 432,
+		},
+		{
+			name: "Shelley at genesis ignores unused zero Byron K",
+			mutate: func(nodeCfg *cardano.CardanoNodeConfig) {
+				enabled := false
+				epoch := uint64(0)
+				nodeCfg.ExperimentalHardForksEnabled = &enabled
+				nodeCfg.TestShelleyHardForkAtEpoch = &epoch
+				nodeCfg.ByronGenesis().ProtocolConsts.K = 0
+				nodeCfg.ShelleyGenesis().SecurityParam = 432
+			},
+			wantHook:          true,
+			wantRollbackOkay:  true,
+			wantSecurityParam: 432,
 		},
 		{
 			name: "zero Byron K before Shelley",
@@ -544,6 +568,7 @@ func TestLoadWithDBConfiguresRawChainSecurityParamBeforeHooks(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			var loadConfig ledger.LedgerStateConfig
 			var rollbackErr error
+			var selectedSecurityParam int
 			hookCalled := false
 			oldNewLedgerStateForLoad := newLedgerStateForLoad
 			oldInstallHook := installEpochBoundarySnapshotHookForLoad
@@ -559,6 +584,11 @@ func TestLoadWithDBConfiguresRawChainSecurityParamBeforeHooks(t *testing.T) {
 				}
 				if err == nil && test.mutate != nil {
 					test.mutate(cfg.CardanoNodeConfig)
+				}
+				if err == nil {
+					selectedSecurityParam, _ = loadSecurityParamForConfig(
+						cfg.CardanoNodeConfig,
+					)
 				}
 				return state, err
 			}
@@ -592,6 +622,11 @@ func TestLoadWithDBConfiguresRawChainSecurityParamBeforeHooks(t *testing.T) {
 			}
 			require.ErrorIs(t, err, stopAfterRollbackValidation)
 			require.Equal(t, test.wantHook, hookCalled)
+			require.Equal(
+				t,
+				test.wantSecurityParam,
+				selectedSecurityParam,
+			)
 			if test.wantRollbackOkay {
 				require.False(
 					t,


### PR DESCRIPTION
## Summary

- validate raw Byron and Shelley security parameters before load hooks or replay
- select Shelley K when the configuration declares Shelley at epoch zero
- configure rollback recovery from the validated replay-start K and fail closed on invalid reachable values

## Tests

- focused production regression with red/green proof
- full race-enabled `internal/node` package
- repository lint and documentation checks

Closes #3359
