### PR TITLE
fix(database): close immutable chunk after block lookup

### DIFF
--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -654,6 +654,7 @@ func (i *ImmutableDb) GetBlock(point ocommon.Point) (*Block, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = chunk.Close() }()
 	var tmpBlock *Block
 	for {
 		tmpBlock, err = chunk.Next()


### PR DESCRIPTION
Windows cannot remove immutable chunk files while `GetBlock` retains the open chunk reader. Close the reader on every return path so temporary database cleanup succeeds and block lookups do not leak file descriptors.

The failing immutable index regression tests pass under the race detector, and the Windows amd64 test binary cross-compiles.
