### PR TITLE
fix(ledger): reject blocks whose leader eligibility cannot be evaluated

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6662,7 +6662,14 @@ on by the network profile itself rather than by operator configuration:
   because dingo's leadership stake is delegated UTxO only — staking rewards are
   not yet computed — which spuriously rejects the dominant pool's eligible
   blocks on Musashi's concentrated topology. Every cryptographic header check
-  (KES, VRF proof, registered-VRF-key binding, opcert) still applies.
+  (KES, VRF proof, registered-VRF-key binding, opcert) still applies. The same
+  flag is also the only bypass for the two states in which the threshold cannot
+  be computed at all — a zero total active stake while the producing pool holds
+  stake, and an unavailable or non-positive active slot coefficient. Standard
+  profiles reject a block they cannot evaluate rather than accepting it: the
+  stake case is classified as an unavailable snapshot so header verification
+  running ahead of the ledger apply cursor still defers, while the coefficient
+  case is a genesis fault the cursor never resolves and is rejected outright.
 - `SkipDijkstraTxValidation` skips *running* the per-transaction rule set for
   **Dijkstra-era transactions only** (`LedgerState.skipDijkstraTxValidation`);
   Conway and earlier are still validated on a Musashi node. The prototype

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -954,32 +954,70 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 		return nil
 	}
 	if totalStake == 0 {
-		// Genesis snapshot not yet written (very early bootstrap).
-		// Skip rather than reject.
-		ls.config.Logger.Warn(
-			"skipping leader eligibility check: total active stake is zero",
-			"slot", block.SlotNumber(),
-			"epoch", epochId,
-			"snapshot_epoch", snapshotEpoch,
-			"snapshot_type", snapshotType,
-			"component", "ledger",
+		// leaderEligibilityStake already rejected an absent or zero pool
+		// row, so reaching here means the producer holds stake while the
+		// network-wide denominator reads zero: a dingo-side storage or
+		// computation gap rather than an empty network, and a threshold
+		// with no denominator to divide by. Accepting the block would
+		// admit a producer nothing verified, so only the explicitly
+		// selected prototype profile may bypass it.
+		if ls.config.SkipLeaderStakeThresholdCheck {
+			ls.config.Logger.Warn(
+				"leader eligibility unevaluable: total active stake is zero; trusting block (prototype profile)",
+				"slot",
+				block.SlotNumber(),
+				"epoch",
+				epochId,
+				"snapshot_epoch",
+				snapshotEpoch,
+				"snapshot_type",
+				snapshotType,
+				"component",
+				"ledger",
+			)
+			return nil
+		}
+		// Classified as an unavailable snapshot so header verification
+		// running ahead of the ledger apply cursor defers instead of
+		// rejecting (verifyBlockHeaderState); once the cursor has caught
+		// up the same state is a hard rejection.
+		return fmt.Errorf(
+			"%w: block header verification rejected at slot %d: "+
+				"total active stake for epoch %d snapshot %s is zero "+
+				"while producer pool %x holds stake",
+			errLeaderStakeSnapshotUnavailable,
+			block.SlotNumber(),
+			snapshotEpoch,
+			snapshotType,
+			poolKeyHash[:],
 		)
-		return nil
 	}
 
 	// Use the genesis Rat directly to avoid a float64 precision roundtrip.
-	// A zero or negative coefficient would compute a zero threshold and
-	// reject every non-Byron block; treat it as unavailable.
+	// A zero or negative coefficient computes a zero threshold, under which
+	// no VRF output is ever eligible.
 	activeSlotCoeffRat := ls.activeSlotCoeffRat()
 	if activeSlotCoeffRat == nil || activeSlotCoeffRat.Sign() <= 0 {
-		ls.config.Logger.Warn(
-			"skipping leader eligibility check: active slot coefficient unavailable or non-positive",
-			"slot",
+		// The coefficient is a threshold input, so without it eligibility
+		// cannot be evaluated at all. Unlike a missing snapshot this is a
+		// genesis/configuration fault that the apply cursor never
+		// resolves, so it is rejected outright rather than deferred.
+		if ls.config.SkipLeaderStakeThresholdCheck {
+			ls.config.Logger.Warn(
+				"leader eligibility unevaluable: active slot coefficient unavailable or non-positive; trusting block (prototype profile)",
+				"slot",
+				block.SlotNumber(),
+				"component",
+				"ledger",
+			)
+			return nil
+		}
+		return fmt.Errorf(
+			"block header verification rejected at slot %d: "+
+				"active slot coefficient unavailable or non-positive; "+
+				"leader eligibility cannot be evaluated",
 			block.SlotNumber(),
-			"component",
-			"ledger",
 		)
-		return nil
 	}
 
 	// Consensus mode determines the VRF leader-value derivation path.

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1166,6 +1166,39 @@ func (ls *LedgerState) leaderEligibilityStake(
 		if snapshot == nil ||
 			snapshot.TotalStake == 0 ||
 			snapshot.StakeDenominator == 0 {
+			// Mirror the mark path below and separate a storage gap from
+			// genuine ineligibility. A zero denominator leaves the
+			// threshold with no divisor, and an imported distribution
+			// holding no pools at all cannot be the certified nesPd
+			// (which is always populated); both mean dingo cannot yet
+			// answer, so they are classified as unavailable and header
+			// verification ahead of the apply cursor defers. A pool
+			// simply absent from a populated distribution is an
+			// authoritative answer -- cardano-ledger's VRFKeyUnknown --
+			// and stays a rejection.
+			unavailable := snapshot != nil && snapshot.StakeDenominator == 0
+			if !unavailable {
+				if total, terr := ls.db.Metadata().GetTotalActiveStake(
+					epochId,
+					models.PoolStakeSnapshotTypeActive,
+					nil,
+				); terr == nil && total == 0 {
+					unavailable = true
+				}
+			}
+			if unavailable {
+				return 0, 0, epochId,
+					models.PoolStakeSnapshotTypeActive, false,
+					fmt.Errorf(
+						"%w: block header verification rejected at slot %d: "+
+							"producer pool %x missing from active pool distribution "+
+							"for epoch %d (imported distribution is incomplete)",
+						errLeaderStakeSnapshotUnavailable,
+						block.SlotNumber(),
+						poolKeyHash[:],
+						epochId,
+					)
+			}
 			return 0, 0, epochId, models.PoolStakeSnapshotTypeActive, false,
 				fmt.Errorf(
 					"block header verification rejected at slot %d: "+

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -2390,19 +2390,23 @@ func TestVerifyBlockLeaderEligibility_LiveComputedHistoricalMarkStillChecks(
 	)
 }
 
-// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips verifies that
-// when the active slot coefficient is unavailable (Shelley genesis not loaded),
-// the eligibility check is skipped rather than rejecting the block.
-func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips(t *testing.T) {
-	tb := createTestBlock(t, [32]byte{34}, 0, tamperNone)
-
+// newCoeffGuardLedger builds a ledger whose pool stake is already seeded, so
+// verifyBlockLeaderEligibility reaches the active-slot-coefficient guard. cfg
+// is the Shelley genesis under test (nil for "genesis never loaded"), and
+// prototypeProfile selects the Musashi prototype bypass.
+func newCoeffGuardLedger(
+	t *testing.T,
+	tb *testBlockResult,
+	cfg *cardano.CardanoNodeConfig,
+	prototypeProfile bool,
+) *LedgerState {
+	t.Helper()
 	db, err := dbtest.NewDatabase(t, &database.Config{
 		DataDir: "",
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { dbtest.CloseDatabase(db) }) //nolint:errcheck
 
-	// Seed a pool stake snapshot so the check reaches the coeff lookup.
 	poolKeyHash := tb.block.IssuerVkey().Hash()
 	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
 
@@ -2417,67 +2421,172 @@ func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips(t *testing.T) {
 			},
 		},
 		config: LedgerStateConfig{
-			// No CardanoNodeConfig → ActiveSlotCoeff() returns 0 → skip.
-			Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			CardanoNodeConfig:             cfg,
+			SkipLeaderStakeThresholdCheck: prototypeProfile,
+			Logger: slog.New(
+				slog.NewTextHandler(io.Discard, nil),
+			),
 		},
 	}
 	ls.publishSnapshotsLocked()
-
-	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
-	assert.NoError(t, err, "missing active slot coeff should skip, not reject")
+	return ls
 }
 
-// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffSkips_ExplicitZero
-// verifies that a genesis with activeSlotsCoeff=0 also triggers the skip path.
-// A zero coefficient produces a zero threshold and would otherwise reject every
-// non-Byron block.
-func TestVerifyBlockLeaderEligibility_ZeroCoeffSkips(t *testing.T) {
-	tb := createTestBlock(t, [32]byte{36}, 0, tamperNone)
-
-	db, err := dbtest.NewDatabase(t, &database.Config{
-		DataDir: "",
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { dbtest.CloseDatabase(db) }) //nolint:errcheck
-
-	poolKeyHash := tb.block.IssuerVkey().Hash()
-	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
-
-	// Build a genesis config with activeSlotsCoeff explicitly set to 0.
-	// big.Rat.SetString("0") gives Sign()==0, which the guard must catch.
+// newZeroCoeffGenesisCfg returns a Shelley genesis with activeSlotsCoeff
+// explicitly 0. big.Rat.SetString("0") gives Sign()==0, which the guard must
+// catch: a zero coefficient produces a zero threshold, under which no VRF
+// output is ever below the threshold.
+func newZeroCoeffGenesisCfg(t testing.TB) *cardano.CardanoNodeConfig {
+	t.Helper()
 	zeroCoeffJSON := `{
 		"activeSlotsCoeff": 0,
 		"securityParam": 432,
 		"slotsPerKESPeriod": 129600,
 		"systemStart": "2022-10-25T00:00:00Z"
 	}`
-	zeroCfg := &cardano.CardanoNodeConfig{}
+	cfg := &cardano.CardanoNodeConfig{}
 	require.NoError(
 		t,
-		zeroCfg.LoadShelleyGenesisFromReader(strings.NewReader(zeroCoeffJSON)),
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(zeroCoeffJSON)),
 	)
+	return cfg
+}
 
-	ls := &LedgerState{
-		db: db,
-		epochCache: []models.Epoch{
-			{
-				EpochId:       5,
-				StartSlot:     0,
-				LengthInSlots: 1_000_000,
-				Nonce:         tb.epochNonce,
-			},
-		},
-		config: LedgerStateConfig{
-			CardanoNodeConfig: zeroCfg,
-			Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		},
-	}
+// TestVerifyBlockLeaderEligibility_MissingActiveSlotsCoeffRejects verifies that
+// an unavailable active slot coefficient (Shelley genesis not loaded) rejects
+// the block on a standard profile. The coefficient is an input to the
+// leadership threshold, so without it eligibility cannot be evaluated at all;
+// accepting the block anyway admits an unverified producer.
+func TestVerifyBlockLeaderEligibility_MissingActiveSlotsCoeffRejects(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{34}, 0, tamperNone)
+	ls := newCoeffGuardLedger(t, tb, nil, false)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err, "unevaluable eligibility must not be accepted")
+	assert.Contains(t, err.Error(), "active slot coefficient")
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffRejects covers the same
+// guard for a genesis that loads but carries activeSlotsCoeff=0.
+func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffRejects(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{36}, 0, tamperNone)
+	ls := newCoeffGuardLedger(t, tb, newZeroCoeffGenesisCfg(t), false)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err, "a zero coefficient must not be accepted")
+	assert.Contains(t, err.Error(), "active slot coefficient")
+}
+
+// TestVerifyBlockLeaderEligibility_MissingActiveSlotsCoeffPrototypeAccepts
+// pins the one profile that may still bypass the check. The Musashi prototype
+// already trusts stake-derived threshold failures
+// (SkipLeaderStakeThresholdCheck); an unevaluable threshold is bypassed under
+// the same explicitly selected profile and nowhere else.
+func TestVerifyBlockLeaderEligibility_MissingActiveSlotsCoeffPrototypeAccepts(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{34}, 0, tamperNone)
+	ls := newCoeffGuardLedger(t, tb, nil, true)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "prototype profile keeps its documented bypass")
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffPrototypeAccepts is the
+// zero-coefficient half of the prototype bypass.
+func TestVerifyBlockLeaderEligibility_ZeroActiveSlotsCoeffPrototypeAccepts(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{36}, 0, tamperNone)
+	ls := newCoeffGuardLedger(t, tb, newZeroCoeffGenesisCfg(t), true)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "prototype profile keeps its documented bypass")
+}
+
+// seedZeroTotalActiveStakeSummary marks the epoch's mark aggregate ready at
+// zero. GetTotalActiveStake prefers a ready epoch_summary over summing the
+// pool rows, so this reproduces the inconsistency the guard is about: the
+// producing pool holds stake, yet the network-wide denominator reads zero.
+func seedZeroTotalActiveStakeSummary(
+	t *testing.T,
+	db *database.Database,
+	epoch uint64,
+) {
+	t.Helper()
+	require.NoError(
+		t,
+		db.Metadata().SaveEpochSummary(epochSummary(epoch, 0), nil),
+	)
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroTotalActiveStakeRejects verifies that a
+// zero total active stake rejects rather than accepting the block. The pool
+// row carries stake, so this is a storage or computation gap in dingo's own
+// aggregate, not a genuinely empty network — and the threshold's denominator
+// is unusable either way.
+func TestVerifyBlockLeaderEligibility_ZeroTotalActiveStakeRejects(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{37}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
+	seedZeroTotalActiveStakeSummary(t, db, 4)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err, "a zero stake denominator must not be accepted")
+	assert.Contains(t, err.Error(), "total active stake")
+	// Classified as an unavailable snapshot so header verification running
+	// ahead of the ledger apply cursor can defer instead of rejecting.
+	assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+}
+
+// TestVerifyBlockLeaderEligibility_ZeroTotalActiveStakePrototypeAccepts pins
+// the prototype bypass for the stake half of the guard.
+func TestVerifyBlockLeaderEligibility_ZeroTotalActiveStakePrototypeAccepts(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{37}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.config.SkipLeaderStakeThresholdCheck = true
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
+	seedZeroTotalActiveStakeSummary(t, db, 4)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	assert.NoError(t, err, "prototype profile keeps its documented bypass")
+}
+
+// TestVerifyBlockHeaderCryptoBeforeApplyDefersZeroTotalActiveStake verifies
+// that the new rejection does not break blockfetch header verification during
+// catch-up: while the ledger apply cursor is behind the block, a missing
+// aggregate defers, and it only becomes a rejection once the cursor has
+// caught up.
+func TestVerifyBlockHeaderCryptoBeforeApplyDefersZeroTotalActiveStake(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{38}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	seedBlockPoolRegistration(t, db, tb.block)
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
+	seedZeroTotalActiveStakeSummary(t, db, 4)
+
+	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
 	ls.publishSnapshotsLocked()
 
-	err = ls.verifyBlockLeaderEligibility(tb.block, 5)
-	assert.NoError(
-		t,
-		err,
-		"zero active slot coeff should skip, not reject all blocks",
-	)
+	err := ls.verifyBlockHeaderCryptoBeforeApply(tb.block)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
+	assert.Contains(t, err.Error(), "leader stake snapshot state")
+
+	err = ls.verifyBlockHeaderCrypto(tb.block)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errHeaderVerificationDeferred)
+	assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -2590,3 +2590,98 @@ func TestVerifyBlockHeaderCryptoBeforeApplyDefersZeroTotalActiveStake(
 	assert.NotErrorIs(t, err, errHeaderVerificationDeferred)
 	assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
 }
