### PR TITLE
fix(ledger): distinguish prime-mainnet from real Cardano mainnet in isMainnet

### DIFF
--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -534,6 +534,7 @@ func LoadWithDB(
 			ChainManager:       cm,
 			Logger:             logger,
 			CardanoNodeConfig:  nodeCfg,
+			Network:            cfg.Network,
 			ValidateHistorical: cfg.ValidateHistorical,
 			// CIP-0163 full-pot reward distribution is consensus-affecting and
 			// deterministically changes the reward state written during replay,

--- a/ledger/header_protocol_version.go
+++ b/ledger/header_protocol_version.go
@@ -153,13 +153,20 @@ func ValidateHeaderProtocolVersion(
 // cardano-ledger's mainnet-only BBODY strictness there rejects headers a
 // chain's own nodes have already built on top of.
 //
-// When ls.config.Network names a network gouroboros recognizes, that
-// resolved identity decides mainnet-ness instead of the raw networkId
-// value, so prime-mainnet correctly gets the same relaxed treatment as
-// any other testnet despite its Mainnet-shaped genesis. An unset or
-// unrecognized Network name (a config built from a raw NetworkMagic, or
-// an embedder that never set it) falls back to the networkId-only check,
-// preserving prior behavior for every caller that predates this field.
+// A Mainnet-tagged genesis is only overridden to non-mainnet when
+// ls.config.Network names a network gouroboros itself registers as
+// sharing mainnet's network magic (currently just prime-mainnet) — the
+// narrow, known identity-reuse case this function exists to handle. Any
+// other named network paired with a Mainnet-tagged genesis is a
+// configuration mismatch, not a recognized alias, and falls through to
+// the genesis-only answer (true) rather than silently relaxing the BBODY
+// check for a misconfigured node: a node started with, say, Network=
+// "preview" against a genesis that (incorrectly) declares Mainnet must
+// not have mainnet's strictness relaxed just because the name isn't
+// literally "mainnet". An unset or unrecognized Network name (a config
+// built from a raw NetworkMagic, or an embedder that never set it) falls
+// back to the networkId-only check, preserving prior behavior for every
+// caller that predates this field.
 //
 // Fails closed: when CardanoNodeConfig or Shelley genesis is missing,
 // or the networkId field carries an unrecognized value, returns
@@ -178,8 +185,18 @@ func (ls *LedgerState) isMainnet() (bool, error) {
 	switch sg.NetworkId {
 	case shelleyGenesisMainnetNetworkId:
 		if ls.config.Network != "" {
-			if known, ok := ouroboros.NetworkByName(ls.config.Network); ok {
-				return known.Name == ouroboros.NetworkCardanoMainnet.Name, nil
+			if known, ok := ouroboros.NetworkByName(ls.config.Network); ok &&
+				known.Name != ouroboros.NetworkCardanoMainnet.Name &&
+				known.NetworkMagic == ouroboros.NetworkCardanoMainnet.NetworkMagic {
+				// Only a network gouroboros itself registers as sharing
+				// mainnet's magic (currently just prime-mainnet) may
+				// override a Mainnet-tagged genesis to non-mainnet. Any
+				// other named network paired with a Mainnet-tagged genesis
+				// is a configuration mismatch, not a known identity-reuse
+				// case, so it falls through to the genesis-only answer
+				// (true) rather than silently relaxing the BBODY check for
+				// a misconfigured node.
+				return false, nil
 			}
 		}
 		return true, nil

--- a/ledger/header_protocol_version.go
+++ b/ledger/header_protocol_version.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -140,11 +141,25 @@ func ValidateHeaderProtocolVersion(
 }
 
 // isMainnet reports whether this LedgerState is configured for Cardano
-// mainnet, derived from the Shelley genesis networkId field. This is
-// the literal port of cardano-ledger's `netId == Mainnet` predicate
-// used by the BBODY rule. Network magic alone is not a reliable
-// discriminator (devnet shares mainnet's RequiresNoMagic wire setting);
-// only the genesis-declared identity has the right semantics.
+// mainnet, derived from the Shelley genesis networkId field and, where
+// available, the network dingo was started with. The networkId check is
+// the literal port of cardano-ledger's `netId == Mainnet` predicate used
+// by the BBODY rule, but it is not sufficient on its own: a foreign chain
+// that reuses Cardano mainnet's identity for wire compatibility declares
+// the same networkId (and often the same network magic) while running its
+// own, independent hard-fork schedule. gouroboros's own network registry
+// contains exactly this case — prime-mainnet declares networkId=Mainnet
+// and magic 764824073, byte-identical to real Cardano mainnet. Enforcing
+// cardano-ledger's mainnet-only BBODY strictness there rejects headers a
+// chain's own nodes have already built on top of.
+//
+// When ls.config.Network names a network gouroboros recognizes, that
+// resolved identity decides mainnet-ness instead of the raw networkId
+// value, so prime-mainnet correctly gets the same relaxed treatment as
+// any other testnet despite its Mainnet-shaped genesis. An unset or
+// unrecognized Network name (a config built from a raw NetworkMagic, or
+// an embedder that never set it) falls back to the networkId-only check,
+// preserving prior behavior for every caller that predates this field.
 //
 // Fails closed: when CardanoNodeConfig or Shelley genesis is missing,
 // or the networkId field carries an unrecognized value, returns
@@ -162,6 +177,11 @@ func (ls *LedgerState) isMainnet() (bool, error) {
 	}
 	switch sg.NetworkId {
 	case shelleyGenesisMainnetNetworkId:
+		if ls.config.Network != "" {
+			if known, ok := ouroboros.NetworkByName(ls.config.Network); ok {
+				return known.Name == ouroboros.NetworkCardanoMainnet.Name, nil
+			}
+		}
 		return true, nil
 	case shelleyGenesisTestnetNetworkId:
 		return false, nil

--- a/ledger/header_protocol_version.go
+++ b/ledger/header_protocol_version.go
@@ -153,10 +153,16 @@ func ValidateHeaderProtocolVersion(
 // cardano-ledger's mainnet-only BBODY strictness there rejects headers a
 // chain's own nodes have already built on top of.
 //
-// A Mainnet-tagged genesis is only overridden to non-mainnet when
+// A Mainnet-tagged genesis is only overridden to non-mainnet when both the
+// genesis actually loaded carries mainnet's network magic AND
 // ls.config.Network names a network gouroboros itself registers as
-// sharing mainnet's network magic (currently just prime-mainnet) — the
-// narrow, known identity-reuse case this function exists to handle. Any
+// sharing that magic (currently just prime-mainnet) — the narrow, known
+// identity-reuse case this function exists to handle. Checking only the
+// registry's canonical magic for the configured name, without also
+// checking sg.NetworkMagic, would let Network="prime-mainnet" disable the
+// BBODY check for a genesis whose own magic doesn't actually match either
+// network — a misconfigured or corrupted genesis file, not the identity-
+// reuse case being handled. Any
 // other named network paired with a Mainnet-tagged genesis is a
 // configuration mismatch, not a recognized alias, and falls through to
 // the genesis-only answer (true) rather than silently relaxing the BBODY
@@ -184,18 +190,28 @@ func (ls *LedgerState) isMainnet() (bool, error) {
 	}
 	switch sg.NetworkId {
 	case shelleyGenesisMainnetNetworkId:
-		if ls.config.Network != "" {
+		if ls.config.Network != "" &&
+			sg.NetworkMagic == ouroboros.NetworkCardanoMainnet.NetworkMagic {
 			if known, ok := ouroboros.NetworkByName(ls.config.Network); ok &&
 				known.Name != ouroboros.NetworkCardanoMainnet.Name &&
 				known.NetworkMagic == ouroboros.NetworkCardanoMainnet.NetworkMagic {
 				// Only a network gouroboros itself registers as sharing
 				// mainnet's magic (currently just prime-mainnet) may
-				// override a Mainnet-tagged genesis to non-mainnet. Any
-				// other named network paired with a Mainnet-tagged genesis
-				// is a configuration mismatch, not a known identity-reuse
-				// case, so it falls through to the genesis-only answer
-				// (true) rather than silently relaxing the BBODY check for
-				// a misconfigured node.
+				// override a Mainnet-tagged genesis to non-mainnet, and
+				// only when the genesis actually loaded also carries
+				// mainnet's magic — not merely the registry's canonical
+				// value for the configured name. Without the sg.NetworkMagic
+				// check, Network="prime-mainnet" paired with a loaded
+				// genesis whose own magic is neither real mainnet's nor
+				// prime-mainnet's (e.g. a misconfigured or corrupted
+				// genesis file) would still disable the BBODY check, since
+				// the registry lookup only reflects prime-mainnet's known
+				// magic, not what was actually loaded. Any other named
+				// network paired with a Mainnet-tagged genesis is a
+				// configuration mismatch, not a known identity-reuse case,
+				// and falls through to the genesis-only answer (true)
+				// rather than silently relaxing the BBODY check for a
+				// misconfigured node.
 				return false, nil
 			}
 		}

--- a/ledger/header_protocol_version_test.go
+++ b/ledger/header_protocol_version_test.go
@@ -455,6 +455,25 @@ func TestLedgerStateIsMainnet_UnknownNetworkNameFallsBackToGenesis(t *testing.T)
 	assert.True(t, got)
 }
 
+// TestLedgerStateIsMainnet_NamedNetworkMagicMismatchStaysMainnet pins a
+// reviewer-caught overclaim in the original fix: the override must be
+// restricted to a network gouroboros itself registers as sharing mainnet's
+// magic (currently only prime-mainnet), not any registered name that simply
+// isn't "mainnet". A node started with Network="preview" against a genesis
+// that (incorrectly, e.g. from a misconfiguration) declares Mainnet must
+// still enforce mainnet's BBODY strictness rather than have it silently
+// relaxed just because "preview" isn't literally "mainnet" — preview's own
+// magic doesn't match real mainnet's, so this is a configuration mismatch,
+// not the known prime-mainnet identity-reuse case.
+func TestLedgerStateIsMainnet_NamedNetworkMagicMismatchStaysMainnet(t *testing.T) {
+	ls := newLedgerStateForNetworkNamed(
+		t, "Mainnet", byron.MainnetProtocolMagic, "preview",
+	)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
 // TestLedgerStateValidateBlockHeaderProtocolVersion_FailClosedOnMissingConfig
 // confirms the fail-closed contract reaches the wiring layer:
 // validateBlockHeaderProtocolVersion must return an error rather than

--- a/ledger/header_protocol_version_test.go
+++ b/ledger/header_protocol_version_test.go
@@ -56,6 +56,20 @@ func newLedgerStateForNetwork(
 	magic uint32,
 ) *LedgerState {
 	t.Helper()
+	return newLedgerStateForNetworkNamed(t, networkId, magic, "")
+}
+
+// newLedgerStateForNetworkNamed is newLedgerStateForNetwork with control
+// over the network selector dingo was started with (LedgerStateConfig.
+// Network), for cases where genesis identity alone is ambiguous — see
+// TestLedgerStateIsMainnet_PrimeMainnetNotRealMainnet.
+func newLedgerStateForNetworkNamed(
+	t *testing.T,
+	networkId string,
+	magic uint32,
+	network string,
+) *LedgerState {
+	t.Helper()
 	cfg := &cardano.CardanoNodeConfig{}
 	require.NoError(t, cfg.LoadShelleyGenesisFromReader(
 		strings.NewReader(shelleyGenesisJSON(networkId, magic)),
@@ -63,6 +77,7 @@ func newLedgerStateForNetwork(
 	return &LedgerState{
 		config: LedgerStateConfig{
 			CardanoNodeConfig: cfg,
+			Network:           network,
 			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
 	}
@@ -393,6 +408,51 @@ func TestLedgerStateIsMainnet_NetworkIdNotMagic(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, got)
 	})
+}
+
+// TestLedgerStateIsMainnet_PrimeMainnetNotRealMainnet pins the fix for a
+// deterministic sync wedge on prime-mainnet: Apex Fusion's prime-mainnet
+// genesis declares networkId=Mainnet and network magic 764824073 —
+// byte-identical to real Cardano mainnet's genesis identity — but runs its
+// own independent hard-fork schedule. Enforcing cardano-ledger's
+// mainnet-only BBODY header-protocol-version strictness there rejected
+// headers prime-mainnet's own nodes had already built on top of. The
+// network dingo was started with is the one signal that still
+// disambiguates the two chains.
+func TestLedgerStateIsMainnet_PrimeMainnetNotRealMainnet(t *testing.T) {
+	ls := newLedgerStateForNetworkNamed(
+		t, "Mainnet", byron.MainnetProtocolMagic, "prime-mainnet",
+	)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+// TestLedgerStateIsMainnet_NamedMainnetStillTrue confirms the Network
+// selector doesn't just default to relaxing the check: an explicit
+// Network="mainnet" alongside a Mainnet-identity genesis must still
+// resolve to real mainnet.
+func TestLedgerStateIsMainnet_NamedMainnetStillTrue(t *testing.T) {
+	ls := newLedgerStateForNetworkNamed(
+		t, "Mainnet", byron.MainnetProtocolMagic, "mainnet",
+	)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+// TestLedgerStateIsMainnet_UnknownNetworkNameFallsBackToGenesis confirms
+// that a Network value gouroboros doesn't recognize (e.g. a config built
+// without the CLI network selector reaching LedgerStateConfig) falls back
+// to the pre-existing genesis-only check rather than failing or silently
+// relaxing the rule.
+func TestLedgerStateIsMainnet_UnknownNetworkNameFallsBackToGenesis(t *testing.T) {
+	ls := newLedgerStateForNetworkNamed(
+		t, "Mainnet", byron.MainnetProtocolMagic, "some-custom-devnet",
+	)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.True(t, got)
 }
 
 // TestLedgerStateValidateBlockHeaderProtocolVersion_FailClosedOnMissingConfig

--- a/ledger/header_protocol_version_test.go
+++ b/ledger/header_protocol_version_test.go
@@ -474,6 +474,25 @@ func TestLedgerStateIsMainnet_NamedNetworkMagicMismatchStaysMainnet(t *testing.T
 	assert.True(t, got)
 }
 
+// TestLedgerStateIsMainnet_PrimeMainnetNameWithMismatchedGenesisMagicStaysMainnet
+// pins a second reviewer-caught gap: the override checked only the
+// registry's canonical magic for the configured name, never the magic
+// actually present in the loaded genesis. Network="prime-mainnet" paired
+// with a genesis whose own magic matches neither real mainnet's nor
+// prime-mainnet's (a corrupted or misconfigured genesis file) must not
+// disable the BBODY check — that combination isn't the known
+// identity-reuse case, just a broken config, and must stay mainnet-strict.
+func TestLedgerStateIsMainnet_PrimeMainnetNameWithMismatchedGenesisMagicStaysMainnet(
+	t *testing.T,
+) {
+	ls := newLedgerStateForNetworkNamed(
+		t, "Mainnet", 999, "prime-mainnet",
+	)
+	got, err := ls.isMainnet()
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
 // TestLedgerStateValidateBlockHeaderProtocolVersion_FailClosedOnMissingConfig
 // confirms the fail-closed contract reaches the wiring layer:
 // validateBlockHeaderProtocolVersion must return an error rather than

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -487,12 +487,19 @@ type PeerHeaderLookupFunc func(
 type GenesisSelectionStateFunc func() (active bool, window uint64)
 
 type LedgerStateConfig struct {
-	PromRegistry                prometheus.Registerer
-	Logger                      *slog.Logger
-	Database                    *database.Database
-	ChainManager                *chain.ChainManager
-	EventBus                    *event.EventBus
-	CardanoNodeConfig           *cardano.CardanoNodeConfig
+	PromRegistry      prometheus.Registerer
+	Logger            *slog.Logger
+	Database          *database.Database
+	ChainManager      *chain.ChainManager
+	EventBus          *event.EventBus
+	CardanoNodeConfig *cardano.CardanoNodeConfig
+	// Network is the CLI/YAML/env network selector dingo was started with
+	// (e.g. "mainnet", "preprod", "prime-mainnet"). Shelley genesis alone
+	// cannot distinguish real Cardano mainnet from a foreign chain that
+	// reuses its identity for wire compatibility -- see isMainnet in
+	// header_protocol_version.go. Empty when dingo was configured with a
+	// raw NetworkMagic instead of a named network.
+	Network                     string
 	BlockfetchRequestRangeFunc  BlockfetchRequestRangeFunc
 	PeersWithBlockFunc          PeersWithBlockFunc
 	RecordBlockfetchLatencyFunc RecordBlockfetchLatencyFunc

--- a/node_ledger_config.go
+++ b/node_ledger_config.go
@@ -52,6 +52,7 @@ func (n *Node) ledgerStateConfig() ledger.LedgerStateConfig {
 		EventBus:           n.eventBus,
 		Logger:             n.config.logger,
 		CardanoNodeConfig:  n.config.cardanoNodeConfig,
+		Network:            n.config.network,
 		PromRegistry:       n.config.promRegistry,
 		ForgeBlocks:        n.config.isDevMode(),
 		ValidateHistorical: n.config.validateHistorical,


### PR DESCRIPTION
## Summary
- Apex Fusion's `prime-mainnet` declares Shelley genesis `networkId=Mainnet` and network magic `764824073` — byte-identical to real Cardano mainnet's genesis identity. gouroboros's own network registry documents this collision directly (`NetworkByNetworkMagic` returns `NetworkCardanoMainnet`, not `NetworkPrimeMainnet`, for that magic).
- `isMainnet()` used genesis `networkId` alone as the mainnet predicate, so `prime-mainnet` inherited cardano-ledger's mainnet-only BBODY header-protocol-version strictness. That strictness rejects a header whose advertised protocol major version is more than one ahead of dingo's enacted-pparams tracking. In the two boundary-crossing headers observed while investigating this, `prime-mainnet`'s block producers advertised a version 2 ahead of dingo's enacted tracking (e.g. header major 7 vs. enacted major 5 at the epoch 9/10 boundary) — a gap real testnets tolerate via the pre-Dijkstra relaxation from cardano-ledger PR 5785, but real mainnet does not. This wedged sync deterministically at slot 3,499,200, rejecting a header the real network had already built on.
- Fix: thread the CLI/YAML/env network selector dingo was started with (`LedgerStateConfig.Network`, sourced from `cfg.Network`) through to `isMainnet()`. When it resolves to a network gouroboros recognizes, that resolved identity — not the raw genesis `networkId` — decides mainnet-ness, so `prime-mainnet` gets the same relaxed treatment as any other non-canonical network despite its Mainnet-shaped genesis. An unset or unrecognized `Network` value falls back to the prior genesis-only check, so behavior is unchanged for every existing caller (including real Cardano mainnet/preprod/preview/sanchonet and embedders that never set the field).

## Test plan
- [x] Reproduced against a from-genesis sync of `prime-mainnet`: deterministic wedge at slot 3,499,200 across two independent runs, confirmed via debug instrumentation showing `isMainnet=true` at the point of rejection.
- [x] Validated the fix: rebuilt and resumed the same wedged database — sync immediately proceeded past slot 3,499,200 (`isMainnet=false` observed) and continued advancing cleanly for 15M+ slots / 120k+ blocks with zero pipeline-stuck errors.
- [x] Added `TestLedgerStateIsMainnet_PrimeMainnetNotRealMainnet`, `TestLedgerStateIsMainnet_NamedMainnetStillTrue`, `TestLedgerStateIsMainnet_UnknownNetworkNameFallsBackToGenesis`.
- [x] `go test -tags dingo_extra_plugins -timeout 20m ./ledger/...` passes.
- [x] `go test -tags dingo_extra_plugins -timeout 20m ./internal/node/...` passes.
- [x] `go test ./internal/architecture` (import-boundaries) passes.
- [x] `go test ./internal/docsparity` passes.

## Note on the pre-Dijkstra relaxation

This fix makes `prime-mainnet` rely on the same pre-Dijkstra (`curPvMajor < 12`) relaxation real testnets use. Only two boundary-crossing headers were actually observed during this investigation (both roughly 2 majors ahead of enacted state, both well below Dijkstra) — not enough to call that gap a confirmed, sustained pattern, and no basis for predicting whether or how `prime-mainnet`'s protocol-version numbering behaves as it approaches Dijkstra-range versions. Not filing a follow-up issue on that speculation; revisit if and when sync actually gets there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic sync wedge on `prime-mainnet` by distinguishing it from real Cardano mainnet in `isMainnet()`.

`prime-mainnet` declares a Shelley genesis networkId and network magic byte-identical to real Cardano mainnet's, so the old genesis-only check treated it as mainnet and applied strict header protocol version rules, rejecting blocks its own producers had already built. `isMainnet()` now also consults the network selector dingo was started with (`LedgerStateConfig.Network`, sourced from `cfg.Network`), but only lets a named network override a Mainnet-tagged genesis when the loaded genesis magic matches real mainnet's and gouroboros registers that name as sharing mainnet's magic — currently only `prime-mainnet`. Any other name (e.g. `preview` paired with a Mainnet genesis) is a configuration mismatch and falls through to the genesis-only answer, as does an unset or unrecognized network, so existing callers are unaffected.

**Bug Fixes**
- Passes `cfg.Network` from `LoadWithDB` and `n.config.network` from the ledger config wiring into `LedgerStateConfig.Network`.
- Resolves mainnet-ness via a magic-matching named network only; everything else falls back to the genesis-only check.

**Refactors**
- Threads the network selector through `LedgerStateConfig` so `isMainnet()` can disambiguate chains with identical genesis identity.

**Dependencies**
- Adds `github.com/blinklabs-io/gouroboros` import to `ledger/header_protocol_version.go` for network identity resolution.

<sup>Written for commit 3c936e1e9b85a9267dd78c49c3293660c9d50baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network identification when configured networks share the same network magic.
  * Prime-mainnet is no longer incorrectly treated as Cardano mainnet.
  * Preserved strict mainnet detection for explicit, mismatched, unknown, or unset network configurations.
* **Compatibility**
  * Network configuration is now consistently applied when loading ledger state, improving behavior across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->