### PR TITLE
fix(bark): enforce request bounds and operator authorization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6076,20 +6076,26 @@ documented "one operation at a time" invariant (a second call while one is
 running gets `FAILED_PRECONDITION`) and is the backing store for
 `GetOperationHistory` (in-memory only — does not survive a bark restart).
 
-**Authentication** (`bark/auth.go`, dingo#2988). Bind address alone doesn't
-authenticate a caller, so the DatabaseService's destructive RPCs
-(`CreateSnapshot`, `DeleteSnapshot`, `VerifySnapshot`, `Restore`, `Truncate`,
-`CancelOperation` — everything except the read-only status/catalog RPCs and
-the entirely-read-only `ArchiveService`) additionally require mTLS client
-certificate authentication, independent of bind address. `BarkConfig.
-TlsClientCAFilePath` supplies a PEM CA bundle; `startServer` loads it into an
+**Request bounds.** Every Bark Connect handler, including ArchiveService,
+DatabaseService, health, and reflection, uses per-message 1 MiB read and send
+limits. Connect applies the read limit independently to compressed wire bytes
+and the decompressed message before unary decoding reaches an interceptor; the
+send limit is also per message, so `StreamOperationProgress` can remain open
+across arbitrarily many bounded updates. Archive `FetchBlock` additionally
+requires 1–100 block references before it acquires the database, bounding URL
+signing/storage work and response growth. The HTTP server applies a 60-second
+request read timeout but no write timeout, so slow request bodies are bounded
+without imposing an overall deadline on long-lived server streams.
+
+**Authentication and authorization** (`bark/auth.go`, dingo#2988 and #3499).
+Bind address alone doesn't authenticate a caller. Every DatabaseService RPC
+requires mTLS client-certificate authentication, independent of bind address;
+the entirely-read-only ArchiveService remains public. `BarkConfig.
+TlsClientCAFilePath` supplies a PEM CA bundle. `startServer` loads it into an
 `x509.CertPool` and sets the listener's `ClientAuth` to
-`tls.VerifyClientCertIfGiven` — "if given," not "required," because
-read-only RPCs on the same listener must keep working for a caller with no
-client cert at all. Go's TLS stack still fully chain-verifies any certificate
-that *is* presented against `ClientCAs` during the handshake itself, before
-any HTTP request is processed, so a certificate signed by an untrusted CA
-never reaches the request layer regardless of which RPC it's calling.
+`tls.VerifyClientCertIfGiven` — "if given," not "required," because Archive is
+served on the same listener. Go's TLS stack still chain-verifies any presented
+certificate against `ClientCAs` during the handshake before request handling.
 
 Because Connect's `AnyRequest`/`StreamingHandlerConn` don't expose the
 underlying `tls.ConnectionState`, `peerCertContextMiddleware` wraps the mux
@@ -6098,18 +6104,16 @@ connection presented a verified client certificate — plus, for audit
 logging, its Subject Common Name and a SHA-256 fingerprint — into the
 request context. `newOperatorAuthInterceptor`, wired via
 `connect.WithInterceptors` when `databaseconnect.NewDatabaseServiceHandler`
-is constructed, is deny-by-default: it exempts a procedure from requiring a
-verified certificate only if it's named in an explicit `readOnlyDatabaseProcedures`
-allowlist, not merely because it's absent from `destructiveDatabaseProcedures`
-— so a DatabaseService RPC added later without updating either map still
-requires authentication like a known destructive one, rather than silently
-passing through unauthenticated. It rejects with `connect.CodeUnauthenticated`
-if the context shows no verified certificate; every non-read-only call,
-accepted or rejected, is logged with the caller's certificate identity (or
-its absence), since `GetOperationHistory` has no notion of caller identity of
-its own — an unclassified procedure is additionally logged as such, so an
-operator notices and fixes the classification even though it's already
-being safely rejected. Because this all sits beneath `*http.Server`, one check covers
+is constructed, is deny-by-default and enforces two stages. It first rejects
+every DatabaseService request without a verified certificate with
+`connect.CodeUnauthenticated`. It then permits methods explicitly classified
+read-only, while destructive or unclassified methods additionally require the
+certificate's SHA-256 fingerprint in `BarkConfig.
+OperatorCertificateFingerprints`; a verified non-operator receives
+`connect.CodePermissionDenied`. Every non-read-only call, accepted or rejected,
+is logged with the caller's certificate identity. An unclassified procedure is
+also logged and treated as destructive. Because this all sits beneath
+`*http.Server`, one check covers
 Connect, gRPC, and gRPC-Web alike — they're just HTTP requests distinguished
 by content type once they reach the generated handler, not separate code
 paths needing separate wiring. The interceptor implements the full
@@ -6120,17 +6124,18 @@ proposed `LifecycleService`, which calls for the identical "no anonymous
 calls" requirement.
 
 `Start` (not `NewBark`) fails closed: mounting `Lifecycle` without
-`TlsClientCAFilePath` (or without `TlsCertFilePath`/`TlsKeyFilePath` — mTLS
-has no meaning without the server's own TLS listener underneath it) is
-refused rather than silently serving those RPCs unauthenticated. The check
+`TlsClientCAFilePath`, at least one `OperatorCertificateFingerprint`, or
+`TlsCertFilePath`/`TlsKeyFilePath` is refused rather than silently serving
+DatabaseService with a missing authentication or authorization stage. The check
 lives at `Start`, not construction, because a `databaseServiceHandler` built
 via `newDatabaseServiceHandler` and exercised through direct in-process Go
 calls — as most of this package's own handler-level tests do — never goes
 through `Start`'s mux/interceptor wiring and so is never actually
 network-reachable in the first place; `internal/config/validate.go` also
 checks the same invariant upfront (`barkPort` + `databaseLifecycle.
-snapshotDir` set without `barkClientCaFilePath`), so a misconfigured `dingo`
-invocation fails fast at the CLI rather than deep inside `Node.Run()`.
+snapshotDir` set without `barkClientCaFilePath` or
+`barkOperatorCertificateFingerprints`), so a misconfigured `dingo` invocation
+fails fast at the CLI rather than deep inside `Node.Run()`.
 `dingoctl`'s existing `--client-cert`/`--client-key`/`--ca-cert` flags
 (`dingoctl/internal/client/tls.go`) are the client side of this — no new
 dingoctl plumbing was needed.

--- a/README.md
+++ b/README.md
@@ -620,9 +620,13 @@ a target beyond the security parameter, because it exists for disaster-recovery
 scenarios (see CIP-0135) where the chain must be rewound further than Ouroboros
 Praos allows. The resulting database is resync-ready from the target point.
 
-The same operations are also exposed remotely through the Bark
-`DatabaseService`. Bark has no built-in authentication, so do not expose its
-port outside a trusted network.
+The same operations are also exposed remotely through Bark's
+`DatabaseService`. Every `DatabaseService` RPC requires a client certificate
+verified against `barkClientCaFilePath`; destructive RPCs also require the
+certificate's SHA-256 fingerprint in
+`barkOperatorCertificateFingerprints`. Bark's read-only `ArchiveService`
+remains public on the same listener, so expose the Bark port only to the
+intended network.
 
 ## Database Plugins
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ The following environment variables modify Dingo's behavior:
   - Comma-separated HTTPS hostnames additionally allowed for Bark-supplied
     block download URLs. The allowlist always includes the
     `DINGO_BARK_BASE_URL` hostname.
