### PR TITLE
docs: refresh repository documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,5 @@
 # Architecture
 
-Last reviewed: 2026-08-26
-
 ## In-process plugin host
 
 Dingo composition owns one `plugin.Host`. Providers are registered explicitly;
@@ -102,8 +100,11 @@ fixtures when schema seeding or assertions require raw SQL.
 Startup reserves the write connection, acquires the backend migration lock,
 rejects unversioned metadata tables (users must delete the data directory,
 including metadata and blob stores, and resync), and validates/resumes versioned expand/backfill/contract work before
-advertising readiness. The database schema is currently `v1alpha1` (integer
-migration version 1). It then checks the read pool. File-backed SQLite uses a
+advertising readiness. The current registry has migrations 1 through 4:
+`v1alpha1`, `leios-key-registration`, `token-registry-metadata`, and
+`account-import-baseline`. `DATABASE.md` is the source of truth for their
+schema changes and upgrade behavior. It then checks the read pool. File-backed
+SQLite uses a
 cross-process lock file; isolated in-memory databases use a process lock. A
 failed or interrupted phase leaves readiness false and carries the migration
 version and phase in the returned error. Backfill data and its opaque cursor
@@ -241,6 +242,7 @@ graph TB
         DB["Database<br/><i>database/</i>"]
         Blob["BlobStore<br/>badger / s3 / gcs"]
         Meta["MetadataStore<br/>sqlite / postgres / mysql"]
+        DLC["Database lifecycle<br/><i>database/lifecycle/</i>"]
         DBLC["DBLifecycleManager<br/><i>internal/dblifecycle/</i>"]
     end
 
@@ -249,6 +251,8 @@ graph TB
         BFA["Blockfrost API<br/><i>api/blockfrost/</i>"]
         Mesh["Mesh API<br/><i>api/mesh/</i>"]
         Bark["Bark<br/><i>bark/</i>"]
+        MidnightIndex["Midnight indexer<br/><i>midnight/indexer/</i>"]
+        Midnight["MidnightState gRPC<br/><i>midnight/server/</i>"]
     end
 
     subgraph "History Expiry"
@@ -258,7 +262,7 @@ graph TB
     EB["EventBus<br/><i>event/</i>"]
 
     Node --> CM & PG & OB & ChM & LS & MP & DB & EB
-    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark & HExpiry & DBLC
+    Node -.->|"optional"| BF & LE & URPC & BFA & Mesh & Bark & MidnightIndex & Midnight & HExpiry & DBLC
 
     PG -->|"outbound conn requests"| CM
     CM -->|"connections"| OB
@@ -268,6 +272,7 @@ graph TB
     LS -->|"validate txs"| MP
     ChM --> DB
     DB --> Blob & Meta
+    DLC --> DB
     HExpiry --> LS & DB
     BF --> LE & MP & ChM
     SM -->|"stake snapshots"| DB
@@ -275,16 +280,18 @@ graph TB
     CSel -->|"switch active peer"| CS
     CS -->|"stall detection"| CM
 
-    EB -.->|"events"| LS & ChM & CS & CSel & PG & SM & DBLC & OB & MP
+    EB -.->|"events"| LS & ChM & CS & CSel & PG & SM & DBLC & OB & MP & MidnightIndex
     URPC & BFA & Mesh -.-> LS & DB
     Bark -.-> DB
+    MidnightIndex -.-> DB
+    Midnight -.-> DB
 ```
 
 ### Package Dependency Tree
 
-Internal import relationships between production dingo packages. External
-dependencies and tests are omitted. This graph was refreshed from `go list` on
-2026-06-23.
+Selected internal import relationships between production Dingo packages.
+External dependencies and tests are omitted; the source tree remains the
+authoritative import graph.
 
 ```mermaid
 graph LR
@@ -293,6 +300,7 @@ graph LR
     chain["chain"]
     chainsync["chainsync"]
     chainsel["chainselection"]
+    praos["consensus/praos"]
     connmgr["connmanager"]
     db["database"]
     db_models["database/models"]
@@ -304,6 +312,7 @@ graph LR
     db_meta_impl["database/plugin/metadata/{sqlite,sqlstore}"]
     db_meta_util["database/plugin/metadata/{deferred,labelcodec}"]
     db_immutable["database/immutable"]