+
+// newImportedActiveLedger builds a ledger positioned inside a Mithril-imported
+// epoch, so leaderEligibilityStake takes the imported active-distribution
+// branch rather than the rotated mark snapshot.
+func newImportedActiveLedger(
+	t *testing.T,
+	tb *testBlockResult,
+) (*LedgerState, *database.Database) {
+	t.Helper()
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	if tb.block.slot <= 1 {
+		// Slot 0 disables the Mithril boundary sentinel; move the mock
+		// block past it. This test exercises stake-source selection, not
+		// VRF proof input.
+		tb.block.slot = 2
+	}
+	ls.currentEpoch = models.Epoch{
+		EpochId:       5,
+		StartSlot:     0,
+		LengthInSlots: 1_000_000,
+		Nonce:         tb.epochNonce,
+	}
+	ls.mithrilLedgerSlot = tb.block.slot - 1
+	ls.publishSnapshotsLocked()
+	return ls, db
+}
+
+// TestVerifyBlockLeaderEligibility_ImportedActiveZeroDenominatorIsUnavailable
+// verifies that a pool row carrying stake with a zero stake denominator is
+// classified as an unavailable snapshot. The denominator is the threshold's
+// divisor, so its absence means eligibility cannot be evaluated — a storage
+// gap in the import, not a statement that the pool is ineligible.
+func TestVerifyBlockLeaderEligibility_ImportedActiveZeroDenominatorIsUnavailable(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{39}, 0, tamperNone)
+	ls, db := newImportedActiveLedger(t, tb)
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	seedPoolStakeSnapshotOfType(
+		t,
+		db,
+		5,
+		models.PoolStakeSnapshotTypeActive,
+		poolKeyHash[:],
+		1_000_000_000,
+		0,
+	)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+}
+
+// TestVerifyBlockLeaderEligibility_ImportedActiveEmptyDistributionIsUnavailable
+// covers an imported epoch with no active rows at all. cardano-ledger's
+// nesPd is always populated, so an empty one is dingo-side incompleteness.
+func TestVerifyBlockLeaderEligibility_ImportedActiveEmptyDistributionIsUnavailable(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{40}, 0, tamperNone)
+	ls, _ := newImportedActiveLedger(t, tb)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing from active pool distribution")
+	assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+}
+
+// TestVerifyBlockLeaderEligibility_ImportedActivePoolAbsentStaysHardRejection
+// is the negative case that keeps the classification honest: when the imported
+// distribution is populated and this pool is simply not in it, the answer is
+// authoritative. That is cardano-ledger's VRFKeyUnknown and must stay a
+// rejection, not become a deferrable "snapshot unavailable".
+func TestVerifyBlockLeaderEligibility_ImportedActivePoolAbsentStaysHardRejection(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{41}, 0, tamperNone)
+	ls, db := newImportedActiveLedger(t, tb)
+	otherPool := make([]byte, 28)
+	otherPool[0] = 0xAB
+	seedPoolStakeSnapshotOfType(
+		t,
+		db,
+		5,
+		models.PoolStakeSnapshotTypeActive,
+		otherPool,
+		1_000_000_000,
+		1_000_000_000,
+	)
+
+	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing from active pool distribution")
+	assert.NotErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+}


