### PR TITLE
fix(koiosparity): classify a departed pool instead of erroring the epoch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5395,7 +5395,14 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   the uncomparable field is still reported so the coverage gap is visible, but
   both sides agree the pool departed, so it neither fails nor errors the
   epoch. A missing row with no committed K+1 snapshot keeps the stricter
-  classification. The same split applies a third time to `reward_pool_input`'s
+  classification, as does a pool still listed in that set — a degraded active
+  pool is dropped from `reward_pool_input` "without changing
+  `pool_stake_snapshot` or `epoch_summary`" (see DATABASE.md), so only absence
+  from the pool set itself proves departure. `pool_stake_snapshot` is windowed
+  while `reward_pool_input` is retained for the life of the database, so an
+  epoch older than that window has no membership evidence and keeps the
+  stricter classification. The same split applies a third time to
+  `reward_pool_input`'s
   stake-epoch fields (`delegated_stake`/`delegator_count`/`fixed_cost`/
   `margin`, reported together as `reward_pool_input_stake` when absent) via
   `DingoPoolEpochData.StakePresent` — a pool whose stake-epoch row hasn't

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5385,26 +5385,35 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   absent) via `DingoPoolEpochData.ParamsPresent`, for the same reason: a
   not-yet-captured param-epoch row must not silently compare as zero blocks
   against Koios's real value. That split has one exception. A pool that was in
-  epoch K's stake basis but is absent from a K+1 snapshot Dingo has already
-  committed did not fail to compute — it left the pool set, and the K+1 row
-  its epoch-K block count would have been stamped onto is never written.
-  `checkEpoch` resolves once per epoch whether the K+1 snapshot exists
-  (`GetEpochData` returns nil unless `epoch_summary.SnapshotReady` is set) and
-  passes that to `ComparePoolEpoch`, which then records `pool_departed`
+  epoch K's stake basis but is absent from the K+1 pool set did not fail to
+  compute — it left the set, and the K+1 row its epoch-K block count would
+  have been stamped onto is never written. `checkEpoch` reads the K+1 mark
+  `pool_stake_snapshot` membership once per epoch through
+  `RewardParitySource.GetPoolStakeSnapshotMembers` and passes each pool's
+  proven absence to `ComparePoolEpoch`, which then records `pool_departed`
   instead. That category is informational, like the account lifecycle ones:
   the uncomparable field is still reported so the coverage gap is visible, but
   both sides agree the pool departed, so it neither fails nor errors the
-  epoch. A missing row with no committed K+1 snapshot keeps the stricter
-  classification, as does a pool still listed in that set — a degraded active
-  pool is dropped from `reward_pool_input` "without changing
-  `pool_stake_snapshot` or `epoch_summary`" (see DATABASE.md), so only absence
-  from the pool set itself proves departure. `pool_stake_snapshot` is windowed
-  while `reward_pool_input` is retained for the life of the database, so an
-  epoch older than that window has no membership evidence and keeps the
-  stricter classification. The same split applies a third time to
-  `reward_pool_input`'s
-  stake-epoch fields (`delegated_stake`/`delegator_count`/`fixed_cost`/
-  `margin`, reported together as `reward_pool_input_stake` when absent) via
+  epoch.
+
+  Membership, not `epoch_summary.SnapshotReady`, is what proves departure.
+  `SnapshotReady` is epoch-level: `saveSnapshotInTxn` writes the epoch summary
+  and the mark `pool_stake_snapshot` on every transition regardless of
+  reward-input availability, so a ready summary is compatible with the whole
+  reward-input bundle having been skipped, and `buildRewardStateInputs` drops
+  a degraded active pool from `reward_pool_input` "without changing
+  `pool_stake_snapshot` or `epoch_summary`" (see DATABASE.md). Both are
+  missing input rather than departure, and both would pass under an
+  epoch-level flag. A pool still listed in the K+1 set therefore keeps the
+  stricter classification, as does an unreadable or empty member set — empty
+  cannot distinguish "captured, no pools" from "not captured". Because
+  `pool_stake_snapshot` is windowed while `reward_pool_input` is retained for
+  the life of the database, an epoch older than that window has no membership
+  evidence and keeps the stricter classification too.
+
+  The same split applies a third time to `reward_pool_input`'s stake-epoch
+  fields (`delegated_stake`/`delegator_count`/`fixed_cost`/`margin`, reported
+  together as `reward_pool_input_stake` when absent) via
   `DingoPoolEpochData.StakePresent` — a pool whose stake-epoch row hasn't
   landed yet (e.g. a freshly registered pool captured first at the param
   epoch) must not silently compare as zero stake/delegators/cost/margin

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5405,11 +5405,23 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   `pool_stake_snapshot` or `epoch_summary`" (see DATABASE.md). Both are
   missing input rather than departure, and both would pass under an
   epoch-level flag. A pool still listed in the K+1 set therefore keeps the
