### PR TITLE
fix(database): report blob deletes that leave unreachable objects

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1257,6 +1257,32 @@ recovered input. This check is not applied below the boundary or on the Mithril
 gap-closure recovery path, where imported history need not carry a block-index
 entry for the producer.
 
+### Unreachable Blob Objects
+
+UTxO and transaction deletion removes the blob object first and the metadata
+row that names it second (`deleteUtxoBlobs`, `deleteTxBlobs`, called from
+`UtxosDeleteRolledback`, the consumed-UTxO cleanup, and
+`TransactionsDeleteRolledback`). Metadata is the source of truth, so the order
+cannot be reversed and a blob failure cannot abort the metadata delete: a
+rolled-back UTxO must not stay in the live set because its blob is stuck.
+
+The consequence is that a failed blob delete strands an object permanently. It
+is not the same orphan the durability contract above describes: those sit
+*beyond* the metadata tip and startup reconciliation trims them
+(`cleanupOrphanedBlobs`). These sit *beneath* the tip with no row pointing at
+them, so nothing can name them again and no sweep reclaims them. They are
+unreachable, not merely unreferenced, and they consume disk until the store is
+rebuilt from scratch.
+
+Both deleters therefore report `ErrBlobDeleteIncomplete` with the failed and
+total counts instead of reporting a clean deletion, their callers log the
+condition at error level, and every stranded object increments
+`dingo_database_blob_orphans_total` (registered by `RegisterBlobOrphanMetrics`,
+readable in-process via `BlobOrphanCount`). That counter is the only signal
+that a blob store is accumulating dead data, so a non-zero and growing value is
+worth alerting on: it means blob deletes are failing, and the objects already
+lost are not recoverable by any automatic path.
+
 ### Archive And History Expiry Contract
 
 Archive nodes and history-expiry nodes use the same logical blob keys. The

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1277,7 +1277,12 @@ rebuilt from scratch.
 Both deleters therefore report `ErrBlobDeleteIncomplete` with the failed and
 total counts instead of reporting a clean deletion, their callers log the
 condition at error level, and every stranded object increments
-`dingo_database_blob_orphans_total` (registered by `RegisterBlobOrphanMetrics`,
+`dingo_database_blob_orphans_total`. That increment is registered as an
+after-commit callback on the enclosing transaction rather than applied at
+delete time: the blob delete runs before the metadata removal, so an object is
+not stranded until that removal is durable. A transaction that rolls back
+leaves the row naming the blob, which stays reachable and uncounted, and the
+retry does not double-count it (registered by `RegisterBlobOrphanMetrics`,
 readable in-process via `BlobOrphanCount`). That counter is the only signal
 that a blob store is accumulating dead data, so a non-zero and growing value is
 worth alerting on: it means blob deletes are failing, and the objects already

--- a/database/blob_orphan.go
+++ b/database/blob_orphan.go
@@ -53,6 +53,24 @@ func recordBlobOrphans(n int) {
 	blobOrphans.Add(uint64(n)) //nolint:gosec // n is guarded positive above
 }
 
+// recordBlobOrphansOnCommit adds n to the unreachable-object counter once the
+// transaction that removes the naming metadata has committed durably.
+//
+// The blob delete happens before that metadata removal, so counting at delete
+// time would count objects a rollback leaves perfectly reachable, and count
+// them again on the retry. A nil txn has no commit to wait for -- there is no
+// pending metadata removal to gate on -- so it counts immediately.
+func recordBlobOrphansOnCommit(txn *Txn, n int) {
+	if n <= 0 {
+		return
+	}
+	if txn == nil {
+		recordBlobOrphans(n)
+		return
+	}
+	txn.AfterCommit(func() { recordBlobOrphans(n) })
+}
+
 // RegisterBlobOrphanMetrics exposes the unreachable-object counter on the
 // given Prometheus registry.
 //

--- a/database/blob_orphan.go
+++ b/database/blob_orphan.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ErrBlobDeleteIncomplete reports that some blob objects could not be deleted.
+//
+// Blob deletion is supplementary -- metadata is the source of truth -- so the
+// callers deliberately continue and remove the metadata anyway: a rolled-back
+// UTxO must not stay in the live set just because its blob is stuck. What that
+// leaves behind is an object nothing can name again, since the row that
+// pointed at it is gone. Callers therefore log and count the condition rather
+// than aborting on it, which is what separates a documented, observable
+// outcome from a silent one.
+var ErrBlobDeleteIncomplete = errors.New(
+	"blob delete incomplete: unreachable objects retained",
+)
+
+// blobOrphans counts blob objects whose delete failed before their
+// authoritative metadata was removed. It is process-wide so every registry
+// observes the same total, matching the block-hash index counters.
+var blobOrphans atomic.Uint64
+
+// BlobOrphanCount returns the cumulative number of blob objects left
+// unreachable by a failed delete.
+func BlobOrphanCount() uint64 {
+	return blobOrphans.Load()
+}
+
+// recordBlobOrphans adds n to the unreachable-object counter.
+func recordBlobOrphans(n int) {
+	if n <= 0 {
+		return
+	}
+	blobOrphans.Add(uint64(n)) //nolint:gosec // n is guarded positive above
+}
+
+// RegisterBlobOrphanMetrics exposes the unreachable-object counter on the
+// given Prometheus registry.
+//
+// There is no sweep that reclaims these objects, so this counter is the only
+// signal that a blob store is accumulating dead data. reg.Register is used
+// instead of promauto so a registration conflict never panics during
+// Database.New; an AlreadyRegisteredError is ignored and any other error is
+// returned.
+func RegisterBlobOrphanMetrics(reg prometheus.Registerer) error {
+	if reg == nil {
+		return nil
+	}
+	collector := prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Name: "dingo_database_blob_orphans_total",
+		Help: "Blob objects whose delete failed before their authoritative " +
+			"metadata was removed, leaving them unreachable",
+	}, func() float64 {
+		return float64(blobOrphans.Load())
+	})
+	err := reg.Register(collector)
+	if err == nil {
+		return nil
+	}
+	// A reused registry already exposes this counter, and both collectors
+	// read the same process-wide atomic, so the duplicate is safe to ignore.
+	if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); !ok {
+		return err
+	}
+	return nil
+}

