### PR TITLE
fix(koiosparity): correct pool presence and pool-parameter epoch alignment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5227,7 +5227,8 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   `koiosStakeEpoch`/`koiosParamEpoch` and reads each field group from the one
   that actually matches:
   - **stake epoch (K-1):** `epoch_summary.TotalActiveStake` and
-    `reward_pool_input`'s `DelegatedStake`/`DelegatorCount` are the mark stake
+    `reward_pool_input`'s `DelegatedStake`/`DelegatorCount`/`Margin`/`Cost`
+    are the mark stake
     distribution Praos actually used as K's active-stake/reward-calculation
     basis — derived from `ledger/reward_calculation.go`'s
     `stakeRewardEpochsForNewEpoch` (`epochs.snapshot = epochs.performance - 1`,
@@ -5244,12 +5245,19 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
     `compareEpochAccounts` (`check.go`) reads Dingo's `reward_account_output`
     at `stakeEpoch`, reusing `koiosStakeEpoch` rather than deriving a second,
     possibly-diverging offset.
-  - **param epoch (K+1):** `reward_pool_input`'s `BlocksProduced`, `Margin`,
-    and `Cost` (fixed cost) describe the epoch *before* the row's own Epoch —
-    `ledger/snapshot/rotation.go`'s `buildRewardStateInputs` stamps them from
-    `evt.PreviousEpoch` onto the row captured for the new epoch at snapshot
-    time, independent of the stake-epoch offset above (which governs that
-    same row's `DelegatedStake`/`DelegatorCount` instead).
+  - **param epoch (K+1):** `reward_pool_input`'s `BlocksProduced` describes
+    the epoch *before* the row's own Epoch — `ledger/snapshot/rotation.go`'s
+    `buildRewardStateInputs` stamps it from `evt.PreviousEpoch` onto the row
+    captured for the new epoch at snapshot time, independent of the
+    stake-epoch offset above (which governs that same row's
+    `DelegatedStake`/`DelegatorCount` instead). `BlocksProduced` is the only
+    field read here. `Margin` and `Cost` were read at this epoch too until
+    dingo #3484: a mark snapshot records the pool parameters as of its own
+    boundary, and those are the ones in force for the epoch that snapshot is
+    the basis for, so they belong with the stake epoch. Both are constant for
+    most pools, which is why the wrong alignment stayed invisible until a
+    preview pool changed its cost and another changed its margin at epoch
+    13.
   - `reward_ada_pots` (treasury/reserves/fees, compared in
     `CompareEpochTotals`) is unaffected by either offset: it is a
     point-in-time ledger pot balance captured at the boundary into K itself,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5211,8 +5211,9 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   | `/pool_history` | exact-match | `epoch_no` | The filtered response must contain exactly the requested reporting epoch K. |
   | `/pool_history` | derived-match | `pool_id_bech32` | Request identity is decoded to Dingo's pool key hash for set membership. |
   | `/pool_history` | derived-match | `active_stake`, `delegator_cnt` | Exact values against `reward_pool_input` at stake epoch K-1. |
-  | `/pool_history` | derived-match | `block_cnt`, `fixed_cost` | Exact values against `reward_pool_input` at parameter epoch K+1. |
-  | `/pool_history` | derived-match | `margin` | K+1 values compared as equivalent rational numbers. |
+  | `/pool_history` | derived-match | `block_cnt` | Exact value against `reward_pool_input` at parameter epoch K+1. |
+  | `/pool_history` | derived-match | `fixed_cost` | Exact value against `reward_pool_input` at stake epoch K-1: a mark snapshot records the pool parameters in force for the epoch it is the basis for. |
+  | `/pool_history` | derived-match | `margin` | K-1 values compared as equivalent rational numbers. |
   | `/pool_history` | derived-match | `member_rewards` | Exact lovelace equality with aggregated `reward_pool_output.member_reward_total` at K-1. |
   | `/pool_history` | intentionally-incomparable | `pool_fees`, `deleg_rewards` | Koios derives these from an approximation that omits the pledge/owner-stake bonus and rounds components. |
   | `/pool_history` | unsupported | `active_stake_pct`, `saturation_pct`, `epoch_ros` | Dingo has no matching persisted pool aggregate. |
@@ -5366,18 +5367,19 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   calculation may simply not have finished yet); past that window it is
   `dingo_db_missing` (a genuine gap in Dingo's own computation). Both are
   `ERROR`, never a silent `PASS`. `ComparePoolEpoch` applies the identical
-  presence/grace split to `reward_pool_input`'s param-epoch fields
-  (`blocks_produced`/`fixed_cost`/`margin`, reported together as
-  `reward_pool_input_params` when absent) via `DingoPoolEpochData.
-  ParamsPresent`, for the same reason: a not-yet-captured param-epoch row must
-  not silently compare as zero blocks/cost/margin against Koios's real values.
-  The same split applies a third time to `reward_pool_input`'s stake-epoch
-  fields (`delegated_stake`/`delegator_count`, reported together as
+  presence/grace split to `reward_pool_input`'s param-epoch field
+  (`blocks_produced` alone, reported as `reward_pool_input_params` when
+  absent) via `DingoPoolEpochData.ParamsPresent`, for the same reason: a
+  not-yet-captured param-epoch row must not silently compare as zero blocks
+  against Koios's real value. The same split applies a third time to
+  `reward_pool_input`'s stake-epoch fields (`delegated_stake`/
+  `delegator_count`/`fixed_cost`/`margin`, reported together as
   `reward_pool_input_stake` when absent) via `DingoPoolEpochData.
   StakePresent` — a pool whose stake-epoch row hasn't landed yet (e.g. a
   freshly registered pool captured first at the param epoch) must not
-  silently compare as zero stake/delegators against Koios's real values
-  either.
+  silently compare as zero stake/delegators/cost/margin against Koios's real
+  values either. `fixed_cost` and `margin` sit on this side of the split, not
+  with `blocks_produced`, because they are read at K-1 (dingo #3484).
 
 **Mismatch categories:** `value_mismatch`, `pool_only_dingo`, `pool_only_koios`,
 `dingo_db_missing` (epoch/pool row not yet computed by Dingo), `dingo_db_error`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7937,8 +7937,10 @@ reward application first, ADA-pot capture last) by
 
 ### Reward Calculation And Precomputation
 
-Reward protocol parameters and epoch length come from the RUPD calculation
-epoch, while block-production counts use the delayed performance epoch. TPraos
+Reward protocol parameters and block-production counts come from the delayed
+performance epoch, while epoch length comes from the RUPD calculation epoch —
+see "Blockchain State Management" above for the derivation from
+cardano-ledger's `startStep`. TPraos
 overlay slots are excluded while decentralization is non-zero. Pre-Babbage
 calculation resolves the reward prefilter from stake-account certificate
 history immediately before the first reward-update slot, using the RUPD

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -313,7 +313,8 @@ const preStakingThroughEpoch = 1
 // reward_pool_input's stake fields exactly. See ARCHITECTURE.md's Koios
 // Parity Tracker "Epoch alignment" section for the full derivation and
 // koiosParamEpoch below for the distinct offset reward_pool_input's
-// BlocksProduced/Margin/FixedCost fields need instead.
+// BlocksProduced field needs instead. Margin/FixedCost share this stake-epoch
+// offset rather than that one (dingo #3484).
 //
 // ok is false for koiosEpoch <= preStakingThroughEpoch (0 and 1), neither of
 // which has a valid stake epoch (checkEpoch never reaches this for those
@@ -330,13 +331,15 @@ func koiosStakeEpoch(koiosEpoch uint64) (epoch uint64, ok bool) {
 }
 
 // koiosParamEpoch returns the Dingo reward_pool_input epoch whose
-// BlocksProduced and pool Margin/FixedCost fields describe Koios reporting
-// epoch koiosEpoch ("K+1"). ledger/snapshot/rotation.go's
-// buildRewardStateInputs stamps these fields from evt.PreviousEpoch (the just
-// -ended epoch) onto the row captured for the *new* epoch — one epoch after
-// the epoch they describe — independent of the stake-epoch offset above,
-// which governs the same row's DelegatedStake/DelegatorCount instead. See
-// koiosStakeEpoch's doc comment and ARCHITECTURE.md.
+// BlocksProduced field describes Koios reporting epoch koiosEpoch ("K+1").
+// ledger/snapshot/rotation.go's buildRewardStateInputs stamps it from
+// evt.PreviousEpoch (the just-ended epoch) onto the row captured for the
+// *new* epoch — one epoch after the epoch it describes — independent of the
+// stake-epoch offset above, which governs the same row's DelegatedStake/
+// DelegatorCount/Margin/Cost instead. BlocksProduced is the only field read
+// at this offset: a mark snapshot records the pool parameters as of its own
+// boundary, so Margin/FixedCost belong with the stake epoch (dingo #3484).
+// See koiosStakeEpoch's doc comment and ARCHITECTURE.md.
 func koiosParamEpoch(koiosEpoch uint64) uint64 {
 	return koiosEpoch + 1
 }
@@ -476,8 +479,8 @@ func checkEpoch(
 	)
 
 	// 2. Bulk-load all pool reward data for this epoch from Dingo's DB,
-	// spread across stakeEpoch (active stake/delegator count/member rewards)
-	// and paramEpoch (blocks produced/margin/fixed cost) — see
+	// spread across stakeEpoch (active stake/delegator count/member rewards,
+	// plus margin/fixed cost) and paramEpoch (blocks produced) — see
 	// GetPoolEpochDataMap's doc comment. Two-to-three queries regardless of
 	// how many pools Koios knows about.
 	var dingoPoolMap map[string]*DingoPoolEpochData

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -563,7 +563,19 @@ func checkEpoch(
 	// Convert key-hash hex back to bech32 so PoolBech32 is consistently formatted.
 	var onlyDingo []string
 	if dingoPoolErr == nil {
-		for keyHex := range dingoPoolMap {
+		for keyHex, dingoPool := range dingoPoolMap {
+			// GetPoolEpochDataMap returns the union of the stake-epoch
+			// (K-1) and param-epoch (K+1) reads, so a pool that registered
+			// during K appears here through its param-epoch row alone: its
+			// first mark snapshot is captured at the boundary into K+1, and
+			// it is not part of K's active-stake basis at all. Koios has no
+			// pool_history row for it until K+2, so comparing presence at K
+			// would report a divergence where both sides agree the pool did
+			// not yet exist. Only a pool actually in K's stake basis can be
+			// present-only-in-Dingo (dingo #3483).
+			if !dingoPool.StakePresent {
+				continue
+			}
 			if _, inKoios := koiosKeySet[keyHex]; !inKoios {
 				poolBech32, bechErr := PoolKeyHashHexToBech32(keyHex)
 				if bechErr != nil {

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -400,6 +400,8 @@ func TestCheckAlignsRewardScheduleEpochsEndToEnd(t *testing.T) {
 		PoolKeyHash:    poolHash,
 		DelegatedStake: types.Uint64(5_000_000),
 		DelegatorCount: 7,
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
 	}).Error)
 	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
 		Epoch:             9,
@@ -407,14 +409,15 @@ func TestCheckAlignsRewardScheduleEpochsEndToEnd(t *testing.T) {
 		MemberRewardTotal: types.Uint64(123_456),
 	}).Error)
 
-	// Param epoch (11 = K+1).
+	// Param epoch (11 = K+1): blocks only. Its own stake and pool params
+	// belong to a later epoch and must not surface.
 	realBlocks := uint64(4)
 	require.NoError(t, gdb.Create(&models.RewardPoolInput{
 		Epoch:          11,
 		PoolKeyHash:    poolHash,
 		DelegatedStake: types.Uint64(2), // irrelevant at this epoch
-		Cost:           types.Uint64(340_000_000),
-		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+		Cost:           types.Uint64(999_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 2)},
 		BlocksProduced: &realBlocks,
 	}).Error)
 
@@ -974,6 +977,8 @@ func seedPoolPresenceFixture(
 		PoolKeyHash:    poolHash,
 		DelegatedStake: types.Uint64(5_000_000),
 		DelegatorCount: 7,
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
 	}).Error)
 	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
 		Epoch:             stakeEpoch,
