### PR TITLE
test(api): stabilize listener shutdown checks

### DIFF
--- a/api/blockfrost/listener_test.go
+++ b/api/blockfrost/listener_test.go
@@ -16,7 +16,6 @@ package blockfrost
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -35,36 +34,19 @@ func stopNow(t *testing.T, srv *Blockfrost) error {
 	return srv.Stop(ctx)
 }
 
-// The shutdown protocol these two tests exercise is covered in depth, with the
+// The shutdown protocol this test exercises is covered in depth, with the
 // windows constructed rather than raced, in internal/apilistener. What is
 // checked here is that this package is wired to it -- that a Blockfrost server
 // keeps the promise its Stop makes.
-
-// TestServerStopReleasesPortBeforeServeRegisters covers the window between
-// net.Listen and Serve registering that listener with the http.Server.
-// http.Server.Shutdown closes only registered listeners, so a Stop landing
-// inside the window used to return with the port still bound.
-func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
-	for i := range 100 {
-		srv, addr := startOnFreePort(
-			t, t.Context(), BlockfrostConfig{},
-		)
-
-		require.NoError(t, stopNow(t, srv))
-
-		require.False(
-			t, portAccepts(addr),
-			"listener still accepting when Stop returned "+
-				"(iteration %d)", i,
-		)
-	}
-}
 
 // TestServerRebindsAfterStop is the production path this fix exists for: a
 // live database restore or truncate quiesces the API capabilities and
 // reinitializeAPIServers brings them back up on the same configured port (see
 // node_lifecycle.go). A Stop that returned while the socket was still bound
-// left that restart failing with EADDRINUSE.
+// left that restart failing with EADDRINUSE. The constructed tests in
+// internal/apilistener assert closure on the original listener object; dialing
+// a released ephemeral address here could instead reach another package's
+// listener when the suite runs concurrently.
 func TestServerRebindsAfterStop(t *testing.T) {
 	srv, addr := startOnFreePort(t, t.Context(), BlockfrostConfig{})
 	require.NoError(t, stopNow(t, srv))
@@ -77,14 +59,4 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		"a capability restart must rebind the port Stop released",
 	)
 	require.NoError(t, stopNow(t, restarted))
-}
-
-// portAccepts reports whether a TCP connection to addr succeeds.
-func portAccepts(addr string) bool {
-	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
 }

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -284,29 +284,6 @@ func TestServerGracefulShutdown(t *testing.T) {
 	)
 }
 
-// TestServerStopReleasesPortBeforeServeRegisters covers the window
-// between startServer binding the socket and the goroutine it launches
-// reaching http.Server.Serve: Shutdown closes only the listeners Serve
-// registered, so in that window Stop used to return with the port still
-// bound -- which the capability restart in node_lifecycle.go then fails
-// to rebind. Stopping straight after Start lands in the window often
-// but not every time, so the assertion is repeated.
-func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
-	for i := range 100 {
-		srv, addr := startOnFreePort(
-			t, t.Context(), newTestDeps(),
-		)
-
-		require.NoError(t, srv.Stop(t.Context()))
-
-		require.False(
-			t, portAccepts(addr),
-			"listener still accepting when Stop returned "+
-				"(iteration %d)", i,
-		)
-	}
-}
-
 // TestConcurrentStartStopNeverLeavesThePortBound hammers the interleavings the
 // individual lifecycle tests each pin one of: Start racing Stop, Stop racing the
 // context monitor, and a restart on the same address immediately after.
@@ -365,13 +342,10 @@ func TestConcurrentStartStopNeverLeavesThePortBound(t *testing.T) {
 			t, srv.Stop(t.Context()),
 			"a second Stop must stay clean (iteration %d)", i,
 		)
-		require.False(
-			t, portAccepts(addr),
-			"Stop returned nil but the port is still accepting "+
-				"(iteration %d)", i,
-		)
-
 		// The contract Stop's nil return promises: the address is rebindable.