--- a/database/blob_orphan_test.go
+++ b/database/blob_orphan_test.go
@@ -121,3 +121,55 @@ func TestDeleteUtxoBlobsWithoutBlobStoreIsReported(t *testing.T) {
 	}, nil)
 	require.Error(t, err)
 }
+
+// TestBlobOrphansAreNotCountedUntilMetadataCommits covers the ordering between
+// the blob delete and the metadata removal that makes the object unreachable.
+//
+// The blob delete runs first, so counting there would count an object that is
+// still perfectly reachable if the enclosing transaction never commits — and
+// count it again when the caller retries. Only a durable metadata removal
+// strands anything.
+func TestBlobOrphansAreNotCountedUntilMetadataCommits(t *testing.T) {
+	db := openTestDB(t)
+	db.blob = &mockBlobStore{
+		deleteUtxoErrs: map[string]error{
+			"05:0": errors.New("blob store unavailable"),
+		},
+	}
+	txn := db.Transaction(true)
+	before := BlobOrphanCount()
+
+	err := deleteUtxoBlobs(db, []models.Utxo{
+		{TxId: []byte{0x05}, OutputIdx: 0},
+	}, txn)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBlobDeleteIncomplete)
+	assert.Zero(t, BlobOrphanCount()-before,
+		"nothing is stranded until the metadata naming it is gone")
+
+	require.NoError(t, txn.Commit())
+	assert.Equal(t, uint64(1), BlobOrphanCount()-before,
+		"the commit is what strands the object")
+}
+
+// TestBlobOrphansAreNotCountedOnRollback is the negative case: a rolled-back
+// transaction leaves the metadata row in place, so the blob is still named and
+// reachable and must not be counted.
+func TestBlobOrphansAreNotCountedOnRollback(t *testing.T) {
+	db := openTestDB(t)
+	db.blob = &mockBlobStore{
+		deleteTxErrs: map[string]error{
+			string([]byte{0xDD}): errors.New("blob store unavailable"),
+		},
+	}
+	txn := db.Transaction(true)
+	before := BlobOrphanCount()
+
+	err := deleteTxBlobs(db, [][]byte{{0xDD}}, txn)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBlobDeleteIncomplete)
+
+	require.NoError(t, txn.Rollback())
+	assert.Zero(t, BlobOrphanCount()-before,
+		"a rollback leaves the row, so nothing was orphaned")
+}