@@ -985,8 +990,8 @@ func seedPoolPresenceFixture(
 		Epoch:          paramEpoch,
 		PoolKeyHash:    poolHash,
 		DelegatedStake: types.Uint64(2),
-		Cost:           types.Uint64(340_000_000),
-		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+		Cost:           types.Uint64(999_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 2)},
 		BlocksProduced: &realBlocks,
 	}).Error)
 	require.NoError(t, gdb.Create(&models.RewardAdaPots{

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -941,3 +941,205 @@ func TestEffectiveCheckOutcome(t *testing.T) {
 	require.Equal(t, []uint64{2}, bounded.FailEpochs)
 	require.Equal(t, []uint64{3}, bounded.ErrorEpochs)
 }
+
+// seedPoolPresenceFixture builds the shared Koios-epoch-K fixture for the two
+// pool-presence tests below: one established pool that matches Koios exactly
+// at every field, plus a second pool seeded only where the caller asks for it.
+// It returns the Dingo data dir and cache path ready for Check.
+func seedPoolPresenceFixture(
+	t *testing.T,
+	network string,
+	koiosEpoch uint64,
+	secondPoolStakeEpochRow bool,
+	secondPoolHash []byte,
+) (dingoDir, cachePath string) {
+	t.Helper()
+	stakeEpoch := koiosEpoch - 1
+	paramEpoch := koiosEpoch + 1
+
+	poolHash := testPoolKeyHash(t, 0x03)
+	poolBech32, err := PoolKeyHashHexToBech32(hex.EncodeToString(poolHash))
+	require.NoError(t, err)
+
+	dingoDir, gdb := newTestDingoDB(t)
+
+	// Established pool: complete rows at both epochs.
+	require.NoError(t, gdb.Create(&models.EpochSummary{
+		Epoch:            stakeEpoch,
+		TotalActiveStake: types.Uint64(5_000_000),
+		SnapshotReady:    true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    poolHash,
+		DelegatedStake: types.Uint64(5_000_000),
+		DelegatorCount: 7,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
+		Epoch:             stakeEpoch,
+		PoolKeyHash:       poolHash,
+		MemberRewardTotal: types.Uint64(123_456),
+	}).Error)
+	realBlocks := uint64(4)
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          paramEpoch,
+		PoolKeyHash:    poolHash,
+		DelegatedStake: types.Uint64(2),
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+		BlocksProduced: &realBlocks,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAdaPots{
+		Epoch:    koiosEpoch,
+		Treasury: types.Uint64(1_000),
+		Reserves: types.Uint64(2_000),
+		Fees:     types.Uint64(300),
+	}).Error)
+
+	// Second pool. Its param-epoch row always exists; the stake-epoch row is
+	// what distinguishes "registered during K, not yet in K's stake basis"
+	// from "in K's stake basis but absent from Koios".
+	if secondPoolStakeEpochRow {
+		require.NoError(t, gdb.Create(&models.RewardPoolInput{
+			Epoch:          stakeEpoch,
+			PoolKeyHash:    secondPoolHash,
+			DelegatedStake: types.Uint64(9_497_623_854),
+			DelegatorCount: 1,
+		}).Error)
+	}
+	newBlocks := uint64(0)
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          paramEpoch,
+		PoolKeyHash:    secondPoolHash,
+		DelegatedStake: types.Uint64(9_497_623_854),
+		DelegatorCount: 1,
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+		BlocksProduced: &newBlocks,
+	}).Error)
+
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	cachePath = filepath.Join(t.TempDir(), "cache.db")
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	fetchedAt := time.Now().Add(-time.Hour).UTC()
+	// Koios lists only the established pool for epoch K.
+	require.NoError(t, cache.CommitEpochData(
+		KoiosEpochInfo{
+			Network:      network,
+			Epoch:        koiosEpoch,
+			ActiveStake:  "5000000",
+			EpochEndTime: fetchedAt,
+			FetchedAt:    fetchedAt,
+		},
+		[]KoiosPoolEpoch{{
+			Network:       network,
+			Epoch:         koiosEpoch,
+			PoolBech32:    poolBech32,
+			ActiveStake:   "5000000",
+			BlockCnt:      4,
+			Delegators:    7,
+			Margin:        "0.1",
+			FixedCost:     "340000000",
+			MemberRewards: "123456",
+			FetchedAt:     fetchedAt,
+		}},
+		&KoiosTotals{
+			Network:   network,
+			Epoch:     koiosEpoch,
+			Treasury:  "1000",
+			Reserves:  "2000",
+			Fees:      "300",
+			FetchedAt: fetchedAt,
+		},
+	))
+	return dingoDir, cachePath
+}
+
+// TestCheckIgnoresParamEpochOnlyPoolForPresence covers a pool that registered
+// during Koios epoch K. Its first mark snapshot is captured at the boundary
+// into K+1, so Dingo has a reward_pool_input row at the param epoch (K+1) but
+// none at the stake epoch (K-1) — it is not part of K's active-stake basis at
+// all. Koios has no pool_history row for it until K+2.
+//
+// The presence check must therefore ignore it. Flagging it pool_only_dingo
+// reports a Dingo defect where both sides in fact agree: the pool simply did
+// not exist yet for the epoch being compared. Observed on preview epoch 7,
+// where two pools registered mid-epoch failed the strict observer (dingo
+// #3483).
+func TestCheckIgnoresParamEpochOnlyPoolForPresence(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(10)
+	newPoolHash := testPoolKeyHash(t, 0x07)
+
+	dingoDir, cachePath := seedPoolPresenceFixture(
+		t, network, koiosEpoch, false, newPoolHash,
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(t, result.FailEpochs)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		mismatches,
+		"a pool known only through the param epoch is not part of epoch "+
+			"%d's stake basis and must not be reported as present only in "+
+			"Dingo", koiosEpoch,
+	)
+}
+
+// TestCheckFlagsStakeEpochPoolMissingFromKoios is the negative case: a pool
+// that IS in epoch K's stake basis but absent from Koios's pool set is a real
+// divergence and must still be flagged, so the fix above cannot be widened
+// into suppressing genuine pool_only_dingo findings.
+func TestCheckFlagsStakeEpochPoolMissingFromKoios(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(10)
+	newPoolHash := testPoolKeyHash(t, 0x07)
+
+	dingoDir, cachePath := seedPoolPresenceFixture(
+		t, network, koiosEpoch, true, newPoolHash,
+	)
+
+	_, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+
+	var found bool
+	for _, m := range mismatches {
+		if m.Field == "pool_presence" &&
+			m.Category == CategoryPoolOnlyDingo {
+			found = true
+		}
+	}
+	require.True(
+		t,
+		found,
+		"a pool in epoch %d's stake basis but absent from Koios is a real "+
+			"divergence and must stay flagged", koiosEpoch,
+	)
+}

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -356,10 +356,11 @@ func newTestDingoDB(t *testing.T) (dataDir string, gdb *testDB) {
 //
 //   - epoch_summary at epoch 9 (K-1): the mark stake distribution Praos used
 //     as epoch 10's active-stake basis.
-//   - reward_pool_input at epoch 9 (K-1): DelegatedStake/DelegatorCount.
+//   - reward_pool_input at epoch 9 (K-1): DelegatedStake/DelegatorCount,
+//     plus Margin/FixedCost — the parameters in force for epoch 10.
 //   - reward_pool_output at epoch 9 (K-1): MemberRewardTotal.
-//   - reward_pool_input at epoch 11 (K+1): BlocksProduced/Margin/FixedCost,
-//     describing epoch 10 per rotation.go's buildRewardStateInputs.
+//   - reward_pool_input at epoch 11 (K+1): BlocksProduced alone, describing
+//     epoch 10 per rotation.go's buildRewardStateInputs.
 //   - reward_ada_pots at epoch 10 (unshifted — a point-in-time pot balance,
 //     not a delayed reward-calculation input; see ARCHITECTURE.md).
 //   - a decoy reward_pool_input row at epoch 10 itself with wrong values in

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -401,10 +401,49 @@ func ComparePoolEpoch(
 				CheckedAt:  now,
 			})
 		}