+		// Rebinding is the package-level assertion: dialing a released
+		// ephemeral address could instead reach another package's listener
+		// when the suite runs concurrently.
 		next := newTestServer(
 			t, newTestDeps(),
 			func(c *ServerConfig) { c.ListenAddress = addr },

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -264,9 +264,8 @@ func TestServerStopIsIdempotent(t *testing.T) {
 	require.NoError(t, srv.Stop(t.Context()))
 }
 
-// TestServerGracefulShutdown asserts Stop closes the listener so the
-// port stops accepting connections, and that it has done so by the time
-// Stop returns rather than some time afterwards.
+// TestServerGracefulShutdown asserts Stop releases the listener before it
+// returns by immediately starting a replacement on the same address.
 func TestServerGracefulShutdown(t *testing.T) {
 	srv, addr := startOnFreePort(
 		t, t.Context(), newTestDeps(),
@@ -278,10 +277,13 @@ func TestServerGracefulShutdown(t *testing.T) {
 	defer cancel()
 	require.NoError(t, srv.Stop(stopCtx))
 
-	require.False(
-		t, portAccepts(addr),
-		"listener still accepting after Stop",
+	restarted := newTestServer(
+		t,
+		newTestDeps(),
+		func(c *ServerConfig) { c.ListenAddress = addr },
 	)
+	require.NoError(t, restarted.Start(t.Context()))
+	require.NoError(t, restarted.Stop(t.Context()))
 }
 
 // TestConcurrentStartStopNeverLeavesThePortBound hammers the interleavings the

--- a/api/utxorpc/listener_test.go
+++ b/api/utxorpc/listener_test.go
@@ -20,45 +20,26 @@ import (
 	"net"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/stretchr/testify/require"
 )
 
-// The shutdown protocol these two tests exercise is covered in depth, with the
+// The shutdown protocol this test exercises is covered in depth, with the
 // windows constructed rather than raced, in internal/apilistener. What is
 // checked here is that this package is wired to it -- that a utxorpc server
 // keeps the promise its Stop makes, including on the force-close escalation
 // paths that are this listener's own.
 
-// TestServerStopReleasesPortBeforeServeRegisters covers the window between
-// net.Listen and Serve registering that listener with the http.Server.
-// http.Server.Shutdown closes only registered listeners, so a Stop landing
-// inside the window used to return with the port still bound.
-func TestServerStopReleasesPortBeforeServeRegisters(t *testing.T) {
-	for i := range 100 {
-		u, addr := startOnFreePort(
-			t, t.Context(),
-			apiconfig.EffectiveTLS{}, apiconfig.EffectiveAuth{},
-		)
-
-		stopUtxorpc(t, u)
-
-		require.False(
-			t, portAccepts(addr),
-			"listener still accepting when Stop returned "+
-				"(iteration %d)", i,
-		)
-	}
-}
-
 // TestServerRebindsAfterStop is the production path this fix exists for: a
 // live database restore or truncate quiesces the API capabilities and
 // reinitializeAPIServers brings them back up on the same configured port (see
 // node_lifecycle.go). A Stop that returned while the socket was still bound
-// left that restart failing with EADDRINUSE.
+// left that restart failing with EADDRINUSE. The constructed tests in
+// internal/apilistener assert closure on the original listener object; dialing
+// a released ephemeral address here could instead reach another package's
+// listener when the suite runs concurrently.
 func TestServerRebindsAfterStop(t *testing.T) {
 	u, addr := startOnFreePort(
 		t, t.Context(),
@@ -81,14 +62,4 @@ func TestServerRebindsAfterStop(t *testing.T) {
 		"a capability restart must rebind the port Stop released",
 	)
 	stopUtxorpc(t, restarted)
-}
-
-// portAccepts reports whether a TCP connection to addr succeeds.
-func portAccepts(addr string) bool {
-	conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
 }

--- a/internal/apilistener/listener_test.go
+++ b/internal/apilistener/listener_test.go
@@ -193,27 +193,10 @@ func TestShutdownClosesAListenerServeNeverRegistered(t *testing.T) {
 
 	require.NoError(t, stopNow(t, l))
 
-	require.False(
-		t, portAccepts(addr),
-		"Stop must release a socket Serve never registered",
+	require.ErrorIs(
+		t, ln.Close(), net.ErrClosed,
+		"Stop must close the original socket Serve never registered",
 	)
-}
-
-// TestStopReleasesPortBeforeServeRegisters is the same defect through the real
-// bind path, where the window is narrow and the failure probabilistic. It
-// complements the deterministic test above rather than replacing it.
-func TestStopReleasesPortBeforeServeRegisters(t *testing.T) {
-	for i := range 100 {
-		l, addr := startOnFreePort(t)
-
-		require.NoError(t, stopNow(t, l))
-
-		require.False(
-			t, portAccepts(addr),
-			"listener still accepting when Stop returned "+
-				"(iteration %d)", i,
-		)
-	}
 }
 
 // --- bind ---------------------------------------------------------------
@@ -673,13 +656,10 @@ func TestConcurrentBindStopNeverLeavesThePortBound(t *testing.T) {
 			t, stopNow(t, l),
 			"a second Stop must stay clean (iteration %d)", i,
 		)
-		require.False(
-			t, portAccepts(addr),
-			"Stop returned nil but the port is still accepting "+
-				"(iteration %d)", i,
-		)
-
 		// The contract Stop's nil return promises: the address is rebindable.
+		// Rebinding is the externally observable assertion here. Closure of
+		// the original listener object is checked directly above, without
+		// confusing a concurrently rebound address for the old listener.
 		next := newListener()
 		nextSrv, bindDone, err := publish(next, addr)
 		require.NoError(t, err)


### PR DESCRIPTION
Fixes #3542.

- Remove repeated post-shutdown dials that could reach a different listener after ephemeral-address reuse.
- Keep each API package's stop-and-rebind coverage.
- Verify the shared unregistered-listener path closes the original listener object.