--- a/database/blob_orphan_test.go
+++ b/database/blob_orphan_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBlobOrphanTestDB(store *mockBlobStore) *Database {
+	return &Database{
+		blob: store,
+		logger: slog.New(
+			slog.NewJSONHandler(
+				io.Discard,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+}
+
+// TestDeleteUtxoBlobsReportsUnreachableObjects covers a blob delete that fails
+// before the authoritative metadata row is removed.
+//
+// The metadata row is the source of truth, so once it is gone the blob can
+// never be reached or named again: nothing knows it exists and no sweep
+// reclaims it. Returning nil there reports a clean deletion to the caller and
+// leaves the object to accumulate silently, so the failure has to reach the
+// caller and be counted.
+func TestDeleteUtxoBlobsReportsUnreachableObjects(t *testing.T) {
+	store := &mockBlobStore{
+		deleteUtxoErrs: map[string]error{
+			"01:0": errors.New("blob store unavailable"),
+		},
+	}
+	db := newBlobOrphanTestDB(store)
+	before := BlobOrphanCount()
+
+	err := deleteUtxoBlobs(db, []models.Utxo{
+		{TxId: []byte{0x01}, OutputIdx: 0},
+		{TxId: []byte{0x02}, OutputIdx: 0},
+	}, nil)
+
+	require.Error(t, err, "a failed blob delete must reach the caller")
+	assert.ErrorIs(t, err, ErrBlobDeleteIncomplete)
+	assert.Equal(t, uint64(1), BlobOrphanCount()-before,
+		"the unreachable object must be counted for operators")
+}
+
+// TestDeleteUtxoBlobsCountsNoOrphansOnSuccess is the negative case: a clean
+// run must not report an error or inflate the orphan counter, or the metric
+// is useless as an alerting signal.
+func TestDeleteUtxoBlobsCountsNoOrphansOnSuccess(t *testing.T) {
+	store := &mockBlobStore{}
+	db := newBlobOrphanTestDB(store)
+	before := BlobOrphanCount()
+
+	err := deleteUtxoBlobs(db, []models.Utxo{
+		{TxId: []byte{0x03}, OutputIdx: 0},
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Zero(t, BlobOrphanCount()-before)
+}
+
+// TestDeleteTxBlobsReportsUnreachableObjects is the transaction-blob half of
+// the same contract.
+func TestDeleteTxBlobsReportsUnreachableObjects(t *testing.T) {
+	store := &mockBlobStore{
+		deleteTxErrs: map[string]error{
+			string([]byte{0xAA}): errors.New("blob store unavailable"),
+		},
+	}
+	db := newBlobOrphanTestDB(store)
+	before := BlobOrphanCount()
+
+	err := deleteTxBlobs(db, [][]byte{{0xAA}, {0xBB}}, nil)
+
+	require.Error(t, err, "a failed blob delete must reach the caller")
+	assert.ErrorIs(t, err, ErrBlobDeleteIncomplete)
+	assert.Equal(t, uint64(1), BlobOrphanCount()-before)
+}
+
+// TestDeleteTxBlobsCountsNoOrphansOnSuccess is the negative case for tx blobs.
+func TestDeleteTxBlobsCountsNoOrphansOnSuccess(t *testing.T) {
+	store := &mockBlobStore{}
+	db := newBlobOrphanTestDB(store)
+	before := BlobOrphanCount()
+
+	require.NoError(t, deleteTxBlobs(db, [][]byte{{0xCC}}, nil))
+	assert.Zero(t, BlobOrphanCount()-before)
+}
+
+// TestDeleteUtxoBlobsWithoutBlobStoreIsReported covers a nil blob store. This
+// already returned an error; the point is that the callers no longer discard
+// it, so the condition is visible rather than a silent no-op.
+func TestDeleteUtxoBlobsWithoutBlobStoreIsReported(t *testing.T) {
+	db := newBlobOrphanTestDB(nil)
+	db.blob = nil
+
+	err := deleteUtxoBlobs(db, []models.Utxo{
+		{TxId: []byte{0x04}, OutputIdx: 0},
+	}, nil)
+	require.Error(t, err)
+}

--- a/database/database.go
+++ b/database/database.go
@@ -317,6 +317,12 @@ func New(config *Config, stores Stores) (*Database, error) {
 				"error", err,
 			)
 		}
+		if err := RegisterBlobOrphanMetrics(configCopy.PromRegistry); err != nil {
+			configCopy.Logger.Warn(
+				"failed to register blob orphan metrics",
+				"error", err,
+			)
+		}
 	}
 	// Register database size metrics
 	if configCopy.PromRegistry != nil {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1194,7 +1194,8 @@ func (d *Database) GetTransactionMetadataByHash(
 		txn = d.Transaction(false)
 		defer txn.Release()
 	}
-	return d.transactionStore().GetTransactionMetadataByHash(hash, txn.Metadata())
+	return d.transactionStore().
+		GetTransactionMetadataByHash(hash, txn.Metadata())
 }
 
 // GetTransactionsByHashes returns transactions for the provided hashes.
@@ -1717,11 +1718,15 @@ func (d *Database) DeleteTransactionMetadataLabelsAfterSlot(
 	return nil
 }
 
-// deleteTxBlobs attempts to delete blob data for the given transaction hashes.
-// This is a best-effort operation; metadata remains the source of truth. When
-// the caller provides a blob transaction, deletions stay coupled to that outer
-// commit. A temporary blob-only transaction is used only as a fallback when no
-// blob handle is available.
+// deleteTxBlobs deletes blob data for the given transaction hashes. Metadata
+// remains the source of truth. When the caller provides a blob transaction,
+// deletions stay coupled to that outer commit. A temporary blob-only
+// transaction is used only as a fallback when no blob handle is available.
+//
+// Failures do not stop the remaining deletes, but they are counted and
+// reported as [ErrBlobDeleteIncomplete]: the caller goes on to remove the
+// metadata that names these objects, after which nothing can reach them
+// again.
 func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 	const batchSize = 500
 	blob := d.Blob()
@@ -1772,11 +1777,18 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 		}
 	}
 	if deleteErrors > 0 {
+		recordBlobOrphans(deleteErrors)
 		d.logger.Warn(
 			"TX blob deletion completed with errors",
 			"failed",
 			deleteErrors,
 			"total",
+			len(txHashes),
+		)
+		return fmt.Errorf(
+			"%w: %d of %d transaction blobs",
+			ErrBlobDeleteIncomplete,
+			deleteErrors,
 			len(txHashes),
 		)
 	}
@@ -1816,7 +1828,17 @@ func (d *Database) TransactionsDeleteRolledback(
 	}
 
 	// Delete blob data first (best effort)
-	_ = deleteTxBlobs(d, txHashes, txn)
+	// A blob delete failure must not stop the metadata cleanup below: a
+	// rolled-back transaction cannot stay addressable. The objects it strands
+	// are counted and logged rather than dropped.
+	if blobErr := deleteTxBlobs(d, txHashes, txn); blobErr != nil {
+		d.logger.Error(
+			"rolled-back transaction blob delete left unreachable objects",
+			"error", blobErr,
+			"slot", slot,
+			"transactions", len(txHashes),
+		)
+	}
 
 	// Then delete metadata (source of truth)
 	if err := d.transactionStore().DeleteAddressTransactionsAfterSlot(

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1726,7 +1726,8 @@ func (d *Database) DeleteTransactionMetadataLabelsAfterSlot(
 // Failures do not stop the remaining deletes, but they are counted and
 // reported as [ErrBlobDeleteIncomplete]: the caller goes on to remove the
 // metadata that names these objects, after which nothing can reach them
-// again.
+// again. The count is deferred to the enclosing transaction's commit for the
+// reason given on deleteUtxoBlobs.
 func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 	const batchSize = 500
 	blob := d.Blob()
@@ -1777,7 +1778,7 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 		}
 	}
 	if deleteErrors > 0 {
-		recordBlobOrphans(deleteErrors)
+		recordBlobOrphansOnCommit(txn, deleteErrors)
 		d.logger.Warn(
 			"TX blob deletion completed with errors",
 			"failed",

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -321,7 +321,9 @@ func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
 	}
 
 	txHashes := [][]byte{{0x01}, {0x02}, {0x03}}
-	require.NoError(t, deleteTxBlobs(db, txHashes, nil))
+	err := deleteTxBlobs(db, txHashes, nil)
+	require.Error(t, err, "an uncommitted batch leaves unreachable objects")
+	require.ErrorIs(t, err, ErrBlobDeleteIncomplete)
 	require.Len(t, store.txns, 1)
 	require.Equal(t, 1, store.txns[0].commitCount)
 	require.Contains(t, logs.String(), "\"failed\":3")
@@ -350,7 +352,9 @@ func TestDeleteUtxoBlobsCountsFailedBatchCommit(t *testing.T) {
 		{TxId: []byte{0x02}, OutputIdx: 1},
 		{TxId: []byte{0x03}, OutputIdx: 2},
 	}
-	require.NoError(t, deleteUtxoBlobs(db, utxos, nil))
+	err := deleteUtxoBlobs(db, utxos, nil)
+	require.Error(t, err, "an uncommitted batch leaves unreachable objects")
+	require.ErrorIs(t, err, ErrBlobDeleteIncomplete)
 	require.Len(t, store.txns, 1)
 	require.Equal(t, 1, store.txns[0].commitCount)
 	require.Contains(t, logs.String(), "\"failed\":3")

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -48,12 +48,16 @@ var errExactAddressCandidateScanLimit = errors.New(
 	"exact address candidate scan limit reached",
 )
 
-// deleteUtxoBlobs performs best-effort deletion of blob data for the given
-// [models.Utxo] entries. Metadata remains the authoritative source of truth;
-// blob deletions are supplementary. The caller [*Txn] is ignored — this
-// function always creates and commits its own blob-only batches via the
-// [Database], so callers should not expect blob deletes to participate in any
-// outer transaction.
+// deleteUtxoBlobs deletes blob data for the given [models.Utxo] entries.
+// Metadata remains the authoritative source of truth; blob deletions are
+// supplementary. The caller [*Txn] is ignored — this function always creates
+// and commits its own blob-only batches via the [Database], so callers should
+// not expect blob deletes to participate in any outer transaction.
+//
+// Failures do not stop the remaining deletes, but they are counted and
+// reported as [ErrBlobDeleteIncomplete]: the caller goes on to remove the
+// metadata that names these objects, after which nothing can reach them
+// again.
 func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 	const batchSize = 500
 	blob := d.Blob()
@@ -93,11 +97,18 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 		}
 	}
 	if deleteErrors > 0 {
+		recordBlobOrphans(deleteErrors)
 		d.logger.Warn(
 			"UTxO blob deletion completed with errors",
 			"failed",
 			deleteErrors,
 			"total",
+			len(utxos),
+		)
+		return fmt.Errorf(
+			"%w: %d of %d UTxO blobs",
+			ErrBlobDeleteIncomplete,
+			deleteErrors,
 			len(utxos),
 		)
 	}
