### PR TITLE
fix(config): reject a peer snapshot from another network

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3439,6 +3439,20 @@ later ledger peer refreshes still query the live ledger/database provider.
 If the snapshot produces no usable peers, startup falls back to topology
 bootstrap peers.
 
+Because that replacement is what makes the snapshot useful, a snapshot from the
+wrong network is rejected at startup rather than loaded: `configValidate`
+refuses a configuration whose `peerSnapshotFile` carries a `NetworkMagic`
+different from the node's (`internal/config.PeerSnapshotNetworkMismatch`, and
+see the same function for why magic 0 counts as unspecified on either side).
+cardano-node records the snapshot's own magic in the file, so a foreign
+snapshot is self-identifying. Left unchecked it costs the node both peer sets
+at once: its relays displace the configured bootstrap peers, and then every one
+of them is denied at the handshake for a network-magic mismatch
+(`permanentlyDenyNetworkMagicMismatch`), so the node ends up with no peers and
+no route back to the bootstrap list. The `added == 0` fallback above does not
+help, because the addresses were added successfully — they only fail later, at
+the handshake.
+
 These snapshot-seeded ledger peers are the configured corroborators for the
 Genesis corroboration gate (see Chain Selection → Ouroboros Genesis trust
 model). In a GSA-style deployment the fast source is a trustable `localRoots`

--- a/config.go
+++ b/config.go
@@ -559,6 +559,28 @@ func (n *Node) configValidate() error {
 			ouroboros.NetworkCardanoMusashi.NetworkMagic,
 		)
 	}
+	// A peer snapshot carries the network magic it was taken on. During
+	// Genesis selection its relays replace the configured bootstrap peers, so
+	// a snapshot from another network aims the node at that network's relays
+	// and discards the addresses that would have worked. Those relays are then
+	// each denied at the handshake for a magic mismatch, leaving the node with
+	// no peers and no route back to the bootstrap list -- an outage-shaped
+	// failure with a configuration cause. Reject it at startup instead.
+	if n.config.topologyConfig != nil &&
+		n.config.topologyConfig.PeerSnapshot != nil &&
+		internalconfig.PeerSnapshotNetworkMismatch(
+			n.config.topologyConfig.PeerSnapshot.NetworkMagic,
+			n.config.cfg.NetworkMagic,
+		) {
+		return fmt.Errorf(
+			"peer snapshot network mismatch: snapshot networkMagic %d does "+
+				"not match the configured networkMagic %d; its relays would "+
+				"replace the configured bootstrap peers and then be refused "+
+				"at the handshake",
+			n.config.topologyConfig.PeerSnapshot.NetworkMagic,
+			n.config.cfg.NetworkMagic,
+		)
+	}
 	// The block-decode pipeline's vendored decode stage
 	// (gouroboros/pipeline.DecodeStage) calls ledger.NewBlockFromCbor
 	// directly and has no hook for dingo's Leios-extended-header Conway