+    db_lifecycle["database/lifecycle"]
     cardano_cfg["config/cardano"]
     ev["event"]
     ledger["ledger"]
@@ -322,19 +331,21 @@ graph LR
     intcfg["internal/config"]
     intplugins["internal/plugins"]
     intnode["internal/node"]
+    intdblifecycle["internal/dblifecycle"]
     intnode_ledgerpeers["internal/node/ledgerpeers"]
     intrecycler["internal/chainsyncrecycler"]
     utxorpc["api/utxorpc"]
     blockfrost["api/blockfrost"]
     mesh["api/mesh"]
     bark["bark"]
+    midnight["midnight/{indexer,server}"]
     mithril["mithril<br/>(no internal dingo imports)"]
     keystore["keystore"]
 
     root --> chain & chainsync & chainsel & connmgr & db & ev
     root --> ledger & ledger_forging & ledger_leader & ledger_leios & ledger_snapshot
     root --> mempool & ouroboros & peergov & topology & plugin & intplugins
-    root --> intnode_ledgerpeers & intrecycler
+    root --> intnode_ledgerpeers & intrecycler & intdblifecycle & midnight
     root --> utxorpc & blockfrost & mesh & bark & cardano_cfg
 
     cmd --> root & cardano_cfg & db & db_models & plugin & intplugins
@@ -343,7 +354,7 @@ graph LR
 
     chain --> db & db_models & ev
     chainsync --> chain & ev
-    chainsel --> ev
+    chainsel --> ev & praos
     connmgr --> ev
     peergov --> connmgr & ev & topology
     intnode_ledgerpeers --> ledger & peergov
@@ -352,7 +363,7 @@ graph LR
     ouroboros --> chain & chainsel & chainsync & connmgr
     ouroboros --> ev & ledger & mempool & peergov
 
-    ledger --> chain & chainsel & cardano_cfg
+    ledger --> chain & chainsel & cardano_cfg & praos
     ledger --> db & db_models & db_meta & db_types & ev
     ledger --> ledger_eras & ledger_forging & ledger_governance & ledger_hardfork
     ledger_eras --> cardano_cfg & ledger_hardfork
@@ -378,6 +389,7 @@ graph LR
     intnode --> root & chain & chainsync & cardano_cfg
     intnode --> db & db_immutable & db_models & db_meta
     intnode --> ledger & ledger_eras & ledger_governance & intcfg
+    intdblifecycle --> db_lifecycle
 
     ledgerstate --> db & db_models & db_meta & db_types & ledger_eras
 
@@ -385,7 +397,8 @@ graph LR
     utxorpc --> ledger & ledger_eras & mempool & plugin
     mesh --> chain & db & db_models & ev & ledger & mempool & plugin
     blockfrost --> db & db_models & db_meta_util & ledger & ledger_eras & mempool & plugin
