### PR TITLE
test(database): stabilize witness cleanup cost check

### DIFF
--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_cleanup_plan_test.go
@@ -357,18 +357,18 @@ func witnessCleanupSweep(
 }
 
 // TestTransactionWitnessCleanupCostFlatAcrossCardinality is the cardinality
-// sweep behind issue #3253: per-transaction cleanup cost must not grow with the
-// number of transactions already written.
+// sweep behind issue #3253: indexed cleanup must remain in a different cost
+// regime from the same cleanup after the relevant indexes are removed.
 //
 // The absolute durations are not asserted -- a shared machine makes any
-// wall-clock threshold a coin flip. What is asserted is the growth ratio across
-// an eightfold increase in rows, measured against a control store in the same
-// process that additionally drops the three indexes this fix retains. The
-// control both reproduces the reported decay and proves the measurement can
-// see it, so a flat result from the fixed store is a real result rather than a
-// sweep too small to distinguish the two.
+// wall-clock threshold a coin flip. The indexed store is compared with a
+// control store in the same process that additionally drops the three indexes
+// this fix retains. The comparison is made at the largest cardinality, where
+// the scan term is widest, rather than between two first-to-last ratios whose
+// endpoints carry unrelated scheduler and cache noise.
 func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
-	t.Parallel()
+	// Keep the wall-clock sweeps serial within this package. Running them as
+	// parallel tests makes each sweep measure the other's scan workload.
 	steps := []int{500, 1000, 2000, 4000}
 	const repetitions = 21
 
@@ -393,76 +393,38 @@ func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
 	t.Logf("rows=%v fixed=%v control=%v", steps, fixed, control)
 	requireResolvableTimings(t, steps, fixed, control)
 
-	ratio := func(medians []time.Duration) float64 {
-		return float64(medians[len(medians)-1]) / float64(medians[0])
-	}
-	fixedRatio := ratio(fixed)
 	growth := float64(slices.Max(steps)) / float64(slices.Min(steps))
+	controlLast := control[len(control)-1]
 
-	// Both stores execute the same four statements per pass, so both pay the
-	// same cardinality-independent cost per pass: statement preparation and
-	// one commit per table, which no index changes. The fixed store's median
-	// is that cost plus a bounded number of b-tree descents, which is what
-	// makes it a usable estimate of the floor. The control's growth is
-	// therefore measured on the difference -- the scan component, the only
-	// term the row count drives. Dividing the raw medians instead mixes the
-	// floor into both ends of the ratio and understates the decay whenever
-	// the floor is large, which on a loaded machine it is.
-	scanCost := func(step int) float64 {
-		return float64(control[step] - fixed[step])
-	}
-	// Read the sensitivity check at the largest cardinality, where the scan
-	// term is widest and clears the timing floor by the largest margin. At the
-	// smallest cardinality it asks a 500-row scan to be measurable while the
-	// other sweeps in this package compete for the same CPU, and the two
-	// sweeps are run one after the other rather than interleaved, so the
-	// difference there has been observed going negative on an unchanged store.
-	require.Positive(
+	// Both terms are taken at the same cardinality. This avoids comparing the
+	// indexed store's noisiest endpoint with a control endpoint measured in a
+	// different scheduler or cache phase. At this row count the control performs
+	// three full scans while the fixed store performs indexed searches, so the
+	// two must occupy measurably different cost regimes.
+	require.Greater(
 		t,
-		scanCost(len(control)-1),
-		"the control must be slower than the fixed store once the tables are "+
+		float64(controlLast),
+		float64(fixed[len(fixed)-1])*3,
+		"the control must reach a different cost regime once the tables are "+
 			"large, or the two stores are not differing in the three indexes "+
 			"under test: fixed %v, control %v",
 		fixed, control,
 	)
-	// Growth of the control's own medians. Dividing the scan-cost difference
-	// by its value at the smallest cardinality put a floor-dominated, possibly
-	// negative term in the denominator, which inverts the ratio rather than
-	// understating it.
-	controlRatio := float64(control[len(control)-1]) / float64(control[0])
-
-	// Bounded at 2x rather than near-linear: this ratio is taken on the raw
-	// control medians, which carry the cardinality-independent floor at both
-	// ends and so understate the scan growth. A store whose cleanup cost did
-	// not track its row count sits near 1x; the observed range here is 3.4x to
-	// 4.4x across an eightfold spread, which straddles growth/2 and is what
-	// makes that threshold the wrong one for a floor-inclusive ratio.
+	// Sensitivity: the control must still show the cardinality-dependent decay
+	// reported in #3253. The separation above is the strong signal; this modest
+	// bound rejects a sweep whose control is uniformly slow for another reason.
 	require.Greater(
 		t,
-		controlRatio,
-		2.0,
-		"control (three transaction_id indexes dropped) must show the "+
-			"reported decay, or this sweep is too small to measure "+
-			"anything: rows grew %.0fx, control cost grew %.1fx (fixed %v, "+
-			"control %v)",
-		growth, controlRatio, fixed, control,
+		float64(controlLast),
+		float64(control[0])*1.5,
+		"the control must show the reported decay across the sweep, or this "+
+			"sweep is too small to measure anything: rows grew %.0fx "+
+			"(control %v)",
+		growth, control,
 	)
-	require.Less(
-		t,
-		fixedRatio,
-		3.0,
-		"cleanup cost must stay flat as rows grow: rows grew %.0fx, cost "+
-			"grew %.1fx (fixed %v)",
-		growth, fixedRatio, fixed,
-	)
-	require.Less(
-		t,
-		fixedRatio*2,
-		controlRatio,
-		"the retained indexes must measurably flatten the curve: fixed "+
-			"grew %.1fx, control grew %.1fx",
-		fixedRatio, controlRatio,
-	)
+	// No bound is asserted on the indexed store's first-to-last ratio. Its two
+	// endpoints are independent noise samples; the deterministic query-plan
+	// tests above prove that every cleanup remains an indexed search.
 }
 
 // TestSetTransactionCostFlatAfterDeferredIndexDrop widens the sweep above from