--- a/internal/config/peer_snapshot_network_test.go
+++ b/internal/config/peer_snapshot_network_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestPeerSnapshotNetworkMismatch(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		snapshotMagic uint32
+		networkMagic  uint32
+		want          bool
+	}{
+		{
+			name:          "different networks mismatch",
+			snapshotMagic: 764824073,
+			networkMagic:  2,
+			want:          true,
+		},
+		{
+			name:          "same network does not",
+			snapshotMagic: 2,
+			networkMagic:  2,
+		},
+		{
+			// A snapshot that omits the field must not be rejected on the
+			// strength of an absent value; no real network uses magic 0.
+			name:         "unset snapshot magic is unspecified",
+			networkMagic: 2,
+		},
+		{
+			// Startup resolves the magic from the network name before
+			// validating, so this is defensive rather than reachable.
+			name:          "unset node magic is unspecified",
+			snapshotMagic: 2,
+		},
+		{
+			name: "both unset",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PeerSnapshotNetworkMismatch(
+				tt.snapshotMagic,
+				tt.networkMagic,
+			)
+			if got != tt.want {
+				t.Fatalf(
+					"PeerSnapshotNetworkMismatch(%d, %d) = %v, want %v",
+					tt.snapshotMagic,
+					tt.networkMagic,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -119,6 +119,29 @@ func MusashiNetworkIdentityConflict(
 	return "", false
 }
 
+// PeerSnapshotNetworkMismatch reports whether a topology peer snapshot names a
+// different network than the node is configured for.
+//
+// cardano-node writes the snapshot's own NetworkMagic into the file, so a
+// snapshot taken on another network is self-identifying. It matters because
+// the snapshot's relays *replace* the configured bootstrap peers during
+// Genesis selection: accepting a foreign one aims the node at another
+// network's relays and throws away the only addresses that could have worked.
+// Every one of those relays is then denied at the handshake on a network-magic
+// mismatch, leaving the node with no peers and nothing to fall back to.
+//
+// A zero magic on either side is "unspecified" rather than a network -- no
+// real network uses magic 0, and a hand-written or older snapshot may omit the
+// field -- so it is not treated as a mismatch.
+func PeerSnapshotNetworkMismatch(
+	snapshotMagic uint32,
+	networkMagic uint32,
+) bool {
+	return snapshotMagic != 0 &&
+		networkMagic != 0 &&
+		snapshotMagic != networkMagic
+}
+
 // MusashiPrototypeNetwork reports whether network/networkMagic unambiguously
 // identifies the Musashi prototype network, and is therefore permitted to run
 // with the prototype's consensus/ledger trust bypasses.

--- a/peer_snapshot_network_test.go
+++ b/peer_snapshot_network_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/topology"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// peerSnapshotTopology builds a topology carrying a peer snapshot for the
+// given network magic, plus a configured bootstrap peer. The bootstrap peer
+// matters because a node that accepts the snapshot drops it.
+func peerSnapshotTopology(snapshotMagic uint32) *topology.TopologyConfig {
+	return &topology.TopologyConfig{
+		BootstrapPeers: []topology.TopologyConfigP2PBootstrapPeer{
+			{Address: "backup.example", Port: 3001},
+		},
+		PeerSnapshot: &topology.PeerSnapshotConfig{
+			NetworkMagic: snapshotMagic,
+			LedgerPools: []topology.PeerSnapshotLedgerPool{
+				{
+					Relays: []topology.TopologyConfigP2PAccessPoint{
+						{Address: "relay.example", Port: 3001},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestPeerSnapshotFromAnotherNetworkRejected proves a peer snapshot naming a
+// different network cannot start the node.
+//
+// The snapshot's relays replace the configured bootstrap peers during Genesis
+// selection, so accepting a foreign snapshot points the node at another
+// network's relays and discards the only addresses that could have worked.
+// Each of those relays is then denied at the handshake on a network-magic
+// mismatch, which leaves the node with no peers at all and no way back to the
+// bootstrap list — a failure that looks like a network outage rather than the
+// misconfiguration it is.
+func TestPeerSnapshotFromAnotherNetworkRejected(t *testing.T) {
+	tests := []struct {
+		name          string
+		network       string
+		snapshotMagic uint32
+		wantErr       string
+	}{
+		{
+			name:          "preview node given a mainnet snapshot",
+			network:       "preview",
+			snapshotMagic: 764824073,
+			wantErr:       "peer snapshot network mismatch",
+		},
+		{
+			name:          "mainnet node given a preprod snapshot",
+			network:       "mainnet",
+			snapshotMagic: 1,
+			wantErr:       "peer snapshot network mismatch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(NewConfig(
+				WithPrometheusRegistry(prometheus.NewRegistry()),
+				WithListeners(ListenerConfig{
+					ListenNetwork: "tcp",
+					ListenAddress: "127.0.0.1:0",
+				}),
+				WithNetwork(tt.network),
+				WithTopologyConfig(peerSnapshotTopology(tt.snapshotMagic)),
+			))
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestPeerSnapshotMatchingNetworkAccepted is the negative case: a snapshot for
+// the node's own network must still start, or the check would break every
+// Genesis bootstrap it is meant to protect.
+func TestPeerSnapshotMatchingNetworkAccepted(t *testing.T) {
+	n, err := New(NewConfig(
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithNetwork("preview"),
+		WithTopologyConfig(peerSnapshotTopology(2)),
+	))
+	require.NoError(t, err)
+	require.NotNil(t, n)
+}
+
+// TestPeerSnapshotWithoutNetworkMagicAccepted covers a snapshot that omits the
+// field. Zero is "unspecified" rather than a network, and no real network uses
+// it, so a hand-written or older snapshot must not be rejected on the strength
+// of an absent field.
+func TestPeerSnapshotWithoutNetworkMagicAccepted(t *testing.T) {
+	n, err := New(NewConfig(
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithNetwork("preview"),
+		WithTopologyConfig(peerSnapshotTopology(0)),
+	))
+	require.NoError(t, err)
+	require.NotNil(t, n)
+}


### PR DESCRIPTION
Refs #1649

`topology.PeerSnapshotConfig.NetworkMagic` is parsed from the snapshot file and
read nowhere in production code — the only reference outside this change is a
config test asserting it was parsed. A snapshot taken on another network was
therefore accepted and used.

That matters because of what accepting one does. During Genesis selection the
snapshot's relays *replace* the configured bootstrap peers
(`WithoutBootstrapPeers`), so a foreign snapshot costs the node both peer sets
at once:

1. the configured bootstrap peers are dropped, then
2. every snapshot relay is denied at the handshake for a network-magic
   mismatch (`permanentlyDenyNetworkMagicMismatch`),

leaving the node with no peers and no route back to the bootstrap list. The
existing `added == 0` fallback does not cover this: the addresses were added
successfully and only fail later, at the handshake. The result looks like a
network outage but is a configuration error.

`configValidate` now rejects the configuration at startup, following the
existing `MusashiNetworkIdentityConflict` check in the same file. A magic of 0
on either side is "unspecified" rather than a network — no real network uses 0
— so a hand-written or older snapshot that omits the field is still accepted.

Scope: this is the network-identity half of the peer-snapshot item in #1649.
Validating snapshot relay access points and valencies is #3291 and is left
alone.

Documentation: `ARCHITECTURE.md`'s peer-snapshot paragraph records the check and
why the existing fallback does not cover it. `DATABASE.md` checked, not
affected.

Validation:

- `go test -race -count=1 . ./internal/config ./peergov ./topology` — pass,
  exit 0
- `go test -count=1 ./internal/test/conformance` — pass
- `./internal/test/devnet/run-tests.sh` (all-Dingo) — pass, exit 0
- `golangci-lint`, `nilaway` on `.` and `./internal/config/...` — clean
- `make import-boundaries`, `make docs-parity` — pass
- `golines` — changed files clean

Both rejection cases were confirmed failing before the change. The two
acceptance cases (matching magic, absent magic) passed before and after, so
they guard against over-rejection rather than proving the fix; the predicate
also has direct table coverage including both zero cases.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects peer snapshots taken on another network at startup so a misconfigured node fails fast instead of silently losing all its peers.

`topology.PeerSnapshotConfig.NetworkMagic` was parsed from the snapshot file but never read in production code, so a foreign snapshot was accepted and its relays replaced the configured bootstrap peers during Genesis selection. Each relay was then denied at the handshake for a network-magic mismatch, leaving the node with no peers and no route back to the bootstrap list. The existing `added == 0` fallback didn't help because the addresses were added successfully and only failed later at the handshake.

`configValidate` now returns `peer snapshot network mismatch` when the snapshot's magic differs from the node's, following the existing `MusashiNetworkIdentityConflict` check. A magic of 0 on either side is treated as unspecified, so hand-written or older snapshots that omit the field are still accepted.

**New Features**
- Adds `PeerSnapshotNetworkMismatch` in `internal/config` for the new validation.

<sup>Written for commit 05d17f09b3d7a7e38c15afe340afb327cb89344f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer snapshots with a different network configuration are now rejected during startup.
  * Prevents invalid snapshot peers from replacing valid bootstrap peers and causing connection failures.
  * Snapshots with matching or unspecified network settings continue to be accepted.

* **Tests**
  * Added coverage for matching, mismatched, and unspecified network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->