+- `DINGO_BARK_CLIENT_CA_FILE_PATH`
+  - PEM CA bundle used to authenticate every Bark DatabaseService caller.
+- `DINGO_BARK_OPERATOR_CERTIFICATE_FINGERPRINTS`
+  - Comma-separated SHA-256 client certificate fingerprints authorized for
+    destructive Bark DatabaseService RPCs.
 - `DINGO_DEBUG_BIND_ADDR`
   - IP address to bind for unauthenticated pprof endpoints (default:
     `127.0.0.1`)

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -17,6 +17,7 @@ package bark
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 
@@ -39,6 +40,23 @@ func (a *archiveServiceHandler) FetchBlock(
 	req *connect.Request[archive.FetchBlockRequest],
 ) (*connect.Response[archive.FetchBlockResponse], error) {
 	resp := &archive.FetchBlockResponse{}
+	blocks := req.Msg.GetBlocks()
+	if len(blocks) == 0 {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("at least one block reference is required"),
+		)
+	}
+	if len(blocks) > DefaultMaxFetchBlockRefs {
+		return nil, connect.NewError(
+			connect.CodeResourceExhausted,
+			fmt.Errorf(
+				"block reference count %d exceeds maximum %d",
+				len(blocks),
+				DefaultMaxFetchBlockRefs,
+			),
+		)
+	}
 
 	db, release, err := a.bark.Acquire()
 	if err != nil {
@@ -46,7 +64,7 @@ func (a *archiveServiceHandler) FetchBlock(
 	}
 	defer release()
 
-	for _, b := range req.Msg.GetBlocks() {
+	for _, b := range blocks {
 		hash, err := hex.DecodeString(b.GetHash())
 		if err != nil {
 			return nil,

--- a/bark/auth.go
+++ b/bark/auth.go
@@ -20,8 +20,10 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 	databaseconnect "github.com/blinklabs-io/bark/proto/v1alpha1/database/databasev1alpha1connect"
@@ -53,14 +55,10 @@ var destructiveDatabaseProcedures = map[string]bool{
 	databaseconnect.DatabaseServiceCancelOperationProcedure: true,
 }
 
-// readOnlyDatabaseProcedures is the only set of DatabaseService procedures
-// operatorAuthInterceptor.authorize exempts from requiring a verified mTLS
-// client certificate. This is deliberately an allowlist, not the inverse of
-// destructiveDatabaseProcedures: a procedure absent from BOTH maps — e.g. a
-// new DatabaseService RPC added to the proto without updating either one —
-// is still required to authenticate, the same as a known-destructive one.
-// See authorize's doc comment for why the runtime check is structured this
-// way.
+// readOnlyDatabaseProcedures is the set of authenticated DatabaseService
+// procedures that do not additionally require operator authorization. This is
+// deliberately an allowlist: a procedure absent from both maps is treated as
+// destructive and therefore requires an allowed operator fingerprint.
 var readOnlyDatabaseProcedures = map[string]bool{
 	databaseconnect.DatabaseServiceGetSnapshotStatusProcedure:       true,
 	databaseconnect.DatabaseServiceListSnapshotsProcedure:           true,
@@ -73,9 +71,9 @@ var readOnlyDatabaseProcedures = map[string]bool{
 }
 
 // peerIdentity is what peerCertContextMiddleware extracts from a verified
-// mTLS client certificate and stashes in the request context — just enough
-// to authorize (Verified) and audit-log (CommonName/Fingerprint) a
-// destructive call, not a general certificate representation.
+// mTLS client certificate and stashes in the request context — just enough to
+// authenticate every DatabaseService request, authorize destructive calls by
+// fingerprint, and identify callers in audit logs.
 type peerIdentity struct {
 	Verified    bool
 	CommonName  string
@@ -148,22 +146,46 @@ func peerCertContextMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// errAnonymousDestructiveCall is returned by newOperatorAuthInterceptor for
-// any destructive DatabaseService call whose connection presented no
-// verified client certificate.
-var errAnonymousDestructiveCall = errors.New(
-	"this RPC requires a verified mTLS client certificate: destructive " +
-		"DatabaseService operations cannot be called anonymously",
+// errAnonymousDatabaseCall is returned for every DatabaseService call whose
+// connection presented no verified client certificate.
+var errAnonymousDatabaseCall = errors.New(
+	"DatabaseService RPCs require a verified mTLS client certificate",
 )
 
-// newOperatorAuthInterceptor returns a connect.Interceptor that rejects any
-// call to a procedure not in readOnly with connect.CodeUnauthenticated
-// unless peerCertContextMiddleware recorded a verified client certificate
-// on the request's connection. Every non-read-only call — accepted or
-// rejected — is logged with the caller's certificate identity (or its
-// absence), so an operator can audit who ran a Restore/Truncate/
-// DeleteSnapshot/etc. after the fact; GetOperationHistory (database.go) has
-// no notion of caller identity of its own to fall back on.
+var errOperatorPermissionDenied = errors.New(
+	"the authenticated client certificate is not authorized for destructive " +
+		"DatabaseService operations",
+)
+
+func normalizeOperatorCertificateFingerprints(
+	values []string,
+) (map[string]struct{}, error) {
+	ret := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		normalized := strings.ReplaceAll(strings.TrimSpace(value), ":", "")
+		decoded, err := hex.DecodeString(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not hexadecimal: %w", value, err)
+		}
+		if len(decoded) != sha256.Size {
+			return nil, fmt.Errorf(
+				"%q decodes to %d bytes, expected %d",
+				value,
+				len(decoded),
+				sha256.Size,
+			)
+		}
+		ret[hex.EncodeToString(decoded)] = struct{}{}
+	}
+	return ret, nil
+}
+
+// newOperatorAuthInterceptor enforces DatabaseService's two-stage policy:
+// every call requires a verified client certificate, and every non-read-only
+// call additionally requires its fingerprint in operatorFingerprints.
+// Destructive calls are logged with the caller's certificate identity so an
+// operator can audit who ran a Restore/Truncate/DeleteSnapshot/etc. after the
+// fact; GetOperationHistory has no caller identity of its own to fall back on.
 //
 // Implements the full connect.Interceptor interface — including
 // WrapStreamingHandler/WrapStreamingClient, which are no-ops for every
@@ -175,40 +197,49 @@ func newOperatorAuthInterceptor(
 	logger *slog.Logger,
 	destructive map[string]bool,
 	readOnly map[string]bool,
+	operatorFingerprints map[string]struct{},
 ) connect.Interceptor {
 	return &operatorAuthInterceptor{
-		logger:      logger,
-		destructive: destructive,
-		readOnly:    readOnly,
+		logger:               logger,
+		destructive:          destructive,
+		readOnly:             readOnly,
+		operatorFingerprints: operatorFingerprints,
 	}
 }
 
 type operatorAuthInterceptor struct {
-	logger      *slog.Logger
-	destructive map[string]bool
-	readOnly    map[string]bool
+	logger               *slog.Logger
+	destructive          map[string]bool
+	readOnly             map[string]bool
+	operatorFingerprints map[string]struct{}
 }
 
-// authorize is deliberately deny-by-default: it allows a procedure through
-// unauthenticated only if readOnly explicitly names it, not merely because
-// destructive doesn't. That means a DatabaseService RPC absent from BOTH
-// maps — most plausibly a new one added to the proto without updating
-// either — still requires a verified certificate, the same as a known
-// destructive one, instead of silently passing through unauthenticated the
-// way an "allow unless listed as destructive" check would. This mirrors
-// peerCertContextMiddleware's own fail-closed default (an absent/failed
-// verification leaves peerIdentity.Verified false, never true).
+// authorize is deliberately deny-by-default. Every procedure requires a
+// verified certificate. A procedure absent from both classification maps —
+// most plausibly a new RPC added without updating this file — additionally
+// requires operator authorization exactly like a known destructive RPC.
 // TestDestructiveDatabaseProcedures_CoversEveryGeneratedMethod keeps
 // destructive/readOnly's classification of every current method accurate
 // and pins that neither map is ever missing one, but this function's
 // runtime behavior does not depend on that test having run: an
 // unclassified procedure here is logged (so an operator notices and fixes
-// the classification) and still authenticated exactly like a known
-// destructive one, never allowed through by default.
+// the classification) and still requires operator authorization.
 func (i *operatorAuthInterceptor) authorize(
 	ctx context.Context,
 	procedure string,
 ) error {
+	id := peerIdentityFromContext(ctx)
+	if !id.Verified {
+		i.logger.Warn(
+			"rejected anonymous call to DatabaseService RPC",
+			"component", "bark",
+			"procedure", procedure,
+		)
+		return connect.NewError(
+			connect.CodeUnauthenticated,
+			errAnonymousDatabaseCall,
+		)
+	}
 	if i.readOnly[procedure] {
 		return nil
 	}
@@ -222,16 +253,17 @@ func (i *operatorAuthInterceptor) authorize(
 			procedure,
 		)
 	}
-	id := peerIdentityFromContext(ctx)
-	if !id.Verified {
+	if _, ok := i.operatorFingerprints[id.Fingerprint]; !ok {
 		i.logger.Warn(
-			"rejected anonymous call to destructive DatabaseService RPC",
+			"rejected destructive DatabaseService RPC from non-operator identity",
 			"component", "bark",
 			"procedure", procedure,
+			"client_cn", id.CommonName,
+			"client_cert_fingerprint", id.Fingerprint,
 		)
 		return connect.NewError(
-			connect.CodeUnauthenticated,
-			errAnonymousDestructiveCall,
+			connect.CodePermissionDenied,
+			errOperatorPermissionDenied,
 		)
 	}
 	i.logger.Info(

--- a/bark/auth_test.go
+++ b/bark/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -74,8 +75,7 @@ func TestDestructiveDatabaseProcedures_CoversEveryGeneratedMethod(
 			"procedure %q is not classified as destructive (auth.go's "+
 				"destructiveDatabaseProcedures) or read-only (this test's "+
 				"readOnlyDatabaseProcedures) -- a new DatabaseService RPC "+
-				"must be explicitly added to one of those, not silently "+
-				"left unauthenticated by default", procedure)
+				"must be explicitly added to one of those", procedure)
 		assert.Falsef(
 			t,
 			isDestructive && isReadOnly,
@@ -89,17 +89,13 @@ func TestDestructiveDatabaseProcedures_CoversEveryGeneratedMethod(
 // runtime property that makes readOnlyDatabaseProcedures an allowlist
 // rather than destructiveDatabaseProcedures a denylist: a procedure name
 // present in NEITHER map -- standing in for a new DatabaseService RPC added
-// to the proto without updating either one -- must still require a
-// verified client certificate, exactly like a known destructive procedure,
-// not be silently let through the way "allow unless listed as destructive"
-// would. TestDestructiveDatabaseProcedures_CoversEveryGeneratedMethod is
-// what keeps that situation from actually arising in practice, but this
-// test pins that authorize itself does not depend on that check having
-// run.
+// without updating either one -- must still require authentication and
+// operator authorization exactly like a known destructive procedure.
 func TestOperatorAuthInterceptor_FailsClosedForUnclassifiedProcedure(
 	t *testing.T,
 ) {
 	const unclassified = "/bark.v1alpha1.database.DatabaseService/SomeFutureRPC"
+	const operatorFingerprint = "operator"
 	require.False(t, destructiveDatabaseProcedures[unclassified])
 	require.False(t, readOnlyDatabaseProcedures[unclassified])
 
@@ -107,11 +103,69 @@ func TestOperatorAuthInterceptor_FailsClosedForUnclassifiedProcedure(
 		logger:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		destructive: destructiveDatabaseProcedures,
 		readOnly:    readOnlyDatabaseProcedures,
+		operatorFingerprints: map[string]struct{}{
+			operatorFingerprint: {},
+		},
 	}
 
 	err := interceptor.authorize(context.Background(), unclassified)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+
+	err = interceptor.authorize(
+		withPeerIdentity(t.Context(), peerIdentity{
+			Verified:    true,
+			Fingerprint: "reader",
+		}),
+		unclassified,
+	)
+	require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	require.NoError(t, interceptor.authorize(
+		withPeerIdentity(t.Context(), peerIdentity{
+			Verified:    true,
+			Fingerprint: operatorFingerprint,
+		}),
+		unclassified,
+	))
+}
+
+func TestOperatorAuthInterceptorEnforcesTwoStagesForEveryProcedure(
+	t *testing.T,
+) {
+	const operatorFingerprint = "operator"
+	interceptor := &operatorAuthInterceptor{
+		logger:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		destructive: destructiveDatabaseProcedures,
+		readOnly:    readOnlyDatabaseProcedures,
+		operatorFingerprints: map[string]struct{}{
+			operatorFingerprint: {},
+		},
+	}
+	readerCtx := withPeerIdentity(t.Context(), peerIdentity{
+		Verified:    true,
+		Fingerprint: "reader",
+	})
+	operatorCtx := withPeerIdentity(t.Context(), peerIdentity{
+		Verified:    true,
+		Fingerprint: operatorFingerprint,
+	})
+
+	for procedure := range readOnlyDatabaseProcedures {
+		t.Run("read-only "+procedure, func(t *testing.T) {
+			err := interceptor.authorize(t.Context(), procedure)
+			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+			require.NoError(t, interceptor.authorize(readerCtx, procedure))
+		})
+	}
+	for procedure := range destructiveDatabaseProcedures {
+		t.Run("destructive "+procedure, func(t *testing.T) {
+			err := interceptor.authorize(t.Context(), procedure)
+			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+			err = interceptor.authorize(readerCtx, procedure)
+			require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+			require.NoError(t, interceptor.authorize(operatorCtx, procedure))
+		})
+	}
 }
 
 // TestPeerCertContextMiddleware_KeysOffVerifiedChains pins the exact bug
@@ -136,6 +190,9 @@ func TestPeerCertContextMiddleware_KeysOffVerifiedChains(t *testing.T) {
 		logger:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		destructive: destructiveDatabaseProcedures,
 		readOnly:    readOnlyDatabaseProcedures,
+		operatorFingerprints: map[string]struct{}{
+			certFingerprint(leaf): {},
+		},
 	}
 
 	cases := []struct {
@@ -263,6 +320,43 @@ func TestStart_RejectsLifecycleWithoutTLS(t *testing.T) {
 		err.Error(),
 		"TlsCertFilePath and TlsKeyFilePath are required",
 	)
+}
+
+func TestStartRejectsLifecycleWithoutOperatorAllowlist(t *testing.T) {
+	serverCertPath, serverKeyPath := writeTestTLSCertKey(t)
+	_, _, caCertPath := writeTestCA(t)
+
+	b, err := NewBark(BarkConfig{
+		DB:                  newTestDB(t),
+		Lifecycle:           newTestLifecycleService(t),
+		SnapshotDir:         t.TempDir(),
+		Host:                "127.0.0.1",
+		Port:                freeTCPPort(t),
+		TlsCertFilePath:     serverCertPath,
+		TlsKeyFilePath:      serverKeyPath,
+		TlsClientCAFilePath: caCertPath,
+	})
+	require.NoError(t, err)
+
+	err = b.Start(context.Background())
+	require.ErrorContains(t, err, "OperatorCertificateFingerprint")
+}
+
+func TestNewBarkNormalizesOperatorCertificateFingerprints(t *testing.T) {
+	b, err := NewBark(BarkConfig{
+		DB: newTestDB(t),
+		OperatorCertificateFingerprints: []string{
+			strings.Repeat("AB:", 31) + "AB",
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, b.operatorFingerprints, strings.Repeat("ab", 32))
+
+	_, err = NewBark(BarkConfig{
+		DB:                              newTestDB(t),
+		OperatorCertificateFingerprints: []string{"invalid"},
+	})
+	require.ErrorContains(t, err, "invalid operator certificate fingerprint")
 }
 
 // TestStart_RejectsClientCAWithoutTLS_NoLifecycle exercises startServer's

--- a/bark/auth_wire_test.go
+++ b/bark/auth_wire_test.go
@@ -30,16 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDatabaseServiceRequiresClientCertForDestructiveRPCs is the wire-level
-// proof for bark#2988: an anonymous caller (no client cert) can still use
-// the DatabaseService's read-only RPCs but is rejected on a destructive one;
-// a caller presenting a certificate signed by a different, untrusted CA
-// never even completes the TLS handshake; and a caller presenting a
-// certificate signed by the configured CA gets past the auth check
-// entirely (it may still fail for an unrelated reason, e.g. an unknown
-// operation ID — the assertion here is specifically about authentication,
-// not about that RPC's own business logic succeeding).
-func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
+// TestDatabaseServiceAuthenticationAndOperatorAuthorization is the wire-level
+// proof of Bark's two-stage DatabaseService contract: every method requires a
+// verified client identity, while destructive methods additionally require an
+// explicitly allowed certificate fingerprint.
+func TestDatabaseServiceAuthenticationAndOperatorAuthorization(t *testing.T) {
 	block1 := testBlock(1, 0x01)
 
 	barkDataDir := t.TempDir()
@@ -74,6 +69,9 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 	trustedClientCertPath, trustedClientKeyPath := writeTestClientCert(
 		t, trustedCA, trustedCAKey, "trusted-operator",
 	)
+	readerClientCertPath, readerClientKeyPath := writeTestClientCert(
+		t, trustedCA, trustedCAKey, "trusted-reader",
+	)
 
 	untrustedCA, untrustedCAKey, _ := writeTestCA(t)
 	untrustedClientCertPath, untrustedClientKeyPath := writeTestClientCert(
@@ -89,6 +87,9 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 		TlsCertFilePath:     serverCertPath,
 		TlsKeyFilePath:      serverKeyPath,
 		TlsClientCAFilePath: trustedCACertPath,
+		OperatorCertificateFingerprints: []string{
+			testCertificateFingerprint(t, trustedClientCertPath),
+		},
 	})
 	require.NoError(t, err)
 	require.NoError(t, b.Start(t.Context()))
@@ -103,7 +104,7 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 	}
 
 	t.Run(
-		"anonymous client: read-only succeeds, destructive is rejected",
+		"anonymous client is rejected from read-only and destructive RPCs",
 		func(t *testing.T) {
 			client := newClient("", "")
 
@@ -111,11 +112,8 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 				context.Background(),
 				connect.NewRequest(&databasev1alpha1.GetDatabaseInfoRequest{}),
 			)
-			require.NoError(
-				t,
-				err,
-				"read-only RPCs must stay reachable without a client cert",
-			)
+			require.Error(t, err)
+			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 
 			_, err = client.CancelOperation(
 				context.Background(),
@@ -125,6 +123,28 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 			)
 			require.Error(t, err)
 			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+		},
+	)
+
+	t.Run(
+		"authenticated reader cannot invoke destructive RPCs",
+		func(t *testing.T) {
+			client := newClient(readerClientCertPath, readerClientKeyPath)
+
+			_, err := client.GetDatabaseInfo(
+				context.Background(),
+				connect.NewRequest(&databasev1alpha1.GetDatabaseInfoRequest{}),
+			)
+			require.NoError(t, err)
+
+			_, err = client.CancelOperation(
+				context.Background(),
+				connect.NewRequest(&databasev1alpha1.CancelOperationRequest{
+					OperationId: "nonexistent",
+				}),
+			)
+			require.Error(t, err)
+			require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 		},
 	)
 
@@ -153,29 +173,17 @@ func TestDatabaseServiceRequiresClientCertForDestructiveRPCs(t *testing.T) {
 				connect.NewRequest(&databasev1alpha1.GetDatabaseInfoRequest{}),
 			)
 			if err != nil {
-				// The handshake was rejected outright — also an acceptable
-				// outcome, and nothing further to check on this connection.
+				// Either the TLS handshake rejected the untrusted chain or the
+				// DatabaseService interceptor rejected the resulting anonymous
+				// identity. Both enforce the authentication boundary.
 				return
 			}
-
-			_, err = client.CancelOperation(
-				context.Background(),
-				connect.NewRequest(&databasev1alpha1.CancelOperationRequest{
-					OperationId: "nonexistent",
-				}),
-			)
-			require.Error(t, err)
-			require.Equal(
-				t,
-				connect.CodeUnauthenticated,
-				connect.CodeOf(err),
-				"an unverified cert must be rejected on a destructive RPC exactly like an anonymous caller",
-			)
+			require.Fail(t, "an untrusted certificate reached a read-only handler")
 		},
 	)
 
 	t.Run(
-		"cert signed by the configured CA passes the auth check",
+		"allowed operator certificate passes both stages",
 		func(t *testing.T) {
 			client := newClient(trustedClientCertPath, trustedClientKeyPath)
 

--- a/bark/bark.go
+++ b/bark/bark.go
@@ -39,6 +39,22 @@ import (
 	"github.com/blinklabs-io/dingo/internal/tlsutil"
 )
 
+const (
+	// DefaultMaxRequestBody bounds each incoming Connect message before it is
+	// decoded or authenticated. Connect applies this per-message limit to both
+	// compressed wire bytes and the decompressed message.
+	DefaultMaxRequestBody = 1 << 20 // 1 MiB
+	// DefaultMaxResponseBody bounds each outgoing Connect message without
+	// imposing a whole-stream limit on StreamOperationProgress.
+	DefaultMaxResponseBody = 1 << 20 // 1 MiB
+	// DefaultMaxFetchBlockRefs bounds the storage/signing work and response
+	// growth driven by one anonymous ArchiveService request.
+	DefaultMaxFetchBlockRefs = 100
+	// DefaultRequestReadTimeout bounds request headers and bodies while leaving
+	// response writes unbounded for long-lived server streams.
+	DefaultRequestReadTimeout = 60 * time.Second
+)
+
 type Bark struct {
 	// mu protects server and listenerAddr, plus config.DB writes (ResumeDB
 	// takes it too). It must never be held across a blocking call whose
@@ -50,6 +66,10 @@ type Bark struct {
 	server       *http.Server
 	config       BarkConfig
 	listenerAddr net.Addr
+	// operatorFingerprints is immutable after construction. A verified client
+	// identity must also appear here before a destructive DatabaseService RPC
+	// is authorized.
+	operatorFingerprints map[string]struct{}
 	// dbGate guards config.DB across a live Restore/Truncate's close-and-
 	// replace window: PauseDB write-locks it before the old database is
 	// closed, ResumeDB publishes the replacement and unlocks it. Acquire
@@ -91,14 +111,21 @@ type BarkConfig struct {
 	// DeleteSnapshot, VerifySnapshot, Restore, Truncate, CancelOperation)
 	// refuse any request whose connection didn't present a certificate
 	// verified against this CA — see newOperatorAuthInterceptor in auth.go.
-	// Read-only RPCs (status/catalog/Archive) never require one. Requires
-	// TlsCertFilePath/TlsKeyFilePath to also be set, since mTLS has no
-	// meaning without the server's own TLS listener underneath it. Start
-	// (not NewBark) fails closed if Lifecycle is set without this — see
-	// Start's doc comment for why the check lives there.
+	// ArchiveService remains public, but every DatabaseService RPC requires a
+	// verified certificate. Destructive DatabaseService RPCs additionally
+	// require a fingerprint in OperatorCertificateFingerprints. Requires
+	// TlsCertFilePath/TlsKeyFilePath to also be set, since mTLS has no meaning
+	// without the server's own TLS listener underneath it. Start (not NewBark)
+	// fails closed if Lifecycle is set without these policies.
 	TlsClientCAFilePath string
-	Host                string
-	Port                uint
+	// OperatorCertificateFingerprints is the explicit authorization policy for
+	// destructive DatabaseService calls. Values are SHA-256 fingerprints of
+	// client certificate DER bytes; hexadecimal values may contain colons and
+	// are matched case-insensitively. Read-only DatabaseService calls require a
+	// verified client certificate but do not require membership in this list.
+	OperatorCertificateFingerprints []string
+	Host                            string
+	Port                            uint
 	// CORSAllowedOrigins configures Access-Control-Allow-Origin.
 	// Empty disables CORS.
 	CORSAllowedOrigins []string
@@ -205,6 +232,15 @@ func NewBark(cfg BarkConfig) (*Bark, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
+	operatorFingerprints, err := normalizeOperatorCertificateFingerprints(
+		cfg.OperatorCertificateFingerprints,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"bark: invalid operator certificate fingerprint: %w",
+			err,
+		)
+	}
 	if cfg.Host == "" {
 		cfg.Host = "0.0.0.0"
 	}
@@ -212,7 +248,8 @@ func NewBark(cfg BarkConfig) (*Bark, error) {
 		cfg.Port = 9091
 	}
 	return &Bark{
-		config: cfg,
+		config:               cfg,
+		operatorFingerprints: operatorFingerprints,
 	}, nil
 }
 
@@ -253,27 +290,42 @@ func (b *Bark) Start(ctx context.Context) error {
 				"no meaning without the server's own TLS listener",
 		)
 	}
+	if b.config.Lifecycle != nil && len(b.operatorFingerprints) == 0 {
+		b.mu.Unlock()
+		return errors.New(
+			"bark: at least one OperatorCertificateFingerprint is required to " +
+				"start with lifecycle set — verified client identity alone does " +
+				"not authorize destructive DatabaseService RPCs",
+		)
+	}
 
 	mux := http.NewServeMux()
-	compress1KB := connect.WithCompressMinBytes(1024)
+	commonHandlerOptions := connect.WithOptions(
+		connect.WithCompressMinBytes(1024),
+		connect.WithReadMaxBytes(DefaultMaxRequestBody),
+		connect.WithSendMaxBytes(DefaultMaxResponseBody),
+	)
 
 	serviceNames := []string{archiveconnect.ArchiveServiceName}
 
 	archivePath, archiveHandler := archiveconnect.NewArchiveServiceHandler(
 		&archiveServiceHandler{bark: b},
-		compress1KB,
+		commonHandlerOptions,
 	)
 	mux.Handle(archivePath, archiveHandler)
 
 	if b.config.Lifecycle != nil {
 		databasePath, databaseHandler := databaseconnect.NewDatabaseServiceHandler(
 			newDatabaseServiceHandler(b),
-			compress1KB,
-			connect.WithInterceptors(newOperatorAuthInterceptor(
-				b.config.Logger,
-				destructiveDatabaseProcedures,
-				readOnlyDatabaseProcedures,
-			)),
+			connect.WithOptions(
+				commonHandlerOptions,
+				connect.WithInterceptors(newOperatorAuthInterceptor(
+					b.config.Logger,
+					destructiveDatabaseProcedures,
+					readOnlyDatabaseProcedures,
+					b.operatorFingerprints,
+				)),
+			),
 		)
 		mux.Handle(databasePath, databaseHandler)
 		serviceNames = append(serviceNames, databaseconnect.DatabaseServiceName)
@@ -282,13 +334,13 @@ func (b *Bark) Start(ctx context.Context) error {
 	mux.Handle(
 		grpchealth.NewHandler(
 			grpchealth.NewStaticChecker(serviceNames...),
-			compress1KB,
+			commonHandlerOptions,
 		),
 	)
 	mux.Handle(
 		grpcreflect.NewHandlerV1(
 			grpcreflect.NewStaticReflector(serviceNames...),
-			compress1KB,
+			commonHandlerOptions,
 		),
 	)
 
@@ -309,6 +361,7 @@ func (b *Bark) Start(ctx context.Context) error {
 			Addr:              listenAddr,
 			Handler:           handler,
 			ReadHeaderTimeout: 60 * time.Second,
+			ReadTimeout:       DefaultRequestReadTimeout,
 			IdleTimeout:       120 * time.Second,
 		}
 	} else {
@@ -320,6 +373,7 @@ func (b *Bark) Start(ctx context.Context) error {
 			Handler:           handler,
 			Protocols:         unencryptedHTTP2Protocols(),
 			ReadHeaderTimeout: 60 * time.Second,
+			ReadTimeout:       DefaultRequestReadTimeout,
 			IdleTimeout:       120 * time.Second,
 		}
 	}
@@ -427,10 +481,10 @@ func (b *Bark) startServer(server *http.Server) error {
 			}
 			server.TLSConfig.ClientCAs = pool
 			// VerifyClientCertIfGiven, not RequireAndVerifyClientCert: this
-			// listener also serves read-only RPCs (status/catalog/Archive)
-			// that must keep working for a caller with no client cert at
-			// all. Only the destructive DatabaseService procedures actually
-			// require one — enforced per-request by
+			// listener also serves the public ArchiveService, which must keep
+			// working without a client certificate. Every DatabaseService
+			// procedure requires a verified identity, and destructive ones also
+			// require an allowed fingerprint; both checks are enforced per RPC by
 			// newOperatorAuthInterceptor (auth.go), not at the handshake.
 			// Go's TLS stack still fully chain-verifies any cert that IS
 			// presented against ClientCAs during the handshake itself, so a

--- a/bark/bark_test.go
+++ b/bark/bark_test.go
@@ -80,6 +80,7 @@ func TestBarkServerTimeoutsSupportStreaming(t *testing.T) {
 			require.Zero(t, server.WriteTimeout,
 				"streaming responses must not have an overall write deadline")
 			require.Equal(t, 60*time.Second, server.ReadHeaderTimeout)
+			require.Equal(t, DefaultRequestReadTimeout, server.ReadTimeout)
 			require.Equal(t, 120*time.Second, server.IdleTimeout)
 		})
 	}

--- a/bark/database_wire_test.go
+++ b/bark/database_wire_test.go
@@ -132,6 +132,9 @@ func TestDatabaseServiceOverRealHTTP(t *testing.T) {
 		TlsCertFilePath:     serverCertPath,
 		TlsKeyFilePath:      serverKeyPath,
 		TlsClientCAFilePath: caCertPath,
+		OperatorCertificateFingerprints: []string{
+			testCertificateFingerprint(t, clientCertPath),
+		},
 	})
 	require.NoError(t, err)
 

--- a/bark/request_limit_test.go
+++ b/bark/request_limit_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bark
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	archivev1alpha1 "github.com/blinklabs-io/bark/proto/v1alpha1/archive"
+	archiveconnect "github.com/blinklabs-io/bark/proto/v1alpha1/archive/archivev1alpha1connect"
+	databaseconnect "github.com/blinklabs-io/bark/proto/v1alpha1/database/databasev1alpha1connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func gzipBarkRequestBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, err := writer.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return compressed.Bytes()
+}
+
+func sendBarkProtoRequest(
+	t *testing.T,
+	client *http.Client,
+	baseURL string,
+	procedure string,
+	body []byte,
+	compressed bool,
+) *http.Response {
+	t.Helper()
+	if compressed {
+		body = gzipBarkRequestBody(t, body)
+	}
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		baseURL+procedure,
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/proto")
+	req.Header.Set("Connect-Protocol-Version", "1")
+	if compressed {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestBarkConnectLimitRejectsOversizedDecompressedMessageBeforeAuth(
+	t *testing.T,
+) {
+	serverCertPath, serverKeyPath := writeTestTLSCertKey(t)
+	_, _, clientCAPath := writeTestCA(t)
+	b, err := NewBark(BarkConfig{
+		DB:                              newTestDB(t),
+		Lifecycle:                       newTestLifecycleService(t),
+		SnapshotDir:                     t.TempDir(),
+		Host:                            "127.0.0.1",
+		Port:                            freeTCPPort(t),
+		TlsCertFilePath:                 serverCertPath,
+		TlsKeyFilePath:                  serverKeyPath,
+		TlsClientCAFilePath:             clientCAPath,
+		OperatorCertificateFingerprints: []string{strings.Repeat("00", 32)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.Start(t.Context()))
+	t.Cleanup(func() { _ = b.Stop(t.Context()) })
+
+	// A highly-compressible unknown protobuf field expands beyond the limit.
+	// The destructive procedure would reject this anonymous client at the
+	// interceptor, so HTTP 429 also proves the decoder enforced the limit first.
+	body := protowire.AppendTag(nil, 100, protowire.BytesType)
+	body = protowire.AppendBytes(
+		body,
+		bytes.Repeat([]byte{'a'}, DefaultMaxRequestBody),
+	)
+	compressed := gzipBarkRequestBody(t, body)
+	require.Less(t, len(compressed), DefaultMaxRequestBody)
+
+	resp := sendBarkProtoRequest(
+		t,
+		mtlsHTTPClient(t, "", ""),
+		"https://"+b.Addr(),
+		databaseconnect.DatabaseServiceCancelOperationProcedure,
+		body,
+		true,
+	)
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+}
+
+func TestBarkConnectLimitRejectsOversizedCompressedWireMessage(t *testing.T) {
+	b, err := NewBark(BarkConfig{
+		DB:   newTestDB(t),
+		Host: "127.0.0.1",
+		Port: freeTCPPort(t),
+	})
+	require.NoError(t, err)
+	require.NoError(t, b.Start(t.Context()))
+	t.Cleanup(func() { _ = b.Stop(t.Context()) })
+
+	// Random payload bytes do not compress, so gzip expands the request. The
+	// decoded protobuf message remains within the limit while the compressed
+	// wire message exceeds it, isolating the pre-decompression wire bound.
+	payload := make([]byte, DefaultMaxRequestBody-5)
+	_, err = rand.NewChaCha8([32]byte{1}).Read(payload)
+	require.NoError(t, err)
+	body := protowire.AppendTag(nil, 100, protowire.BytesType)
+	body = protowire.AppendBytes(body, payload)
+	compressed := gzipBarkRequestBody(t, body)
+	require.LessOrEqual(t, len(body), DefaultMaxRequestBody)
+	require.Greater(t, len(compressed), DefaultMaxRequestBody)
+
+	resp := sendBarkProtoRequest(
+		t,
+		http.DefaultClient,
+		"http://"+b.Addr(),
+		archiveconnect.ArchiveServiceFetchBlockProcedure,
+		body,
+		true,
+	)
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+}
+
+func TestArchiveFetchBlockRejectsInvalidBatchSizes(t *testing.T) {
+	db := newTestDB(t)
+	handler := &archiveServiceHandler{bark: newTestBark(t, db)}
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := handler.FetchBlock(
+			t.Context(),
+			connect.NewRequest(&archivev1alpha1.FetchBlockRequest{}),
+		)
+		require.Error(t, err)
+		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("oversized", func(t *testing.T) {
+		blocks := make(
+			[]*archivev1alpha1.BlockRef,
+			DefaultMaxFetchBlockRefs+1,
+		)
+		for i := range blocks {
+			blocks[i] = &archivev1alpha1.BlockRef{}
+		}
+		_, err := handler.FetchBlock(
+			t.Context(),
+			connect.NewRequest(&archivev1alpha1.FetchBlockRequest{
+				Blocks: blocks,
+			}),
+		)
+		require.Error(t, err)
+		require.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	})
+
+	t.Run("maximum reaches storage", func(t *testing.T) {
+		block := testBlock(1, 0x42)
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks := make(
+			[]*archivev1alpha1.BlockRef,
+			DefaultMaxFetchBlockRefs,
+		)
+		for i := range blocks {
+			blocks[i] = &archivev1alpha1.BlockRef{
+				Hash: new(hex.EncodeToString(block.Hash)),
+				Slot: new(block.Slot),
+			}
+		}
+		_, err := handler.FetchBlock(
+			t.Context(),
+			connect.NewRequest(&archivev1alpha1.FetchBlockRequest{
+				Blocks: blocks,
+			}),
+		)
+		// The in-memory test blob store deliberately does not support signed
+		// URLs. Reaching its exact error proves equality passed the count guard;
+		// an accidental >= comparison would return ResourceExhausted first.
+		require.ErrorContains(t, err, "GetBlockURL not supported")
+		require.NotEqual(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	})
+}

--- a/bark/tls_test.go
+++ b/bark/tls_test.go
@@ -193,6 +193,17 @@ func writeTestClientCert(
 	return certPath, keyPath
 }
 
+func testCertificateFingerprint(t *testing.T, certPath string) string {
+	t.Helper()
+	pemBytes, err := os.ReadFile(certPath)
+	require.NoError(t, err)
+	block, _ := pem.Decode(pemBytes)
+	require.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return certFingerprint(cert)
+}
+
 // TestTLSServerReusesPreloadedCertAfterFilesChange guards against a real
 // bug: startServer's TLS path used to hand server.ServeTLS the same
 // on-disk cert/key paths it had just preflight-loaded, causing ServeTLS to

--- a/config.go
+++ b/config.go
@@ -1820,6 +1820,12 @@ func (c *Config) BarkBlockDownloadHosts() []string {
 	return c.cfg.BarkBlockDownloadHosts
 }
 
+// BarkOperatorCertificateFingerprints returns the SHA-256 client certificate
+// fingerprints authorized to invoke destructive Bark DatabaseService RPCs.
+func (c *Config) BarkOperatorCertificateFingerprints() []string {
+	return slices.Clone(c.cfg.BarkOperatorCertificateFingerprints)
+}
+
 // TlsCertFilePath returns the path to the TLS certificate for gRPC APIs.
 func (c *Config) TlsCertFilePath() string {
 	return c.cfg.TlsCertFilePath

--- a/config.go
+++ b/config.go
@@ -220,6 +220,7 @@ type Config struct {
 	barkBlockDownloadHosts                                                              []string
 	barkHost                                                                            string
 	barkClientCAFilePath                                                                string
+	barkOperatorCertificateFingerprints                                                 []string
 	databaseLifecycle                                                                   internalconfig.DatabaseLifecycleConfig
 	historyExpiry                                                                       HistoryExpiryConfig
 	koiosParity                                                                         KoiosParityConfig
@@ -714,6 +715,9 @@ func (c *Config) syncCompatFields() {
 	c.barkBaseUrl, c.barkPort, c.barkBlockDownloadHosts = c.cfg.BarkBaseUrl, c.cfg.BarkPort, c.cfg.BarkBlockDownloadHosts
 	c.barkHost = c.cfg.BarkHost
 	c.barkClientCAFilePath = c.cfg.BarkClientCAFilePath
+	c.barkOperatorCertificateFingerprints = slices.Clone(
+		c.cfg.BarkOperatorCertificateFingerprints,
+	)
 	c.databaseLifecycle = c.cfg.DatabaseLifecycle
 	c.corsAllowedOrigins, c.intersectTip = c.cfg.CORSAllowedOrigins, c.cfg.IntersectTip
 	c.peerSharing = c.cfg.PeerSharing != nil && *c.cfg.PeerSharing
@@ -1502,14 +1506,24 @@ func WithBarkHost(host string) ConfigOptionFunc {
 	}
 }
 
-// WithBarkClientCAFilePath sets the PEM CA bundle Bark verifies client
-// certificates (mTLS) against. Required whenever the database lifecycle
-// service is mounted — see BarkConfig.TlsClientCAFilePath's doc comment in
-// bark/bark.go for what this gates.
+// WithBarkClientCAFilePath sets the PEM CA bundle Bark uses to authenticate
+// every DatabaseService caller. Destructive methods additionally require an
+// allowlisted fingerprint set by WithBarkOperatorCertificateFingerprints.
 func WithBarkClientCAFilePath(path string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.cfg.BarkClientCAFilePath = path
 		c.barkClientCAFilePath = path
+	}
+}
+
+// WithBarkOperatorCertificateFingerprints sets the SHA-256 client certificate
+// fingerprints authorized to invoke destructive DatabaseService RPCs.
+func WithBarkOperatorCertificateFingerprints(
+	fingerprints []string,
+) ConfigOptionFunc {
+	return func(c *Config) {
+		c.cfg.BarkOperatorCertificateFingerprints = slices.Clone(fingerprints)
+		c.barkOperatorCertificateFingerprints = slices.Clone(fingerprints)
 	}
 }
 

--- a/dingo.yaml.example
+++ b/dingo.yaml.example
@@ -244,17 +244,24 @@ barkHost: ""
 
 # PEM CA bundle Bark verifies client certificates (mTLS) against. Required
 # whenever the database lifecycle service is enabled (barkPort set alongside
-# databaseLifecycle.snapshotDir below): its destructive DatabaseService RPCs
-# (CreateSnapshot, DeleteSnapshot, VerifySnapshot, Restore, Truncate,
-# CancelOperation) refuse any caller whose connection didn't present a
-# certificate verified against this CA -- Dingo refuses to start rather than
-# mount them unauthenticated. Also requires tlsCertFilePath/tlsKeyFilePath
-# above to be set. Read-only RPCs (status/catalog/Archive) never require a
-# client certificate. dingoctl's --client-cert/--client-key/--ca-cert flags
-# are the client side of this.
+# databaseLifecycle.snapshotDir below): every DatabaseService RPC requires a
+# certificate verified against this CA. ArchiveService remains public.
+# Also requires tlsCertFilePath/tlsKeyFilePath above to be set. dingoctl's
+# --client-cert/--client-key/--ca-cert flags are the client side of this.
 # Can be overridden with DINGO_BARK_CLIENT_CA_FILE_PATH
 # CLI: --bark-client-ca-file-path
 barkClientCaFilePath: ""
+
+# SHA-256 fingerprints of client certificate DER bytes authorized to invoke
+# destructive DatabaseService RPCs (CreateSnapshot, DeleteSnapshot,
+# VerifySnapshot, Restore, Truncate, CancelOperation). Hex is matched
+# case-insensitively and may contain colons. At least one is required whenever
+# the database lifecycle service is enabled; a CA-valid certificate not in this
+# list may use read-only DatabaseService RPCs but receives PERMISSION_DENIED for
+# destructive ones.
+# Can be overridden with DINGO_BARK_OPERATOR_CERTIFICATE_FINGERPRINTS
+# CLI: --bark-operator-certificate-fingerprints
+barkOperatorCertificateFingerprints: []
 
 # Local immutable block history expiry. When enabled, Dingo replaces block CBOR
 # older than the ledger-derived stability window with an expired-history marker
@@ -831,10 +838,10 @@ databaseLifecycle:
   # mounted at all (it's silently skipped, leaving only bark's Archive
   # service, if this is empty). Every snapshot is always written here,
   # regardless of whether snapshotCloudDestination is also set. Setting
-  # this alongside barkPort also requires barkClientCaFilePath (and
-  # tlsCertFilePath/tlsKeyFilePath) above -- Dingo refuses to start
-  # otherwise, since the DatabaseService's destructive RPCs must not be
-  # mounted without a way to authenticate callers.
+  # this alongside barkPort also requires barkClientCaFilePath,
+  # barkOperatorCertificateFingerprints, and tlsCertFilePath/tlsKeyFilePath
+  # above -- Dingo refuses to start otherwise, since DatabaseService must not
+  # be mounted without both authentication and operator authorization.
   #
   # Docker image note: the container always runs as a non-root user with a
   # pinned UID:GID of 1000:1000 (see Dockerfile) and never chowns anything

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -546,14 +546,18 @@ type Config struct {
 	// BarkClientCAFilePath is a PEM CA bundle Bark verifies client
 	// certificates (mTLS) against. Required whenever the database lifecycle
 	// service is mounted (databaseLifecycle.snapshotDir set alongside
-	// barkPort): its destructive DatabaseService RPCs (CreateSnapshot,
-	// DeleteSnapshot, VerifySnapshot, Restore, Truncate, CancelOperation)
-	// refuse any caller whose connection didn't present a certificate
-	// verified against this CA — see bark.Bark.Start and bark/auth.go. Also
-	// requires TlsCertFilePath/TlsKeyFilePath to be set.
-	BarkClientCAFilePath string   `yaml:"barkClientCaFilePath"         envconfig:"DINGO_BARK_CLIENT_CA_FILE_PATH"`
-	CORSAllowedOrigins   []string `yaml:"corsAllowedOrigins"           envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
-	MetricsPort          uint     `yaml:"metricsPort"                                                                    split_words:"true"`
+	// barkPort): every DatabaseService RPC requires a certificate verified
+	// against this CA. Destructive methods additionally require an explicit
+	// BarkOperatorCertificateFingerprints match. Also requires
+	// TlsCertFilePath/TlsKeyFilePath to be set.
+	BarkClientCAFilePath string `yaml:"barkClientCaFilePath"         envconfig:"DINGO_BARK_CLIENT_CA_FILE_PATH"`
+	// BarkOperatorCertificateFingerprints is the explicit operator allowlist
+	// for destructive DatabaseService RPCs. Every DatabaseService caller must
+	// authenticate with BarkClientCAFilePath; only these SHA-256 certificate
+	// fingerprints may invoke destructive methods.
+	BarkOperatorCertificateFingerprints []string `yaml:"barkOperatorCertificateFingerprints" envconfig:"DINGO_BARK_OPERATOR_CERTIFICATE_FINGERPRINTS"`
+	CORSAllowedOrigins                  []string `yaml:"corsAllowedOrigins"                    envconfig:"DINGO_CORS_ALLOWED_ORIGINS"`
+	MetricsPort                         uint     `yaml:"metricsPort"                                                                    split_words:"true"`
 	// DebugBindAddr is the interface used by the unauthenticated pprof
 	// listener. It defaults to loopback independently of BindAddr and
 	// PrivateBindAddr; operators must set this field explicitly to expose
@@ -1051,38 +1055,39 @@ type DatabaseLifecycleConfig struct {
 var configMu sync.RWMutex
 
 var globalConfig = &Config{
-	Plugins:              defaultPluginsConfig(),
-	BindAddr:             "0.0.0.0",
-	CardanoConfig:        "", // Will be set dynamically based on network
-	DatabasePath:         ".dingo",
-	SocketPath:           "dingo.socket",
-	IntersectTip:         false,
-	ValidateHistorical:   true,
-	StrictUtxoValidation: true,
-	Tracing:              false,
-	TracingStdout:        false,
-	Network:              "preview",
-	NetworkMagic:         0,
-	MetricsPort:          12798,
-	DebugBindAddr:        DefaultDebugBindAddr,
-	DebugPort:            0,
-	PrivateBindAddr:      "127.0.0.1",
-	PrivatePort:          3002,
-	RelayPort:            3001,
-	BarkBaseUrl:          "",
-	BarkPort:             0,
-	BarkHost:             "",
-	BarkClientCAFilePath: "",
-	CORSAllowedOrigins:   []string{"*"},
-	Topology:             "",
-	TlsCertFilePath:      "",
-	TlsKeyFilePath:       "",
-	StorageMode:          "core",
-	RunMode:              RunModeServe,
-	StartEra:             StartEraDefault,
-	ImmutableDbPath:      "",
-	ShutdownTimeout:      DefaultShutdownTimeout,
-	LedgerCatchupTimeout: DefaultLedgerCatchupTimeout,
+	Plugins:                             defaultPluginsConfig(),
+	BindAddr:                            "0.0.0.0",
+	CardanoConfig:                       "", // Will be set dynamically based on network
+	DatabasePath:                        ".dingo",
+	SocketPath:                          "dingo.socket",
+	IntersectTip:                        false,
+	ValidateHistorical:                  true,
+	StrictUtxoValidation:                true,
+	Tracing:                             false,
+	TracingStdout:                       false,
+	Network:                             "preview",
+	NetworkMagic:                        0,
+	MetricsPort:                         12798,
+	DebugBindAddr:                       DefaultDebugBindAddr,
+	DebugPort:                           0,
+	PrivateBindAddr:                     "127.0.0.1",
+	PrivatePort:                         3002,
+	RelayPort:                           3001,
+	BarkBaseUrl:                         "",
+	BarkPort:                            0,
+	BarkHost:                            "",
+	BarkClientCAFilePath:                "",
+	BarkOperatorCertificateFingerprints: nil,
+	CORSAllowedOrigins:                  []string{"*"},
+	Topology:                            "",
+	TlsCertFilePath:                     "",
+	TlsKeyFilePath:                      "",
+	StorageMode:                         "core",
+	RunMode:                             RunModeServe,
+	StartEra:                            StartEraDefault,
+	ImmutableDbPath:                     "",
+	ShutdownTimeout:                     DefaultShutdownTimeout,
+	LedgerCatchupTimeout:                DefaultLedgerCatchupTimeout,
 	// Defaults for database worker pool and API backfill tuning
 	DatabaseWorkers:   5,
 	DatabaseQueueSize: 50,
@@ -1204,6 +1209,10 @@ func cloneConfig(cfg *Config) *Config {
 	clone.BarkBlockDownloadHosts = append(
 		[]string(nil),
 		cfg.BarkBlockDownloadHosts...,
+	)
+	clone.BarkOperatorCertificateFingerprints = append(
+		[]string(nil),
+		cfg.BarkOperatorCertificateFingerprints...,
 	)
 	clone.CORSAllowedOrigins = append([]string(nil), cfg.CORSAllowedOrigins...)
 	if cfg.PeerSharing != nil {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -370,7 +370,12 @@ var flagSpecs = []flagSpec{
 		"BarkClientCAFilePath",
 		"bark-client-ca-file-path",
 		"",
-		"path to a PEM CA bundle; client certs verified against it authenticate Bark's destructive DatabaseService RPCs (required whenever the database lifecycle service is enabled)",
+		"path to a PEM CA bundle; client certs verified against it authenticate every Bark DatabaseService RPC (required whenever the database lifecycle service is enabled)",
+	),
+	stringSliceFlag(
+		"BarkOperatorCertificateFingerprints",
+		"bark-operator-certificate-fingerprints",
+		"SHA-256 client certificate fingerprints authorized for destructive Bark DatabaseService RPCs",
 	),
 
 	// History expiry

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -114,6 +114,7 @@ var logPlainConfigFields = []string{
 	"BackfillBatchSize",
 	"BarkClientCAFilePath",
 	"BarkHost",
+	"BarkOperatorCertificateFingerprints",
 	"BarkPort",
 	"BindAddr",
 	"BlockPipelineEnabled",

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -401,22 +403,39 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		errs = append(errs, err)
 	}
 
-	// Bark's DatabaseService mounts its destructive RPCs (CreateSnapshot/
-	// DeleteSnapshot/VerifySnapshot/Restore/Truncate/CancelOperation)
-	// whenever bark is enabled with a snapshot directory configured —
-	// exactly node.go's Run() gating for lifecycleEnabled. Those RPCs must
-	// never be reachable without a way to authenticate callers, regardless
-	// of bind address (BarkHost/effectiveBarkHost is a network control, not
-	// an identity one), so a client CA is required upfront here rather than
-	// left to fail deep inside bark.Bark.Start at startup.
+	// Bark's DatabaseService is mounted whenever bark is enabled with a snapshot
+	// directory configured. Every method must authenticate its caller, and its
+	// destructive methods additionally require explicit operator authorization.
+	// Validate both policies here rather than failing deep in Bark.Start.
 	if serving && c.BarkPort > 0 && c.DatabaseLifecycle.SnapshotDir != "" &&
 		c.BarkClientCAFilePath == "" {
 		errs = append(errs, errors.New(
 			"barkClientCaFilePath is required when bark is enabled "+
 				"(barkPort) alongside databaseLifecycle.snapshotDir: its "+
-				"destructive DatabaseService RPCs must not be mounted "+
-				"without a way to authenticate callers",
+				"DatabaseService RPCs must not be mounted without a way to "+
+				"authenticate callers",
 		))
+	}
+	if serving && c.BarkPort > 0 && c.DatabaseLifecycle.SnapshotDir != "" &&
+		len(c.BarkOperatorCertificateFingerprints) == 0 {
+		errs = append(errs, errors.New(
+			"barkOperatorCertificateFingerprints requires at least one SHA-256 "+
+				"client certificate fingerprint when bark is enabled (barkPort) "+
+				"alongside databaseLifecycle.snapshotDir: verified identity alone "+
+				"does not authorize destructive DatabaseService RPCs",
+		))
+	}
+	for idx, fingerprint := range c.BarkOperatorCertificateFingerprints {
+		normalized := strings.ReplaceAll(strings.TrimSpace(fingerprint), ":", "")
+		decoded, err := hex.DecodeString(normalized)
+		if err != nil || len(decoded) != sha256.Size {
+			errs = append(errs, fmt.Errorf(
+				"barkOperatorCertificateFingerprints[%d] must be a %d-byte "+
+					"SHA-256 certificate fingerprint encoded as hexadecimal",
+				idx,
+				sha256.Size,
+			))
+		}
 	}
 	// mTLS client verification also needs the server's own TLS pair --
 	// without it, bark.Bark.Start's own equivalent check (independent of

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -946,6 +947,9 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			cfg.DatabaseLifecycle.SnapshotDir = dir
 			cfg.BarkPort = 8091
 			cfg.BarkClientCAFilePath = "/certs/ca.crt"
+			cfg.BarkOperatorCertificateFingerprints = []string{
+				strings.Repeat("00", 32),
+			}
 			cfg.TlsCertFilePath = "/certs/tls.crt"
 			cfg.TlsKeyFilePath = "/certs/tls.key"
 			err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
@@ -956,6 +960,58 @@ func TestValidateDatabaseLifecycleSnapshotDirWritability(t *testing.T) {
 			}
 		},
 	)
+}
+
+func TestValidateBarkDatabaseServiceSecurity(t *testing.T) {
+	newConfig := func(t *testing.T) *Config {
+		t.Helper()
+		cfg := validTestConfig()
+		cfg.BarkPort = 8091
+		cfg.DatabaseLifecycle.SnapshotDir = t.TempDir()
+		cfg.BarkClientCAFilePath = "/certs/ca.crt"
+		cfg.BarkOperatorCertificateFingerprints = []string{
+			strings.Repeat("AB:", 31) + "AB",
+		}
+		cfg.TlsCertFilePath = "/certs/tls.crt"
+		cfg.TlsKeyFilePath = "/certs/tls.key"
+		return cfg
+	}
+
+	t.Run("complete policy", func(t *testing.T) {
+		require.NoError(
+			t,
+			newConfig(t).validate(RunModeServe, minUnprivilegedPort),
+		)
+	})
+
+	t.Run("missing client CA", func(t *testing.T) {
+		cfg := newConfig(t)
+		cfg.BarkClientCAFilePath = ""
+		err := cfg.validate(RunModeServe, minUnprivilegedPort)
+		require.ErrorContains(t, err, "barkClientCaFilePath is required")
+	})
+
+	t.Run("missing operator allowlist", func(t *testing.T) {
+		cfg := newConfig(t)
+		cfg.BarkOperatorCertificateFingerprints = nil
+		err := cfg.validate(RunModeServe, minUnprivilegedPort)
+		require.ErrorContains(
+			t,
+			err,
+			"barkOperatorCertificateFingerprints requires at least one",
+		)
+	})
+
+	t.Run("invalid operator fingerprint", func(t *testing.T) {
+		cfg := newConfig(t)
+		cfg.BarkOperatorCertificateFingerprints = []string{"not-a-fingerprint"}
+		err := cfg.validate(RunModeServe, minUnprivilegedPort)
+		require.ErrorContains(
+			t,
+			err,
+			"must be a 32-byte SHA-256 certificate fingerprint",
+		)
+	})
 }
 
 func TestValidateDatabaseLifecycleSnapshotCloudDestinationPrefix(t *testing.T) {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -530,6 +530,9 @@ func buildDingoConfig(
 		dingo.WithBarkPort(cfg.BarkPort),
 		dingo.WithBarkHost(cfg.BarkHost),
 		dingo.WithBarkClientCAFilePath(cfg.BarkClientCAFilePath),
+		dingo.WithBarkOperatorCertificateFingerprints(
+			cfg.BarkOperatorCertificateFingerprints,
+		),
 		dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
 			Enabled:   cfg.HistoryExpiry.Enabled,
 			Frequency: cfg.HistoryExpiry.Frequency,

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -244,6 +245,43 @@ func TestBuildDingoConfigWiresAPIConfig(t *testing.T) {
 		t.Fatalf(
 			"expected api.auth.token to flow through, got %+v",
 			got.Auth,
+		)
+	}
+}
+
+// TestBuildDingoConfigWiresBarkOperatorFingerprints pins the production
+// composition boundary between loaded YAML/env/CLI configuration and the root
+// configuration that Run passes to dingo.New and, in turn, Bark.
+func TestBuildDingoConfigWiresBarkOperatorFingerprints(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		strings.Repeat("ab", 32),
+		strings.Repeat("cd", 32),
+	}
+	cfg := &config.Config{
+		BarkOperatorCertificateFingerprints: want,
+	}
+
+	built := buildDingoConfig(
+		cfg,
+		slog.New(slog.NewTextHandler(new(bytes.Buffer), nil)),
+		nil,
+		nil,
+		false,
+		dingo.StorageModeCore,
+		30*time.Second,
+		chainsync.DefaultStallTimeout,
+		chainsync.HeaderSyncStrategyPrimary,
+	)
+
+	if got := built.BarkOperatorCertificateFingerprints(); !slices.Equal(
+		got,
+		want,
+	) {
+		t.Fatalf(
+			"expected Bark operator fingerprints to flow through, got %v",
+			got,
 		)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -413,8 +413,8 @@ func (n *Node) apiPluginSelection(
 // bark's own existing default behavior (all interfaces) is preserved for
 // deployments only using it for the read-only Archive service. Bind address
 // is a network control, independent of the mTLS client-certificate
-// authentication check Bark.Start enforces whenever lifecycleEnabled (see
-// BarkConfig.TlsClientCAFilePath) -- this default narrows exposure as
+// authentication and operator-fingerprint authorization checks Bark.Start
+// enforces whenever lifecycleEnabled -- this default narrows exposure as
 // defense in depth, it is not what makes those RPCs safe to reach.
 func effectiveBarkHost(configuredHost string, lifecycleEnabled bool) string {
 	if configuredHost != "" {
@@ -1372,21 +1372,22 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 		barkHost := effectiveBarkHost(n.config.barkHost, lifecycleEnabled)
 		if barkHost != n.config.barkHost {
 			n.config.logger.Warn(
-				"bark database lifecycle service (Restore/Truncate and friends) defaults to a loopback-only bind since no --bark-host was set; its destructive RPCs also require a verified mTLS client certificate (--bark-client-ca-file-path) independent of bind address, but widen this bind only behind your own trusted network controls",
+				"bark database lifecycle service (Restore/Truncate and friends) defaults to a loopback-only bind since no --bark-host was set; every DatabaseService RPC requires a verified mTLS client certificate (--bark-client-ca-file-path), and destructive RPCs require an allowlisted certificate fingerprint (--bark-operator-certificate-fingerprints), independent of bind address; widen this bind only behind your own trusted network controls",
 				"component",
 				"bark",
 			)
 		}
 		barkConfig := bark.BarkConfig{
-			Logger:              n.config.logger,
-			DB:                  db,
-			TlsCertFilePath:     n.config.tlsCertFilePath,
-			TlsKeyFilePath:      n.config.tlsKeyFilePath,
-			TlsClientCAFilePath: n.config.barkClientCAFilePath,
-			Host:                barkHost,
-			Port:                n.config.barkPort,
-			CORSAllowedOrigins:  n.config.corsAllowedOrigins,
-			DestinationRegistry: n.destinationRegistry,
+			Logger:                          n.config.logger,
+			DB:                              db,
+			TlsCertFilePath:                 n.config.tlsCertFilePath,
+			TlsKeyFilePath:                  n.config.tlsKeyFilePath,
+			TlsClientCAFilePath:             n.config.barkClientCAFilePath,
+			OperatorCertificateFingerprints: n.config.barkOperatorCertificateFingerprints,
+			Host:                            barkHost,
+			Port:                            n.config.barkPort,
+			CORSAllowedOrigins:              n.config.corsAllowedOrigins,
+			DestinationRegistry:             n.destinationRegistry,
 		}
 		// Mount the DatabaseService only when a snapshot directory is
 		// configured — bark.NewBark requires one alongside Lifecycle, and


### PR DESCRIPTION
## Summary

- bound compressed, decoded, and response data for Bark Connect handlers
- cap FetchBlock references before database access
- require CA-verified mTLS and operator authorization for DatabaseService
- wire operator fingerprints through CLI/config composition and document the contract

## Validation

- exact-parent request-limit and authorization regressions
- production config-composition red/green regression
- tagged Bark/config/node race suites and conformance
- docs parity, architecture boundaries, vet, lint, and builds

Closes #3499


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3499 by bounding all Bark Connect requests and adding explicit operator authorization to Bark's `DatabaseService`. Previously, read-only DatabaseService RPCs worked without a client certificate and any verified certificate could run destructive RPCs; now every DatabaseService RPC requires a verified mTLS certificate, and destructive RPCs also require a SHA-256 certificate fingerprint from the new `barkOperatorCertificateFingerprints` allowlist.

**Request bounds**
- All Connect handlers (Archive, DatabaseService, health, reflection) enforce 1 MiB compressed and decompressed read limits plus a 1 MiB per-message send limit.
- `FetchBlock` rejects requests with 0 or more than 100 block references before acquiring the database.
- The HTTP server adds a 60-second read timeout without a write timeout, so `StreamOperationProgress` and other long-lived streams are unaffected.

**Authorization**
- Every DatabaseService RPC now requires a verified client certificate; read-only RPCs previously worked anonymously, and an unverified cert on a read-only RPC was previously accepted.
- Destructive RPCs additionally require a certificate fingerprint from `barkOperatorCertificateFingerprints`, configured via YAML, `DINGO_BARK_OPERATOR_CERTIFICATE_FINGERPRINTS`, or `--bark-operator-certificate-fingerprints`; a verified cert not on the list receives `PERMISSION_DENIED`.
- Fingerprint values are case-insensitive hexadecimal and may contain colons.
- `Start` and config validation refuse to mount DatabaseService without both a client CA and at least one operator fingerprint, so existing deployments must add the new setting.
- Procedures absent from both classification maps are treated as destructive and require operator authorization.
- The public `ArchiveService` still requires no certificate.

<sup>Written for commit 449caadf85cf29f00ebd52587bf6487a720ea3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added mandatory mTLS authentication for all DatabaseService operations.
  * Restricted destructive database operations to approved client certificate fingerprints.
  * Added configuration options and validation for client CA certificates and operator fingerprints.

* **Reliability**
  * Added request and response size limits, request timeouts, and FetchBlock batch-size validation.

* **Documentation**
  * Updated setup guidance, environment variables, and security behavior for Bark services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->