@@ -482,7 +444,8 @@ func TestTransactionWitnessCleanupCostFlatAcrossCardinality(t *testing.T) {
 // seeding buys the eightfold spread that makes the difference visible without
 // spending the test budget writing rows nobody measures.
 func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
-	t.Parallel()
+	// Keep the wall-clock sweeps serial within this package. Running them as
+	// parallel tests makes each sweep measure the other's write workload.
 	steps := []int{2000, 4000, 8000, 16000}
 	// Timed transactions per cardinality. Odd, so the median is a sample.
 	const timed = 121
@@ -518,12 +481,9 @@ func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
 	// commit and page-cache behavior -- so its own first-to-last ratio is a
 	// ratio of two noise samples and lands either side of 1 from run to run.
 	//
-	// Both terms are read at the same step so both carry whatever contention
-	// the run is under. This package runs several timing sweeps in parallel,
-	// and taking the fixed store's worst step instead imports the single most
-	// contended phase of the run into a comparison against a control measured
-	// under different conditions, which is enough on its own to invert the
-	// result.
+	// Both terms are read at the same step. Taking the fixed store's worst step
+	// instead imports a different scheduler and cache phase into the comparison,
+	// which is enough on its own to invert the result.
 	require.Greater(
 		t,
 		float64(controlLast),
@@ -549,12 +509,11 @@ func TestSetTransactionCostFlatAfterDeferredIndexDrop(t *testing.T) {
 		growth, control,
 	)
 	// No bound is asserted on the fixed store's own spread across the sweep.
-	// That spread tracks how much of the run each step shared with the other
-	// parallel sweeps in this package, not the row count: it has been observed
-	// falling from 3.8ms at the smallest cardinality to 0.9ms at the largest,
-	// the opposite direction to the effect under test. A store that did track
-	// its row count would fail the separation check above, which is where that
-	// claim belongs.
+	// That spread tracks scheduler, page-cache, and WAL phases rather than only
+	// the row count: it has been observed falling from 3.8ms at the smallest
+	// cardinality to 0.9ms at the largest, the opposite direction to the effect
+	// under test. A store that did track its row count would fail the separation
+	// check above, which is where that claim belongs.
 }
 
 // setTransactionSweep times a fixed window of SetTransaction calls at each


### PR DESCRIPTION
`TestTransactionWitnessCleanupCostFlatAcrossCardinality` compared two independent first-to-last timing ratios, so scheduler and cache variation could fail the test while the indexed store remained substantially faster than its unindexed control.

Compare fixed and control costs at the same largest cardinality, retain the control sensitivity check, and run the package's two wall-clock sweeps serially. Deterministic query-plan assertions remain the index-contract gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated transaction cleanup performance tests to run sequentially for more consistent timing results.
  * Refined performance assertions to compare final and initial measurements more reliably.
  * Updated test comments to clarify expected timing variation and performance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->