### PR DESCRIPTION
Refs #1649

Two paths in `verifyBlockLeaderEligibility` returned `nil` when the Praos
leadership threshold could not be computed, so the node accepted a block that
no eligibility check had verified:

- `totalStake == 0`. `leaderEligibilityStake` already rejects an absent or
  zero pool row, so reaching this means the producing pool holds stake while
  the network-wide denominator reads zero — a dingo-side storage or
  computation gap, not an empty network, and no denominator to divide by.
- `activeSlotCoeffRat()` nil or non-positive: Shelley genesis absent, or
  `activeSlotsCoeff <= 0`. The coefficient is a threshold input, so
  eligibility cannot be evaluated at all.

Both now reject on standard profiles. The Musashi prototype keeps the bypass
it already has for stake-derived threshold failures
(`SkipLeaderStakeThresholdCheck`), which is now also the only bypass for these
two states.

The zero-stake rejection wraps `errLeaderStakeSnapshotUnavailable`, so
`verifyBlockHeaderState` still defers when header verification runs ahead of
the ledger apply cursor; catch-up behaviour is unchanged. The coefficient fault
is a genesis misconfiguration the apply cursor never resolves, so it is not
deferrable.

Scope: this covers the "Consensus fail-open cases" section of #1649. The
Mithril-reconstructed mark bypass (`skipEligibility`) is unchanged — it needs
the halt-and-recover mechanism the issue describes, and ARCHITECTURE.md
documents it as a deliberate conservative bypass tied to certified snapshot
provenance.

