### PR TITLE
fix(chain): keep an ephemeral rollback off the common prefix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -546,7 +546,11 @@ check and iterator lookup is resolved against the primary chain's active
 in-memory points and cache; the fork's divergent tail is resolved from its own
 in-memory points. If the primary has since rolled the common point back, it is
 not considered held even though the retained cache can still resolve it by
-point.
+point. Rolling an ephemeral fork back draws the same boundary: a block at or
+below the fork point is a common-prefix block with no entry in the fork's own
+buffer, so the rollback deletes nothing there, and once the rollback point
+lands below the fork point the fork re-anchors its common prefix to that point
+rather than leaving it above the new tip.
 
 ### Peer-to-Peer Networking
 

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -772,6 +772,33 @@ func (c *Chain) rollbackForkDepth(
 // underflow that caused the misclassification.
 //
 // Callers must hold c.mutex and c.manager.mutex.
+// checkEphemeralBufferSpan verifies that a fork's in-memory buffer holds an
+// entry for every block it claims above its fork point. rollbackLocked indexes
+// that buffer per rolled-back block, so a short buffer would otherwise surface
+// as an out-of-range offset part-way through the deletion loop, after blocks
+// had already been removed. Checking once up front keeps the rollback
+// all-or-nothing. blockByIndexLocked applies the same bounds per lookup.
+//
+// Reaching the error means this chain's tip index and buffer already disagree,
+// which no public call path produces; it is a corruption report, not a
+// rejection of the caller's rollback point.
+func (c *Chain) checkEphemeralBufferSpan() error {
+	if c.persistent || c.tipBlockIndex <= c.lastCommonBlockIndex {
+		return nil
+	}
+	want := c.tipBlockIndex - c.lastCommonBlockIndex
+	if want <= uint64(len(c.blocks)) { //nolint:gosec
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %d blocks above fork point %d, buffer holds %d",
+		ErrRollbackBeyondEphemeralChain,
+		want,
+		c.lastCommonBlockIndex,
+		len(c.blocks),
+	)
+}
+
 func (c *Chain) rollbackPointBlock(
 	point ocommon.Point,
 ) (models.Block, error) {
@@ -943,6 +970,11 @@ func (c *Chain) rollbackLocked(
 		)
 		return nil, ErrRollbackExceedsSecurityParam
 	}
+	// Validate the in-memory buffer before deleting anything, so a
+	// corrupt span fails the rollback whole rather than part-way through.
+	if err := c.checkEphemeralBufferSpan(); err != nil {
+		return nil, err
+	}
 	// Capture old tip for fork event before we modify it
 	oldTip := c.currentTip
 	// Collect and delete rolled-back blocks in a single pass
@@ -973,9 +1005,13 @@ func (c *Chain) rollbackLocked(
 					rolledBackBlocks = append(rolledBackBlocks, block)
 				}
 			}
-			// Decrement our fork point block index if we rollback beyond it
-			if i < c.lastCommonBlockIndex {
-				c.lastCommonBlockIndex = i
+			// Blocks at or below the fork point belong to the
+			// common prefix held by the primary chain, not to this
+			// fork's in-memory buffer, so there is nothing to delete
+			// here. blockByIndexLocked draws the same boundary with
+			// <=; using < placed the fork point itself on the buffer
+			// side, where its index computes to -1.
+			if i <= c.lastCommonBlockIndex {
 				continue
 			}
 			// Remove from memory buffer
@@ -986,6 +1022,13 @@ func (c *Chain) rollbackLocked(
 				memBlockIndex+1,
 			)
 		}
+	}
+	// A rollback past the fork point shortens the prefix this chain
+	// shares with the primary: every block it still holds is now common.
+	// Re-anchor here, after the loop has finished reading the old value
+	// for buffer offsets, so lastCommonBlockIndex never exceeds the tip.
+	if !c.persistent && rollbackBlockIndex < c.lastCommonBlockIndex {
+		c.lastCommonBlockIndex = rollbackBlockIndex
 	}
 	// Clear out any headers
 	c.headers = slices.Delete(c.headers, 0, len(c.headers))

