### PR TITLE
fix(ledger): guard runtime-asserted ledger capabilities at compile time

### DIFF
--- a/internal/test/conformance/state_provider.go
+++ b/internal/test/conformance/state_provider.go
@@ -417,3 +417,10 @@ func extractCostModels(
 
 // Compile-time interface check
 var _ conformance.StateProvider = (*DingoStateProvider)(nil)
+
+// conformance.StateProvider does not include DRepDelegationState: the Conway
+// reward-withdrawal rule discovers it with a runtime type assertion instead.
+// Without this guard the harness would keep compiling after a signature drift
+// and stop exercising the protocol-version 10/11 withdrawal rule it exists to
+// cover, matching ledger.LedgerView's guard for the production path.
+var _ common.DRepDelegationState = (*DingoStateProvider)(nil)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -9138,6 +9138,14 @@ func (ls *LedgerState) txValidationSnapshot() txValidationSnapshot {
 	}
 }
 
+// Both the block builder and the mempool discover the validation-session
+// capability with a runtime type assertion on the TxValidator they were handed
+// and silently fall back to unpinned per-transaction validation when it fails,
+// so drift in WithTxValidationSession would quietly drop the snapshot pinning
+// rather than break the build. The mempool's identical interface is guarded in
+// the root package, which is where *LedgerState is wired in as its validator.
+var _ forging.TxValidationSessionProvider = (*LedgerState)(nil)
+
 // WithTxValidationSession pins a mempool revalidation batch to one immutable
 // ledger publication, one validation slot/era/parameter set, and one
 // repeatable-read database transaction. stillCurrent lets the mempool reject

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -79,6 +79,19 @@ var _ eras.MinPoolMarginProvider = (*LedgerView)(nil)
 // back to weaker existence-only proposal ancestry checks.
 var _ lcommon.GovPurposeRootsState = (*LedgerView)(nil)
 