Documentation: `ARCHITECTURE.md` Musashi prototype profile boundary updated.
`DATABASE.md` checked, not affected.

Validation on this head:

- `go test -race -count=1 ./ledger` — pass (two runs, 251s / 260s)
- `go test -count=1 ./internal/test/conformance` — pass
- `./internal/test/devnet/run-tests.sh` (all-Dingo) — pass, exit 0;
  `TestEpochBoundaryConsensus` 450s, `TestSustainedConsensus` 102s,
  txpump submitted=9 rejected=0 error=0
- `golangci-lint run ./ledger/...`, `nilaway ./ledger/...`,
  `modernize ./ledger/...` — clean
- `make import-boundaries`, `make docs-parity`, `make gorm-check` — pass
- `golines` — the two changed files are clean

The four rejection tests were confirmed failing before the fix; the three
prototype-bypass tests were confirmed failing under a mutation that removes the
bypass.

Not run: Antithesis, and the `--conformance` DevNet mode against `cardano-node`
(the change alters no wire or reference-comparable behaviour; the all-Dingo run
covers block acceptance and the epoch boundary).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block validation when active stake is zero or active slot coefficient data is missing or invalid.
  * Standard profiles now reject blocks when leader eligibility cannot be evaluated.
  * Header verification can defer validation when active stake data is temporarily unavailable.
  * The Musashi prototype profile continues to allow these conditions when its bypass setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->