### PR TITLE
fix(ledger): enforce stake threshold outside genesis overlay slots

### DIFF
--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -769,53 +769,6 @@ func activeSlotCoeffInverse(activeSlotsCoeff *big.Rat) uint64 {
 	return inv.Uint64()
 }
 
-func (ls *LedgerState) genesisDelegationActiveForSlot(slot uint64) bool {
-	if pparams := ls.genesisOverlayProtocolParamsForSlot(slot); pparams != nil {
-		return decentralizedParamActive(pparams)
-	}
-	if ls.config.CardanoNodeConfig == nil {
-		return false
-	}
-	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
-	if shelleyGenesis == nil ||
-		shelleyGenesis.ProtocolParameters.Decentralization == nil {
-		return false
-	}
-	return shelleyGenesis.ProtocolParameters.Decentralization.Sign() > 0
-}
-
-// genesisOverlayProtocolParamsForSlot resolves the protocol parameters that
-// govern the slot's epoch. ProtocolParamsForSlot intentionally forecasts from
-// the current state for forging, but that is not a historical lookup: at an
-// epoch boundary it can return the previous epoch's decentralization value.
-// Prefer the epoch-specific metadata row, falling back to the current/forecast
-// value only when the target epoch is not persisted yet. Header callers defer
-// that not-yet-authoritative case before making an overlay decision.
-func (ls *LedgerState) genesisOverlayProtocolParamsForSlot(
-	slot uint64,
-) lcommon.ProtocolParameters {
-	if epoch, err := ls.epochForSlot(slot); err == nil {
-		snapshot := ls.loadConsensusSnapshot()
-		if epoch.EpochId == snapshot.currentEpoch.EpochId {
-			return snapshot.currentPParams
-		}
-		if ls.db != nil {
-			era, ok := ls.eraById(epoch.EraId)
-			if ok && era != nil && era.DecodePParamsFunc != nil {
-				if pparams, pparamsErr := ls.db.GetPParams(
-					epoch.EpochId,
-					era.Id,
-					era.DecodePParamsFunc,
-					nil,
-				); pparamsErr == nil && pparams != nil {
-					return pparams
-				}
-			}
-		}
-	}
-	return ls.ProtocolParamsForSlot(slot)
-}
-
 // genesisOverlayProtocolParamsForBlock resolves protocol parameters for the
 // block body era rather than only the epoch's current era. A hard-fork
 // boundary block may be encoded in the predecessor era while its header
@@ -857,13 +810,6 @@ func (ls *LedgerState) genesisOverlayProtocolParamsForBlock(
 		}
 	}
 	return ls.ProtocolParamsForSlot(slot)