-    bark --> db & db_blob & db_types
+    bark --> db & db_blob & db_types & db_lifecycle
+    midnight --> db & ev
 ```
 
 ### Data Flow
@@ -696,6 +709,7 @@ dingo/
 │   ├── event.go         # Selection events
 │   ├── peer_tip.go      # Peer tip tracking
 │   └── vrf.go           # VRF verification
+├── consensus/praos/     # Praos comparison, snapshots, and ledger views
 ├── chainsync/           # Block synchronization protocol state
 │   ├── chainsync.go     # Multi-client sync state, stall detection
 │   └── strategy.go      # Configurable multi-active header-sync strategy
@@ -709,6 +723,7 @@ dingo/
 │   ├── hot_cache.go     # Hot cache for frequently accessed data
 │   ├── block_lru_cache.go # Block-level LRU cache
 │   ├── immutable/       # ImmutableDB chunk reader
+│   ├── lifecycle/       # Snapshot, restore, and truncation library
 │   ├── models/          # Database models
 │   ├── types/           # Database types
 │   ├── sops/            # Storage operations
@@ -852,6 +867,7 @@ dingo/
 │   ├── chainsyncrecycler/ # Chainsync stall/plateau recycler component
 │   │   └── recycler.go  # Start/Stop loop, tick decision logic
 │   ├── config/          # Configuration parsing
+│   ├── dblifecycle/     # CLI and automatic snapshot orchestration
 │   ├── integration/     # Integration tests
 │   ├── node/            # Node orchestration (CLI wiring)
 │   │   ├── node.go      # Run(), signal handling, metrics server

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A high-performance Cardano blockchain node implementation in Go by Blink Labs. D
 - Peer governance with dynamic peer selection, ledger peers, and topology support
 - Chain rollback support for handling forks with automatic state restoration
 - Fast bootstrapping via built-in Mithril client
+- Optional Midnight event indexing and MidnightState gRPC service
 - Multiple external interfaces: general-purpose APIs (UTxO RPC, Blockfrost-compatible REST, Mesh/Rosetta) plus Bark for Dingo-to-Dingo C2 and archive services
 
 Note: On Windows systems, named pipes are used instead of Unix sockets for node-to-client communication.
@@ -870,6 +871,7 @@ validation record.
   - [ ] WIP Blockfrost-compatible REST API (required endpoint families are
         implemented; compatibility hardening and reward parity are ongoing)
   - [x] Mesh (Coinbase Rosetta) API
+  - [x] Optional Midnight event indexer and MidnightState gRPC service
 - [x] Mithril Bootstrap
   - [x] Built-in Mithril client
   - [x] Ledger state import (UTxOs, accounts, pools, DReps, epochs)

--- a/benchmark_results_api_backfill.md
+++ b/benchmark_results_api_backfill.md
@@ -1,16 +1,18 @@
 # Dingo Mithril API Backfill Benchmark Results
 
 Focused Mithril API-mode metadata backfill results are tracked here separately
-from the broader ledger and database benchmark table.
+from the broader ledger and database benchmark table. This is a historical
+snapshot, not a measurement of the current branch or current releases.
 
 ## May 29-30, 2026 Preview Backfill
 
-The latest local Kubernetes preview run measured `origin/main` commit
-`d73407b6`. Clean current `main` failed during Mithril ledger-state UTxO asset
-import because deferred SQLite index handling drops the asset uniqueness needed
-by `ON CONFLICT (utxo_id, policy_id, name) DO NOTHING`; that blocker is tracked
-as #2457. The completed measurement used only a local diagnostic workaround for
-#2457, keeping `asset.policy_id` out of the deferred-index manifest.
+This local Kubernetes Preview run measured commit `d73407b6`. At that revision,
+Mithril ledger-state UTxO asset import required a local diagnostic workaround:
+the deferred-index manifest dropped the asset uniqueness required by the
+import's `ON CONFLICT` target. The
+[deferred asset index fix](https://github.com/blinklabs-io/dingo/pull/2461)
+removed that index from the deferred manifest; this historical blocker is
+resolved in the current source and released builds.
 
 | Metric | Value |
 |--------|-------|

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dingo implements a Cardano blockchain node.
+//
+// It composes ledger validation, chain synchronization and selection,
+// networking, block production, storage, and optional API services into a
+// single Node. A Node owns its configuration, event bus, and plugin host;
+// providers are registered explicitly during composition.
+package dingo

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,12 +32,11 @@ By default Compose builds Dingo from this checkout as
 `dingo-examples-dingo:local`. Set `DINGO_IMAGE=ghcr.io/blinklabs-io/dingo:<tag>`
 if you explicitly want to use a published image.
 
-Building from the checkout is the recommended path, because the examples track
-API work that reaches `main` before it reaches a release. If you do pin a
-published image, use 0.68.0 or newer: the address summary endpoint, the DRep
-list endpoint, and exact-address UTxO matching all landed in 0.68.0. The
-explorer's retiring-pools and pool-metadata views need a build newer than
-0.68.0 and report themselves as unavailable on anything older.
+Building from the checkout is the recommended path when exercising the current
+source tree. Published images are compatible with the full shared stack from
+0.70.0 onward. The explorer's address summary, DRep list, exact-address UTxO
+matching, retiring-pools, and pool-metadata views are available from 0.69.0
+onward.
 
 The shipped database credentials are local-development defaults. Change
 `POSTGRES_PASSWORD` and `DINGO_GOV_LENS_PASSWORD` before exposing the stack

--- a/examples/dingo-blockfrost-explorer/README.md
+++ b/examples/dingo-blockfrost-explorer/README.md
@@ -48,19 +48,10 @@ asset, metadata, account, DRep, and pool data from Dingo's API indexes.
 
 ### Dingo version
 
-Use 0.68.0 or newer. The address summary, DRep list, and the aligned DRep
-response landed in 0.68.0, so against an older node those views return 404 or
-render empty fields.
-
-Two views need a Dingo built from `main` newer than 0.68.0, because the
-endpoints behind them are not in a tagged release yet:
-
-- Pending Retirements, from `GET /api/v0/pools/retiring`
-- Pool Metadata, from `GET /api/v0/pools/{pool_id}/metadata`
-
-Against 0.68.0 those two sections report the endpoint as unavailable and the
-rest of the explorer works normally. The Compose stack in `examples/` builds
-Dingo from this checkout, so it has both.
+Use 0.69.0 or newer. The address summary, DRep list, and aligned DRep response
+landed in 0.68.0. Pending Retirements (`GET /api/v0/pools/retiring`) and Pool
+Metadata (`GET /api/v0/pools/{pool_id}/metadata`) landed in 0.69.0. Against an
+older node, those views can return 404 or render unavailable fields.
 
 ### Kubernetes
 

--- a/examples/dingo-gov-lens/README.md
+++ b/examples/dingo-gov-lens/README.md
@@ -179,17 +179,11 @@ from a Secret in your own chart overlay.
 
 ### Dingo version
 
-Use 0.68.0 or newer. DRep activity renewal from certificates landed in 0.68.0,
-and without it `drep.expiry_epoch` is not maintained from vote and update
-certificates, so the expiry column and the `expiry` filter report stale
-answers rather than wrong-looking ones. CIP-0163 account expiry columns need
-0.67.0, and the reward metadata tables need 0.65.0.
-
-The Epochs tab reaches only the last four epochs on a released node. Retaining
-`epoch_summary` and the per-epoch reward tables for the life of the database is
-newer than 0.68.0 and not in a tagged release yet; before it, those rows were
-pruned to `epoch < current-3` at every epoch transition. The tab works either
-way, it just shows a short window until you run a node built from `main`.
+Use 0.70.0 or newer. DRep activity renewal from certificates landed in 0.68.0,
+the historical epoch/reward retention used by the Epochs tab landed in 0.69.0,
+and the current CIP-0163 withdrawal witness behavior landed in 0.70.0. Older
+nodes can therefore leave fields stale, show only the short retained epoch
+window, or omit withdrawal history.
 
 ## Read-Only Database User
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -23,8 +23,10 @@ package docsparity_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -49,14 +51,6 @@ var historicalDocs = map[string]bool{
 	"benchmark_results_api_backfill.md": true,
 	"benchmark_results_bp_pi.md":        true,
 	"benchmark_results_targeted.md":     true,
-}
-
-// skippedDirs never contain documentation this package owns.
-var skippedDirs = map[string]bool{
-	".git":         true,
-	".worktrees":   true,
-	".tools":       true,
-	"node_modules": true,
 }
 
 // repoRoot walks up from the working directory until it finds the module
@@ -94,41 +88,30 @@ func readRepoFile(t *testing.T, root, rel string) string {
 	return strings.ReplaceAll(string(data), "\r\n", "\n")
 }
 
-// filesMatching returns repository-relative paths of every file under root
-// for which match reports true.
+// filesMatching returns tracked repository-relative paths for which match
+// reports true. Using Git's index keeps local worktrees and other untracked
+// files out of documentation parity checks.
 func filesMatching(
 	t *testing.T,
 	root string,
-	match func(name string) bool,
+	match func(rel string) bool,
 ) []string {
 	t.Helper()
 
 	var found []string
-	err := filepath.WalkDir(
-		root,
-		func(path string, entry os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if entry.IsDir() {
-				if skippedDirs[entry.Name()] {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if !match(entry.Name()) {
-				return nil
-			}
-			rel, err := filepath.Rel(root, path)
-			if err != nil {
-				return err
-			}
-			found = append(found, rel)
-			return nil
-		},
-	)
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
+	output, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("walk %s: %v", root, err)
+		t.Fatalf("list tracked files in %s: %v", root, err)
+	}
+	for rel := range strings.SplitSeq(string(output), "\x00") {
+		if rel == "" {
+			continue
+		}
+		rel = filepath.FromSlash(rel)
+		if match(rel) {
+			found = append(found, rel)
+		}
 	}
 	return found
 }
@@ -137,8 +120,8 @@ func filesMatching(
 func markdownFiles(t *testing.T, root string) []string {
 	t.Helper()
 
-	all := filesMatching(t, root, func(name string) bool {
-		return strings.HasSuffix(name, ".md")
+	all := filesMatching(t, root, func(rel string) bool {
+		return strings.HasSuffix(rel, ".md")
 	})
 	kept := make([]string, 0, len(all))
 	for _, rel := range all {
@@ -154,7 +137,8 @@ func markdownFiles(t *testing.T, root string) []string {
 func dockerfiles(t *testing.T, root string) []string {
 	t.Helper()
 
-	return filesMatching(t, root, func(name string) bool {
+	return filesMatching(t, root, func(rel string) bool {
+		name := filepath.Base(rel)
 		return name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.")
 	})
 }
@@ -163,24 +147,67 @@ func dockerfiles(t *testing.T, root string) []string {
 func workflowFiles(t *testing.T, root string) []string {
 	t.Helper()
 
-	dir := filepath.Join(root, ".github", "workflows")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read %s: %v", dir, err)
+	return filesMatching(t, root, func(rel string) bool {
+		return (strings.HasSuffix(rel, ".yml") ||
+			strings.HasSuffix(rel, ".yaml")) &&
+			filepath.Dir(rel) == filepath.Join(".github", "workflows")
+	})
+}
+
+func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init")
+
+	writeTestFile(t, root, "docs/tracked.md")
+	writeTestFile(t, root, "Dockerfile")
+	writeTestFile(t, root, ".github/workflows/tracked.yml")
+	writeTestFile(t, root, ".claude/worktrees/scratch/ignored.md")
+	writeTestFile(t, root, ".claude/worktrees/scratch/Dockerfile")
+	writeTestFile(t, root, ".github/workflows/ignored.yaml")
+	runGit(
+		t,
+		root,
+		"add",
+		"docs/tracked.md",
+		"Dockerfile",
+		".github/workflows/tracked.yml",
+	)
+
+	got, want := markdownFiles(t, root), []string{"docs/tracked.md"}
+	if !slices.Equal(got, want) {
+		t.Errorf("markdownFiles() = %v, want %v", got, want)
 	}
-	var found []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() {
-			continue
-		}
-		if !strings.HasSuffix(name, ".yml") &&
-			!strings.HasSuffix(name, ".yaml") {
-			continue
-		}
-		found = append(found, filepath.Join(".github", "workflows", name))
+	got, want = dockerfiles(t, root), []string{"Dockerfile"}
+	if !slices.Equal(got, want) {
+		t.Errorf("dockerfiles() = %v, want %v", got, want)
 	}
-	return found
+	got, want = workflowFiles(t, root), []string{
+		filepath.Join(".github", "workflows", "tracked.yml"),
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("workflowFiles() = %v, want %v", got, want)
+	}
+}
+
+func writeTestFile(t *testing.T, root, rel string) {
+	t.Helper()
+
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create directory for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func runGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
 }
 
 // markdownBlock is one logical chunk of a markdown document: a paragraph, a

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -100,6 +100,14 @@ func filesMatching(
 	t.Helper()
 
 	var found []string
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return filesMatchingWalk(t, root, match)
+	}
+	topLevel, err := exec.Command("git", "-C", root, "rev-parse", "--show-toplevel").Output()
+	if err != nil || filepath.Clean(strings.TrimSpace(string(topLevel))) != filepath.Clean(rootAbs) {
+		return filesMatchingWalk(t, root, match)
+	}
 	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
 	output, err := cmd.Output()
 	if err != nil {
@@ -226,6 +234,15 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	}
 	if !slices.Equal(got, want) {
 		t.Errorf("workflowFiles() = %v, want %v", got, want)
+	}
+
+	parent := t.TempDir()
+	runGit(t, parent, "init")
+	nested := filepath.Join(parent, "nested")
+	writeTestFile(t, nested, "docs/archive.md")
+	got, want = markdownFiles(t, nested), []string{"docs/archive.md"}
+	if !slices.Equal(got, want) {
+		t.Errorf("nested markdownFiles() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -90,7 +90,8 @@ func readRepoFile(t *testing.T, root, rel string) string {
 
 // filesMatching returns tracked repository-relative paths for which match
 // reports true. Using Git's index keeps local worktrees and other untracked
-// files out of documentation parity checks.
+// files out of documentation parity checks. Source archives without Git
+// metadata fall back to walking the extracted tree.
 func filesMatching(
 	t *testing.T,
 	root string,
@@ -102,7 +103,7 @@ func filesMatching(
 	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
 	output, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("list tracked files in %s: %v", root, err)
+		return filesMatchingWalk(t, root, match)
 	}
 	for rel := range strings.SplitSeq(string(output), "\x00") {
 		if rel == "" {
@@ -112,6 +113,45 @@ func filesMatching(
 		if match(rel) {
 			found = append(found, rel)
 		}
+	}
+	return found
+}
+
+func filesMatchingWalk(
+	t *testing.T,
+	root string,
+	match func(rel string) bool,
+) []string {
+	t.Helper()
+
+	skippedDirs := map[string]bool{
+		".git":         true,
+		".worktrees":   true,
+		".tools":       true,
+		"node_modules": true,
+	}
+	var found []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if skippedDirs[entry.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if match(rel) {
+			found = append(found, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
 	}
 	return found
 }

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package dingo
+
 // This file implements live database restore/truncate against an
 // already-running Node, in-process, without a full process restart.
 //
@@ -55,7 +57,6 @@
 // replacement from the retained n.ouroborosConfig. Callbacks the node handed
 // to other components resolve n.ouroboros when they fire rather than binding
 // an instance, so they follow the replacement automatically.
-package dingo
 
 import (
 	"context"

--- a/node_lifecycle_multinode_integration_test.go
+++ b/node_lifecycle_multinode_integration_test.go
@@ -119,11 +119,11 @@ func devnetCardanoConfig(t testing.TB) *cardano.CardanoNodeConfig {
 
 // dbReadySignalHandler wraps a real slog.Handler and additionally signals
 // once (non-blocking) when a specific log message is emitted. Used here for
-// two distinct synchronization needs: (1) knowing when a node's
-// database.New() (and the global, NOT concurrency-safe plugin-option state
-// it mutates — see plugin.SetPluginOption's own doc comment) has finished,
-// so a second node's database.New() can be started only afterward rather
-// than racing it; (2) giving a background-started Run() goroutine's n.db
+// two distinct synchronization needs: (1) knowing when the forger's
+// database.New() has finished before constructing its syncer, which gives the
+// test deterministic topology setup; each Node has its own instance-owned
+// plugin.Host, so this ordering is not serialization around process-global
+// plugin-option state; (2) giving a background-started Run() goroutine's n.db
 // assignment (node.go's `n.db = db`, itself unsynchronized — nothing in
 // normal operation needs to read it that early) a real happens-before edge
 // against a test goroutine that starts polling n.db immediately after, as
@@ -278,12 +278,11 @@ func runNodeInBackground(t *testing.T, n *Node) {
 }
 
 // startTwoNodeDevnet builds and starts a dev-mode forger and a syncing
-// node pointed at it, serializing their startup so the syncer's
-// database.New() (and the global, not-concurrency-safe plugin-option
-// state it mutates — see plugin.SetPluginOption's doc comment) cannot
-// interleave with the forger's: it waits for the forger's own
-// database.New() to finish (signalled via its logger, not a raw field
-// poll or a sleep) before constructing the syncer at all.
+// node pointed at it, staging their startup so the forger's database has
+// initialized before constructing the syncer. This reduces early topology
+// startup overlap; it is not protection for plugin configuration, because each
+// Node owns an instance-owned plugin.Host. The signal comes from the forger's
+// logger rather than a raw field poll or a sleep.
 //
 // It also waits for the syncer's own database.New() to finish before
 // returning. Run() assigns n.db without holding liveLifecycleMu (nothing


### PR DESCRIPTION
Refresh repository documentation to match the current schema, package layout, released example requirements, and Midnight interfaces.

- Update architecture, API, benchmark, and example documentation.
- Add root package documentation and correct stale plugin-host comments.
- Restrict docs parity discovery to the target repository, with archive and nested-repository regression coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes repository documentation to match the current schema, package layout, released example requirements, and Midnight interfaces, and fixes docs parity discovery to ignore untracked files.

- Updates architecture, API, benchmark, and example docs; adds root package doc and corrects stale plugin-host comments.
- Docs parity checks now use `git ls-files` to discover tracked files only, with a fallback to directory walking for non-Git checkouts.

<sup>Written for commit 42bfcbef9c459f8b300ffce10a90c4898c23b7e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