+
+		// fixed_cost — reward_pool_input.cost vs Koios
+		// pool_history.fixed_cost. A mark snapshot records the pool
+		// parameters as of its own boundary, and those are the ones in force
+		// for the epoch that snapshot is the basis for, so cost and margin
+		// align with the stake epoch (K-1) rather than with blocks_produced
+		// at the param epoch (dingo #3484).
+		if koiosPool.FixedCost != "" && dingoPool.FixedCost != koiosPool.FixedCost {
+			out = append(out, CheckMismatch{
+				Network:    network,
+				Epoch:      epoch,
+				PoolBech32: koiosPool.PoolBech32,
+				Field:      "fixed_cost",
+				DingoValue: dingoPool.FixedCost,
+				KoiosValue: koiosPool.FixedCost,
+				Category:   CategoryValueMismatch,
+				CheckedAt:  now,
+			})
+		}
+
+		// margin — compare as rationals so Koios "0.1" matches Dingo "1/10".
+		// Only guard on the Koios side being non-empty, matching fixed_cost
+		// above: an empty dingoPool.Margin here means a corrupted/partial row
+		// despite StakePresent being true (the "not ready yet" case is
+		// already handled by the outer StakePresent check), so it must be
+		// flagged as a mismatch, not silently skipped. rationalsEqual returns
+		// false (not a panic) when given an empty string.
+		if koiosPool.Margin != "" && !rationalsEqual(dingoPool.Margin, koiosPool.Margin) {
+			out = append(out, CheckMismatch{
+				Network:    network,
+				Epoch:      epoch,
+				PoolBech32: koiosPool.PoolBech32,
+				Field:      "margin",
+				DingoValue: dingoPool.Margin,
+				KoiosValue: koiosPool.Margin,
+				Category:   CategoryValueMismatch,
+				CheckedAt:  now,
+			})
+		}
 	}
 
