### PR TITLE
fix(ledger): seed post-Byron epoch nonce at multi-era boundary transitions

### DIFF
--- a/ledger/byron_shelley_boundary_test.go
+++ b/ledger/byron_shelley_boundary_test.go
@@ -422,6 +422,98 @@ func TestByronShelleyBoundaryProcessesFirstShelleyBlockWithPParams(
 	assert.Equal(t, firstShelley.SlotNumber(), ls.currentTip.Point.Slot)
 }
 
+// TestByronShelleyBoundarySeedsEpochNonceOnProductionPath pins the fix for
+// #3559 through the same production path as
+// TestByronShelleyBoundaryProcessesFirstShelleyBlockWithPParams: without the
+// post-Byron nonce seeding in applyBoundaryEraTransitions (ledger/state.go),
+// calculateEpochNonce returns a nil nonce for any rollover whose source era is
+// Byron, regardless of the destination era, and the transitioned epoch is
+// persisted with no nonce at all. That existing test only asserts on era,
+// pparams, and tip, so it still passes with the nonce-seeding block deleted;
+// this test asserts on the nonce itself, in all three places a caller can
+// observe it — the in-memory current epoch, the epoch cache, and the
+// persisted database row — and fails without the fix.
+func TestByronShelleyBoundarySeedsEpochNonceOnProductionPath(t *testing.T) {
+	ls, _, firstShelley := newByronShelleyBoundaryLedger(t)
+	require.True(t, ls.validationEnabled)
+
+	results := make(chan readChainResult, 1)
+	results <- readChainResult{blocks: []gledger.Block{firstShelley}}
+	close(results)
+
+	require.NoError(t, ls.ledgerProcessBlocksFromSource(
+		context.Background(),
+		results,
+	))
+	require.Equal(t, eras.ShelleyEraDesc.Id, ls.currentEra.Id)
+
+	// The fix seeds the nonce/evolving/candidate nonce from the Shelley
+	// genesis hash, which newByronShelleyBoundaryLedger sets to 32 bytes of
+	// 0x42 (ShelleyGenesisHash: strings.Repeat("42", 32)).
+	expectedNonce := bytes.Repeat([]byte{0x42}, 32)
+	transitionedEpoch := ls.currentEpoch.EpochId
+
+	// In-memory current epoch.
+	assert.Equal(
+		t,
+		expectedNonce,
+		[]byte(ls.currentEpoch.Nonce),
+		"in-memory epoch must carry the seeded nonce",
+	)
+	assert.Equal(
+		t,
+		expectedNonce,
+		[]byte(ls.currentEpoch.EvolvingNonce),
+	)
+	assert.Equal(
+		t,
+		expectedNonce,
+		[]byte(ls.currentEpoch.CandidateNonce),
+	)
+
+	// Epoch cache.
+	var cached *models.Epoch
+	for i := range ls.epochCache {
+		if ls.epochCache[i].EpochId == transitionedEpoch {
+			cached = &ls.epochCache[i]
+			break
+		}
+	}
+	require.NotNil(
+		t,
+		cached,
+		"epoch cache must contain the transitioned epoch",
+	)
+	assert.Equal(
+		t,
+		expectedNonce,
+		[]byte(cached.Nonce),
+		"epoch cache entry must carry the seeded nonce",
+	)
+
+	// Persisted epoch row.
+	epochs, err := ls.db.GetEpochs(nil)
+	require.NoError(t, err)
+	var persisted *models.Epoch
+	for i := range epochs {
+		if epochs[i].EpochId == transitionedEpoch {
+			persisted = &epochs[i]
+			break
+		}
+	}
+	require.NotNil(
+		t,
+		persisted,
+		"the transitioned epoch must be persisted",
+	)
+	assert.Equal(
+		t,
+		expectedNonce,
+		[]byte(persisted.Nonce),
+		"persisted epoch row must carry the seeded nonce",
+	)
+}
+
 func TestRollbackChainAndStateClearsShelleyPParamsInsideByronPrefix(
 	t *testing.T,
 ) {

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4906,6 +4906,18 @@ func (ls *LedgerState) processEpochRollover(
 	currentPParams lcommon.ProtocolParameters,
 	deferBoundarySnapshot bool,
 ) (*EpochRolloverResult, error) {
+	// Fail closed at the top of the production rollover path rather than
+	// letting a nil config reach one of the several unchecked
+	// ls.config.CardanoNodeConfig dereferences below (e.g. the
+	// ShelleyGenesis() read further down, or applyBoundaryEraTransitions's
+	// post-Byron nonce seeding) -- any of which would panic instead of
+	// returning an error. NewLedgerState does not itself require a non-nil
+	// CardanoNodeConfig, so this is the boundary that must catch it.
+	if ls.config.CardanoNodeConfig == nil {
+		return nil, errors.New(
+			"process epoch rollover: CardanoNodeConfig is nil",
+		)
+	}
 	epochStartSlot := currentEpoch.StartSlot + uint64(
 		currentEpoch.LengthInSlots,
 	)

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4564,7 +4564,13 @@ func (ls *LedgerState) calculateEpochNonce(
 	currentEra eras.EraDesc,
 	currentEpoch models.Epoch,
 ) ([]byte, []byte, []byte, []byte, error) {
-	// No epoch nonce in Byron
+	// No epoch nonce in Byron. NOTE: currentEra is the SOURCE era being
+	// rolled over, not necessarily the era the new epoch will run at — a
+	// rollover whose source era is Byron but whose destination era (per
+	// the caller's later era-transition decision) is Shelley or beyond
+	// still returns nil here. applyBoundaryEraTransitions seeds a real
+	// nonce for that case once the destination era is known; see the
+	// comment there.
 	if currentEra.Id == 0 {
 		return nil, nil, nil, nil, nil
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3475,6 +3475,34 @@ func (ls *LedgerState) applyBoundaryEraTransitions(
 	newEpoch.EraId = workingEraId
 	newEpoch.SlotLength = slotLength
 	newEpoch.LengthInSlots = epochLength
+	// calculateEpochNonce short-circuits to an all-nil nonce whenever the
+	// ROLLOVER'S SOURCE era is Byron (no Praos nonce there), regardless of
+	// what era this boundary actually transitions into. That is correct
+	// when the new epoch stays in Byron, but here workingEraId has just
+	// been advanced past Byron (that is the only way this function runs),
+	// so the epoch needs a real nonce for header verification in its new
+	// era. Seed it the same way every other from-genesis nonce path does
+	// (computeEpochNonceForSlot, calculateEpochNonce's own no-prior-nonce
+	// branch): the Shelley genesis hash for nonce/evolving/candidate, with
+	// LastEpochBlockNonce left at NeutralNonce (nil) — see #2734. Without
+	// this, header verification permanently rejects every block in the
+	// new era with "epoch has no nonce for slot" for any Byron-prefixed
+	// network that syncs from genesis instead of a Mithril snapshot.
+	if workingEraId != 0 && len(newEpoch.Nonce) == 0 {
+		genesisHashBytes, err := hex.DecodeString(
+			ls.config.CardanoNodeConfig.ShelleyGenesisHash,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"decode Shelley genesis hash for post-Byron epoch nonce: %w",
+				err,
+			)
+		}
+		newEpoch.Nonce = genesisHashBytes
+		newEpoch.EvolvingNonce = genesisHashBytes
+		newEpoch.CandidateNonce = genesisHashBytes
+		newEpoch.LastEpochBlockNonce = nil
+	}
 	if err := ls.db.SetEpoch(
 		newEpoch.StartSlot,
 		newEpoch.EpochId,
@@ -3515,6 +3543,10 @@ func (ls *LedgerState) applyBoundaryEraTransitions(
 			rolloverResult.NewEpochCache[i].EraId = workingEraId
 			rolloverResult.NewEpochCache[i].SlotLength = slotLength
 			rolloverResult.NewEpochCache[i].LengthInSlots = epochLength
+			rolloverResult.NewEpochCache[i].Nonce = newEpoch.Nonce
+			rolloverResult.NewEpochCache[i].EvolvingNonce = newEpoch.EvolvingNonce
+			rolloverResult.NewEpochCache[i].CandidateNonce = newEpoch.CandidateNonce
+			rolloverResult.NewEpochCache[i].LastEpochBlockNonce = newEpoch.LastEpochBlockNonce
 		}
 	}
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3489,6 +3489,16 @@ func (ls *LedgerState) applyBoundaryEraTransitions(
 	// new era with "epoch has no nonce for slot" for any Byron-prefixed
 	// network that syncs from genesis instead of a Mithril snapshot.
 	if workingEraId != 0 && len(newEpoch.Nonce) == 0 {
+		if ls.config.CardanoNodeConfig == nil {
+			return nil, errors.New(
+				"seed post-Byron epoch nonce: CardanoNodeConfig is nil",
+			)
+		}
+		if ls.config.CardanoNodeConfig.ShelleyGenesisHash == "" {
+			return nil, errors.New(
+				"seed post-Byron epoch nonce: could not get Shelley genesis hash",
+			)
+		}
 		genesisHashBytes, err := hex.DecodeString(
 			ls.config.CardanoNodeConfig.ShelleyGenesisHash,
 		)
@@ -3496,6 +3506,12 @@ func (ls *LedgerState) applyBoundaryEraTransitions(
 			return nil, fmt.Errorf(
 				"decode Shelley genesis hash for post-Byron epoch nonce: %w",
 				err,
+			)
+		}
+		if len(genesisHashBytes) != lcommon.Blake2b256Size {
+			return nil, fmt.Errorf(
+				"seed post-Byron epoch nonce: Shelley genesis hash is %d bytes, expected %d",
+				len(genesisHashBytes), lcommon.Blake2b256Size,
 			)
 		}
 		newEpoch.Nonce = genesisHashBytes


### PR DESCRIPTION
## Summary
- `calculateEpochNonce` short-circuits to an all-nil nonce whenever the epoch rollover's *source* era is Byron (no Praos nonce there), even when `applyBoundaryEraTransitions` has just advanced the epoch's actual (destination) era past Byron in that same rollover.
- This is correct when the new epoch stays in Byron, but wrong the one time it doesn't: the new era has no nonce, so header verification permanently rejects every block of the new era with "epoch has no nonce for slot" — a hard stall at the first epoch boundary of any Byron-prefixed network synced from genesis instead of a Mithril snapshot.
- Fix: seed the epoch's nonce/evolving-nonce/candidate-nonce from the Shelley genesis hash in `applyBoundaryEraTransitions` when `workingEraId != 0 && len(newEpoch.Nonce) == 0`, the same way every other from-genesis nonce path already does. `LastEpochBlockNonce` is left at `NeutralNonce` (nil).

## Test plan
- [x] Reproduced against a from-genesis sync of Apex Fusion's `prime-mainnet` (a Byron-prefixed network with no Mithril snapshot available): stalled permanently at the first epoch boundary (slot 43200) with the bug present.
- [x] Validated the fix over two independent fresh from-genesis sync runs: the epoch cache advanced cleanly through 8+ sequential epoch rollovers, each with a distinct, correctly-evolving nonce.
- [x] `go test -tags dingo_extra_plugins -timeout 20m ./ledger/...` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hard stall at the first epoch boundary when a Byron-prefixed network syncs from genesis without a Mithril snapshot. Previously the epoch nonce was left nil whenever the rollover's source era was Byron, even if the boundary transitioned into a later era, so header verification rejected every block of the new era. Now `applyBoundaryEraTransitions` seeds the nonce from the Shelley genesis hash.

- Nonce, evolving nonce, and candidate nonce all get the Shelley genesis hash; `LastEpochBlockNonce` stays nil.
- The same values are also written to the new epoch cache entries.
- Seeding now errors instead of panicking on a nil `CardanoNodeConfig` or silently writing an unusable nonce from an empty `ShelleyGenesisHash`; the nil-config guard also protects the top of `processEpochRollover` before the config is otherwise dereferenced.
- Validated on `prime-mainnet` from genesis: previously wedged at slot 43200, now syncs through 8+ rollovers; `go test -tags dingo_extra_plugins -timeout 20m ./ledger/...` passes. A new regression test asserts the seeded nonce in the in-memory epoch, the epoch cache, and the persisted database row.

<sup>Written for commit 4447a847505ef0c28dd6d3845502048b33d2a1b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved epoch transitions after Byron to correctly initialize required nonce values from the Shelley genesis hash.
  * Preserved the absence of a last-epoch block nonce when appropriate.
  * Updated transitioned epoch state to retain all relevant nonce information.
  * Clarified handling of Byron-origin epoch rollovers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->