### PR TITLE
fix(database): bound Badger GC shutdown wait

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,9 @@ stops scheduling value-log GC before close and prevents a successful rewrite
 from chaining another pass. Because Badger cannot cancel a rewrite already in
 flight, an expired stop context bounds the host's wait while the one-time close
 continues after that rewrite drains; direct close calls join the same cleanup.
+Live restore and truncate classify that deadline as an unconfirmed storage
+drain and request a supervised restart; they never resolve a replacement store
+against the same data directory while the prior close may still own it.
 API providers are resolved for lifecycle only because node composition has no
 in-process consumer of their concrete server values. Each API provider's
 TLS/authentication policy goes through a merged-config handoff, not a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last reviewed: 2026-08-03
+Last reviewed: 2026-08-26
 
 ## In-process plugin host
 
@@ -16,6 +16,11 @@ configured port is nonzero, so core-mode nodes and disabled ports resolve
 none of them. Failures unwind providers in reverse order. Normal shutdown
 orders APIs, mempool, ledger/database, then storage.
 Database receives provider-owned stores through `database.Stores`.
+Storage lifecycle contexts cross the provider boundary. In particular, Badger
+stops scheduling value-log GC before close and prevents a successful rewrite
+from chaining another pass. Because Badger cannot cancel a rewrite already in
+flight, an expired stop context bounds the host's wait while the one-time close
+continues after that rewrite drains; direct close calls join the same cleanup.
 API providers are resolved for lifecycle only because node composition has no
 in-process consumer of their concrete server values. Each API provider's
 TLS/authentication policy goes through a merged-config handoff, not a

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -11,6 +11,13 @@ behavior, and persisted formats are unchanged. Library callers of Mithril
 `Sync` or `NeedsSync` may leave `SyncConfig.StoragePlugins` unset to select the
 local `badger` blob and `sqlite` metadata providers.
 
+The Badger provider threads the host's stop context through its close path.
+Stopping periodic value-log GC prevents a successful rewrite from starting a
+second pass. Badger does not expose cancellation for a rewrite already in
+flight, so that rewrite drains through a one-time background close while the
+provider returns the stop context error at its deadline. A later direct
+`Close` waits for that same cleanup instead of starting a competing close.
+
 Standalone command/bootstrap composition owns these stores through
 `internal/plugins.DatabaseRuntime`. `OpenDatabase` returns either a live
 runtime with a nil error or a nil runtime with an error, so conventional error

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -17,6 +17,9 @@ second pass. Badger does not expose cancellation for a rewrite already in
 flight, so that rewrite drains through a one-time background close while the
 provider returns the stop context error at its deadline. A later direct
 `Close` waits for that same cleanup instead of starting a competing close.
+Live restore and truncate treat this deadline as an unconfirmed drain and
+request a supervised restart instead of reopening the same data directory
+while the background close may still own it.
 
 Standalone command/bootstrap composition owns these stores through
 `internal/plugins.DatabaseRuntime`. `OpenDatabase` returns either a live

--- a/database/plugin/PLUGIN_DEVELOPMENT.md
+++ b/database/plugin/PLUGIN_DEVELOPMENT.md
@@ -102,6 +102,11 @@ and returns at the deadline while a non-cancelable in-flight rewrite drains
 through the same one-time close. If a store's own start/stop accepts a context,
 thread it through instead.
 
+Composition code must not treat a context-bounded storage `Stop` as proof that
+the resource has drained. A live replacement must either observe completed
+cleanup or fail closed; it must never resolve a new provider against the same
+path while the old provider may still be closing in the background.
+
 Test strict configuration decoding, construction/start failures, normal stop,
 and the subsystem contract. Storage providers must preserve transaction,
 iterator-lifetime, commit-timestamp, optimization, and persisted-format

--- a/database/plugin/PLUGIN_DEVELOPMENT.md
+++ b/database/plugin/PLUGIN_DEVELOPMENT.md
@@ -93,11 +93,14 @@ Factories should construct resources without starting background work.
 the host stops that provider before returning the error. Composition code owns
 unwinding previously started providers around their non-plugin dependents.
 