-	// blocks_produced/fixed_cost/margin all come from the same reward_pool_input
-	// "param epoch" (K+1) row — see DingoPoolEpochData's doc comment. That row
+	// blocks_produced comes from the reward_pool_input "param epoch" (K+1)
+	// row — see DingoPoolEpochData's doc comment. That row
 	// not existing yet is never a silent pass: within the grace window it may
 	// simply not be captured yet (reference_lag); past it, it's a genuine gap
 	// in Dingo's own computation (dingo_db_missing).
@@ -436,40 +475,6 @@ func ComparePoolEpoch(
 				Field:      "blocks_produced",
 				DingoValue: dingoBlockStr,
 				KoiosValue: koiosBlockStr,
-				Category:   CategoryValueMismatch,
-				CheckedAt:  now,
-			})
-		}
-
-		// fixed_cost — reward_pool_input.cost vs Koios pool_history.fixed_cost.
-		if koiosPool.FixedCost != "" && dingoPool.FixedCost != koiosPool.FixedCost {
-			out = append(out, CheckMismatch{
-				Network:    network,
-				Epoch:      epoch,
-				PoolBech32: koiosPool.PoolBech32,
-				Field:      "fixed_cost",
-				DingoValue: dingoPool.FixedCost,
-				KoiosValue: koiosPool.FixedCost,
-				Category:   CategoryValueMismatch,
-				CheckedAt:  now,
-			})
-		}
-
-		// margin — compare as rationals so Koios "0.1" matches Dingo "1/10".
-		// Only guard on the Koios side being non-empty, matching fixed_cost
-		// above: an empty dingoPool.Margin here means a corrupted/partial row
-		// despite ParamsPresent being true (the "not ready yet" case is
-		// already handled by the outer ParamsPresent check), so it must be
-		// flagged as a mismatch, not silently skipped. rationalsEqual returns
-		// false (not a panic) when given an empty string.
-		if koiosPool.Margin != "" && !rationalsEqual(dingoPool.Margin, koiosPool.Margin) {
-			out = append(out, CheckMismatch{
-				Network:    network,
-				Epoch:      epoch,
-				PoolBech32: koiosPool.PoolBech32,
-				Field:      "margin",
-				DingoValue: dingoPool.Margin,
-				KoiosValue: koiosPool.Margin,
 				Category:   CategoryValueMismatch,
 				CheckedAt:  now,
 			})

--- a/internal/koiosparity/compare_test.go
+++ b/internal/koiosparity/compare_test.go
@@ -232,12 +232,14 @@ func TestComparePoolEpochFixedCostAndMargin(t *testing.T) {
 }
 
 // TestComparePoolEpochEmptyDingoSideIsFlagged guards against reintroducing an
-// asymmetry between the fixed_cost and margin guards: once ParamsPresent is
-// true (the reward_pool_input row at the param epoch genuinely exists — the
-// "not ready yet" case is already handled by the outer ParamsPresent check),
+// asymmetry between the fixed_cost and margin guards: once StakePresent is
+// true (the reward_pool_input row at the stake epoch genuinely exists — the
+// "not ready yet" case is already handled by the outer StakePresent check),
 // an unexpectedly empty dingoPool.FixedCost/Margin means a corrupted/partial
 // row, not a legitimate skip condition, and must be reported as a
 // value_mismatch like any other divergence rather than silently passed over.
+// Both fields are read at the stake epoch (dingo #3484), so StakePresent, not
+// ParamsPresent, is the flag that governs them.
 func TestComparePoolEpochEmptyDingoSideIsFlagged(t *testing.T) {
 	now := time.Now()
 	koios := &KoiosPoolEpoch{

--- a/internal/koiosparity/compare_test.go
+++ b/internal/koiosparity/compare_test.go
@@ -289,10 +289,15 @@ func TestComparePoolEpochParamsNotPresent(t *testing.T) {
 		FixedCost:   "340000000",
 		Margin:      "0.1",
 	}
+	// FixedCost/Margin are stake-epoch fields (dingo #3484), so they are
+	// present here and match Koios: the only thing missing is the
+	// param-epoch row, and blocks_produced is the only field it still owns.
 	dingo := &DingoPoolEpochData{
 		StakePresent:   true,
 		DelegatedStake: "1000",
 		DelegatorCount: 3,
+		FixedCost:      "340000000",
+		Margin:         "1/10",
 		ParamsPresent:  false,
 	}
 

--- a/internal/koiosparity/coverage.go
+++ b/internal/koiosparity/coverage.go
@@ -309,15 +309,15 @@ var koiosCoverageMatrix = []KoiosFieldCoverage{
 		Endpoint:   "/pool_history",
 		Field:      "margin",
 		Class:      CoverageDerivedMatch,
-		DingoField: "reward_pool_input.margin at K+1",
+		DingoField: "reward_pool_input.margin at K-1",
 		Reason:     "compared as equivalent rational numbers",
 	},
 	{
 		Endpoint:   "/pool_history",
 		Field:      "fixed_cost",
 		Class:      CoverageDerivedMatch,
-		DingoField: "reward_pool_input.cost at K+1",
-		Reason:     "exact lovelace equality after parameter-epoch alignment",
+		DingoField: "reward_pool_input.cost at K-1",
+		Reason:     "exact lovelace equality after stake-epoch alignment",
 	},
 	{
 		Endpoint: "/pool_history",

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -98,25 +98,30 @@ type DingoPoolEpochData struct {
 	// reporting the row as genuinely missing. See ComparePoolEpoch, which
 	// must never silently treat StakePresent == false as a comparison pass.
 	StakePresent bool
-	// DelegatedStake/DelegatorCount come from reward_pool_input at the "stake
-	// epoch" (Koios epoch K's K-1): the mark stake distribution Praos actually
-	// used as K's active-stake/reward-calculation basis.
+	// DelegatedStake/DelegatorCount/FixedCost/Margin come from
+	// reward_pool_input at the "stake epoch" (Koios epoch K's K-1): the mark
+	// stake distribution Praos actually used as K's active-stake/
+	// reward-calculation basis. A mark snapshot records the pool parameters
+	// as of its own boundary, and those are the ones in force for the epoch
+	// that snapshot is the basis for, so cost and margin align here rather
+	// than with BlocksProduced at the param epoch (dingo #3484).
 	DelegatedStake string // lovelace decimal string
 	DelegatorCount uint64
-
-	// ParamsPresent distinguishes "no reward_pool_input row yet at the
-	// 'param epoch' (K+1)" from "row exists with legitimately zero/empty
-	// BlocksProduced/FixedCost/Margin" — see ComparePoolEpoch, which must
-	// never silently treat the former as a comparison pass.
-	ParamsPresent bool
-	// BlocksProduced/FixedCost/Margin come from reward_pool_input at the
-	// "param epoch" (K+1): that row's BlocksProduced/pool-params fields
-	// describe the epoch immediately before it (K), because
-	// buildRewardStateInputs (ledger/snapshot/rotation.go) stamps them from
-	// evt.PreviousEpoch at capture time, not from the row's own Epoch.
-	BlocksProduced uint64
 	FixedCost      string // lovelace decimal string (reward_pool_input.cost)
 	Margin         string // rational string (e.g. "1/10"); empty when null
+
+	// ParamsPresent distinguishes "no reward_pool_input row yet at the
+	// 'param epoch' (K+1)" from "row exists with a legitimately zero
+	// BlocksProduced" — see ComparePoolEpoch, which must never silently
+	// treat the former as a comparison pass. It covers BlocksProduced only;
+	// FixedCost/Margin presence follows StakePresent.
+	ParamsPresent bool
+	// BlocksProduced comes from reward_pool_input at the "param epoch"
+	// (K+1): that row's BlocksProduced describes the epoch immediately
+	// before it (K), because buildRewardStateInputs
+	// (ledger/snapshot/rotation.go) stamps it from evt.PreviousEpoch at
+	// capture time, not from the row's own Epoch.
+	BlocksProduced uint64
 
 	// MemberRewardPresent distinguishes "no reward_pool_output row yet at the
 	// stake epoch (K-1)" — reward calculation not finished for this
@@ -267,15 +272,16 @@ func (d *DingoDB) GetEpochData(
 //
 //   - stakeEpoch (K-1): the mark stake distribution actually used as Praos's
 //     active-stake/reward-calculation basis for K. reward_pool_input's
-//     DelegatedStake/DelegatorCount and reward_pool_output's
-//     MemberRewardTotal are both read at this epoch — reward_calculation.go's
+//     DelegatedStake/DelegatorCount/Margin/FixedCost and
+//     reward_pool_output's MemberRewardTotal are all read at this epoch — reward_calculation.go's
 //     stakeRewardEpochsForNewEpoch computes both from the same
 //     epochs.snapshot value, so input and output always share one Epoch.
-//   - paramEpoch (K+1): reward_pool_input's BlocksProduced and pool
-//     Margin/FixedCost are captured onto the row for the epoch *after* the
-//     one they describe — see ledger/snapshot/rotation.go's
-//     buildRewardStateInputs, which stamps these from evt.PreviousEpoch, not
-//     from the row's own Epoch.
+//   - paramEpoch (K+1): reward_pool_input's BlocksProduced is captured onto
+//     the row for the epoch *after* the one it describes — see
+//     ledger/snapshot/rotation.go's buildRewardStateInputs, which stamps it
+//     from evt.PreviousEpoch, not from the row's own Epoch. Only
+//     BlocksProduced is read there; Margin/FixedCost are stake-epoch fields
+//     (dingo #3484).
 //
 // See koiosStakeEpoch/koiosParamEpoch in check.go and ARCHITECTURE.md's Koios
 // Parity Tracker "Epoch alignment" section for the full derivation.
@@ -295,7 +301,7 @@ func (d *DingoDB) GetPoolEpochDataMap(
 ) (map[string]*DingoPoolEpochData, error) {
 	rows, err := d.query(
 		ctx,
-		`SELECT pool_key_hash, delegated_stake, delegator_count FROM reward_pool_input WHERE epoch = ?`,
+		`SELECT pool_key_hash, delegated_stake, delegator_count, cost, margin FROM reward_pool_input WHERE epoch = ?`,
 		stakeEpoch,
 	)
 	if err != nil {
@@ -311,14 +317,29 @@ func (d *DingoDB) GetPoolEpochDataMap(
 		var poolHash []byte
 		var stake types.Uint64
 		var delegators uint64
-		if err := rows.Scan(&poolHash, &stake, &delegators); err != nil {
+		var cost sql.NullInt64
+		var margin types.Rat
+		if err := rows.Scan(
+			&poolHash, &stake, &delegators, &cost, &margin,
+		); err != nil {
 			return nil, err
 		}
-		m[hex.EncodeToString(poolHash)] = &DingoPoolEpochData{
+		data := &DingoPoolEpochData{
 			StakePresent:   true,
 			DelegatedStake: strconv.FormatUint(uint64(stake), 10),
 			DelegatorCount: delegators,
 		}
+		if cost.Valid {
+			data.FixedCost = strconv.FormatUint(
+				//nolint:gosec // metadata values are non-negative
+				uint64(cost.Int64),
+				10,
+			)
+		}
+		if margin.Rat != nil {
+			data.Margin = margin.String()
+		}
+		m[hex.EncodeToString(poolHash)] = data
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -326,7 +347,7 @@ func (d *DingoDB) GetPoolEpochDataMap(
 
 	rows, err = d.query(
 		ctx,
-		`SELECT pool_key_hash, blocks_produced, cost, margin FROM reward_pool_input WHERE epoch = ?`,
+		`SELECT pool_key_hash, blocks_produced FROM reward_pool_input WHERE epoch = ?`,
 		paramEpoch,
 	)
 	if err != nil {
@@ -338,9 +359,8 @@ func (d *DingoDB) GetPoolEpochDataMap(
 	}
 	for rows.Next() {
 		var poolHash []byte
-		var blocks, cost sql.NullInt64
-		var margin types.Rat
-		if err := rows.Scan(&poolHash, &blocks, &cost, &margin); err != nil {
+		var blocks sql.NullInt64
+		if err := rows.Scan(&poolHash, &blocks); err != nil {
 			_ = rows.Close() //nolint:sqlclosecheck
 			return nil, err
 		}
@@ -360,18 +380,6 @@ func (d *DingoDB) GetPoolEpochDataMap(
 			data.BlocksProduced = uint64( //nolint:gosec // metadata values are non-negative
 				blocks.Int64,
 			)
-		}
-		if cost.Valid {
-			data.FixedCost = strconv.FormatUint(
-				//nolint:gosec // metadata values are non-negative
-				uint64(
-					cost.Int64,
-				),
-				10,
-			)
-		}
-		if margin.Rat != nil {
-			data.Margin = margin.String()
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/koiosparity/dingo_db_test.go
+++ b/internal/koiosparity/dingo_db_test.go
@@ -48,8 +48,8 @@ func testPoolKeyHash(t *testing.T, b byte) []byte {
 // TestGetPoolEpochDataMapAlignsRewardScheduleEpochs is a boundary test built
 // directly from Dingo's actual snapshot/reward lifecycle layout — see
 // ledger/snapshot/rotation.go's buildRewardStateInputs (which stamps
-// BlocksProduced/Margin/FixedCost from evt.PreviousEpoch onto the *next*
-// epoch's reward_pool_input row) and ledger/reward_calculation.go's
+// BlocksProduced from evt.PreviousEpoch onto the *next* epoch's
+// reward_pool_input row) and ledger/reward_calculation.go's
 // stakeRewardEpochsForNewEpoch (epochs.snapshot = epochs.performance - 1,
 // with reward_pool_output written at epochs.snapshot alongside the
 // reward_pool_input row actually consumed for that computation) — rather
@@ -187,8 +187,9 @@ func TestGetPoolEpochDataMapAlignsRewardScheduleEpochs(t *testing.T) {
 // TestGetPoolEpochDataMapMissingParamEpochRow proves a pool with a stake
 // -epoch row but no param-epoch row yet still gets an entry, with
 // ParamsPresent left false rather than silently defaulting to a
-// zero-value BlocksProduced/FixedCost/Margin that ComparePoolEpoch could
-// mistake for a real (and wrong) value.
+// zero-value BlocksProduced that ComparePoolEpoch could mistake for a real
+// (and wrong) value. FixedCost/Margin are stake-epoch fields and so are
+// unaffected by the param-epoch row's absence (dingo #3484).
 func TestGetPoolEpochDataMapMissingParamEpochRow(t *testing.T) {
 	dingo, gdb := openTestDingoDB(t)
 	defer dingo.Close() //nolint:errcheck

--- a/internal/koiosparity/dingo_db_test.go
+++ b/internal/koiosparity/dingo_db_test.go
@@ -62,10 +62,13 @@ func testPoolKeyHash(t *testing.T, b byte) []byte {
 //   - reward_pool_output at epoch 9 (same stake epoch): MemberRewardTotal,
 //     written alongside reward_pool_input in the same reward-application
 //     event.
-//   - reward_pool_input at epoch 11 (K+1, the "param epoch"):
-//     BlocksProduced/Margin/FixedCost, captured onto the boundary *after*
-//     epoch 10 — the row describing epoch 10's ended-epoch block count and
-//     effective pool params.
+//   - reward_pool_input at epoch 9 (K-1) also carries Margin/FixedCost: a
+//     mark snapshot records the pool parameters as of its own boundary, and
+//     those are the ones in force for the epoch that snapshot is the basis
+//     for. They therefore align with the stake epoch, not the param epoch.
+//   - reward_pool_input at epoch 11 (K+1, the "param epoch"): BlocksProduced
+//     alone, captured onto the boundary *after* epoch 10 — the row
+//     describing epoch 10's ended-epoch block count.
 //
 // A decoy reward_pool_input row is also seeded at epoch 10 itself with
 // deliberately wrong values in every field, so the test fails loudly if
@@ -101,6 +104,8 @@ func TestGetPoolEpochDataMapAlignsRewardScheduleEpochs(t *testing.T) {
 		PoolKeyHash:    poolHash,
 		DelegatedStake: types.Uint64(5_000_000),
 		DelegatorCount: 7,
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
 	}).Error)
 
 	// reward_pool_output shares the stake epoch (9), not epoch 10 or 11.
@@ -110,16 +115,17 @@ func TestGetPoolEpochDataMapAlignsRewardScheduleEpochs(t *testing.T) {
 		MemberRewardTotal: types.Uint64(123_456),
 	}).Error)
 
-	// Param epoch (11 = K+1): BlocksProduced/Margin/FixedCost are the real
-	// values describing epoch 10.
+	// Param epoch (11 = K+1): BlocksProduced is the real value describing
+	// epoch 10. Its stake and pool parameters belong to a later epoch and
+	// must not surface, so they are seeded as decoys.
 	require.NoError(t, gdb.Create(&models.RewardPoolInput{
 		Epoch:       11,
 		PoolKeyHash: poolHash,
 		DelegatedStake: types.Uint64(
 			222,
 		), // irrelevant at this epoch; must not surface
-		Cost:           types.Uint64(340_000_000),
-		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+		Cost:           types.Uint64(999_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 2)},
 		BlocksProduced: &blocksAtParamEpoch,
 	}).Error)
 
@@ -156,8 +162,18 @@ func TestGetPoolEpochDataMapAlignsRewardScheduleEpochs(t *testing.T) {
 		data.BlocksProduced,
 		"blocks_produced must come from the param epoch (K+1), not K",
 	)
-	require.Equal(t, "340000000", data.FixedCost)
-	require.Equal(t, "1/10", data.Margin)
+	require.Equal(
+		t,
+		"340000000",
+		data.FixedCost,
+		"fixed_cost must come from the stake epoch (K-1), not the param epoch",
+	)
+	require.Equal(
+		t,
+		"1/10",
+		data.Margin,
+		"margin must come from the stake epoch (K-1), not the param epoch",
+	)
 
 	require.True(t, data.MemberRewardPresent)
 	require.Equal(
@@ -315,4 +331,90 @@ func TestPoolKeyHashRoundTrip(t *testing.T) {
 	var pid lcommon.PoolId
 	copy(pid[:], h)
 	require.Len(t, pid[:], 28)
+}
+
+// TestGetPoolEpochDataMapTracksChangingPoolParams reproduces the preview
+// pools that exposed dingo #3484. Both fields are constant for the great
+// majority of pools, so a wrong epoch alignment is invisible until a pool
+// actually changes its margin or cost; these two did, at preview epoch 13.
+//
+// Observed values, with Koios epoch 13 as the reporting epoch K:
+//
+//	pool1nk3uj… reward_pool_input.cost   epoch 12 = 411000000, epoch 13 = 412000000
+//	            Koios pool_history       epoch 13 = 411000000, epoch 14 = 412000000
+//	pool1z9nsz… reward_pool_input.margin epoch 12 = 1/20,      epoch 13 = 1/25
+//	            Koios pool_history       epoch 13 = 0.05,      epoch 14 = 0.04
+//
+// Koios epoch 13's values are on Dingo's epoch-12 row — the stake epoch —
+// while its block count is on the epoch-14 row. Reading cost and margin from
+// the param epoch compared 412000000 against 411000000 and 1/25 against 0.05.
+func TestGetPoolEpochDataMapTracksChangingPoolParams(t *testing.T) {
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	const koiosEpoch = uint64(13)
+	stakeEpoch, ok := koiosStakeEpoch(koiosEpoch)
+	require.True(t, ok)
+	paramEpoch := koiosParamEpoch(koiosEpoch)
+
+	poolHash := testPoolKeyHash(t, 0x11)
+	blocksAtParamEpoch := uint64(10)
+
+	// Stake epoch (12): the parameters in force for Koios epoch 13.
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    poolHash,
+		DelegatedStake: types.Uint64(5_000_000),
+		DelegatorCount: 1,
+		Cost:           types.Uint64(411_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 20)},
+	}).Error)
+
+	// The pool raised its cost and lowered its margin, so the next snapshot
+	// carries different values. Koios places these at epoch 14, not 13.
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:       koiosEpoch,
+		PoolKeyHash: poolHash,
+		Cost:        types.Uint64(412_000_000),
+		Margin:      &types.Rat{Rat: big.NewRat(1, 25)},
+	}).Error)
+
+	// Param epoch (14): owns blocks_produced for epoch 13 and nothing else.
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          paramEpoch,
+		PoolKeyHash:    poolHash,
+		Cost:           types.Uint64(412_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 25)},
+		BlocksProduced: &blocksAtParamEpoch,
+	}).Error)
+
+	m, err := dingo.GetPoolEpochDataMap(
+		context.Background(),
+		stakeEpoch,
+		paramEpoch,
+	)
+	require.NoError(t, err)
+
+	data, ok := m[hex.EncodeToString(poolHash)]
+	require.True(t, ok)
+	require.Equal(
+		t,
+		"411000000",
+		data.FixedCost,
+		"the cost in force for epoch %d is on the stake-epoch row",
+		koiosEpoch,
+	)
+	require.Equal(
+		t,
+		"1/20",
+		data.Margin,
+		"the margin in force for epoch %d is on the stake-epoch row",
+		koiosEpoch,
+	)
+	require.Equal(
+		t,
+		blocksAtParamEpoch,
+		data.BlocksProduced,
+		"blocks_produced still comes from the param epoch",
+	)
 }

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -227,11 +227,16 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 	}
 	m := make(map[string]*DingoPoolEpochData, len(stakeInputs))
 	for _, inp := range stakeInputs {
-		m[hex.EncodeToString(inp.PoolKeyHash)] = &DingoPoolEpochData{
+		data := &DingoPoolEpochData{
 			StakePresent:   true,
 			DelegatedStake: strconv.FormatUint(uint64(inp.DelegatedStake), 10),
 			DelegatorCount: inp.DelegatorCount,
+			FixedCost:      strconv.FormatUint(uint64(inp.Cost), 10),
 		}
+		if inp.Margin != nil && inp.Margin.Rat != nil {
+			data.Margin = inp.Margin.String()
+		}
+		m[hex.EncodeToString(inp.PoolKeyHash)] = data
 	}
 
 	paramInputs, err := meta.GetRewardPoolInputs(paramEpoch, txn.Metadata())
@@ -252,10 +257,6 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 		data.ParamsPresent = true
 		if inp.BlocksProduced != nil {
 			data.BlocksProduced = *inp.BlocksProduced
-		}
-		data.FixedCost = strconv.FormatUint(uint64(inp.Cost), 10)
-		if inp.Margin != nil && inp.Margin.Rat != nil {
-			data.Margin = inp.Margin.String()
 		}
 	}
 

--- a/internal/koiosparity/source_test.go
+++ b/internal/koiosparity/source_test.go
@@ -143,8 +143,8 @@ func TestDatabaseSourceGetEpochDataRewardAdaPotsAbsent(t *testing.T) {
 }
 
 // TestDatabaseSourceGetPoolEpochDataMap mirrors DingoDB's own
-// GetPoolEpochDataMap semantics: DelegatedStake/DelegatorCount come from
-// stakeEpoch, BlocksProduced/FixedCost/Margin from paramEpoch, and
+// GetPoolEpochDataMap semantics: DelegatedStake/DelegatorCount/FixedCost/
+// Margin come from stakeEpoch, BlocksProduced from paramEpoch, and
 // MemberRewardTotal from stakeEpoch's reward_pool_output -- each field
 // group's *Present flag reflects only whether its own row existed.
 func TestDatabaseSourceGetPoolEpochDataMap(t *testing.T) {

--- a/internal/koiosparity/source_test.go
+++ b/internal/koiosparity/source_test.go
@@ -16,6 +16,8 @@ package koiosparity
 
 import (
 	"context"
+	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -156,13 +158,16 @@ func TestDatabaseSourceGetPoolEpochDataMap(t *testing.T) {
 		PoolKeyHash:    poolKeyHash,
 		DelegatedStake: types.Uint64(500_000),
 		DelegatorCount: 3,
+		Cost:           types.Uint64(340_000_000),
 	}).Error)
 	blocksProduced := uint64(7)
+	// The param-epoch row owns blocks_produced only; its cost belongs to a
+	// later epoch and must not surface (dingo #3484).
 	require.NoError(t, gormDB.Create(&models.RewardPoolInput{
 		Epoch:          12,
 		PoolKeyHash:    poolKeyHash,
 		BlocksProduced: &blocksProduced,
-		Cost:           types.Uint64(340_000_000),
+		Cost:           types.Uint64(999_000_000),
 	}).Error)
 	require.NoError(t, gormDB.Create(&models.RewardPoolOutput{
 		Epoch:             10,
@@ -331,4 +336,80 @@ func TestDatabaseSourceCoreModePruningTiming(t *testing.T) {
 	accounts, err = source.GetRewardAccountOutputs(context.Background(), epoch)
 	require.NoError(t, err)
 	require.Empty(t, accounts)
+}
+
+// TestDatabaseSourceGetPoolEpochDataMapTracksChangingPoolParams is the
+// in-process counterpart of dingo_db_test.go's
+// TestGetPoolEpochDataMapTracksChangingPoolParams. Both implementations of
+// RewardParitySource must resolve the same field-to-epoch mapping, and only
+// this one runs inside the node — the standalone CLI reads SQLite directly.
+//
+// The two drifted once: dingo #3484 was fixed in DingoDB while
+// DatabaseSource kept reading Margin/FixedCost from the param epoch, so the
+// unit tests passed while a live preview replay still failed at epoch 13.
+func TestDatabaseSourceGetPoolEpochDataMapTracksChangingPoolParams(
+	t *testing.T,
+) {
+	db := newTestDatabaseSourceDB(t)
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+
+	const (
+		koiosEpoch = uint64(13)
+		stakeEpoch = koiosEpoch - 1
+		paramEpoch = koiosEpoch + 1
+	)
+	poolHash := testPoolKeyHash(t, 0x11)
+	blocksAtParamEpoch := uint64(10)
+	meta := db.Metadata()
+
+	// Stake epoch (12): the parameters in force for Koios epoch 13.
+	require.NoError(t, meta.SaveRewardPoolInputs([]*models.RewardPoolInput{{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    poolHash,
+		DelegatedStake: types.Uint64(5_000_000),
+		DelegatorCount: 1,
+		Cost:           types.Uint64(411_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 20)},
+	}}, nil))
+
+	// Param epoch (14): owns blocks_produced for epoch 13. Its own cost and
+	// margin belong to a later epoch and must not surface.
+	require.NoError(t, meta.SaveRewardPoolInputs([]*models.RewardPoolInput{{
+		Epoch:          paramEpoch,
+		PoolKeyHash:    poolHash,
+		Cost:           types.Uint64(412_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 25)},
+		BlocksProduced: &blocksAtParamEpoch,
+	}}, nil))
+
+	m, err := source.GetPoolEpochDataMap(
+		context.Background(),
+		stakeEpoch,
+		paramEpoch,
+	)
+	require.NoError(t, err)
+
+	data, ok := m[hex.EncodeToString(poolHash)]
+	require.True(t, ok)
+	require.Equal(
+		t,
+		"411000000",
+		data.FixedCost,
+		"the cost in force for epoch %d is on the stake-epoch row",
+		koiosEpoch,
+	)
+	require.Equal(
+		t,
+		"1/20",
+		data.Margin,
+		"the margin in force for epoch %d is on the stake-epoch row",
+		koiosEpoch,
+	)
+	require.Equal(
+		t,
+		blocksAtParamEpoch,
+		data.BlocksProduced,
+		"blocks_produced still comes from the param epoch",
+	)
 }


### PR DESCRIPTION
Fixes #3483. Fixes #3484. Stacked on #3482 — retarget to `main` once that and #3478 merge.

Two independent defects in the Koios parity comparison, one commit each. Both are comparison-side: Dingo's ledger data was correct in every case.

## 1. Pool presence (#3483)

`GetPoolEpochDataMap` returns the **union** of the stake-epoch (K-1) and param-epoch (K+1) reads, and the presence loop flagged every key in that union missing from Koios's epoch-K pool set as `pool_only_dingo`.

A pool registered *during* epoch K has no K-1 row — it did not exist yet — but does have a K+1 row, because its first mark snapshot is captured at the boundary into K+1. It is not part of K's active-stake basis, and Koios has no `pool_history` row for it until K+2, so flagging it reported a divergence where both sides agree.

Observed on Preview epoch 7, where two pools registered mid-epoch stopped the strict observer. Koios places their active stake (`9497623854`, `19495450477`) at epoch 9, exactly matching Dingo's epoch-8 rows — confirming the K-1 mapping is right and the presence check was at fault.

The fix skips pools whose `StakePresent` is false. That flag exists for exactly this shape — its doc comment names "a freshly registered pool whose stake-epoch row hasn't landed yet" — and `ComparePoolEpoch` already consults it; only the presence loop did not. A pool genuinely in K's stake basis but absent from Koios is still flagged.

## 2. Pool parameter alignment (#3484)

`Margin` and `FixedCost` were read from the param epoch (K+1) alongside `BlocksProduced`. Only `BlocksProduced` belongs there: a mark snapshot records the pool parameters as of its own boundary, and those are the ones in force for the epoch that snapshot is the basis for, so cost and margin align with the stake epoch (K-1).

Pinned on one Preview pool:

| | Dingo e12 | Dingo e13 | Dingo e14 | Koios e13 | Koios e14 |
| --- | ---: | ---: | ---: | ---: | ---: |
| blocks | 0 | 0 | **10** | **10** | 15 |
| cost | **411000000** | 412000000 | 412000000 | **411000000** | 412000000 |

Blocks align at K+1; cost aligns at K-1. A second pool confirms the same for margin (Dingo e12 = 1/20 ↔ Koios e13 = 0.05; Dingo e13 = 1/25 ↔ Koios e14 = 0.04).

Both fields are constant for the great majority of pools, so the wrong alignment stayed invisible until a pool actually changed one — on Preview, epoch 13.

The fix moves both fields onto the stake-epoch read and moves their comparison into `ComparePoolEpoch`'s `StakePresent` branch, so their presence follows `StakePresent` rather than `ParamsPresent`. `ParamsPresent` now covers `BlocksProduced` alone.

**Both implementations of `RewardParitySource` are corrected.** They drifted during this work: `DingoDB` was fixed while `DatabaseSource` — the one the in-process observer actually uses — was not, so the unit tests passed while a live replay still failed at epoch 13 with identical values. `TestDatabaseSourceGetPoolEpochDataMapTracksChangingPoolParams` now covers the in-process path so they cannot diverge unnoticed again.

## Validation: live Preview genesis replay

```
dingo serve --network preview --data-dir <dir> --storage-mode api \
  --socket-path /tmp/dg/n.socket \
  --port 3451 --private-port 3452 --metrics-port 12851 --debug-port 0 \
  --koios-parity-enabled --koios-parity-strict --koios-parity-accounts=false
```

- Before #3483: fails at epoch 7.
- After #3483: fails at epoch 13.
- After both: every epoch through **13** validates and the run reaches slot **1319110**, past the slot 1295990 target in #3381.

## Tests

All fail on the parent branch and pass here, verified by reverting the source files and re-running:

- `TestCheckIgnoresParamEpochOnlyPoolForPresence` — a pool with only a K+1 row must not be flagged.
- `TestCheckFlagsStakeEpochPoolMissingFromKoios` — negative case; a pool in K's stake basis but absent from Koios must stay flagged, so the fix cannot widen into suppressing genuine findings.
- `TestGetPoolEpochDataMapTracksChangingPoolParams` — the real Preview values, on `DingoDB`.
- `TestDatabaseSourceGetPoolEpochDataMapTracksChangingPoolParams` — the same, on the in-process `DatabaseSource`.
- `TestGetPoolEpochDataMapAlignsRewardScheduleEpochs` updated: the stake-epoch row now carries the real cost/margin and the param-epoch row carries decoys, so a regression to the old grouping fails loudly.

Four other fixtures across `check_test.go`, `compare_test.go` and `source_test.go` encoded the old grouping and were updated to the corrected contract.

`ARCHITECTURE.md`'s "Epoch alignment" section and `DingoPoolEpochData`'s field comments both documented the incorrect grouping and are corrected.

## Known follow-up

The replay now stops at **epoch 14** with an ERROR, filed as #3485: the mirror image of the first defect. A pool that is in epoch K's stake basis but *leaves* the pool set at K+1 has no param-epoch row, so its epoch-K `blocks_produced` is unreachable and reports `dingo_db_missing`, which escalates to ERROR and halts a strict-mode node. Both sides agree on that pool's lifecycle — Dingo's epoch-15 snapshot is complete at 47 pools and correctly omits it, and Koios has no epoch-16 row for it either.

## Checks

- `make test` (race): pass
- `golangci-lint run ./...`: 0 issues; `nilaway`: clean
- `modernize`: 5 findings, all pre-existing on an `origin/main` baseline in untouched files
- `make import-boundaries`, `make docs-parity`, `make golines`: pass
- Live Preview genesis replay with the strict in-process Koios observer, as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reward calculations to use performance-epoch parameters while retaining calculation-epoch timing data.
  * Improved reward handling across epoch boundaries, including preview calculations.
  * Corrected pool cost and margin comparisons to use stake-epoch data, while block counts use parameter-epoch data.
  * Prevented pools present only in parameter-epoch data from being incorrectly flagged.
  * Improved missing-data detection so absent records are not treated as zero values.

* **Documentation**
  * Clarified epoch alignment and data validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->