-}
-
-func decentralizedParamActive(
-	pparams lcommon.ProtocolParameters,
-) bool {
-	rat := decentralizationParamRat(pparams)
-	return rat != nil && rat.Sign() > 0
 }
 
 func decentralizationParamRat(
@@ -915,6 +861,12 @@ func (ls *LedgerState) ledgerTipBehindSlot(slot uint64) bool {
 // how the VRF leader value is derived from the output bytes; ConsensusModeForEpoch
 // selects the correct path for the block's era.
 //
+// The production caller first runs verifyGenesisDelegateHeader, which handles
+// or rejects exact genesis-overlay slots. Reaching this function from that path
+// means the block is in a Praos slot and must receive the pool threshold check,
+// even when the decentralization parameter enables overlay slots elsewhere in
+// the same epoch.
+//
 // Byron blocks are skipped (PBFT). A missing total-stake or unavailable active
 // slot coefficient is logged and skipped rather than rejecting, to tolerate
 // early-chain bootstrap states where the genesis snapshot is not yet written.
@@ -923,18 +875,6 @@ func (ls *LedgerState) verifyBlockLeaderEligibility(
 	epochId uint64,
 ) error {
 	if block.Era().Id == byron.EraIdByron {
-		return nil
-	}
-	if ls.genesisDelegationActiveForSlot(block.SlotNumber()) {
-		ls.config.Logger.Warn(
-			"skipping leader eligibility check: decentralization parameter active",
-			"slot",
-			block.SlotNumber(),
-			"epoch",
-			epochId,
-			"component",
-			"ledger",
-		)
 		return nil
 	}
 

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1371,17 +1371,26 @@ func TestGenesisOverlayUsesEffectiveEpochPParamsAtBoundary(t *testing.T) {
 		nil,
 	))
 
-	// The preceding epoch remains genesis-overlay active, while canonical
-	// epoch-2 slots use decentralisationParam=0 and must fall through to the
-	// normal pool path. A current-epoch-only lookup regresses here by reading
-	// epoch-1's d=1 and returning genesisOverlayNonActive.
-	require.True(t, ls.genesisDelegationActiveForSlot(172_780))
-	require.False(t, ls.genesisDelegationActiveForSlot(172_836))
+	// The preceding epoch has an active overlay slot, while canonical epoch-2
+	// slots use decentralisationParam=0 and must fall through to the normal
+	// pool path. A current-epoch-only lookup regresses here by reading epoch-1's
+	// d=1 and returning genesisOverlayNonActive for the epoch-2 block.
+	precedingBlock := &mockBoundaryAlonzoBlock{
+		Block: &mockBabbageBlock{slot: 172_780},
+		slot:  172_780,
+	}
+	_, status, err := ls.genesisOverlayDelegationForBlock(
+		precedingBlock,
+		genesisCfg.ShelleyGenesis(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, genesisOverlayActive, status)
+
 	block := &mockBoundaryAlonzoBlock{
 		Block: &mockBabbageBlock{slot: 172_836},
 		slot:  172_836,
 	}
-	_, status, err := ls.genesisOverlayDelegationForBlock(
+	_, status, err = ls.genesisOverlayDelegationForBlock(
 		block,
 		genesisCfg.ShelleyGenesis(),
 	)
@@ -1552,11 +1561,11 @@ func TestVerifyBlockHeaderState_GenesisDelegateInactiveOverlaySlotFails(
 	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
 }
 
-func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotFallsThrough(
+func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotUsesPoolThreshold(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{54}, 0, tamperNone)
-	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
 	delegateHash := tb.block.IssuerVkey().Hash()
 	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
 	require.NoError(t, err)
@@ -1571,10 +1580,26 @@ func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotFallsThrough(
 		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1000)},
 	}
 	ls.publishSnapshotsLocked()
+	seedBlockPoolRegistration(t, db, tb.block)
+	seedPoolStakeSnapshot(t, db, 4, delegateHash.Bytes(), 1)
+	dummyPool := make([]byte, lcommon.Blake2b224Size)
+	dummyPool[0] = 0xFF
+	seedPoolStakeSnapshot(t, db, 4, dummyPool, 1_000_000_000_000_000_000)
+
+	_, status, err := ls.genesisOverlayDelegationForBlock(
+		tb.block,
+		ls.config.CardanoNodeConfig.ShelleyGenesis(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, genesisOverlayNone, status)
 
 	err = ls.verifyBlockHeaderState(tb.block, 5, false)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, models.ErrPoolNotFound)
+	require.Error(
+		t,
+		err,
+		"a non-overlay slot must apply the Praos leader threshold",
+	)
+	assert.Contains(t, err.Error(), "VRF leader value exceeds stake-derived threshold")
 
 	// A stale decentralized parameter set can classify this future slot as
 	// genesisOverlayNone. Header verification must defer before that
@@ -2148,26 +2173,6 @@ func TestVerifyBlockLeaderEligibility_VRFAboveThresholdFails(t *testing.T) {
 		err.Error(),
 		"VRF leader value exceeds stake-derived threshold",
 	)
-}
-
-func TestVerifyBlockLeaderEligibility_DecentralizationActiveSkipsThreshold(
-	t *testing.T,
-) {
-	tb := createTestBlock(t, [32]byte{52}, 0, tamperNone)
-	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
-	ls.currentPParams = &shelley.ShelleyProtocolParameters{
-		Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
-	}
-	ls.publishSnapshotsLocked()
-
-	poolKeyHash := tb.block.IssuerVkey().Hash()
-	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1)
-	dummyHash := make([]byte, 28)
-	dummyHash[0] = 0xFF
-	seedPoolStakeSnapshot(t, db, 4, dummyHash, 1_000_000_000_000_000_000)
-
-	err := ls.verifyBlockLeaderEligibility(tb.block, 5)
-	require.NoError(t, err)
 }
 
 func TestVerifyBlockHeaderCrypto_SkipLeaderStakeThresholdCheckWarnsAndAccepts(


### PR DESCRIPTION
Closes #3521

Genesis overlay delegation is slot-specific, but leader eligibility was also gated by an epoch-level decentralization check. This change lets `verifyGenesisDelegateHeader` handle active overlay slots while non-overlay slots continue through registered-pool stake-threshold validation.

The tests cover mixed delegation state across an epoch boundary and exercise the production header-state path.