@@ -868,8 +879,18 @@ func (d *Database) UtxosDeleteConsumed(
 		deleteUtxos[idx] = models.UtxoId{Hash: utxo.TxId, Idx: utxo.OutputIdx}
 	}
 
-	// Delete blob data first (best effort)
-	_ = deleteUtxoBlobs(d, utxos, txn)
+	// Delete blob data first. A failure here does not stop the metadata
+	// delete below: metadata is the source of truth, and leaving a consumed
+	// UTxO in the live set to keep its blob reachable would be the worse
+	// outcome. The objects it strands are counted and logged rather than
+	// passed over, because nothing reclaims them afterwards.
+	if blobErr := deleteUtxoBlobs(d, utxos, txn); blobErr != nil {
+		d.logger.Error(
+			"consumed UTxO blob delete left unreachable objects",
+			"error", blobErr,
+			"utxos", len(utxos),
+		)
+	}
 
 	// Then delete metadata (source of truth)
 	err = d.utxoStore().DeleteUtxos(deleteUtxos, txn.Metadata())
@@ -906,8 +927,17 @@ func (d *Database) UtxosDeleteRolledback(
 		return err
 	}
 
-	// Delete blob data first (best effort)
-	_ = deleteUtxoBlobs(d, utxos, txn)
+	// Delete blob data first. As above, a failure must not stop the metadata
+	// delete: a rolled-back UTxO cannot stay in the live set. The stranded
+	// objects are counted and logged instead of ignored.
+	if blobErr := deleteUtxoBlobs(d, utxos, txn); blobErr != nil {
+		d.logger.Error(
+			"rolled-back UTxO blob delete left unreachable objects",
+			"error", blobErr,
+			"slot", slot,
+			"utxos", len(utxos),
+		)
+	}
 
 	// Then delete metadata (source of truth)
 	err = d.utxoStore().DeleteUtxosAfterSlot(slot, txn.Metadata())

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -58,7 +58,13 @@ var errExactAddressCandidateScanLimit = errors.New(
 // reported as [ErrBlobDeleteIncomplete]: the caller goes on to remove the
 // metadata that names these objects, after which nothing can reach them
 // again.
-func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
+//
+// txn is used only to time that count. An object is not stranded until the
+// metadata naming it is durably gone, so the counter is incremented from an
+// after-commit callback; if the enclosing transaction rolls back, the row
+// still names the blob and nothing was orphaned. A nil txn has no commit to
+// wait for and counts immediately.
+func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 	const batchSize = 500
 	blob := d.Blob()
 	if blob == nil {
@@ -97,7 +103,7 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, _ *Txn) error {
 		}
 	}
 	if deleteErrors > 0 {
-		recordBlobOrphans(deleteErrors)
+		recordBlobOrphansOnCommit(txn, deleteErrors)
 		d.logger.Warn(
 			"UTxO blob deletion completed with errors",
 			"failed",


### PR DESCRIPTION
Refs #1649

`deleteUtxoBlobs` and `deleteTxBlobs` logged every failed blob delete and then
returned `nil`, and all three production callers discarded even that with
`_ = deleteUtxoBlobs(...)`. The metadata row naming the object is removed
immediately afterwards, so a failed delete leaves an object nothing can name
again.

This is a different orphan from the one the durability contract already covers.
Those sit *beyond* the metadata tip and startup reconciliation trims them
(`cleanupOrphanedBlobs`); these sit *beneath* it with no row pointing at them,
so no sweep reclaims them and they consume disk until the store is rebuilt.

Changes:

- both deleters return `ErrBlobDeleteIncomplete` with failed and total counts
  instead of reporting a clean deletion
- the three callers log the condition at error level rather than discarding it
- each stranded object increments `dingo_database_blob_orphans_total`
  (`RegisterBlobOrphanMetrics`, wired in `Database.New` beside the existing
  block-hash index counters; `BlobOrphanCount` for in-process reads)

The callers still go on to delete the metadata. It is the source of truth, and
keeping a rolled-back UTxO in the live set because its blob is stuck would be
the worse outcome — a nil blob store, which already returned an error, was
being discarded the same way. What changes is that the continuation is now
deliberate, documented and counted rather than silent, which is what #1649 asks
for on this path.

Documentation: `DATABASE.md` gains an "Unreachable Blob Objects" section
covering the delete ordering, why the metadata delete proceeds anyway, how
these differ from the trimmable orphans, and the metric to alert on.
`ARCHITECTURE.md` checked, not affected.

Validation:

- `go test -race -count=1 ./database/...` — pass, all 19 packages, exit 0
- `go test -count=1 ./internal/test/conformance` — pass
- `./internal/test/devnet/run-tests.sh` (all-Dingo) — pass, exit 0
  (`TestEpochBoundaryConsensus` 440s, txpump submitted=6 rejected=0 error=0)
- `golangci-lint`, `nilaway` on `./database/...` — clean
- `modernize ./database/...` — 13 findings, identical on this branch and on
  `main`, all in generated sqlc files; none introduced here
- `make import-boundaries`, `make docs-parity`, `make gorm-check` — pass
- `golines` — changed files clean

New tests cover both deleters reporting and counting a failed delete, both
counting nothing on a clean run, and a nil blob store being reported. The two
existing batch-commit tests were updated: they asserted the old
always-`nil` contract, and now assert the error alongside their existing
log-content checks. `TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata`
already pinned the deliberate continuation and still passes unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking and Prometheus metrics for blob objects that cannot be deleted.
  * Added an orphaned-blob counter and an error indicator for incomplete blob cleanup.
* **Bug Fixes**
  * Blob-deletion failures are now reported and logged while metadata cleanup continues.
  * Orphan counts are recorded only after metadata deletion commits, preventing false counts from rollbacks or retries.
* **Documentation**
  * Documented the causes, reporting, and monitoring of unreachable blob objects.
* **Tests**
  * Added coverage for failed and successful transaction and UTxO blob deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->