### PR TITLE
fix(forging): guard the Leios block-builder capability at compile time

### DIFF
--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -188,6 +188,13 @@ func (b *DefaultBlockBuilder) BuildBlock(
 	return b.buildBlock(slot, kesPeriod, LeiosBlockData{})
 }
 
+// BlockForger.buildBlock discovers the Leios capability with a runtime type
+// assertion on the BlockBuilder it was handed and fails the forge when it
+// misses, so drift in BuildBlockWithLeios would break Leios forging at forge
+// time rather than at build time. Unlike the session-provider assertion above
+// this one is loud, but it is the same class of defect the guard prevents.
+var _ LeiosBlockBuilder = (*DefaultBlockBuilder)(nil)
+
 // BuildBlockWithLeios creates a Dijkstra block with Leios prototype
 // announcement or certificate data committed into the block body/header.
 func (b *DefaultBlockBuilder) BuildBlockWithLeios(


### PR DESCRIPTION
## What

Follow-up to #3537, which merged while this was in progress.

`BlockForger.buildBlock` discovers `LeiosBlockBuilder` with a runtime type
assertion on the `BlockBuilder` it was handed (`ledger/forging/forger.go:898`).
`*DefaultBlockBuilder` is the only production implementor, so drift in
`BuildBlockWithLeios` would fail Leios forging at forge time rather than at
build time.

Adds `var _ LeiosBlockBuilder = (*DefaultBlockBuilder)(nil)`.

This assertion fails loudly with an error rather than silently degrading, and
only when `leiosData` is non-empty, so it is lower severity than the set
guarded in #3537 — but it is the same defect class: a signature change the
build accepts and a runtime path rejects.

Raised by @wolf31o2 in review of #3537.

## Why the original audit missed it

The #3537 sweep matched interface names ending in
`Provider|State|Source|Capability`, which excluded `LeiosBlockBuilder`. A
broader sweep for interface type assertions across the tree found no further
cases of the same shape. What it did surface, and why each is excluded:

- `evt.Data.(SomeEvent)` sites (~25) assert concrete event structs out of an
  `any` payload, not interface capabilities.
- `database/lifecycle` (`blob.Backuper`, `metadata.Restorer`,
  `blob.Resettable`, `SnapshotLister`, `CloudDeleter`, …),
  `metadata.SlotRangeStore` / `BulkLoadOptimizer` / `PlannerStatsUpdater`, and
  `mempool.AdmissionHeadroom` are capability negotiation across pluggable
  backends, where a backend legitimately may not implement the capability and
  the caller handles that. Pinning them would assert a contract the plugin
  architecture deliberately leaves open. (`metadata.DeferredIndexManager`
  already carries a guard on `*sqlstore.Store` from earlier work.)

## Testing

Verified the guard is live by drifting the method and confirming the build
breaks:

```
ledger/forging/builder.go:196:27: cannot use (*DefaultBlockBuilder)(nil) ...
*DefaultBlockBuilder does not implement LeiosBlockBuilder
(missing method BuildBlockWithLeios)
```

Edit reverted afterward.

- `go build ./...`, `go vet ./ledger/forging/`
- `go test -race ./ledger/forging/` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compile-time assertion that `*DefaultBlockBuilder` implements `LeiosBlockBuilder`. `BlockForger.buildBlock` discovers the Leios builder via a runtime type assertion, so drift in `BuildBlockWithLeios` would only break Leios forging at forge time; this guard makes it fail at build time instead.

<sup>Written for commit a7e388c08e8854277f4963b394a27ba81c66f07f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a compile-time check to ensure the default block builder continues to satisfy the required block-building interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->