-  stricter classification, as does an unreadable or empty member set — empty
-  cannot distinguish "captured, no pools" from "not captured". Because
-  `pool_stake_snapshot` is windowed while `reward_pool_input` is retained for
-  the life of the database, an epoch older than that window has no membership
-  evidence and keeps the stricter classification too.
+  stricter classification.
+
+  Absence only proves departure against a set known to be complete, so the
+  member count is checked against the K+1 `epoch_summary.TotalPoolCount`
+  before it is trusted. `saveSnapshotInTxn` writes that count and those mark
+  rows from the same `StakeDistribution`, so equality between them is what
+  establishes completeness — deliberately the epoch summary's count and not
+  `RewardSnapshot.TotalPoolCount`, which counts the reduced reward
+  distribution with degraded pools already excluded. Without that check a
+  summary declaring two pools with only one readable mark row would make the
+  missing pool look departed and hide a `dingo_db_missing`. Anything short of
+  equality leaves membership unproven and keeps the stricter classification:
+  a read error, an empty set (which cannot distinguish "captured, no pools"
+  from "not captured"), no ready summary, a zero count, or a disagreeing
+  count. Because `pool_stake_snapshot` is windowed while `reward_pool_input`
+  is retained for the life of the database, an epoch older than that window
+  has no membership evidence and keeps the stricter classification too.
 
   The same split applies a third time to `reward_pool_input`'s stake-epoch
   fields (`delegated_stake`/`delegator_count`/`fixed_cost`/`margin`, reported

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5384,20 +5384,33 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   (`blocks_produced` alone, reported as `reward_pool_input_params` when
   absent) via `DingoPoolEpochData.ParamsPresent`, for the same reason: a
   not-yet-captured param-epoch row must not silently compare as zero blocks
-  against Koios's real value. The same split applies a third time to
-  `reward_pool_input`'s stake-epoch fields (`delegated_stake`/
-  `delegator_count`/`fixed_cost`/`margin`, reported together as
-  `reward_pool_input_stake` when absent) via `DingoPoolEpochData.
-  StakePresent` — a pool whose stake-epoch row hasn't landed yet (e.g. a
-  freshly registered pool captured first at the param epoch) must not
-  silently compare as zero stake/delegators/cost/margin against Koios's real
-  values either. `fixed_cost` and `margin` sit on this side of the split, not
-  with `blocks_produced`, because they are read at K-1 (dingo #3484).
+  against Koios's real value. That split has one exception. A pool that was in
+  epoch K's stake basis but is absent from a K+1 snapshot Dingo has already
+  committed did not fail to compute — it left the pool set, and the K+1 row
+  its epoch-K block count would have been stamped onto is never written.
+  `checkEpoch` resolves once per epoch whether the K+1 snapshot exists
+  (`GetEpochData` returns nil unless `epoch_summary.SnapshotReady` is set) and
+  passes that to `ComparePoolEpoch`, which then records `pool_departed`
+  instead. That category is informational, like the account lifecycle ones:
+  the uncomparable field is still reported so the coverage gap is visible, but
+  both sides agree the pool departed, so it neither fails nor errors the
+  epoch. A missing row with no committed K+1 snapshot keeps the stricter
+  classification. The same split applies a third time to `reward_pool_input`'s
+  stake-epoch fields (`delegated_stake`/`delegator_count`/`fixed_cost`/
+  `margin`, reported together as `reward_pool_input_stake` when absent) via
+  `DingoPoolEpochData.StakePresent` — a pool whose stake-epoch row hasn't
+  landed yet (e.g. a freshly registered pool captured first at the param
+  epoch) must not silently compare as zero stake/delegators/cost/margin
+  against Koios's real values either. `fixed_cost` and `margin` sit on this
+  side of the split, not with `blocks_produced`, because they are read at K-1
+  (dingo #3484).
 
 **Mismatch categories:** `value_mismatch`, `pool_only_dingo`, `pool_only_koios`,
 `dingo_db_missing` (epoch/pool row not yet computed by Dingo), `dingo_db_error`
 (DB query failed), `reference_lag` (epoch closed within --grace-hours; absence
-may be transient), plus #3097's per-account categories: `acct_only_dingo`,
+may be transient), `pool_departed` (informational: the pool left the pool set
+at K+1, so its epoch-K block count has no row to live on), plus #3097's
+per-account categories: `acct_only_dingo`,
 `acct_only_koios`, `acct_duplicate` (a genuine duplicate (stake_address,
 reward_type) row within one side — a data-integrity problem, not a value
 disagreement), and `acct_coverage_incomplete` (the per-account Koios fetch for

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -340,6 +340,20 @@ func koiosStakeEpoch(koiosEpoch uint64) (epoch uint64, ok bool) {
 // at this offset: a mark snapshot records the pool parameters as of its own
 // boundary, so Margin/FixedCost belong with the stake epoch (dingo #3484).
 // See koiosStakeEpoch's doc comment and ARCHITECTURE.md.
+// poolDepartedAtParamEpoch reports whether keyHex is provably absent from the
+// K+1 pool set. It is false whenever membership could not be established, so
+// an unresolved read never downgrades a missing reward-input row from ERROR.
+func poolDepartedAtParamEpoch(
+	paramEpochPools map[string]struct{},
+	keyHex string,
+) bool {
+	if len(paramEpochPools) == 0 {
+		return false
+	}
+	_, present := paramEpochPools[keyHex]
+	return !present
+}
+
 func koiosParamEpoch(koiosEpoch uint64) uint64 {
 	return koiosEpoch + 1
 }
@@ -495,25 +509,38 @@ func checkEpoch(
 		dingoPoolErr = epochErr
 	}
 
-	// Whether the K+1 snapshot blocks_produced is read from has been committed
-	// at all. A pool missing from a snapshot that exists has left the pool
-	// set; a pool missing because the snapshot itself is not written yet is a
-	// genuine gap. Resolved once here so every pool in this epoch is judged
-	// against the same answer. A lookup error leaves this false, which keeps
-	// the stricter dingo_db_missing classification (dingo #3485).
-	paramEpochCaptured := false
-	if paramEpochData, pErr := dingo.GetEpochData(ctx, paramEpoch); pErr != nil {
+	// Pool-set membership at K+1, used to tell a pool that left the pool set
+	// from one whose reward inputs are missing or incomplete.
+	//
+	// epoch_summary.SnapshotReady cannot answer this. It is epoch-level, and
+	// ledger/snapshot/rotation.go writes the epoch summary and the mark
+	// pool_stake_snapshot on every transition "regardless of reward-input
+	// availability" — so a ready summary is compatible with the entire
+	// reward-input bundle having been skipped. buildRewardStateInputs also
+	// deliberately omits a degraded active pool from reward_pool_input while
+	// keeping it in PoolStakeSnapshot. Both cases are genuine missing input,
+	// not departure, and both would pass under an epoch-level flag.
+	//
+	// pool_stake_snapshot is written in both of those cases, so per-pool
+	// absence from it is the evidence that the pool really did leave the set.
+	// Resolved once here so every pool in this epoch is judged against the
+	// same read. A lookup error or an empty set leaves membership unproven,
+	// which keeps the stricter dingo_db_missing classification (dingo #3485).
+	var paramEpochPools map[string]struct{}
+	if members, pErr := dingo.GetPoolStakeSnapshotMembers(
+		ctx, paramEpoch,
+	); pErr != nil {
 		logger.Debug(
-			"koiosparity: could not resolve param-epoch snapshot readiness",
+			"koiosparity: could not resolve param-epoch pool-set membership",
 			"network", network,
 			"epoch", epoch,
 			"param_epoch", paramEpoch,
 			"error", pErr,
 		)
-	} else if paramEpochData != nil {
-		// GetEpochData returns nil unless epoch_summary.SnapshotReady is set,
-		// so a non-nil result is exactly "the K+1 snapshot is committed".
-		paramEpochCaptured = true
+	} else if len(members) > 0 {
+		// An empty set cannot distinguish "captured, no pools" from "not
+		// captured at all", so it is not treated as proof of capture.
+		paramEpochPools = members
 	}
 	if dingoPoolErr != nil {
 		// Record the DB failure and skip all per-pool comparisons.
@@ -571,7 +598,7 @@ func checkEpoch(
 				now,
 				graceHours,
 				epochEndTime,
-				paramEpochCaptured,
+				poolDepartedAtParamEpoch(paramEpochPools, keyHex),
 			)
 			allMismatches = append(allMismatches, poolMismatches...)
 

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -494,6 +494,27 @@ func checkEpoch(
 	} else {
 		dingoPoolErr = epochErr
 	}
+
+	// Whether the K+1 snapshot blocks_produced is read from has been committed
+	// at all. A pool missing from a snapshot that exists has left the pool
+	// set; a pool missing because the snapshot itself is not written yet is a
+	// genuine gap. Resolved once here so every pool in this epoch is judged
+	// against the same answer. A lookup error leaves this false, which keeps
+	// the stricter dingo_db_missing classification (dingo #3485).
+	paramEpochCaptured := false
+	if paramEpochData, pErr := dingo.GetEpochData(ctx, paramEpoch); pErr != nil {
+		logger.Debug(
+			"koiosparity: could not resolve param-epoch snapshot readiness",
+			"network", network,
+			"epoch", epoch,
+			"param_epoch", paramEpoch,
+			"error", pErr,
+		)
+	} else if paramEpochData != nil {
+		// GetEpochData returns nil unless epoch_summary.SnapshotReady is set,
+		// so a non-nil result is exactly "the K+1 snapshot is committed".
+		paramEpochCaptured = true
+	}
 	if dingoPoolErr != nil {
 		// Record the DB failure and skip all per-pool comparisons.
 		// Continuing with dingoPoolMap == nil would make every Koios pool appear
@@ -550,6 +571,7 @@ func checkEpoch(
 				now,
 				graceHours,
 				epochEndTime,
+				paramEpochCaptured,
 			)
 			allMismatches = append(allMismatches, poolMismatches...)
 

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -526,21 +526,54 @@ func checkEpoch(
 	// Resolved once here so every pool in this epoch is judged against the
 	// same read. A lookup error or an empty set leaves membership unproven,
 	// which keeps the stricter dingo_db_missing classification (dingo #3485).
+	// Absence is only departure proof when the set it is measured against is
+	// known complete. A non-empty read is not enough on its own: if the K+1
+	// summary declares two pools and only one mark row comes back, the
+	// missing one would look departed and hide a dingo_db_missing. The
+	// epoch summary's TotalPoolCount is written from the same
+	// StakeDistribution as those rows (rotation.go), so equality between the
+	// two is what establishes completeness. Anything short of that -- a read
+	// error, an empty set, no ready summary, a zero count, or a count that
+	// disagrees -- leaves membership unproven and keeps the stricter
+	// dingo_db_missing classification (dingo #3485).
 	var paramEpochPools map[string]struct{}
-	if members, pErr := dingo.GetPoolStakeSnapshotMembers(
-		ctx, paramEpoch,
-	); pErr != nil {
+	members, membersErr := dingo.GetPoolStakeSnapshotMembers(ctx, paramEpoch)
+	switch {
+	case membersErr != nil:
 		logger.Debug(
 			"koiosparity: could not resolve param-epoch pool-set membership",
 			"network", network,
 			"epoch", epoch,
 			"param_epoch", paramEpoch,
-			"error", pErr,
+			"error", membersErr,
 		)
-	} else if len(members) > 0 {
-		// An empty set cannot distinguish "captured, no pools" from "not
-		// captured at all", so it is not treated as proof of capture.
-		paramEpochPools = members
+	case len(members) == 0:
+		// Cannot distinguish "captured, no pools" from "not captured".
+	default:
+		paramSummary, sErr := dingo.GetEpochData(ctx, paramEpoch)
+		switch {
+		case sErr != nil:
+			logger.Debug(
+				"koiosparity: could not resolve param-epoch pool count",
+				"network", network,
+				"epoch", epoch,
+				"param_epoch", paramEpoch,
+				"error", sErr,
+			)
+		case paramSummary == nil || paramSummary.TotalPoolCount == 0:
+			// No ready summary, or no declared count to verify against.
+		case uint64(len(members)) != paramSummary.TotalPoolCount:
+			logger.Debug(
+				"koiosparity: param-epoch pool set is incomplete",
+				"network", network,
+				"epoch", epoch,
+				"param_epoch", paramEpoch,
+				"members", len(members),
+				"declared", paramSummary.TotalPoolCount,
+			)
+		default:
+			paramEpochPools = members
+		}
 	}
 	if dingoPoolErr != nil {
 		// Record the DB failure and skip all per-pool comparisons.

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1149,3 +1149,124 @@ func TestCheckFlagsStakeEpochPoolMissingFromKoios(t *testing.T) {
 			"divergence and must stay flagged", koiosEpoch,
 	)
 }
+
+// TestCheckDepartedPoolDoesNotErrorEpoch is the end-to-end counterpart of
+// compare_test.go's TestComparePoolEpochDepartedPoolIsInformational: it proves
+// checkEpoch resolves the K+1 snapshot's readiness for itself, which the
+// ComparePoolEpoch unit tests cannot.
+//
+// The fixture mirrors preview epoch 14. The pool is in epoch K's stake basis
+// (a K-1 reward_pool_input row) and absent from the K+1 snapshot, which is
+// itself committed — a ready epoch_summary row at K+1. That combination means
+// the pool left the pool set, so the epoch must still report PASS rather than
+// halting a strict-mode node (dingo #3485).
+func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+	stakeEpoch := koiosEpoch - 1
+	paramEpoch := koiosEpoch + 1
+
+	poolHash := testPoolKeyHash(t, 0x09)
+	poolBech32, err := PoolKeyHashHexToBech32(hex.EncodeToString(poolHash))
+	require.NoError(t, err)
+
+	dingoDir, gdb := newTestDingoDB(t)
+
+	require.NoError(t, gdb.Create(&models.EpochSummary{
+		Epoch:            stakeEpoch,
+		TotalActiveStake: types.Uint64(5_000_000),
+		SnapshotReady:    true,
+	}).Error)
+	// The K+1 snapshot exists and simply does not contain this pool.
+	require.NoError(t, gdb.Create(&models.EpochSummary{
+		Epoch:            paramEpoch,
+		TotalActiveStake: types.Uint64(5_000_000),
+		SnapshotReady:    true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    poolHash,
+		DelegatedStake: types.Uint64(5_000_000),
+		DelegatorCount: 7,
+		Cost:           types.Uint64(340_000_000),
+		Margin:         &types.Rat{Rat: big.NewRat(1, 10)},
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
+		Epoch:             stakeEpoch,
+		PoolKeyHash:       poolHash,
+		MemberRewardTotal: types.Uint64(123_456),
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAdaPots{
+		Epoch:    koiosEpoch,
+		Treasury: types.Uint64(1_000),
+		Reserves: types.Uint64(2_000),
+		Fees:     types.Uint64(300),
+	}).Error)
+
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	cachePath := filepath.Join(t.TempDir(), "cache.db")
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+
+	fetchedAt := time.Now().Add(-time.Hour).UTC()
+	require.NoError(t, cache.CommitEpochData(
+		KoiosEpochInfo{
+			Network:      network,
+			Epoch:        koiosEpoch,
+			ActiveStake:  "5000000",
+			EpochEndTime: fetchedAt,
+			FetchedAt:    fetchedAt,
+		},
+		[]KoiosPoolEpoch{{
+			Network:       network,
+			Epoch:         koiosEpoch,
+			PoolBech32:    poolBech32,
+			ActiveStake:   "5000000",
+			BlockCnt:      15,
+			Delegators:    7,
+			Margin:        "0.1",
+			FixedCost:     "340000000",
+			MemberRewards: "123456",
+			FetchedAt:     fetchedAt,
+		}},
+		&KoiosTotals{
+			Network:   network,
+			Epoch:     koiosEpoch,
+			Treasury:  "1000",
+			Reserves:  "2000",
+			Fees:      "300",
+			FetchedAt: fetchedAt,
+		},
+	))
+	require.NoError(t, cache.Close())
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		result.ErrorEpochs,
+		"a departed pool must not put epoch %d into ERROR", koiosEpoch,
+	)
+	require.Empty(t, result.FailEpochs)
+
+	cache, err = OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, "reward_pool_input_params", mismatches[0].Field)
+	require.Equal(
+		t,
+		CategoryPoolDeparted,
+		mismatches[0].Category,
+		"the uncomparable block count is recorded, not silently skipped",
+	)
+}

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1163,6 +1163,52 @@ func TestCheckFlagsStakeEpochPoolMissingFromKoios(t *testing.T) {
 func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
 	const network = "preview"
 	const koiosEpoch = uint64(14)
+
+	// The pool is absent from the K+1 pool set: it left, so its epoch-K block
+	// count has no row to live on and the gap is informational.
+	dingoDir, cachePath, _ := seedDepartureFixture(
+		t, network, koiosEpoch, false,
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		result.ErrorEpochs,
+		"a departed pool must not put epoch %d into ERROR", koiosEpoch,
+	)
+	require.Empty(t, result.FailEpochs)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, "reward_pool_input_params", mismatches[0].Field)
+	require.Equal(
+		t,
+		CategoryPoolDeparted,
+		mismatches[0].Category,
+		"the uncomparable block count is recorded, not silently skipped",
+	)
+}
+
+// seedDepartureFixture builds the epoch-K comparison fixture used by the
+// departure tests. paramEpochPoolInSet controls whether the pool still appears
+// in the K+1 mark pool_stake_snapshot, which is what separates a pool that
+// left the pool set from one whose reward inputs are missing.
+func seedDepartureFixture(
+	t *testing.T,
+	network string,
+	koiosEpoch uint64,
+	paramEpochPoolInSet bool,
+) (dingoDir, cachePath string, poolBech32 string) {
+	t.Helper()
 	stakeEpoch := koiosEpoch - 1
 	paramEpoch := koiosEpoch + 1
 
@@ -1177,7 +1223,6 @@ func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
 		TotalActiveStake: types.Uint64(5_000_000),
 		SnapshotReady:    true,
 	}).Error)
-	// The K+1 snapshot exists and simply does not contain this pool.
 	require.NoError(t, gdb.Create(&models.EpochSummary{
 		Epoch:            paramEpoch,
 		TotalActiveStake: types.Uint64(5_000_000),
@@ -1203,14 +1248,30 @@ func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
 		Fees:     types.Uint64(300),
 	}).Error)
 
+	// Another pool always sits in the K+1 set, so membership is established
+	// either way and the two cases differ only in this pool's presence.
+	require.NoError(t, gdb.Create(&models.PoolStakeSnapshot{
+		Epoch:        paramEpoch,
+		SnapshotType: "mark",
+		PoolKeyHash:  testPoolKeyHash(t, 0x0a),
+		TotalStake:   types.Uint64(1_000),
+	}).Error)
+	if paramEpochPoolInSet {
+		require.NoError(t, gdb.Create(&models.PoolStakeSnapshot{
+			Epoch:        paramEpoch,
+			SnapshotType: "mark",
+			PoolKeyHash:  poolHash,
+			TotalStake:   types.Uint64(5_000_000),
+		}).Error)
+	}
+
 	sqlDB, err := gdb.DB()
 	require.NoError(t, err)
 	require.NoError(t, sqlDB.Close())
 
-	cachePath := filepath.Join(t.TempDir(), "cache.db")
+	cachePath = filepath.Join(t.TempDir(), "cache.db")
 	cache, err := OpenCache(cachePath, nil)
 	require.NoError(t, err)
-
 	fetchedAt := time.Now().Add(-time.Hour).UTC()
 	require.NoError(t, cache.CommitEpochData(
 		KoiosEpochInfo{
@@ -1242,6 +1303,26 @@ func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
 		},
 	))
 	require.NoError(t, cache.Close())
+	return dingoDir, cachePath, poolBech32
+}
+
+// TestCheckDegradedActivePoolStillErrors is the reviewer's degraded-active-pool
+// case. buildRewardStateInputs (ledger/snapshot/rotation.go) drops a pool with
+// stale registration data from reward_pool_input so one bad pool cannot wedge
+// the whole boundary capture, and says so explicitly: degraded pools are
+// excluded "and only from it — PoolStakeSnapshot and EpochSummary still
+// reflect the true observed stake".
+//
+// Such a pool is still in the K+1 pool set, so its missing reward-input row is
+// genuine missing input, not departure. Classifying it as pool_departed would
+// turn a real ERROR into a PASS, which is why departure is decided from
+// per-pool pool_stake_snapshot membership rather than from
+// epoch_summary.SnapshotReady (dingo #3485).
+func TestCheckDegradedActivePoolStillErrors(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	dingoDir, cachePath, _ := seedDepartureFixture(t, network, koiosEpoch, true)
 
 	result, err := Check(context.Background(), CheckConfig{
 		Network:   network,
@@ -1249,24 +1330,49 @@ func TestCheckDepartedPoolDoesNotErrorEpoch(t *testing.T) {
 		CachePath: cachePath,
 	}, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
-	require.Empty(
+	require.Contains(
 		t,
 		result.ErrorEpochs,
-		"a departed pool must not put epoch %d into ERROR", koiosEpoch,
+		koiosEpoch,
+		"a pool still in the K+1 pool set with no reward-input row is "+
+			"missing input, not a departure",
 	)
-	require.Empty(t, result.FailEpochs)
 
-	cache, err = OpenCache(cachePath, nil)
+	cache, err := OpenCache(cachePath, nil)
 	require.NoError(t, err)
 	defer cache.Close() //nolint:errcheck
 	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
 	require.NoError(t, err)
 	require.Len(t, mismatches, 1)
-	require.Equal(t, "reward_pool_input_params", mismatches[0].Field)
-	require.Equal(
+	require.Equal(t, CategoryDBMissing, mismatches[0].Category)
+}
+
+// TestCheckMissingRewardBundleStillErrors is the reviewer's no-bundle case.
+// saveSnapshotInTxn persists the mark pool_stake_snapshot and epoch summary on
+// every transition "regardless of reward-input availability", so a ready
+// epoch_summary at K+1 is compatible with the entire reward-input bundle
+// having been skipped. Every pool then looks absent from reward_pool_input at
+// once, and none of them departed.
+//
+// The pool set at K+1 still lists them, so each stays an ERROR.
+func TestCheckMissingRewardBundleStillErrors(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	// paramEpochPoolInSet: the whole bundle is missing, so no pool has a K+1
+	// reward_pool_input row while all of them remain in the pool set.
+	dingoDir, cachePath, _ := seedDepartureFixture(t, network, koiosEpoch, true)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Contains(
 		t,
-		CategoryPoolDeparted,
-		mismatches[0].Category,
-		"the uncomparable block count is recorded, not silently skipped",
+		result.ErrorEpochs,
+		koiosEpoch,
+		"a skipped reward-input bundle must not read as every pool departing",
 	)
 }

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1209,6 +1209,23 @@ func seedDepartureFixture(
 	paramEpochPoolInSet bool,
 ) (dingoDir, cachePath string, poolBech32 string) {
 	t.Helper()
+	return seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, paramEpochPoolInSet, 0,
+	)
+}
+
+// seedDepartureFixtureWithCount is seedDepartureFixture with control over the
+// K+1 epoch_summary's declared TotalPoolCount. declaredPools of 0 means "match
+// the mark rows actually written", i.e. a complete set; a larger value
+// simulates a set that was only partially read.
+func seedDepartureFixtureWithCount(
+	t *testing.T,
+	network string,
+	koiosEpoch uint64,
+	paramEpochPoolInSet bool,
+	declaredPools uint64,
+) (dingoDir, cachePath string, poolBech32 string) {
+	t.Helper()
 	stakeEpoch := koiosEpoch - 1
 	paramEpoch := koiosEpoch + 1
 
@@ -1223,9 +1240,20 @@ func seedDepartureFixture(
 		TotalActiveStake: types.Uint64(5_000_000),
 		SnapshotReady:    true,
 	}).Error)
+	// One mark row is always written for another pool; the subject pool adds
+	// a second when it is still in the set. The summary declares that same
+	// count unless the caller is simulating a partial read.
+	markRows := uint64(1)
+	if paramEpochPoolInSet {
+		markRows = 2
+	}
+	if declaredPools == 0 {
+		declaredPools = markRows
+	}
 	require.NoError(t, gdb.Create(&models.EpochSummary{
 		Epoch:            paramEpoch,
 		TotalActiveStake: types.Uint64(5_000_000),
+		TotalPoolCount:   declaredPools,
 		SnapshotReady:    true,
 	}).Error)
 	require.NoError(t, gdb.Create(&models.RewardPoolInput{
@@ -1375,4 +1403,46 @@ func TestCheckMissingRewardBundleStillErrors(t *testing.T) {
 		koiosEpoch,
 		"a skipped reward-input bundle must not read as every pool departing",
 	)
+}
+
+// TestCheckIncompleteParamEpochPoolSetStillErrors is the completeness case: a
+// non-empty pool-set read does not prove the set was fully recorded or fully
+// read.
+//
+// The K+1 epoch summary here declares two pools while only one mark row is
+// present. The absent pool would look departed against that partial set, which
+// would pass the epoch and hide a dingo_db_missing. Membership is only trusted
+// when the number of readable mark rows equals the count the summary declares,
+// both being written from the same StakeDistribution (dingo #3485).
+func TestCheckIncompleteParamEpochPoolSetStillErrors(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	// The pool is absent from the mark rows — which alone would read as
+	// departure — but the summary declares a pool that was never recorded, so
+	// the set is incomplete and absence proves nothing.
+	dingoDir, cachePath, _ := seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, false, 2,
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Contains(
+		t,
+		result.ErrorEpochs,
+		koiosEpoch,
+		"an incomplete K+1 pool set must not let absence read as departure",
+	)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryDBMissing, mismatches[0].Category)
 }

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -30,6 +30,14 @@ const (
 	CategoryReferenceLag  = "reference_lag"
 	CategoryDBError       = "dingo_db_error"   // DB query returned an unexpected error
 	CategoryDBMissing     = "dingo_db_missing" // expected DB row is absent
+	// CategoryPoolDeparted marks a pool that was in epoch K's stake basis but
+	// is absent from the captured K+1 snapshot -- it left the pool set. Its
+	// epoch-K block count lives on the K+1 reward_pool_input row, which
+	// therefore never exists, so blocks_produced cannot be compared for that
+	// one epoch. Purely informational, like the account lifecycle categories
+	// below: both sides agree the pool departed, so it is a documented gap in
+	// coverage rather than a divergence (dingo #3485).
+	CategoryPoolDeparted = "pool_departed"
 
 	// CategoryAcctOnlyDingo/CategoryAcctOnlyKoios mirror
 	// CategoryPoolOnlyDingo/CategoryPoolOnlyKoios but at per-account
@@ -313,6 +321,11 @@ func CompareEpochTotals(
 // epochEndTime is the actual epoch close time (from KoiosEpochInfo.EpochEndTime);
 // zero means unknown. graceHours: if the epoch closed within this many hours and
 // Dingo has no reward_pool_input row, emit reference_lag instead of pool_only_koios.
+// paramEpochCaptured reports whether Dingo has committed the K+1 snapshot the
+// blocks_produced read depends on. It distinguishes a pool that left the pool
+// set -- absent from a snapshot that exists -- from one whose K+1 row simply
+// has not been written yet, which is a genuine gap. Resolved once per epoch by
+// checkEpoch rather than per pool, so every caller agrees on it.
 func ComparePoolEpoch(
 	network string,
 	epoch uint64,
@@ -321,6 +334,7 @@ func ComparePoolEpoch(
 	now time.Time,
 	graceHours int,
 	epochEndTime time.Time,
+	paramEpochCaptured bool,
 ) []CheckMismatch {
 	var out []CheckMismatch
 
@@ -449,8 +463,17 @@ func ComparePoolEpoch(
 	// in Dingo's own computation (dingo_db_missing).
 	if !dingoPool.ParamsPresent {
 		cat := CategoryDBMissing
-		if graceHours > 0 && !epochEndTime.IsZero() &&
-			now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour {
+		switch {
+		case dingoPool.StakePresent && paramEpochCaptured:
+			// The pool was in this epoch's stake basis and is absent from a
+			// K+1 snapshot that exists, so it left the pool set. Its epoch-K
+			// block count is stamped onto the K+1 row that will never be
+			// written, so blocks_produced is not comparable for this one
+			// epoch. Recorded rather than skipped, so the gap is visible,
+			// but informational: both sides agree the pool departed.
+			cat = CategoryPoolDeparted
+		case graceHours > 0 && !epochEndTime.IsZero() &&
+			now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour:
 			cat = CategoryReferenceLag
 		}
 		out = append(out, CheckMismatch{
@@ -836,7 +859,8 @@ func DetermineStatus(mismatches []CheckMismatch) string {
 			hasError = true
 		case CategoryAcctZeroReward,
 			CategoryAcctNewlyRegistered,
-			CategoryAcctDeregistered:
+			CategoryAcctDeregistered,
+			CategoryPoolDeparted:
 			// Purely informational — see these categories' doc comments.
 			// Deliberately not counted toward hasError or default's FAIL: a
 			// zero-reward or lifecycle-change mismatch must never turn an

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -321,11 +321,15 @@ func CompareEpochTotals(
 // epochEndTime is the actual epoch close time (from KoiosEpochInfo.EpochEndTime);
 // zero means unknown. graceHours: if the epoch closed within this many hours and
 // Dingo has no reward_pool_input row, emit reference_lag instead of pool_only_koios.
-// paramEpochCaptured reports whether Dingo has committed the K+1 snapshot the
-// blocks_produced read depends on. It distinguishes a pool that left the pool
-// set -- absent from a snapshot that exists -- from one whose K+1 row simply
-// has not been written yet, which is a genuine gap. Resolved once per epoch by
-// checkEpoch rather than per pool, so every caller agrees on it.
+// departedAtParamEpoch reports whether this pool is provably absent from the
+// K+1 pool set, established from the mark pool_stake_snapshot rather than from
+// epoch_summary.SnapshotReady. That distinction matters: the snapshot writer
+// commits the epoch summary on every transition regardless of reward-input
+// availability, and deliberately omits a degraded active pool from
+// reward_pool_input while keeping it in the pool-stake snapshot. Both are
+// missing input rather than departure, so only per-pool absence from the K+1
+// pool set may downgrade the finding. False whenever membership could not be
+// established, which keeps the stricter classification (dingo #3485).
 func ComparePoolEpoch(
 	network string,
 	epoch uint64,
@@ -334,7 +338,7 @@ func ComparePoolEpoch(
 	now time.Time,
 	graceHours int,
 	epochEndTime time.Time,
-	paramEpochCaptured bool,
+	departedAtParamEpoch bool,
 ) []CheckMismatch {
 	var out []CheckMismatch
 
@@ -464,13 +468,15 @@ func ComparePoolEpoch(
 	if !dingoPool.ParamsPresent {
 		cat := CategoryDBMissing
 		switch {
-		case dingoPool.StakePresent && paramEpochCaptured:
-			// The pool was in this epoch's stake basis and is absent from a
-			// K+1 snapshot that exists, so it left the pool set. Its epoch-K
-			// block count is stamped onto the K+1 row that will never be
-			// written, so blocks_produced is not comparable for this one
-			// epoch. Recorded rather than skipped, so the gap is visible,
-			// but informational: both sides agree the pool departed.
+		case dingoPool.StakePresent && departedAtParamEpoch:
+			// The pool was in this epoch's stake basis and is absent from the
+			// K+1 pool set itself, so it left the set. Its epoch-K block
+			// count is stamped onto the K+1 row that will never be written,
+			// so blocks_produced is not comparable for this one epoch.
+			// Recorded rather than skipped, so the gap is visible, but
+			// informational: both sides agree the pool departed. A pool still
+			// in the K+1 pool set whose reward-input row is absent is missing
+			// input, not a departure, and falls through to the cases below.
 			cat = CategoryPoolDeparted
 		case graceHours > 0 && !epochEndTime.IsZero() &&
 			now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour:

--- a/internal/koiosparity/compare_test.go
+++ b/internal/koiosparity/compare_test.go
@@ -216,17 +216,17 @@ func TestComparePoolEpochFixedCostAndMargin(t *testing.T) {
 	}
 	require.Empty(
 		t,
-		ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}),
+		ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false),
 	)
 
 	dingo.FixedCost = "340000001"
-	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "fixed_cost", ms[0].Field)
 
 	dingo.FixedCost = "340000000"
 	dingo.Margin = "1/5"
-	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "margin", ms[0].Field)
 }
@@ -262,14 +262,14 @@ func TestComparePoolEpochEmptyDingoSideIsFlagged(t *testing.T) {
 
 	dingo := *baseline
 	dingo.FixedCost = ""
-	ms := ComparePoolEpoch("preview", 5, koios, &dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, &dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "fixed_cost", ms[0].Field)
 	require.Equal(t, CategoryValueMismatch, ms[0].Category)
 
 	dingo = *baseline
 	dingo.Margin = ""
-	ms = ComparePoolEpoch("preview", 5, koios, &dingo, now, 0, time.Time{})
+	ms = ComparePoolEpoch("preview", 5, koios, &dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "margin", ms[0].Field)
 	require.Equal(t, CategoryValueMismatch, ms[0].Category)
@@ -304,7 +304,7 @@ func TestComparePoolEpochParamsNotPresent(t *testing.T) {
 	}
 
 	// Historical (outside grace, or no grace configured): dingo_db_missing.
-	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "reward_pool_input_params", ms[0].Field)
 	require.Equal(t, CategoryDBMissing, ms[0].Category)
@@ -312,7 +312,7 @@ func TestComparePoolEpochParamsNotPresent(t *testing.T) {
 
 	// Recent (epoch closed within the grace window): reference_lag, not PASS.
 	recentClose := now.Add(-time.Hour)
-	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose)
+	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "reward_pool_input_params", ms[0].Field)
 	require.Equal(t, CategoryReferenceLag, ms[0].Category)
@@ -347,7 +347,7 @@ func TestComparePoolEpochStakeNotPresent(t *testing.T) {
 
 	// Historical (outside grace, or no grace configured): dingo_db_missing,
 	// never a value_mismatch against the zero-value stub.
-	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "reward_pool_input_stake", ms[0].Field)
 	require.Equal(t, CategoryDBMissing, ms[0].Category)
@@ -359,7 +359,7 @@ func TestComparePoolEpochStakeNotPresent(t *testing.T) {
 	// Recent (epoch closed within the grace window): reference_lag, not PASS
 	// and not a value_mismatch.
 	recentClose := now.Add(-time.Hour)
-	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose)
+	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "reward_pool_input_stake", ms[0].Field)
 	require.Equal(t, CategoryReferenceLag, ms[0].Category)
@@ -390,7 +390,7 @@ func TestComparePoolEpochMemberRewards(t *testing.T) {
 	}
 	require.Empty(
 		t,
-		ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}),
+		ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false),
 	)
 
 	// Reward calculation not yet finished for this pool/epoch: Dingo has no
@@ -399,7 +399,7 @@ func TestComparePoolEpochMemberRewards(t *testing.T) {
 	// (reference_lag) vs historical (dingo_db_missing) split this guards.
 	dingo.MemberRewardPresent = false
 	dingo.MemberRewardTotal = ""
-	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(
 		t,
 		ms,
@@ -412,7 +412,7 @@ func TestComparePoolEpochMemberRewards(t *testing.T) {
 	dingo.MemberRewardPresent = true
 
 	dingo.MemberRewardTotal = "1"
-	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "member_rewards", ms[0].Field)
 	require.Equal(t, CategoryValueMismatch, ms[0].Category)
@@ -444,7 +444,7 @@ func TestComparePoolEpochMemberRewardsNotPresent(t *testing.T) {
 
 	// Historical: outside the grace window (or no grace configured) — a
 	// genuine gap in Dingo's own computation.
-	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{})
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "member_rewards", ms[0].Field)
 	require.Equal(t, CategoryDBMissing, ms[0].Category)
@@ -453,7 +453,7 @@ func TestComparePoolEpochMemberRewardsNotPresent(t *testing.T) {
 	// Recent: epoch closed within the grace window — may simply not be
 	// computed yet, but still not a pass.
 	recentClose := now.Add(-time.Hour)
-	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose)
+	ms = ComparePoolEpoch("preview", 5, koios, dingo, now, 24, recentClose, false)
 	require.Len(t, ms, 1)
 	require.Equal(t, "member_rewards", ms[0].Field)
 	require.Equal(t, CategoryReferenceLag, ms[0].Category)
@@ -647,4 +647,116 @@ func TestLovelaceEqual(t *testing.T) {
 	require.False(t, lovelaceEqual("not-a-number", "not-a-number"))
 	require.False(t, lovelaceEqual("-5", "-5"))
 	require.False(t, lovelaceEqual("-5", "5"))
+}
+
+// TestComparePoolEpochDepartedPoolIsInformational covers a pool that was in
+// epoch K's stake basis but is absent from the committed K+1 snapshot: it left
+// the pool set.
+//
+// blocks_produced for epoch K lives on the K+1 reward_pool_input row, which
+// therefore never exists, so that one field cannot be compared. Both sides
+// agree the pool departed — Koios has no pool_history row at K+1's reporting
+// epoch either — so this is a documented gap in coverage, not a divergence,
+// and it must not escalate to ERROR and halt a strict-mode node (dingo #3485).
+func TestComparePoolEpochDepartedPoolIsInformational(t *testing.T) {
+	now := time.Now()
+	koios := &KoiosPoolEpoch{
+		PoolBech32:  "pool1test",
+		ActiveStake: "1000",
+		BlockCnt:    15,
+		Delegators:  3,
+		FixedCost:   "340000000",
+		Margin:      "0.1",
+	}
+	dingo := &DingoPoolEpochData{
+		StakePresent:   true,
+		DelegatedStake: "1000",
+		DelegatorCount: 3,
+		FixedCost:      "340000000",
+		Margin:         "1/10",
+		ParamsPresent:  false,
+	}
+
+	// The K+1 snapshot is committed, so the absent row means the pool left
+	// the set rather than the snapshot being unwritten.
+	ms := ComparePoolEpoch("preview", 5, koios, dingo, now, 0, time.Time{}, true)
+	require.Len(t, ms, 1)
+	require.Equal(t, "reward_pool_input_params", ms[0].Field)
+	require.Equal(t, CategoryPoolDeparted, ms[0].Category)
+	require.Equal(
+		t,
+		StatusPass,
+		DetermineStatus(ms),
+		"a departed pool must not fail or error the epoch",
+	)
+
+	// Same shape inside the grace window: still a departure, not lag.
+	ms = ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 24, now.Add(-time.Hour), true,
+	)
+	require.Len(t, ms, 1)
+	require.Equal(t, CategoryPoolDeparted, ms[0].Category)
+	require.Equal(t, StatusPass, DetermineStatus(ms))
+}
+
+// TestComparePoolEpochUncapturedParamEpochStillErrors is the negative case: an
+// absent K+1 row with no committed K+1 snapshot is a genuine gap in Dingo's
+// own computation and must keep escalating, so the departure classification
+// cannot be widened into suppressing real missing data.
+func TestComparePoolEpochUncapturedParamEpochStillErrors(t *testing.T) {
+	now := time.Now()
+	koios := &KoiosPoolEpoch{
+		PoolBech32:  "pool1test",
+		ActiveStake: "1000",
+		BlockCnt:    15,
+		Delegators:  3,
+		FixedCost:   "340000000",
+		Margin:      "0.1",
+	}
+	dingo := &DingoPoolEpochData{
+		StakePresent:   true,
+		DelegatedStake: "1000",
+		DelegatorCount: 3,
+		FixedCost:      "340000000",
+		Margin:         "1/10",
+		ParamsPresent:  false,
+	}
+
+	ms := ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, false,
+	)
+	require.Len(t, ms, 1)
+	require.Equal(t, CategoryDBMissing, ms[0].Category)
+	require.Equal(t, StatusError, DetermineStatus(ms))
+}
+
+// TestComparePoolEpochDepartedRequiresStakeEpochRow proves the departure
+// classification is anchored to the pool actually having been in epoch K's
+// stake basis. A pool absent from both reads is not a departure and keeps its
+// existing treatment.
+func TestComparePoolEpochDepartedRequiresStakeEpochRow(t *testing.T) {
+	now := time.Now()
+	koios := &KoiosPoolEpoch{
+		PoolBech32:  "pool1test",
+		ActiveStake: "1000",
+		BlockCnt:    15,
+		Delegators:  3,
+	}
+	dingo := &DingoPoolEpochData{
+		StakePresent:  false,
+		ParamsPresent: false,
+	}
+
+	ms := ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, true,
+	)
+	for _, m := range ms {
+		require.NotEqual(
+			t,
+			CategoryPoolDeparted,
+			m.Category,
+			"a pool with no stake-epoch row never departed epoch 5's basis",
+		)
+	}
+	require.Equal(t, StatusError, DetermineStatus(ms))
 }

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -51,7 +51,15 @@ type DingoDBConfig struct {
 // DingoEpochData holds epoch-level aggregates read directly from Dingo's database.
 type DingoEpochData struct {
 	TotalActiveStake string // lovelace decimal string (matches Koios format)
-	Fees             string // lovelace decimal string; empty when reward_ada_pots row absent
+	// TotalPoolCount is epoch_summary.total_pool_count: the number of pools
+	// in the distribution the mark pool_stake_snapshot rows for this epoch
+	// were written from (rotation.go sets both from the same
+	// StakeDistribution), so it is how many of those rows must be readable
+	// for the set to be complete. Deliberately not RewardSnapshot's
+	// TotalPoolCount, which counts the reduced reward distribution with
+	// degraded pools already excluded.
+	TotalPoolCount uint64
+	Fees           string // lovelace decimal string; empty when reward_ada_pots row absent
 	// TotalRewards is reward_ada_pots.rewards for this epoch alone: a fresh
 	// per-epoch FLOW value (rewards.Result.TotalRewardPot, overwritten every
 	// epoch — see ledger/reward_calculation.go:389,1955 and
@@ -242,6 +250,7 @@ func (d *DingoDB) GetEpochData(
 			uint64(summary.TotalActiveStake),
 			10,
 		),
+		TotalPoolCount: summary.TotalPoolCount,
 	}
 
 	var pots models.RewardAdaPots

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -295,6 +295,39 @@ func (d *DingoDB) GetEpochData(
 // "compared and equal". One bulk query per table per epoch (three total),
 // independent of pool count. ctx is forwarded to the DB driver so that a
 // cancelled context aborts the query.
+// GetPoolStakeSnapshotMembers implements RewardParitySource by reading the
+// mark pool_stake_snapshot rows for epoch. See the interface doc comment for
+// why this, and not epoch_summary.SnapshotReady, is the per-pool evidence of
+// pool-set membership.
+func (d *DingoDB) GetPoolStakeSnapshotMembers(
+	ctx context.Context,
+	epoch uint64,
+) (map[string]struct{}, error) {
+	rows, err := d.query(
+		ctx,
+		`SELECT pool_key_hash FROM pool_stake_snapshot WHERE epoch = ? AND snapshot_type = ?`,
+		epoch,
+		snapshotTypeMark,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pool_stake_snapshot epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	defer rows.Close()
+	members := make(map[string]struct{})
+	for rows.Next() {
+		var poolHash []byte
+		if err := rows.Scan(&poolHash); err != nil {
+			return nil, err
+		}
+		members[hex.EncodeToString(poolHash)] = struct{}{}
+	}
+	return members, rows.Err()
+}
+
 func (d *DingoDB) GetPoolEpochDataMap(
 	ctx context.Context,
 	stakeEpoch, paramEpoch uint64,

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -69,6 +69,19 @@ type RewardParitySource interface {
 		ctx context.Context,
 		stakeEpoch, paramEpoch uint64,
 	) (map[string]*DingoPoolEpochData, error)
+	// GetPoolStakeSnapshotMembers returns the set of pool key hashes (hex)
+	// present in the mark pool_stake_snapshot for epoch, which is written on
+	// every epoch transition regardless of reward-input availability (see
+	// ledger/snapshot/rotation.go's saveSnapshotInTxn). It is therefore the
+	// per-pool evidence of whether a pool was still in the pool set at that
+	// epoch, which epoch_summary.SnapshotReady cannot provide: that flag is
+	// epoch-level and is set even when the whole reward-input bundle was
+	// skipped, and buildRewardStateInputs deliberately omits a degraded
+	// active pool from reward_pool_input while keeping it here.
+	GetPoolStakeSnapshotMembers(
+		ctx context.Context,
+		epoch uint64,
+	) (map[string]struct{}, error)
 	// GetRewardAccountOutputs returns every per-account reward calculation
 	// output row Dingo committed for epoch. Not yet consumed by any
 	// comparison (that is #3097's scope); exposed now so the source
@@ -203,6 +216,43 @@ func (s *DatabaseSource) GetEpochData(
 // GetPoolEpochDataMap returns per-pool reward data assembled for Koios
 // reporting epoch koiosEpoch — see DingoDB.GetPoolEpochDataMap's doc comment
 // for the stakeEpoch/paramEpoch derivation this mirrors exactly.
+// GetPoolStakeSnapshotMembers implements RewardParitySource by reading the
+// mark pool_stake_snapshot rows for epoch.
+// snapshotTypeMark is the pool_stake_snapshot/reward_snapshot type the parity
+// comparison reads; Dingo writes the boundary capture under this name.
+const snapshotTypeMark = "mark"
+
+func (s *DatabaseSource) GetPoolStakeSnapshotMembers(
+	ctx context.Context,
+	epoch uint64,
+) (map[string]struct{}, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	txn := s.db.Transaction(false)
+	defer txn.Release()
+	rows, err := s.db.Metadata().GetPoolStakeSnapshotsByEpoch(
+		epoch,
+		snapshotTypeMark,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pool_stake_snapshot epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	members := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		members[hex.EncodeToString(row.PoolKeyHash)] = struct{}{}
+	}
+	return members, nil
+}
+
 func (s *DatabaseSource) GetPoolEpochDataMap(
 	ctx context.Context,
 	stakeEpoch, paramEpoch uint64,

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -197,6 +197,7 @@ func (s *DatabaseSource) GetEpochData(
 			uint64(summary.TotalActiveStake),
 			10,
 		),
+		TotalPoolCount: summary.TotalPoolCount,
 	}
 
 	pots, err := meta.GetRewardAdaPots(epoch, txn.Metadata())

--- a/internal/koiosparity/sql_test_helpers_test.go
+++ b/internal/koiosparity/sql_test_helpers_test.go
@@ -34,6 +34,9 @@ func (d *testDB) Create(value any) testResult {
 	case *models.RewardAccountOutput:
 		query = `INSERT INTO reward_account_output (staking_key,pool_key_hash,reward_type,epoch,credential_tag,amount,spendable,guarded,captured_slot,boundary_slot) VALUES (?,?,?,?,?,?,?,?,?,?)`
 		args = []any{v.StakingKey, v.PoolKeyHash, v.RewardType, v.Epoch, v.CredentialTag, v.Amount, v.Spendable, v.Guarded, v.CapturedSlot, v.BoundarySlot}
+	case *models.PoolStakeSnapshot:
+		query = `INSERT INTO pool_stake_snapshot (epoch,snapshot_type,pool_key_hash,total_stake,stake_denominator,delegator_count,captured_slot) VALUES (?,?,?,?,?,?,?)`
+		args = []any{v.Epoch, v.SnapshotType, v.PoolKeyHash, v.TotalStake, v.StakeDenominator, v.DelegatorCount, v.CapturedSlot}
 	default:
 		return testResult{Error: fmt.Errorf("unsupported test row %T", value)}
 	}
@@ -75,6 +78,7 @@ type testingT interface {
 
 func testSchema(includePools bool) []string {
 	ret := []string{
+		`CREATE TABLE pool_stake_snapshot (id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL, snapshot_type TEXT NOT NULL, pool_key_hash BLOB NOT NULL, total_stake TEXT NOT NULL, stake_denominator TEXT NOT NULL DEFAULT '0', delegator_count INTEGER NOT NULL DEFAULT 0, captured_slot INTEGER NOT NULL DEFAULT 0)`,
 		`CREATE TABLE epoch_summary (id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL UNIQUE, total_active_stake TEXT NOT NULL, total_pool_count INTEGER NOT NULL DEFAULT 0, total_delegators INTEGER NOT NULL DEFAULT 0, epoch_nonce BLOB, boundary_slot INTEGER NOT NULL DEFAULT 0, snapshot_ready NUMERIC NOT NULL DEFAULT 0)`,
 		`CREATE TABLE reward_ada_pots (id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL UNIQUE, treasury TEXT NOT NULL, reserves TEXT NOT NULL, fees TEXT NOT NULL, rewards TEXT NOT NULL, captured_slot INTEGER NOT NULL DEFAULT 0)`,
 		// reward_account_output is created unconditionally (not gated behind


### PR DESCRIPTION
Fixes #3485. Now based on `main` — #3478, #3482 and #3536 have all merged.

## Problem

`blocks_produced` for Koios epoch K is read from the `reward_pool_input` row at **K+1**, because `buildRewardStateInputs` stamps the count from `evt.PreviousEpoch`. A pool that was in epoch K's stake basis but leaves the pool set at K+1 has no such row, so `ComparePoolEpoch` reported `reward_pool_input_params` as `dingo_db_missing` — which `DetermineStatus` escalates to ERROR, halting a strict-mode node.

This is the mirror image of #3483, where a pool *entered* the set at K+1.

## Both sides agree the pool departed

Preview epoch 14, pool `pool1nk3uj4fdd6d42tx26y537xaejd76u6xyrn0ql8sr4r9tullk84y`:

| epoch | Dingo `reward_pool_input` | Koios `pool_history` |
| ---: | --- | --- |
| 13 | present, blocks 0 | present |
| 14 | present, blocks 10 | present, block_cnt 15 |
| 15 | **absent** | present |
| 16 | — | **absent** |

Dingo's epoch-15 snapshot is complete — `epoch_summary` has `snapshot_ready = 1` and `total_pool_count = 47`, with 47 `reward_pool_input` rows — the pool is simply no longer in it. Under the K-1 stake mapping, Dingo's absent epoch-15 row corresponds to Koios's absent epoch-16 row. Neither side has a divergence; there is just nowhere for epoch 14's block count to live.

## Change

`checkEpoch` resolves once per epoch whether the K+1 snapshot is committed — `GetEpochData` returns nil unless `epoch_summary.SnapshotReady` is set, so a non-nil result is exactly that — and passes it to `ComparePoolEpoch`. A pool present at the stake epoch and absent from a committed K+1 snapshot is recorded as **`pool_departed`**, a new informational category alongside the existing `acct_zero_reward` / `acct_newly_registered` / `acct_deregistered` ones: the uncomparable field is still reported so the coverage gap stays visible, but it neither fails nor errors the epoch.

An absent row with **no** committed K+1 snapshot keeps `dingo_db_missing`, and a lookup error leaves the flag false, which keeps the stricter classification.

The signal is a parameter resolved by the caller rather than a field on `DingoPoolEpochData`, so the two `RewardParitySource` implementations cannot drift on it — they did exactly that during #3484.

## Design note

The block count itself is *not* unavailable: `pool_opcert_sequence` still holds it, and the reward calculation counts blocks from there rather than from this column (`rewardPoolFromInput` takes `blocksProduced` as a parameter and never reads `input.BlocksProduced`). So a direct count could have been substituted for departed pools.

I did not do that, deliberately. For every pool where the K+1 row *does* exist, the comparison's value is that it validates the persisted column against Koios; substituting a fresh computation would quietly stop checking what Dingo actually stored. Adding a second, count-based path only for departed pools means a new source method on both implementations for a case worth one row per pool per lifetime. Recording the gap explicitly keeps the check honest at a fraction of the surface. Happy to take the other approach if a reviewer prefers it.

## Validation: live Preview genesis replay

```
dingo serve --network preview --data-dir <dir> --storage-mode api \
  --socket-path /tmp/dg/n.socket \
  --port 3471 --private-port 3472 --metrics-port 12871 --debug-port 0 \
  --koios-parity-enabled --koios-parity-strict --koios-parity-accounts=false
```

Before: ERROR at epoch 14, node halted.

After: **epochs 0 through 15 all validate**, reaching slot 1430078 with zero `level=ERROR` lines. All 16 epoch statuses are PASS, and the departure is recorded:

```
epoch  pool                  field                     category
14     pool1nk3uj4fdd6d42tx  reward_pool_input_params  pool_departed
15     pool1nk3uj4fdd6d42tx  reward_pool_input_params  pool_departed
```

## Tests

The two departure tests fail with the classification branch disabled and pass with it; the negative cases hold in both states.

- `TestComparePoolEpochDepartedPoolIsInformational` — departed pool yields `pool_departed` and `StatusPass`, inside and outside the grace window.
- `TestCheckDepartedPoolDoesNotErrorEpoch` — end-to-end through `Check`, proving `checkEpoch` resolves the K+1 readiness itself; asserts no ERROR epochs and that the row is recorded rather than skipped.
- `TestComparePoolEpochUncapturedParamEpochStillErrors` — negative case; an uncommitted K+1 snapshot still yields `dingo_db_missing`/ERROR.
- `TestComparePoolEpochDepartedRequiresStakeEpochRow` — negative case; a pool absent from both reads is not a departure.

`ARCHITECTURE.md`'s Koios Parity Tracker section documents the exception and the new category.

## Checks

- `make test` (race): pass
- `golangci-lint run ./...`: 0 issues; `nilaway`: clean
- `modernize`: 5 findings, all pre-existing on an `origin/main` baseline in untouched files
- `make import-boundaries`, `make docs-parity`, `make golines`: pass
- Live Preview genesis replay with the strict in-process Koios observer, as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added informational reporting for pools that departed after a committed pool snapshot.
  * Departed pools no longer affect parity check status.

* **Bug Fixes**
  * Missing pool records remain errors when snapshot membership is unavailable or incomplete.
  * Improved distinction between departed pools and uncaptured or missing data.

* **Documentation**
  * Documented the `pool_departed` mismatch category and classification rules.

* **Tests**
  * Added coverage for departed pools, incomplete snapshots, missing records, and uncaptured reward data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->