### PR TITLE
fix(koiosparity): preserve mismatch evidence across failed checks

### DIFF
--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1170,7 +1170,10 @@ func (c *Cache) InsertCheckRun(run CheckRun) error {
 // write never leaves the cache with less evidence than before the check ran.
 // Callers must call this only once every fallible read for the epoch has
 // already succeeded, so prior evidence is never cleared ahead of a
-// still-incomplete replacement.
+// still-incomplete replacement. Each row's Network and Epoch are normalised
+// from the network/epoch parameters before insertion, mirroring
+// CommitEpochData, so a mismatched caller cannot corrupt a different epoch's
+// data.
 func (c *Cache) CommitEpochMismatches(
 	network string,
 	epoch uint64,
@@ -1201,7 +1204,9 @@ func (c *Cache) CommitEpochMismatches(
 			return err
 		}
 		defer stmt.Close()
-		for _, m := range mismatches {
+		for i := range mismatches {
+			mismatches[i].Network, mismatches[i].Epoch = network, epoch
+			m := mismatches[i]
 			if _, err = stmt.Exec(m.Network, m.Epoch, m.PoolBech32, m.StakeAddress, m.Field, m.DingoValue, m.KoiosValue, m.Category, m.CheckedAt); err != nil {
 				return err
 			}

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1162,11 +1162,20 @@ func (c *Cache) InsertCheckRun(run CheckRun) error {
 	return err
 }
 
-// InsertMismatches bulk-inserts mismatch records.
-func (c *Cache) InsertMismatches(mismatches []CheckMismatch) error {
-	if len(mismatches) == 0 {
-		return nil
-	}
+// CommitEpochMismatches atomically replaces all mismatch rows for an epoch:
+// the prior rows are deleted and the new set inserted in a single
+// transaction, the same "delete then bulk insert, commit together" pattern
+// CommitEpochData uses for pool rows. Committing both together means a
+// failure partway through the insert rolls back the delete too, so a failed
+// write never leaves the cache with less evidence than before the check ran.
+// Callers must call this only once every fallible read for the epoch has
+// already succeeded, so prior evidence is never cleared ahead of a
+// still-incomplete replacement.
+func (c *Cache) CommitEpochMismatches(
+	network string,
+	epoch uint64,
+	mismatches []CheckMismatch,
+) error {
 	tx, err := c.db.Begin()
 	if err != nil {
 		return err
@@ -1176,28 +1185,29 @@ func (c *Cache) InsertMismatches(mismatches []CheckMismatch) error {
 			_ = tx.Rollback()
 		}
 	}()
-	stmt, err := tx.Prepare(
-		`INSERT INTO check_mismatches (network, epoch, pool_bech32, stake_address, field, dingo_value, koios_value, category, checked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-	)
-	if err != nil {
-		return err
-	}
-	defer stmt.Close()
-	for _, m := range mismatches {
-		if _, err = stmt.Exec(m.Network, m.Epoch, m.PoolBech32, m.StakeAddress, m.Field, m.DingoValue, m.KoiosValue, m.Category, m.CheckedAt); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
-}
-
-// DeleteEpochMismatches removes all mismatch rows for an epoch (before re-check).
-func (c *Cache) DeleteEpochMismatches(network string, epoch uint64) error {
-	_, err := c.db.Exec(
+	if _, err = tx.Exec(
 		"DELETE FROM check_mismatches WHERE network = ? AND epoch = ?",
 		network,
 		epoch,
-	)
+	); err != nil {
+		return err
+	}
+	if len(mismatches) > 0 {
+		var stmt *sql.Stmt
+		stmt, err = tx.Prepare(
+			`INSERT INTO check_mismatches (network, epoch, pool_bech32, stake_address, field, dingo_value, koios_value, category, checked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		if err != nil {
+			return err
+		}
+		defer stmt.Close()
+		for _, m := range mismatches {
+			if _, err = stmt.Exec(m.Network, m.Epoch, m.PoolBech32, m.StakeAddress, m.Field, m.DingoValue, m.KoiosValue, m.Category, m.CheckedAt); err != nil {
+				return err
+			}
+		}
+	}
+	err = tx.Commit()
 	return err
 }
 

--- a/internal/koiosparity/cache_test.go
+++ b/internal/koiosparity/cache_test.go
@@ -308,3 +308,49 @@ func TestAccountRewardsAdditiveColumnMigration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 }
+
+// TestCommitEpochMismatchesRollsBackOnFailedInsert proves #3410's fix:
+// CommitEpochMismatches deletes and (re)inserts an epoch's mismatch rows in a
+// single transaction, so a write failure partway through the insert rolls
+// the delete back with it instead of leaving the epoch with zero evidence. A
+// BEFORE INSERT trigger raises an error for one sentinel field value so the
+// first row of the replacement batch inserts fine and the second aborts the
+// whole transaction, without touching the production schema.
+func TestCommitEpochMismatchesRollsBackOnFailedInsert(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	const network = "preview"
+	const epoch = uint64(42)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	prior := []CheckMismatch{{
+		Network:    network,
+		Epoch:      epoch,
+		Field:      "prior_evidence",
+		DingoValue: "1",
+		KoiosValue: "2",
+		Category:   CategoryDBError,
+		CheckedAt:  now,
+	}}
+	require.NoError(t, cache.CommitEpochMismatches(network, epoch, prior))
+
+	_, err = cache.db.Exec(`
+		CREATE TRIGGER fail_on_sentinel BEFORE INSERT ON check_mismatches
+		WHEN NEW.field = 'force_fail'
+		BEGIN SELECT RAISE(ABORT, 'forced test failure'); END`)
+	require.NoError(t, err)
+
+	replacement := []CheckMismatch{
+		{Network: network, Epoch: epoch, Field: "ok_row", Category: CategoryDBError, CheckedAt: now},
+		{Network: network, Epoch: epoch, Field: "force_fail", Category: CategoryDBError, CheckedAt: now},
+	}
+	err = cache.CommitEpochMismatches(network, epoch, replacement)
+	require.Error(t, err)
+
+	got, err := cache.GetMismatches(network, epoch, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a failed replacement must leave the prior evidence intact")
+	require.Equal(t, "prior_evidence", got[0].Field)
+}

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -379,16 +379,15 @@ func checkEpoch(
 		return nil, fmt.Errorf("get koios pool epoch: %w", err)
 	}
 
-	// Clear previous mismatch records for this epoch before writing new ones.
-	if err := cache.DeleteEpochMismatches(network, epoch); err != nil {
-		return nil, fmt.Errorf("delete old mismatches: %w", err)
-	}
-
 	// Pre-staking epochs (Koios active_stake=null) have no reference data to
 	// compare against — record PASS with zero mismatches rather than running
 	// comparisons against an empty pool set, which would spuriously flag every
-	// Dingo-side pool as pool_only_dingo.
+	// Dingo-side pool as pool_only_dingo. Nothing fallible needs to complete
+	// first, so it's safe to replace any prior evidence immediately.
 	if koiosEpoch.PreStaking {
+		if err := cache.CommitEpochMismatches(network, epoch, nil); err != nil {
+			return nil, fmt.Errorf("commit mismatches: %w", err)
+		}
 		if err := cache.UpsertCheckEpochStatus(CheckEpochStatus{
 			Network:       network,
 			Epoch:         epoch,
@@ -612,8 +611,13 @@ func checkEpoch(
 
 	status := DetermineStatus(allMismatches)
 
-	if err := cache.InsertMismatches(allMismatches); err != nil {
-		return nil, fmt.Errorf("insert mismatches: %w", err)
+	// Every fallible read above has already succeeded by this point, so it's
+	// safe to replace prior evidence now. CommitEpochMismatches deletes and
+	// (re)inserts in one transaction: if the insert fails partway through,
+	// the delete rolls back with it and the previous record is left intact
+	// instead of being erased with nothing to replace it.
+	if err := cache.CommitEpochMismatches(network, epoch, allMismatches); err != nil {
+		return nil, fmt.Errorf("commit mismatches: %w", err)
 	}
 
 	if err := cache.UpsertCheckEpochStatus(CheckEpochStatus{

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -577,6 +577,101 @@ func TestCheckDetectsMissingKoiosTotalsOnUpgradedCache(t *testing.T) {
 	require.Equal(t, StatusError, statuses[0].Status)
 }
 
+// TestCheckEpochPreservesPriorMismatchEvidenceOnLaterReadFailure guards
+// against #3410: checkEpoch used to clear an epoch's persisted mismatch rows
+// before every fallible Dingo/cache read for that epoch had completed, so a
+// later read failure (here, cache.GetTotals erroring instead of returning
+// sql.ErrNoRows) erased the last known evidence and left nothing behind. The
+// koios_totals table is dropped after seeding to force GetTotals to fail
+// with a real DB error partway through checkEpoch, well after the point
+// where the old code had already deleted the prior rows.
+func TestCheckEpochPreservesPriorMismatchEvidenceOnLaterReadFailure(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(10)
+
+	dingoDir, gdb := newTestDingoDB(t)
+	require.NoError(t, gdb.Create(&models.EpochSummary{
+		Epoch:            9,
+		TotalActiveStake: types.Uint64(5_000_000),
+		SnapshotReady:    true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.EpochSummary{
+		Epoch:            koiosEpoch,
+		TotalActiveStake: types.Uint64(5_000_000),
+		SnapshotReady:    true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAdaPots{
+		Epoch:    koiosEpoch,
+		Treasury: types.Uint64(1_000),
+		Reserves: types.Uint64(2_000),
+		Fees:     types.Uint64(300),
+	}).Error)
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	cachePath := filepath.Join(t.TempDir(), "cache.db")
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	fetchedAt := time.Now().Add(-time.Hour).UTC()
+	require.NoError(t, cache.CommitEpochData(
+		KoiosEpochInfo{
+			Network:      network,
+			Epoch:        koiosEpoch,
+			ActiveStake:  "5000000",
+			EpochEndTime: fetchedAt,
+			FetchedAt:    fetchedAt,
+		},
+		nil,
+		nil,
+	))
+
+	// Prior evidence from an earlier successful check of this epoch.
+	priorEvidence := []CheckMismatch{{
+		Network:    network,
+		Epoch:      koiosEpoch,
+		Field:      "prior_evidence",
+		DingoValue: "1",
+		KoiosValue: "2",
+		Category:   CategoryDBError,
+		CheckedAt:  fetchedAt,
+	}}
+	require.NoError(t, cache.CommitEpochMismatches(network, koiosEpoch, priorEvidence))
+
+	// Force cache.GetTotals to fail with a real DB error (not sql.ErrNoRows),
+	// simulating the koios_totals read failing partway through checkEpoch.
+	_, err = cache.db.Exec("DROP TABLE koios_totals")
+	require.NoError(t, err)
+
+	dingoSource, err := OpenDingoDB(DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir})
+	require.NoError(t, err)
+	defer dingoSource.Close() //nolint:errcheck
+
+	_, err = CheckEpoch(
+		context.Background(),
+		cache,
+		dingoSource,
+		network,
+		koiosEpoch,
+		0,
+		false,
+		slog.New(slog.DiscardHandler),
+	)
+	require.Error(t, err, "a failed koios_totals read must surface as an error")
+
+	got, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(
+		t,
+		got,
+		1,
+		"a later read failure must never erase the prior mismatch evidence",
+	)
+	require.Equal(t, "prior_evidence", got[0].Field)
+}
+
 // TestCheckAccountsCoverageIncompleteIsError proves that enabling
 // CheckConfig.AccountsEnabled without ever having run a successful account
 // fetch (no koios_account_coverage row for the epoch) surfaces as ERROR


### PR DESCRIPTION
## Summary

`checkEpoch` deleted an epoch's prior `check_mismatches` rows before every fallible read for that epoch had completed. A later read or write failure left the epoch with zero recorded evidence instead of its last known result.

Closes #3410

## Changes

- Replace `DeleteEpochMismatches`/`InsertMismatches` in `cache.go` with a single `CommitEpochMismatches` that deletes and reinserts an epoch's mismatch rows in one transaction, so a failed insert rolls the delete back with it.
- Remove the premature delete in `checkEpoch` (`check.go`). The replacement now happens only after every fallible read for the epoch has already succeeded — either in the pre-staking short-circuit (no reads needed) or at the end of `checkEpoch` once the final mismatch set is built.

## Tests

- `TestCommitEpochMismatchesRollsBackOnFailedInsert` (`cache_test.go`): seeds prior evidence, uses a SQLite trigger to force a mid-insert failure on a replacement call, and asserts the prior row survives.
- `TestCheckEpochPreservesPriorMismatchEvidenceOnLaterReadFailure` (`check_test.go`): seeds prior evidence, drops the `koios_totals` table to force a real `GetTotals` failure inside `checkEpoch`, and asserts the prior evidence survives.

Both tests were verified against the prior buggy behavior (temporarily reintroduced) and fail without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mismatch record updates so existing evidence is preserved if saving new results fails.
  * Prevented partial updates when checking an epoch encounters a database error.
  * Ensured mismatch records are replaced consistently for both passing and failing epoch checks.

* **Tests**
  * Added regression coverage for rollback behavior and preservation of prior mismatch evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->