+// The Conway reward-withdrawal rule discovers this capability with a runtime
+// type assertion on the *LedgerView passed to ValidateTx*. On protocol versions
+// 10 and 11 a failed assertion rejects every affected withdrawal
+// (DRepDelegationStateUnavailableError), so signature drift here is a
+// consensus-level break. Make it a compile error instead.
+var _ lcommon.DRepDelegationState = (*LedgerView)(nil)
+
+// Byron redeem and bootstrap witness verification asserts this capability at
+// runtime and fails the transaction when it is absent, so drift in
+// ByronProtocolMagic would reject every Byron transaction carrying those
+// witnesses rather than fail to build.
+var _ eras.ByronProtocolMagicProvider = (*LedgerView)(nil)
+
 func (lv *LedgerView) NetworkId() uint {
 	genesis := lv.ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if genesis == nil {

--- a/node.go
+++ b/node.go
@@ -433,6 +433,14 @@ func (n *Node) ouroboros() *ouroborosPkg.Ouroboros {
 	return n.ouroborosRef.Load()
 }
 
+// Run wires *ledger.LedgerState in as the mempool's TxValidator, and the
+// mempool discovers the optional validation-session capability on it with a
+// runtime type assertion, silently falling back to unpinned per-transaction
+// validation when that fails. Guard the pairing here, in the package that
+// makes it, so drift cannot quietly unpin mempool revalidation from its
+// ledger snapshot.
+var _ mempool.TxValidationSessionProvider = (*ledger.LedgerState)(nil)
+
 //nolint:contextcheck // Run is the lifecycle boundary and derives n.ctx from the caller context.
 func (n *Node) Run(ctx context.Context) (runErr error) {
 	// Configure tracing

--- a/node_forging.go
+++ b/node_forging.go
@@ -556,6 +556,13 @@ type epochInfoAdapter struct {
 	ledgerState *ledger.LedgerState
 }
 
+// computeSchedule discovers the exact-rational coefficient with a runtime type
+// assertion and silently falls back to the float64 accessor when it fails,
+// which yields a strictly larger leadership threshold than the reference node's
+// (dingo #2798). Make that drift a compile error;
+// TestEpochInfoAdapterProvidesExactActiveSlotCoeff covers the same pairing.
+var _ leader.ActiveSlotCoeffRatProvider = (*epochInfoAdapter)(nil)
+
 func (a *epochInfoAdapter) CurrentEpoch() uint64 {
 	return a.ledgerState.CurrentEpoch()
 }


### PR DESCRIPTION
## What

`LedgerView.DRepDelegation` satisfies gouroboros' `common.DRepDelegationState`,
which the Conway rules discover with a runtime type assertion
(`ledger/conway/rules.go:3208`). A drifted signature yields `ok=false` with no
compile-time signal, and on protocol versions 10 and 11 the rule then returns
`DRepDelegationStateUnavailableError` for every affected reward withdrawal.

Adds `var _ lcommon.DRepDelegationState = (*LedgerView)(nil)`, and the same
guard for the other runtime-asserted capabilities whose concrete type dingo
owns.

Closes #2929

## Audit

| Interface | Assertion site | Concrete type | Before | After |
|---|---|---|---|---|
| `lcommon.DRepDelegationState` | gouroboros `conway/rules.go:3208` | `*ledger.LedgerView` | none | added |
| `lcommon.DRepDelegationState` | same rule, conformance path | `*conformance.DingoStateProvider` | none | added |
| `eras.ByronProtocolMagicProvider` | `ledger/eras/byron.go:332` | `*ledger.LedgerView` | none | added |
| `forging.TxValidationSessionProvider` | `ledger/forging/builder.go:116` | `*ledger.LedgerState` | none | added |
| `mempool.TxValidationSessionProvider` | `mempool/mempool.go:1315` | `*ledger.LedgerState` | none | added (root package) |
| `leader.ActiveSlotCoeffRatProvider` | `ledger/leader/election.go:848` | `*epochInfoAdapter` | runtime test | added |
| `lcommon.GovPurposeRootsState` | gouroboros `conway/rules.go:604` | `*ledger.LedgerView` | present | unchanged |
| `eras.MinPoolMarginProvider` | `ledger/eras/validation.go:55` | `*ledger.LedgerView` | present | unchanged |
| `costModelsProvider` | `ledger/view.go:504` | gouroboros pparam types | n/a | left unguarded |

`conformance.StateProvider` (`ouroboros-mock/ledger/backend.go:40`) does not
embed `DRepDelegationState`, so the existing `var _ conformance.StateProvider`
check did not cover `DingoStateProvider.DRepDelegation`.

`costModelsProvider` is asserted against gouroboros era protocol-parameter
types rather than dingo types, and has a working fallback path, so a guard
would pin foreign types for a capability that is genuinely optional.

The `mempool.TxValidationSessionProvider` guard lives in the root package
rather than in `ledger`, since that is where `*LedgerState` is wired in as the
mempool's validator and `ledger` does not otherwise import `mempool`.

## Testing

Each guard was verified live by drifting the underlying method name and
confirming the compiler reports it, e.g.:

```
ledger/view.go:87:37: cannot use (*LedgerView)(nil) ... *LedgerView does not
implement common.DRepDelegationState (missing method DRepDelegation)
node.go:441:45: cannot use (*ledger.LedgerState)(nil) ... does not implement
mempool.TxValidationSessionProvider (missing method WithTxValidationSession)
```

All six drift cases produce a build failure; all edits were reverted afterward.

- `go build ./...`, `go vet`
- `go test -race ./ledger/ ./mempool/ ./internal/test/conformance/` — pass, 0 races
- `make lint` — import-boundaries pass, `golangci-lint` 0 issues; `nilaway` not
  installed in this environment, so that step did not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added compile-time checks to verify compatibility across delegation, transaction validation, protocol, and block-forging interfaces.
  * Improved safeguards against interface drift that could affect withdrawal conformance, transaction validation, or slot leadership calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->