--- a/chain/rollback_buffer_span_internal_test.go
+++ b/chain/rollback_buffer_span_internal_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"errors"
+	"testing"
+
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// TestCheckEphemeralBufferSpan covers rollbackLocked's buffer precondition.
+//
+// No public call path reaches the error: AddBlock and reconcile keep a fork's
+// tip index and its in-memory buffer in step, and the behavioral rollback
+// tests exercise only consistent chains. The check still has to be correct,
+// because the deletion loop indexes that buffer per rolled-back block — a
+// short buffer detected part-way through would leave the rollback half
+// applied. Drive it directly rather than leaving the branch unexecuted.
+func TestCheckEphemeralBufferSpan(t *testing.T) {
+	points := func(n int) []ocommon.Point {
+		out := make([]ocommon.Point, n)
+		for i := range out {
+			out[i] = ocommon.Point{Slot: uint64(i) * 20} //nolint:gosec
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		name       string
+		persistent bool
+		tipIndex   uint64
+		lastCommon uint64
+		bufferLen  int
+		wantErr    bool
+	}{
+		{
+			name:       "buffer exactly spans the fork",
+			tipIndex:   6,
+			lastCommon: 3,
+			bufferLen:  3,
+		},
+		{
+			name:       "buffer longer than the fork",
+			tipIndex:   6,
+			lastCommon: 3,
+			bufferLen:  4,
+		},
+		{
+			name:       "buffer one short",
+			tipIndex:   6,
+			lastCommon: 3,
+			bufferLen:  2,
+			wantErr:    true,
+		},
+		{
+			name:       "buffer empty with blocks above the fork",
+			tipIndex:   6,
+			lastCommon: 3,
+			bufferLen:  0,
+			wantErr:    true,
+		},
+		{
+			name:       "tip at the fork point needs no buffer",
+			tipIndex:   3,
+			lastCommon: 3,
+			bufferLen:  0,
+		},
+		{
+			name:       "tip below the fork point needs no buffer",
+			tipIndex:   2,
+			lastCommon: 3,
+			bufferLen:  0,
+		},
+		{
+			name:       "persistent chains keep no buffer",
+			persistent: true,
+			tipIndex:   6,
+			lastCommon: 0,
+			bufferLen:  0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Chain{
+				persistent:           tc.persistent,
+				tipBlockIndex:        tc.tipIndex,
+				lastCommonBlockIndex: tc.lastCommon,
+				blocks:               points(tc.bufferLen),
+			}
+			err := c.checkEphemeralBufferSpan()
+			if tc.wantErr {
+				if !errors.Is(err, ErrRollbackBeyondEphemeralChain) {
+					t.Fatalf(
+						"want ErrRollbackBeyondEphemeralChain, got %v",
+						err,
+					)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}

--- a/chain/rollback_fork_point_test.go
+++ b/chain/rollback_fork_point_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+
+	"github.com/blinklabs-io/dingo/chain"
+)
+
+// newForkChainFixture builds a persistent primary chain of primaryCount
+// blocks and an ephemeral fork anchored at primary block index forkIdx+1,
+// carrying forkCount blocks of its own.
+func newForkChainFixture(
+	t *testing.T,
+	primaryCount, forkIdx, forkCount int,
+) (primaryBlocks, forkBlocks []ledger.Block, forkChain *chain.Chain) {
+	t.Helper()
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	if err != nil {
+		t.Fatalf("NewManager: %s", err)
+	}
+	mustSetLedger(t, cm, 5)
+	primaryChain := cm.PrimaryChain()
+
+	var origin common.Blake2b256
+	// Start at slot 20, not 0: rollbackLocked treats slot 0 as origin, so a
+	// fixture block there would never resolve to a block index.
+	primaryBlocks = generateTestChain(t, 1, origin, 20, 20, primaryCount)
+	for i, b := range primaryBlocks {
+		if err := primaryChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock primary[%d]: %s", i, err)
+		}
+	}
+
+	forkPoint := ocommon.Point{
+		Slot: primaryBlocks[forkIdx].SlotNumber(),
+		Hash: primaryBlocks[forkIdx].Hash().Bytes(),
+	}
+	forkChain, err = cm.NewChainFromIntersect([]ocommon.Point{forkPoint})
+	if err != nil {
+		t.Fatalf("NewChainFromIntersect: %s", err)
+	}
+
+	forkBlocks = generateTestChain(
+		t,
+		uint64(forkIdx+2), //nolint:gosec
+		primaryBlocks[forkIdx].Hash(),
+		primaryBlocks[forkIdx].SlotNumber()+20,
+		20,
+		forkCount,
+	)
+	for i, b := range forkBlocks {
+		if err := forkChain.AddBlock(b, nil); err != nil {
+			t.Fatalf("AddBlock fork[%d]: %s", i, err)
+		}
+	}
+	return primaryBlocks, forkBlocks, forkChain
+}
+
+// TestChainRollbackEphemeralAtAndBeforeForkPoint covers rolling an ephemeral
+// fork chain back to a point inside its own blocks, to its fork point, and to
+// a common-prefix block before its fork point. The before-fork case walks the
+// deletion loop onto the fork point itself, where the in-memory buffer holds
+// no entry for the block; computing a buffer index there yields -1.
+func TestChainRollbackEphemeralAtAndBeforeForkPoint(t *testing.T) {
+	const (
+		primaryCount = 6
+		forkIdx      = 2 // primary block index 3
+		forkCount    = 3
+	)
+
+	for _, testDef := range []struct {
+		name string
+		// target picks the rollback point from the fixture's blocks.
+		target func(primary, fork []ledger.Block) ledger.Block
+		// want lists the blocks the chain must still deliver afterwards.
+		want func(primary, fork []ledger.Block) []ledger.Block
+	}{
+		{
+			name:   "within fork",
+			target: func(_, fork []ledger.Block) ledger.Block { return fork[0] },
+			want: func(primary, fork []ledger.Block) []ledger.Block {
+				return append(slices.Clone(primary[:forkIdx+1]), fork[0])
+			},
+		},
+		{
+			name: "at fork point",
+			target: func(primary, _ []ledger.Block) ledger.Block {
+				return primary[forkIdx]
+			},
+			want: func(primary, _ []ledger.Block) []ledger.Block {
+				return slices.Clone(primary[:forkIdx+1])
+			},
+		},
+		{
+			name: "one before fork point",
+			target: func(primary, _ []ledger.Block) ledger.Block {
+				return primary[forkIdx-1]
+			},
+			want: func(primary, _ []ledger.Block) []ledger.Block {
+				return slices.Clone(primary[:forkIdx])
+			},
+		},
+		{
+			name: "two before fork point",
+			target: func(primary, _ []ledger.Block) ledger.Block {
+				return primary[forkIdx-2]
+			},
+			want: func(primary, _ []ledger.Block) []ledger.Block {
+				return slices.Clone(primary[:forkIdx-1])
+			},
+		},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			primaryBlocks, forkBlocks, forkChain := newForkChainFixture(
+				t, primaryCount, forkIdx, forkCount,
+			)
+			target := testDef.target(primaryBlocks, forkBlocks)
+			rollbackPoint := ocommon.Point{
+				Slot: target.SlotNumber(),
+				Hash: target.Hash().Bytes(),
+			}
+			if err := forkChain.Rollback(rollbackPoint); err != nil {
+				t.Fatalf("Rollback: %s", err)
+			}
+			gotTip := forkChain.Tip()
+			if gotTip.Point.Slot != target.SlotNumber() {
+				t.Fatalf(
+					"tip slot after rollback: got %d want %d",
+					gotTip.Point.Slot, target.SlotNumber(),
+				)
+			}
+			if gotTip.BlockNumber != target.BlockNumber() {
+				t.Fatalf(
+					"tip block number after rollback: got %d want %d",
+					gotTip.BlockNumber, target.BlockNumber(),
+				)
+			}
+			// The chain must remain usable: iterating from origin has to
+			// deliver exactly the blocks up to the rollback target.
+			iter, err := forkChain.FromPoint(ocommon.NewPointOrigin(), false)
+			if err != nil {
+				t.Fatalf("FromPoint: %s", err)
+			}
+			want := testDef.want(primaryBlocks, forkBlocks)
+			for i, wantBlock := range want {
+				next, err := iter.Next(false)
+				if err != nil {
+					t.Fatalf("iter.Next idx %d: %s", i, err)
+				}
+				if next == nil || next.Rollback {
+					t.Fatalf("iter.Next idx %d unexpected: %+v", i, next)
+				}
+				if next.Block.Number != wantBlock.BlockNumber() {
+					t.Fatalf(
+						"iter idx %d block number: got %d want %d",
+						i, next.Block.Number, wantBlock.BlockNumber(),
+					)
+				}
+			}
+			// Nothing may survive past the rollback target: a stale
+			// in-memory buffer entry would surface as an extra block
+			// here rather than as the chain tip.
+			if _, err := iter.Next(false); !errors.Is(
+				err, chain.ErrIteratorChainTip,
+			) {
+				t.Fatalf(
+					"expected chain tip after %d blocks, got err %v",
+					len(want), err,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #3386

`chain/chain.go`'s `rollbackLocked` deletes from an ephemeral fork's in-memory
buffer for every block index down to the rollback point. Blocks at or below the
fork point are not in that buffer — they are the common prefix held by the
primary chain — so at the fork point itself the buffer offset computes to
`-1` and `slices.Delete` panics.

`blockByIndexLocked` already draws this boundary with `<=` (and guards
`memBlockIndex < 0`); the rollback loop was the only place using `<`.

One correction to the issue as filed: the panic is **not** reachable by rolling
back *to* the fork point. The loop runs `i > rollbackBlockIndex`, so a rollback
to the fork point never visits that index. It takes a rollback strictly *before*
the fork point — to a common-prefix block — to walk the loop onto the fork index.
The `at fork point` case in the new test passes without this change; the
`one before fork point` case is the one that panics.

Flipping the operator alone is not sufficient. The old `<` branch reassigned
`c.lastCommonBlockIndex = i` on each iteration below the fork point, which left
it at `rollbackBlockIndex + 1` — above the new tip. This change instead skips
the buffer for `i <= c.lastCommonBlockIndex` and re-anchors
`lastCommonBlockIndex` to `rollbackBlockIndex` once, after the loop has finished
reading the old value for its buffer offsets.

Documentation: `ARCHITECTURE.md`'s ephemeral-fork common-prefix paragraph
recorded the `<=` boundary for index checks and iterator lookups but not for
rollback; it now covers rollback and the re-anchoring. `DATABASE.md` checked,
not affected.

Validation:

- `go test -race ./chain/...` — pass
- `go test -race ./chainselection/... ./ledger/...` — pass, 10 packages
- `go build ./...` — pass
- `golangci-lint run ./chain/...` — 0 issues
- `make import-boundaries`, `make docs-parity` — pass
- `go test ./internal/test/conformance/...` — pass, vectors ran
- New test verified failing without the fix: `panic: slice bounds out of range
  [-1::]` at `chain.go:983`

Not run:

- `./internal/test/devnet/run-tests.sh` — not run. Coverage here is in-memory
  chain only.
- `nilaway`, `modernize`, `golines` — not installed locally; `nilaway` is not a
  module dependency. The 80-character limit was checked directly instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the panic from #3386 where rolling an ephemeral fork back before its fork point crashed in `slices.Delete`. The rollback loop used `<` to bound the in-memory buffer, but a block at the fork point lives on the primary chain's common prefix and has no buffer entry, so its offset computed to -1.

Applies the same `<=` boundary as `blockByIndexLocked`, re-anchors `lastCommonBlockIndex` to the rollback point after the loop, and validates the buffer span before deleting so a corrupt chain fails the rollback whole rather than part-way through. Updates `ARCHITECTURE.md` and adds table-driven tests for rollback within the fork, at and before the fork point, and the new buffer span check.

<sup>Written for commit cda189c4f3d4b2b6d919a243ce7eabc417101371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback behavior for ephemeral forks at and before the fork point.
  * Preserved shared chain blocks correctly during rollback.
  * Ensured iterators return the expected blocks after rollback.

* **Documentation**
  * Clarified ephemeral fork rollback behavior in the architecture documentation.

* **Tests**
  * Added coverage for rollback scenarios inside, at, and before the fork point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->