-The built-in storage stores expose `Start`/`Stop` with no context parameter, so
-the lifecycle adapter honors cancellation only at the boundary: `StartFunc`
-returns early on `ctx.Err()` before beginning work, but it cannot interrupt a
-`Start` already in progress. `StopFunc` runs cleanup regardless of `ctx` state.
-If your store's own start/stop accept a context, thread it through instead.
+Most built-in storage stores expose `Start`/`Stop` with no context parameter,
+so their lifecycle adapters honor cancellation only at the boundary:
+`StartFunc` returns early on `ctx.Err()` before beginning work, but it cannot
+interrupt a `Start` already in progress. The Badger provider is the exception:
+it threads the stop context into `CloseContext`, stops periodic value-log GC,
+and returns at the deadline while a non-cancelable in-flight rewrite drains
+through the same one-time close. If a store's own start/stop accepts a context,
+thread it through instead.
 
 Test strict configuration decoding, construction/start failures, normal stop,
 and the subsystem contract. Storage providers must preserve transaction,

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -262,8 +262,12 @@ type BlobStoreBadger struct {
 	logger               *slog.Logger
 	gcTicker             *time.Ticker
 	gcStopCh             chan struct{}
+	runValueLogGC        func(float64) error
 	dataDir              string
 	gcWg                 sync.WaitGroup
+	closeOnce            sync.Once
+	closeDone            chan struct{}
+	closeErr             error
 	blockCacheSize       uint64
 	indexCacheSize       uint64
 	valueLogFileSize     int64
@@ -290,6 +294,7 @@ func New(opts ...BlobStoreBadgerOptionFunc) (*BlobStoreBadger, error) {
 		valueLogFileSize:   int64(DefaultValueLogFileSize),
 		memTableSize:       int64(DefaultMemTableSize),
 		valueThreshold:     int64(DefaultValueThreshold),
+		closeDone:          make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(db)
@@ -389,34 +394,52 @@ func (d *BlobStoreBadger) init() error {
 	if d.promRegistry != nil {
 		d.registerBlobMetrics()
 	}
+	if d.runValueLogGC == nil {
+		d.runValueLogGC = d.DB().RunValueLogGC
+	}
 	// Configure GC
 	if d.gcEnabled {
 		d.gcTicker = time.NewTicker(5 * time.Minute)
 		d.gcStopCh = make(chan struct{})
 		d.gcWg.Add(1)
-		go d.blobGc(d.gcTicker, d.gcStopCh)
+		go d.blobGc(d.gcTicker.C, d.gcStopCh)
 	}
 	return nil
 }
 
-func (d *BlobStoreBadger) blobGc(t *time.Ticker, stop <-chan struct{}) {
+func (d *BlobStoreBadger) blobGc(
+	ticks <-chan time.Time,
+	stop <-chan struct{},
+) {
 	defer d.gcWg.Done()
 	for {
 		select {
-		case <-t.C:
-		again:
-			err := d.DB().RunValueLogGC(0.5)
-			if err != nil {
-				// Log any actual errors
-				if !errors.Is(err, badger.ErrNoRewrite) {
-					d.logger.Warn(
-						fmt.Sprintf("blob DB: GC failure: %s", err),
-						"component", "database",
-					)
+		case <-ticks:
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for {
+				err := d.runValueLogGC(0.5)
+				if err != nil {
+					// Log any actual errors
+					if !errors.Is(err, badger.ErrNoRewrite) {
+						d.logger.Warn(
+							fmt.Sprintf("blob DB: GC failure: %s", err),
+							"component", "database",
+						)
+					}
+					break
 				}
-			} else {
-				// Run it again if it just ran successfully
-				goto again
+				// A successful rewrite normally starts another pass. Check the
+				// stop signal first so shutdown bounds the cycle to the rewrite
+				// that was already in flight.
+				select {
+				case <-stop:
+					return
+				default:
+				}
 			}
 		case <-stop:
 			return
@@ -443,22 +466,39 @@ func (d *BlobStoreBadger) Stop() error {
 
 // Close gets the database handle from our BlobStore and closes it
 func (d *BlobStoreBadger) Close() error {
-	// Stop GC ticker if it exists
-	if d.gcTicker != nil {
-		d.gcTicker.Stop()
+	return d.CloseContext(context.Background())
+}
+
+// CloseContext stops background GC and closes the database. Badger does not
+// expose cancellation for an in-flight value-log rewrite, so a deadline may
+// return before cleanup finishes. The rewrite is allowed to drain and the
+// database is then closed by the same one-time cleanup in the background.
+func (d *BlobStoreBadger) CloseContext(ctx context.Context) error {
+	d.closeOnce.Do(func() {
+		if d.closeDone == nil {
+			d.closeDone = make(chan struct{})
+		}
+		if d.gcTicker != nil {
+			d.gcTicker.Stop()
+		}
 		if d.gcStopCh != nil {
 			close(d.gcStopCh)
-			d.gcStopCh = nil
 		}
-		// Wait for GC goroutine to finish
-		d.gcWg.Wait()
-		d.gcTicker = nil
+		go func() {
+			d.gcWg.Wait()
+			if db := d.DB(); db != nil {
+				d.closeErr = db.Close()
+			}
+			close(d.closeDone)
+		}()
+	})
+
+	select {
+	case <-d.closeDone:
+		return d.closeErr
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	db := d.DB()
-	if db == nil {
-		return nil
-	}
-	return db.Close()
 }
 
 // DB returns the database handle

--- a/database/plugin/blob/badger/provider.go
+++ b/database/plugin/blob/badger/provider.go
@@ -118,7 +118,7 @@ func RegisterProvider(host *hostplugin.Host) error {
 			}
 			lifecycle := hostplugin.Lifecycle{
 				StartFunc: func(context.Context) error { return store.Start() },
-				StopFunc:  func(context.Context) error { return store.Stop() },
+				StopFunc:  store.CloseContext,
 			}
 			return store, lifecycle, nil
 		},

--- a/database/plugin/blob/badger/provider_test.go
+++ b/database/plugin/blob/badger/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/plugin"
 	badgerdb "github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
@@ -218,11 +219,10 @@ func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
 	store.gcWg.Add(1)
 	go store.blobGc(gcTicks, store.gcStopCh)
 	gcTicks <- time.Time{}
-	select {
-	case <-gcStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("value-log GC did not start")
-	}
+	testutil.RequireReceive(
+		t, gcStarted, 5*time.Second,
+		"value-log GC did not start",
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -230,23 +230,14 @@ func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
 	go func() {
 		stopDone <- host.Stop(ctx)
 	}()
-	<-ctx.Done()
-
-	var stopErr error
-	returnedAtDeadline := false
-	select {
-	case stopErr = <-stopDone:
-		returnedAtDeadline = true
-	case <-time.After(500 * time.Millisecond):
-	}
+	stopErr := testutil.RequireReceive(
+		t, stopDone, 5*time.Second,
+		"provider stop exceeded its context",
+	)
 
 	release()
-	if !returnedAtDeadline {
-		stopErr = <-stopDone
-	}
 	require.NoError(t, store.Close())
 
-	require.True(t, returnedAtDeadline, "provider stop exceeded its context")
 	require.ErrorIs(t, stopErr, context.DeadlineExceeded)
 	require.Equal(t, int32(1), attempts.Load())
 	require.True(t, store.DB().IsClosed())

--- a/database/plugin/blob/badger/provider_test.go
+++ b/database/plugin/blob/badger/provider_test.go
@@ -236,7 +236,13 @@ func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
 	)
 
 	release()
-	require.NoError(t, store.Close())
+	require.Eventually(
+		t,
+		store.DB().IsClosed,
+		5*time.Second,
+		10*time.Millisecond,
+		"provider-owned close did not finish after value-log GC drained",
+	)
 
 	require.ErrorIs(t, stopErr, context.DeadlineExceeded)
 	require.Equal(t, int32(1), attempts.Load())

--- a/database/plugin/blob/badger/provider_test.go
+++ b/database/plugin/blob/badger/provider_test.go
@@ -16,10 +16,14 @@ package badger
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/plugin"
+	badgerdb "github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -177,4 +181,78 @@ func TestProviderExplicitConfigOverridesDefaults(t *testing.T) {
 	require.False(t, store.compressionEnabled)
 	require.True(t, store.gcEnabled)
 	require.Equal(t, 7, store.compressionLevel)
+}
+
+func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
+	host := plugin.NewHost()
+	require.NoError(t, RegisterProvider(host))
+	store, err := plugin.Resolve[*BlobStoreBadger](
+		context.Background(),
+		host,
+		plugin.CapabilityStorageBlob,
+		"badger",
+		map[string]any{"gc": true},
+		blob.ProviderDependencies{DataDir: t.TempDir()},
+	)
+	require.NoError(t, err)
+
+	gcStarted := make(chan struct{})
+	releaseGC := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseGC) }) }
+	defer func() {
+		release()
+		_ = store.Close()
+	}()
+
+	var attempts atomic.Int32
+	store.runValueLogGC = func(float64) error {
+		if attempts.Add(1) == 1 {
+			close(gcStarted)
+			<-releaseGC
+			return nil
+		}
+		return badgerdb.ErrNoRewrite
+	}
+	gcTicks := make(chan time.Time, 1)
+	store.gcWg.Add(1)
+	go store.blobGc(gcTicks, store.gcStopCh)
+	gcTicks <- time.Time{}
+	select {
+	case <-gcStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("value-log GC did not start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- host.Stop(ctx)
+	}()
+	<-ctx.Done()
+
+	var stopErr error
+	returnedAtDeadline := false
+	select {
+	case stopErr = <-stopDone:
+		returnedAtDeadline = true
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	release()
+	if !returnedAtDeadline {
+		stopErr = <-stopDone
+	}
+	require.NoError(t, store.Close())
+
+	require.True(t, returnedAtDeadline, "provider stop exceeded its context")
+	require.ErrorIs(t, stopErr, context.DeadlineExceeded)
+	require.Equal(t, int32(1), attempts.Load())
+	require.True(t, store.DB().IsClosed())
+	require.ErrorIs(
+		t,
+		host.Stop(context.Background()),
+		context.DeadlineExceeded,
+	)
 }

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -450,6 +450,10 @@ func (n *Node) closeStorageForLiveLifecycleOp(ctx context.Context) error {
 		if stopErr := n.pluginHost.StopCapability(
 			ctx, plugin.CapabilityStorageMetadata,
 		); stopErr != nil {
+			if errors.Is(stopErr, context.Canceled) ||
+				errors.Is(stopErr, context.DeadlineExceeded) {
+				stopErr = errors.Join(errStorageDrainUnconfirmed, stopErr)
+			}
 			err = errors.Join(
 				err,
 				fmt.Errorf("metadata storage shutdown: %w", stopErr),
@@ -458,6 +462,10 @@ func (n *Node) closeStorageForLiveLifecycleOp(ctx context.Context) error {
 		if stopErr := n.pluginHost.StopCapability(
 			ctx, plugin.CapabilityStorageBlob,
 		); stopErr != nil {
+			if errors.Is(stopErr, context.Canceled) ||
+				errors.Is(stopErr, context.DeadlineExceeded) {
+				stopErr = errors.Join(errStorageDrainUnconfirmed, stopErr)
+			}
 			err = errors.Join(
 				err,
 				fmt.Errorf("blob storage shutdown: %w", stopErr),
@@ -1604,9 +1612,10 @@ var errRestoreSwapUnrecoverable = errors.New(
 // errStorageDrainUnconfirmed marks a quiesceForLiveLifecycleOp or
 // closeStorageForLiveLifecycleOp failure where a background goroutine could
 // not be confirmed to have exited before its bounded wait timed out —
-// currently either n.ledgerState.Close()'s rollback-event/dbWorkerPool
-// waits, or the leios persist writer's drain
-// (PauseLeiosPersistWriterForLiveLifecycleOp). Unlike every other error
+// currently n.ledgerState.Close()'s rollback-event/dbWorkerPool waits, the
+// leios persist writer's drain (PauseLeiosPersistWriterForLiveLifecycleOp),
+// or a storage provider whose context-bounded Stop returned before its cleanup
+// completed. Unlike every other error
 // these functions can return, this one means a goroutine may still be
 // reading/writing n.db, not merely that some cleanup step reported failure
 // after the resource was already unused. Restore/Truncate must not treat

--- a/node_lifecycle_test.go
+++ b/node_lifecycle_test.go
@@ -902,34 +902,21 @@ func TestLiveTruncateRejectsTargetAheadOfTipWithoutTearingDownNode(
 	}
 }
 
-// TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode
-// guards against a real half-torn-down state this package used to leave
-// the node in: quiesceForLiveLifecycleOp attempts every one of its stop
-// calls regardless of an earlier one failing, so by the time either it or
-// closeStorageForLiveLifecycleOp returns a non-nil error (e.g. because
-// ctx's deadline passed), the node is already substantially quiesced —
-// forger/mempool/connections/APIs stopped. Truncate/Restore used to just
-// return that error without attempting to resume, leaving the process
-// running but silently unresponsive with no forging, mempool, or
-// networking and no indication a restart was needed. They must instead
-// attempt reinitializeAndResume and bring the node back up on its
-// untouched original data directory.
-//
-// closeStorageForLiveLifecycleOp's deferredIndexMaintenanceDone select is
-// used here as a deterministic failure trigger: setting that channel
-// without ever closing it, combined with a ctx that expires before the
-// select is reached, forces exactly one clean, reproducible error out of
-// closeStorageForLiveLifecycleOp without needing to fake any component's
-// Stop method.
-func TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode(
+// TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed guards the
+// boundary between context-bounded provider shutdown and live storage reopen.
+// A provider may honor the deadline by returning while its one-time cleanup
+// continues in the background. StopCapability has already relinquished that
+// instance, so reopening the same data directory would race the old cleanup.
+// The node must request a supervised restart instead.
+func TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed(
 	t *testing.T,
 ) {
 	const numBlocks = 10
 	n, points := newLiveLifecycleTestNode(t, numBlocks)
 
-	oldCtx := n.ctx
-	oldDB := n.db
-
+	// Expire the operation context before provider shutdown. The real Badger
+	// provider then returns from CloseContext at the deadline while its owned
+	// close continues asynchronously.
 	n.deferredIndexMaintenanceDone = make(chan struct{})
 
 	shortCtx, cancel := context.WithTimeout(
@@ -945,10 +932,72 @@ func TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode(
 	)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "close storage")
+	require.ErrorContains(t, err, "could not confirm")
+	require.Error(t, n.ctx.Err())
+	require.Nil(t, n.db, "storage must not be reopened before provider drain")
 
-	// n.ctx (the node's own long-lived context, distinct from shortCtx
-	// above) must survive untouched, and every subsystem quiesced during
-	// the failed attempt must have been rebuilt rather than left down.
+	// Wait for the provider-owned background close before TempDir cleanup. A
+	// scratch runtime can acquire the same path only after the old Badger lock
+	// is released; the cancelled Node itself remains stopped and never reopens.
+	require.Eventually(t, func() bool {
+		deps := n.storageDependencies(n.config.dataDir)
+		deps.PromRegistry = n.config.promRegistry
+		runtime, openErr := internalplugins.OpenDatabase(
+			context.Background(),
+			n.databaseConfig(),
+			n.storageSelections(),
+			deps,
+		)
+		if openErr != nil {
+			return false
+		}
+		return runtime.Close(context.Background()) == nil
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestLiveTruncateResumesAfterCompletedStorageStopFailure proves that an
+// ordinary provider Stop error still resumes the quiesced node when every
+// provider has completed cleanup. The synthetic provider returns its error
+// synchronously; the real Badger provider behind it also closes before
+// StopCapability returns.
+func TestLiveTruncateResumesAfterCompletedStorageStopFailure(t *testing.T) {
+	const numBlocks = 10
+	n, points := newLiveLifecycleTestNode(t, numBlocks)
+
+	stopFailure := errors.New("completed storage stop failure")
+	require.NoError(t, plugin.Register[string, struct{}, struct{}](
+		n.pluginHost,
+		plugin.Descriptor{
+			Capability: plugin.CapabilityStorageBlob,
+			Name:       "test-stop-error",
+		},
+		func() struct{} { return struct{}{} },
+		func(context.Context, struct{}, struct{}) (string, plugin.Instance, error) {
+			return "test", plugin.Lifecycle{
+				StopFunc: func(context.Context) error { return stopFailure },
+			}, nil
+		},
+	))
+	_, err := plugin.Resolve[string](
+		context.Background(),
+		n.pluginHost,
+		plugin.CapabilityStorageBlob,
+		"test-stop-error",
+		nil,
+		struct{}{},
+	)
+	require.NoError(t, err)
+
+	oldCtx := n.ctx
+	oldDB := n.db
+	targetSlot := points[len(points)/2].Slot
+	_, err = n.Truncate(
+		context.Background(),
+		dblifecycle.TruncateTarget{Slot: &targetSlot},
+	)
+	require.ErrorIs(t, err, stopFailure)
+	require.ErrorContains(t, err, "close storage")
+
 	require.Same(t, oldCtx, n.ctx)
 	require.NoError(t, n.ctx.Err())
 	require.NotSame(t, oldDB, n.db, "storage must be reopened fresh on resume")
@@ -958,9 +1007,6 @@ func TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode(
 	require.NotNil(t, n.connManager)
 	require.NotNil(t, n.peerGov)
 
-	// Nothing was actually truncated — the failure happened before the
-	// data directory was ever touched — so every original block must
-	// still be present.
 	tip, tipErr := n.db.GetTip(nil)
 	require.NoError(t, tipErr)
 	require.Equal(t, points[len(points)-1].Slot, tip.Point.Slot)
@@ -968,18 +1014,14 @@ func TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode(
 		_, blockErr := database.BlockByHash(n.db, p.Hash)
 		require.NoErrorf(
 			t, blockErr,
-			"block at slot %d missing after a resumed truncate failure", p.Slot,
+			"block at slot %d missing after a resumed stop failure", p.Slot,
 		)
 	}
 }
 
 // TestLiveTruncateCancelsInsteadOfResumingWhenStorageDrainUnconfirmed guards
 // against the actual use-after-close race errStorageDrainUnconfirmed exists
-// to prevent — the opposite of
-// TestLiveTruncateResumesAfterCloseStorageFailureInsteadOfStrandingNode
-// above. That test's failure trigger (deferredIndexMaintenanceDone) is a
-// clean failure with no goroutine left running, so resuming on it is
-// safe. Here the trigger is a real dbWorkerPool worker still executing an
+// to prevent. Here the trigger is a real dbWorkerPool worker still executing an
 // operation against the *old* database when Close's bounded wait gives up
 // on it, which is exactly the case reinitializeAndResume must not paper
 // over: reopening storage while that worker might still be using it would


### PR DESCRIPTION
Badger value-log GC cannot cancel a rewrite already in flight, so provider
shutdown could wait past the host stop deadline.

- Thread the provider stop context into Badger cleanup.
- Prevent a successful GC rewrite from starting another pass after shutdown.
- Let a one-time close drain the active rewrite while the provider returns at
  the context deadline.
- Fail closed during live restore or truncate when storage cleanup is still
  pending, rather than reopening the same data directory.
- Cover the provider lifecycle, bounded return, single rewrite, eventual close,
  and safe live-lifecycle ownership transition.

This implements the shutdown-bound portion of #2701. The broader measurement,
observability, benchmark, and default-policy work remains open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database shutdown handling when value-log cleanup is in progress.
  * Stop operations now honor cancellation and deadlines instead of waiting indefinitely.
  * Prevented additional cleanup passes from starting during shutdown.
  * Ensured direct closes and background cleanup share the same completion process.

* **Documentation**
  * Updated architecture, database, and plugin lifecycle guidance to describe context-aware shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
