### PR TITLE
fix(forging): pin block transaction selection to one validation snapshot

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3708,6 +3708,22 @@ Both halves of sigma come from the same Mark row set for the same snapshot epoch
    changing the queued headers.
 7. After successful local adoption, synchronously removes the block's confirmed transactions from the mempool
 
+Step 4's transaction selection runs inside `LedgerState.WithTxValidationSession`
+(the same mechanism the mempool backend rebuilds use above): one pinned ledger
+generation, one validation reference slot, and one repeatable-read transaction
+cover every mempool transaction considered for the candidate block, not a
+fresh snapshot per transaction. If a block, rollback, or protocol-parameter
+change publishes a newer generation before selection finishes, the whole
+candidate is rejected (`transaction validation snapshot changed`) instead of
+being built from transactions checked against different ledger views.
+Selection also re-reads the primary chain tip once it finishes and compares
+it, by slot, hash, and block number, against the parent point the candidate
+already committed to (`nextBlockNumber`/`prevHash`) before selection started;
+a mismatch — a peer block landing mid-selection — rejects the candidate
+before VRF/KES signing (`selected parent changed during block assembly`)
+rather than relying solely on step 6's `Chain.AddLocalBlock` check, which
+still runs as the final backstop against any race not closed here.
+
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.
 KES periods are computed from the era-aware absolute slot (`currentSlot / slotsPerKESPeriod`) for both startup opcert validation and forge-time signing, so networks with Byron-era prefixes do not skew the current KES period by converting wall-clock duration directly through the Shelley slot length.
 

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -15,6 +15,7 @@
 package forging
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -205,6 +206,24 @@ func (b *DefaultBlockBuilder) BuildBlockWithLeios(
 	return b.buildBlock(slot, kesPeriod, leios)
 }
 
+// errParentChangedDuringBuild indicates the chain tip moved while
+// transactions were being selected for a block, after the block's
+// prevHash/blockNumber had already been fixed to the previously-current
+// tip. Returned instead of signing and handing back a block that chain
+// adoption would reject anyway once it re-checks the parent.
+var errParentChangedDuringBuild = errors.New(
+	"selected parent changed during block assembly",
+)
+
+// tipsEqual reports whether two chain tips reference the same point and
+// block number. Slot and hash are both required: a rollback can restore a
+// prior slot, and two forged blocks never share a hash.
+func tipsEqual(a, b ochainsync.Tip) bool {
+	return a.Point.Slot == b.Point.Slot &&
+		a.BlockNumber == b.BlockNumber &&
+		bytes.Equal(a.Point.Hash, b.Point.Hash)
+}
+
 func (b *DefaultBlockBuilder) buildBlock(
 	slot uint64,
 	kesPeriod uint64,
@@ -307,59 +326,73 @@ func (b *DefaultBlockBuilder) buildBlock(
 	// same block can spend outputs from earlier intra-block txs.
 	createdOutputs := make(map[string]lcommon.Utxo)
 
-	// Iterate through transactions and add them until we hit limits
-	for _, mempoolTx := range mempoolTxs {
-		// Use raw CBOR from the mempool transaction
-		txCbor := mempoolTx.Cbor
-		txSize := uint64(len(txCbor))
+	// selectTransactions iterates mempoolTxs and adds them to the block
+	// candidate lists (closed over below) until a limit is hit. It runs
+	// inside withTxValidationSession so every transaction is re-validated
+	// against the same pinned ledger snapshot and repeatable-read
+	// transaction — not a fresh one per call — and stillCurrent is
+	// checked once at the end so a ledger publication observed mid-loop
+	// rejects the whole candidate instead of yielding a block built from
+	// transactions checked against different generations.
+	selectTransactions := func(
+		validate TxValidationFunc,
+		stillCurrent func() bool,
+	) error {
+		for _, mempoolTx := range mempoolTxs {
+			// Use raw CBOR from the mempool transaction
+			txCbor := mempoolTx.Cbor
+			txSize := uint64(len(txCbor))
 
-		// Check MaxTxSize limit
-		if txSize > maxTxSize {
-			b.logger.Debug(
-				"skipping transaction - exceeds MaxTxSize",
-				"component", "forging",
-				"tx_size", txSize,
-				"max_tx_size", maxTxSize,
-			)
-			continue
-		}
+			// Check MaxTxSize limit
+			if txSize > maxTxSize {
+				b.logger.Debug(
+					"skipping transaction - exceeds MaxTxSize",
+					"component", "forging",
+					"tx_size", txSize,
+					"max_tx_size", maxTxSize,
+				)
+				continue
+			}
 
-		// Check MaxBlockSize limit. Dijkstra's block body is not the
-		// segmented tx-body/witness/metadata layout, so it gets an exact
-		// candidate block-body size check after tx decoding below.
-		if limits.era != eraDijkstra && blockSize+txSize > maxBlockSize {
-			b.logger.Debug(
-				"block size limit reached",
-				"component", "forging",
-				"current_size", blockSize,
-				"tx_size", txSize,
-				"max_block_size", maxBlockSize,
-			)
-			break
-		}
+			// Check MaxBlockSize limit. Dijkstra's block body is not the
+			// segmented tx-body/witness/metadata layout, so it gets an exact
+			// candidate block-body size check after tx decoding below.
+			if limits.era != eraDijkstra && blockSize+txSize > maxBlockSize {
+				b.logger.Debug(
+					"block size limit reached",
+					"component", "forging",
+					"current_size", blockSize,
+					"tx_size", txSize,
+					"max_block_size", maxBlockSize,
+				)
+				break
+			}
 
-		// Decode the transaction CBOR into a typed era-specific
-		// transaction via the mempool's tx-type tag. The decoded
-		// instance is used only for in-memory inspection (Inputs,
-		// Witnesses, AuxiliaryData) — its raw body / witness CBOR
-		// is what gets stitched into the block below.
-		fullTx, err := decodeMempoolTx(mempoolTx)
-		if err != nil {
-			b.logger.Debug(
-				"failed to decode full transaction, skipping",
-				"component", "forging",
-				"error", err,
-			)
-			continue
-		}
+			// Decode the transaction CBOR into a typed era-specific
+			// transaction via the mempool's tx-type tag. The decoded
+			// instance is used only for in-memory inspection (Inputs,
+			// Witnesses, AuxiliaryData) — its raw body / witness CBOR
+			// is what gets stitched into the block below.
+			fullTx, err := decodeMempoolTx(mempoolTx)
+			if err != nil {
+				b.logger.Debug(
+					"failed to decode full transaction, skipping",
+					"component", "forging",
+					"error", err,
+				)
+				continue
+			}
 
-		// Re-validate the transaction against the current ledger
-		// state. Between mempool admission and block assembly,
-		// UTxOs may have been consumed, protocol parameters may
-		// have changed, or other state mutations may have
-		// invalidated the transaction.
-		if b.txValidator != nil {
-			if err := b.txValidator.ValidateTxWithOverlay(fullTx, consumedInputs, createdOutputs); err != nil {
+			// Re-validate the transaction against the current ledger
+			// state. Between mempool admission and block assembly,
+			// UTxOs may have been consumed, protocol parameters may
+			// have changed, or other state mutations may have
+			// invalidated the transaction. validate is pinned to one
+			// ledger snapshot for the whole loop (see
+			// withTxValidationSession above/below), so every
+			// transaction in this candidate is checked against the
+			// same UTxO set and protocol parameters.
+			if err := validate(fullTx, consumedInputs, createdOutputs); err != nil {
 				b.logger.Debug(
 					"skipping transaction - failed re-validation",
 					"component", "forging",
@@ -368,209 +401,264 @@ func (b *DefaultBlockBuilder) buildBlock(
 				)
 				continue
 			}
-		}
 
-		// Check for intra-block double-spends: if any input of
-		// this transaction was already consumed by an earlier
-		// transaction in this block candidate, skip it.
-		txInputKeys := make([]string, 0, len(fullTx.Inputs()))
-		doubleSpend := false
-		for _, input := range fullTx.Inputs() {
-			key := fmt.Sprintf(
-				"%s:%d",
-				input.Id().String(),
-				input.Index(),
-			)
-			if _, exists := consumedInputs[key]; exists {
-				b.logger.Debug(
-					"skipping transaction - double-spend within block",
-					"component", "forging",
-					"tx_hash", mempoolTx.Hash,
-					"conflicting_input", key,
+			// Check for intra-block double-spends: if any input of
+			// this transaction was already consumed by an earlier
+			// transaction in this block candidate, skip it.
+			txInputKeys := make([]string, 0, len(fullTx.Inputs()))
+			doubleSpend := false
+			for _, input := range fullTx.Inputs() {
+				key := fmt.Sprintf(
+					"%s:%d",
+					input.Id().String(),
+					input.Index(),
 				)
-				doubleSpend = true
-				break
-			}
-			txInputKeys = append(txInputKeys, key)
-		}
-		if doubleSpend {
-			continue
-		}
-
-		// Pull ExUnits from redeemers in the witness set
-		var estimatedTxExUnits lcommon.ExUnits
-		var exUnitsErr error
-		if witnesses := fullTx.Witnesses(); witnesses != nil {
-			if redeemers := witnesses.Redeemers(); redeemers != nil {
-				for _, redeemer := range redeemers.Iter() {
-					estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
-						estimatedTxExUnits,
-						redeemer.ExUnits,
+				if _, exists := consumedInputs[key]; exists {
+					b.logger.Debug(
+						"skipping transaction - double-spend within block",
+						"component", "forging",
+						"tx_hash", mempoolTx.Hash,
+						"conflicting_input", key,
 					)
-					if exUnitsErr != nil {
-						b.logger.Debug(
-							"skipping transaction - ExUnits overflow",
-							"component", "forging",
-							"error", exUnitsErr,
+					doubleSpend = true
+					break
+				}
+				txInputKeys = append(txInputKeys, key)
+			}
+			if doubleSpend {
+				continue
+			}
+
+			// Pull ExUnits from redeemers in the witness set
+			var estimatedTxExUnits lcommon.ExUnits
+			var exUnitsErr error
+			if witnesses := fullTx.Witnesses(); witnesses != nil {
+				if redeemers := witnesses.Redeemers(); redeemers != nil {
+					for _, redeemer := range redeemers.Iter() {
+						estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
+							estimatedTxExUnits,
+							redeemer.ExUnits,
 						)
-						break
+						if exUnitsErr != nil {
+							b.logger.Debug(
+								"skipping transaction - ExUnits overflow",
+								"component", "forging",
+								"error", exUnitsErr,
+							)
+							break
+						}
 					}
 				}
 			}
-		}
-		if exUnitsErr != nil {
-			continue
-		}
+			if exUnitsErr != nil {
+				continue
+			}
 
-		// Check MaxExUnits limit - skip this tx but continue trying
-		// smaller ones, matching the MaxTxSize behavior above.
-		// Use SafeAddExUnits to avoid overflow in the comparison.
-		candidateExUnits, addErr := eras.SafeAddExUnits(
-			totalExUnits,
-			estimatedTxExUnits,
+			// Check MaxExUnits limit - skip this tx but continue trying
+			// smaller ones, matching the MaxTxSize behavior above.
+			// Use SafeAddExUnits to avoid overflow in the comparison.
+			candidateExUnits, addErr := eras.SafeAddExUnits(
+				totalExUnits,
+				estimatedTxExUnits,
+			)
+			if addErr != nil ||
+				candidateExUnits.Memory > maxExUnits.Memory ||
+				candidateExUnits.Steps > maxExUnits.Steps {
+				b.logger.Debug(
+					"tx exceeds remaining ex units budget, skipping",
+					"component", "forging",
+					"current_memory", totalExUnits.Memory,
+					"current_steps", totalExUnits.Steps,
+					"tx_memory", estimatedTxExUnits.Memory,
+					"tx_steps", estimatedTxExUnits.Steps,
+					"max_memory", maxExUnits.Memory,
+					"max_steps", maxExUnits.Steps,
+				)
+				continue
+			}
+
+			// Handle metadata encoding before adding transaction.
+			var metadataCbor cbor.RawMessage
+			if aux := fullTx.AuxiliaryData(); aux != nil {
+				ac := aux.Cbor()
+				if len(ac) > 0 &&
+					(len(ac) != 1 || (ac[0] != 0xF6 && ac[0] != 0xF5 && ac[0] != 0xF4)) {
+					metadataCbor = ac
+				}
+			}
+			if metadataCbor == nil && fullTx.Metadata() != nil {
+				var err error
+				metadataCbor, err = cbor.Encode(fullTx.Metadata())
+				if err != nil {
+					b.logger.Debug(
+						"failed to encode transaction metadata",
+						"component", "forging",
+						"error", err,
+					)
+					continue
+				}
+			}
+
+			// Add transaction to our lists for later block creation.
+			// Splitting at the byte level keeps block assembly era-
+			// agnostic: we don't need typed body / witness slices once
+			// we have the canonical encoded forms. fullTx.Cbor() returns
+			// the original mempool bytes (preserved via the gouroboros
+			// types' DecodeStoreCbor / SetCborReference machinery);
+			// Dijkstra normalizes those bytes before placing the tx inline
+			// in the block body.
+			fullTxCbor := fullTx.Cbor()
+			bodyBytes, witnessBytes, extractErr := splitTxCbor(fullTxCbor)
+			if extractErr != nil {
+				b.logger.Debug(
+					"failed to split tx CBOR into body+witnesses, skipping",
+					"component", "forging",
+					"tx_hash", mempoolTx.Hash,
+					"error", extractErr,
+				)
+				continue
+			}
+			blockTxCbor := cbor.RawMessage(fullTxCbor)
+			if limits.era == eraDijkstra {
+				var normalizeErr error
+				blockTxCbor, normalizeErr = dijkstraBlockTransactionCbor(
+					fullTxCbor,
+				)
+				if normalizeErr != nil {
+					b.logger.Debug(
+						"failed to encode Dijkstra transaction block form, skipping",
+						"component",
+						"forging",
+						"tx_hash",
+						mempoolTx.Hash,
+						"error",
+						normalizeErr,
+					)
+					continue
+				}
+				candidateTransactions := make(
+					[]cbor.RawMessage,
+					0,
+					len(transactions)+1,
+				)
+				candidateTransactions = append(
+					candidateTransactions,
+					transactions...)
+				candidateTransactions = append(
+					candidateTransactions,
+					blockTxCbor,
+				)
+				candidateBodyCbor, encodeErr := encodeDijkstraBlockBodyCbor(
+					candidateTransactions,
+					[]uint{},
+					nil,
+				)
+				if encodeErr != nil {
+					return fmt.Errorf(
+						"failed to encode candidate Dijkstra block body: %w",
+						encodeErr,
+					)
+				}
+				candidateBodySize := uint64(len(candidateBodyCbor))
+				if candidateBodySize > maxBlockSize {
+					b.logger.Debug(
+						"block body size limit reached",
+						"component", "forging",
+						"candidate_body_size", candidateBodySize,
+						"tx_size", txSize,
+						"max_block_body_size", maxBlockSize,
+					)
+					break
+				}
+			}
+			transactionBodies = append(transactionBodies, bodyBytes)
+			transactionWitnessSets = append(
+				transactionWitnessSets,
+				witnessBytes,
+			)
+			transactions = append(transactions, blockTxCbor)
+			if metadataCbor != nil {
+				transactionMetadataSet[uint(len(transactionBodies))-1] = metadataCbor
+			}
+			blockSize += txSize
+			// Safe to assign: overflow was already checked
+			// via SafeAddExUnits when computing
+			// candidateExUnits above.
+			totalExUnits = candidateExUnits
+
+			// Record consumed inputs so later transactions in this
+			// block cannot spend the same UTxOs.
+			for _, key := range txInputKeys {
+				consumedInputs[key] = struct{}{}
+			}
+			// Record created outputs so later transactions in this block
+			// can spend intra-block outputs without hitting the DB.
+			for _, utxo := range fullTx.Produced() {
+				key := fmt.Sprintf(
+					"%s:%d",
+					utxo.Id.Id().String(),
+					utxo.Id.Index(),
+				)
+				createdOutputs[key] = utxo
+			}
+
+			b.logger.Debug(
+				"added transaction to block candidate lists",
+				"component", "forging",
+				"tx_size", txSize,
+				"block_size", blockSize,
+				"tx_count", len(transactionBodies),
+				"total_memory", totalExUnits.Memory,
+				"total_steps", totalExUnits.Steps,
+			)
+		}
+		if !stillCurrent() {
+			return errTxValidationSnapshotChanged
+		}
+		return nil
+	}
+
+	var selectErr error
+	if b.txValidator != nil {
+		selectErr = withTxValidationSession(b.txValidator, selectTransactions)
+	} else {
+		// No validator configured: skip ledger re-validation entirely
+		// (unchanged from before), but still run the same selection loop
+		// and stillCurrent trivially holds since there is no session to
+		// go stale.
+		selectErr = selectTransactions(
+			func(
+				_ ledger.Transaction,
+				_ map[string]struct{},
+				_ map[string]lcommon.Utxo,
+			) error {
+				return nil
+			},
+			func() bool { return true },
 		)
-		if addErr != nil ||
-			candidateExUnits.Memory > maxExUnits.Memory ||
-			candidateExUnits.Steps > maxExUnits.Steps {
-			b.logger.Debug(
-				"tx exceeds remaining ex units budget, skipping",
-				"component", "forging",
-				"current_memory", totalExUnits.Memory,
-				"current_steps", totalExUnits.Steps,
-				"tx_memory", estimatedTxExUnits.Memory,
-				"tx_steps", estimatedTxExUnits.Steps,
-				"max_memory", maxExUnits.Memory,
-				"max_steps", maxExUnits.Steps,
-			)
-			continue
-		}
+	}
+	if selectErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to select block transactions: %w",
+			selectErr,
+		)
+	}
 
-		// Handle metadata encoding before adding transaction.
-		var metadataCbor cbor.RawMessage
-		if aux := fullTx.AuxiliaryData(); aux != nil {
-			ac := aux.Cbor()
-			if len(ac) > 0 &&
-				(len(ac) != 1 || (ac[0] != 0xF6 && ac[0] != 0xF5 && ac[0] != 0xF4)) {
-				metadataCbor = ac
-			}
-		}
-		if metadataCbor == nil && fullTx.Metadata() != nil {
-			var err error
-			metadataCbor, err = cbor.Encode(fullTx.Metadata())
-			if err != nil {
-				b.logger.Debug(
-					"failed to encode transaction metadata",
-					"component", "forging",
-					"error", err,
-				)
-				continue
-			}
-		}
-
-		// Add transaction to our lists for later block creation.
-		// Splitting at the byte level keeps block assembly era-
-		// agnostic: we don't need typed body / witness slices once
-		// we have the canonical encoded forms. fullTx.Cbor() returns
-		// the original mempool bytes (preserved via the gouroboros
-		// types' DecodeStoreCbor / SetCborReference machinery);
-		// Dijkstra normalizes those bytes before placing the tx inline
-		// in the block body.
-		fullTxCbor := fullTx.Cbor()
-		bodyBytes, witnessBytes, extractErr := splitTxCbor(fullTxCbor)
-		if extractErr != nil {
-			b.logger.Debug(
-				"failed to split tx CBOR into body+witnesses, skipping",
-				"component", "forging",
-				"tx_hash", mempoolTx.Hash,
-				"error", extractErr,
-			)
-			continue
-		}
-		blockTxCbor := cbor.RawMessage(fullTxCbor)
-		if limits.era == eraDijkstra {
-			var normalizeErr error
-			blockTxCbor, normalizeErr = dijkstraBlockTransactionCbor(
-				fullTxCbor,
-			)
-			if normalizeErr != nil {
-				b.logger.Debug(
-					"failed to encode Dijkstra transaction block form, skipping",
-					"component",
-					"forging",
-					"tx_hash",
-					mempoolTx.Hash,
-					"error",
-					normalizeErr,
-				)
-				continue
-			}
-			candidateTransactions := make(
-				[]cbor.RawMessage,
-				0,
-				len(transactions)+1,
-			)
-			candidateTransactions = append(
-				candidateTransactions,
-				transactions...)
-			candidateTransactions = append(
-				candidateTransactions,
-				blockTxCbor,
-			)
-			candidateBodyCbor, encodeErr := encodeDijkstraBlockBodyCbor(
-				candidateTransactions,
-				[]uint{},
-				nil,
-			)
-			if encodeErr != nil {
-				return nil, nil, fmt.Errorf(
-					"failed to encode candidate Dijkstra block body: %w",
-					encodeErr,
-				)
-			}
-			candidateBodySize := uint64(len(candidateBodyCbor))
-			if candidateBodySize > maxBlockSize {
-				b.logger.Debug(
-					"block body size limit reached",
-					"component", "forging",
-					"candidate_body_size", candidateBodySize,
-					"tx_size", txSize,
-					"max_block_body_size", maxBlockSize,
-				)
-				break
-			}
-		}
-		transactionBodies = append(transactionBodies, bodyBytes)
-		transactionWitnessSets = append(transactionWitnessSets, witnessBytes)
-		transactions = append(transactions, blockTxCbor)
-		if metadataCbor != nil {
-			transactionMetadataSet[uint(len(transactionBodies))-1] = metadataCbor
-		}
-		blockSize += txSize
-		// Safe to assign: overflow was already checked
-		// via SafeAddExUnits when computing
-		// candidateExUnits above.
-		totalExUnits = candidateExUnits
-
-		// Record consumed inputs so later transactions in this
-		// block cannot spend the same UTxOs.
-		for _, key := range txInputKeys {
-			consumedInputs[key] = struct{}{}
-		}
-		// Record created outputs so later transactions in this block
-		// can spend intra-block outputs without hitting the DB.
-		for _, utxo := range fullTx.Produced() {
-			key := fmt.Sprintf("%s:%d", utxo.Id.Id().String(), utxo.Id.Index())
-			createdOutputs[key] = utxo
-		}
-
-		b.logger.Debug(
-			"added transaction to block candidate lists",
-			"component", "forging",
-			"tx_size", txSize,
-			"block_size", blockSize,
-			"tx_count", len(transactionBodies),
-			"total_memory", totalExUnits.Memory,
-			"total_steps", totalExUnits.Steps,
+	// currentTip, captured above, is already baked into nextBlockNumber
+	// and will be baked into prevHash below. If a concurrent block
+	// advanced the chain while transactions were being selected above,
+	// binding to that stale parent would only be caught later, after VRF
+	// and KES signing, when chain adoption re-checks the parent and
+	// rejects the block. Recheck now so a stale parent is rejected before
+	// that wasted work, with a diagnostic naming what changed.
+	if reTip := b.chainTip.Tip(); !tipsEqual(reTip, currentTip) {
+		return nil, nil, fmt.Errorf(
+			"%w: parent tip changed from %x/%d to %x/%d during transaction selection",
+			errParentChangedDuringBuild,
+			currentTip.Point.Hash,
+			currentTip.BlockNumber,
+			reTip.Point.Hash,
+			reTip.BlockNumber,
 		)
 	}
 

--- a/ledger/forging/builder_validation_session_test.go
+++ b/ledger/forging/builder_validation_session_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionMockTxValidator implements both TxValidator and
+// TxValidationSessionProvider, so it exercises the same
+// withTxValidationSession path DefaultBlockBuilder.buildBlock uses with a
+// real LedgerState. It lets tests observe how many sessions were opened for
+// one BuildBlock call, and lets a hook run synchronously inside a validate
+// call to simulate a concurrent ledger or chain-tip mutation landing
+// mid-selection (issue #3506).
+type sessionMockTxValidator struct {
+	sessions      int
+	validateCalls int
+	// staleAfterCalls, when non-zero, makes stillCurrent() report false
+	// once validateCalls reaches this count. This simulates a ledger
+	// publication (new block, rollback, epoch transition, or protocol
+	// parameter change) landing while transaction selection is still in
+	// progress.
+	staleAfterCalls int
+	// onValidate, when set, runs synchronously inside each validate call
+	// with the 1-indexed call number. Tests use it to mutate shared state
+	// (e.g. the chain tip) partway through selection, deterministically,
+	// rather than racing real goroutines against a sleep.
+	onValidate func(callNumber int)
+}
+
+func (v *sessionMockTxValidator) ValidateTx(tx ledger.Transaction) error {
+	return v.ValidateTxWithOverlay(tx, nil, nil)
+}
+
+// ValidateTxWithOverlay is only reached if the builder fails to discover the
+// TxValidationSessionProvider capability and falls back to unpinned,
+// per-transaction validation. TestBuildBlockPinsOneValidationSessionPerBlock
+// asserts that does not happen.
+func (v *sessionMockTxValidator) ValidateTxWithOverlay(
+	_ ledger.Transaction,
+	_ map[string]struct{},
+	_ map[string]lcommon.Utxo,
+) error {
+	return nil
+}
+
+func (v *sessionMockTxValidator) WithTxValidationSession(
+	fn func(
+		validate func(
+			tx ledger.Transaction,
+			consumed map[string]struct{},
+			created map[string]lcommon.Utxo,
+		) error,
+		stillCurrent func() bool,
+	) error,
+) error {
+	v.sessions++
+	stale := false
+	validate := func(
+		_ ledger.Transaction,
+		_ map[string]struct{},
+		_ map[string]lcommon.Utxo,
+	) error {
+		v.validateCalls++
+		if v.onValidate != nil {
+			v.onValidate(v.validateCalls)
+		}
+		if v.staleAfterCalls > 0 && v.validateCalls >= v.staleAfterCalls {
+			stale = true
+		}
+		return nil
+	}
+	stillCurrent := func() bool { return !stale }
+	return fn(validate, stillCurrent)
+}
+
+var (
+	_ TxValidator                 = (*sessionMockTxValidator)(nil)
+	_ TxValidationSessionProvider = (*sessionMockTxValidator)(nil)
+)
+
+func threeTxMempoolForSelection(t *testing.T) *mockMempool {
+	t.Helper()
+	return &mockMempool{
+		transactions: []MempoolTransaction{
+			{
+				Hash: "tx1",
+				Cbor: makeMinimalTxCbor(t, 0x01, 0),
+				Type: conway.TxTypeConway,
+			},
+			{
+				Hash: "tx2",
+				Cbor: makeMinimalTxCbor(t, 0x02, 0),
+				Type: conway.TxTypeConway,
+			},
+			{
+				Hash: "tx3",
+				Cbor: makeMinimalTxCbor(t, 0x03, 0),
+				Type: conway.TxTypeConway,
+			},
+		},
+	}
+}
+
+func selectionTestChainTip() *mockChainTip {
+	return &mockChainTip{
+		tip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1000,
+				Hash: bytes.Repeat([]byte{0xAA}, 32),
+			},
+			BlockNumber: 100,
+		},
+	}
+}
+
+func newSelectionTestBuilder(
+	t *testing.T,
+	mempool *mockMempool,
+	chainTip *mockChainTip,
+	validator TxValidator,
+) *DefaultBlockBuilder {
+	t.Helper()
+	pparams := &conway.ConwayProtocolParameters{
+		MaxTxSize:        16384,
+		MaxBlockBodySize: 90112,
+		MaxBlockExUnits: lcommon.ExUnits{
+			Memory: 62000000,
+			Steps:  20000000000,
+		},
+	}
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool:         mempool,
+		PParamsProvider: &mockPParamsProvider{pparams: pparams},
+		ChainTip:        chainTip,
+		EpochNonce: &mockEpochNonceProvider{
+			epoch: 1,
+			nonce: make([]byte, 32),
+		},
+		Credentials: setupTestCredentials(t),
+		TxValidator: validator,
+	})
+	require.NoError(t, err)
+	return builder
+}
+
+// TestBuildBlockPinsOneValidationSessionPerBlock verifies that a whole
+// block's transaction selection runs inside a single validation session
+// (the LedgerState-backed equivalent pins one ledger snapshot and one
+// repeatable-read database transaction for it), rather than opening a fresh
+// session per transaction. Before this, each transaction's
+// ValidateTxWithOverlay call could observe a different ledger generation
+// mid-selection (issue #3506).
+func TestBuildBlockPinsOneValidationSessionPerBlock(t *testing.T) {
+	validator := &sessionMockTxValidator{}
+	builder := newSelectionTestBuilder(
+		t,
+		threeTxMempoolForSelection(t),
+		selectionTestChainTip(),
+		validator,
+	)
+
+	block, _, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err)
+	require.Len(t, block.Transactions(), 3)
+	require.Equal(
+		t,
+		1,
+		validator.sessions,
+		"all transactions in one block must share a single pinned validation session",
+	)
+	require.Equal(t, 3, validator.validateCalls)
+}
+
+// TestBuildBlockRejectsWhenValidationSnapshotGoesStale verifies that a
+// ledger publication observed partway through transaction selection (a new
+// block, rollback, epoch transition, or protocol parameter change) rejects
+// the whole candidate block instead of silently returning one assembled
+// from transactions checked against different generations.
+func TestBuildBlockRejectsWhenValidationSnapshotGoesStale(t *testing.T) {
+	validator := &sessionMockTxValidator{staleAfterCalls: 1}
+	builder := newSelectionTestBuilder(
+		t,
+		threeTxMempoolForSelection(t),
+		selectionTestChainTip(),
+		validator,
+	)
+
+	block, _, err := builder.BuildBlock(1001, 0)
+	require.Error(t, err)
+	require.Nil(t, block)
+	require.ErrorIs(t, err, errTxValidationSnapshotChanged)
+}
+
+// TestBuildBlockRejectsWhenParentChangesDuringSelection simulates a peer
+// block advancing the primary chain tip while a locally-forged block is
+// still selecting mempool transactions against the previously-current
+// parent. The builder must reject the stale candidate itself rather than
+// binding VRF/KES signing to a parent that chain adoption will refuse
+// anyway once the tip has moved (issue #3506).
+func TestBuildBlockRejectsWhenParentChangesDuringSelection(t *testing.T) {
+	chainTip := selectionTestChainTip()
+	validator := &sessionMockTxValidator{}
+	validator.onValidate = func(callNumber int) {
+		if callNumber != 1 {
+			return
+		}
+		// A concurrent peer block lands on the chain mid-selection: the
+		// tip this forge attempt already committed to as its parent is
+		// no longer current.
+		chainTip.tip = ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1001,
+				Hash: bytes.Repeat([]byte{0xBB}, 32),
+			},
+			BlockNumber: 101,
+		}
+	}
+	builder := newSelectionTestBuilder(
+		t,
+		threeTxMempoolForSelection(t),
+		chainTip,
+		validator,
+	)
+
+	block, _, err := builder.BuildBlock(1002, 0)
+	require.Error(t, err)
+	require.Nil(t, block)
+	require.ErrorIs(t, err, errParentChangedDuringBuild)
+}
+
+// TestBuildBlockAcceptsStableParentAcrossSelection is the negative case for
+// TestBuildBlockRejectsWhenParentChangesDuringSelection: when nothing moves
+// the tip during selection, the recheck must not itself reject a
+// legitimately unchanged parent.
+func TestBuildBlockAcceptsStableParentAcrossSelection(t *testing.T) {
+	validator := &sessionMockTxValidator{}
+	builder := newSelectionTestBuilder(
+		t,
+		threeTxMempoolForSelection(t),
+		selectionTestChainTip(),
+		validator,
+	)
+
+	block, _, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err)
+	require.Len(t, block.Transactions(), 3)
+}


### PR DESCRIPTION
Closes #3506.

## Problem

`DefaultBlockBuilder.buildBlock` called `TxValidator.ValidateTxWithOverlay`
once per mempool transaction inside the ranking-block selection loop. Each
call opened its own ledger snapshot and database transaction, so a block,
rollback, epoch transition, or protocol parameter change landing partway
through selection let one candidate block mix transactions checked against
different ledger generations. The chain tip captured at the start of the
loop (used for `prevHash`/`nextBlockNumber`) was never re-checked, so a
concurrent peer block advancing the primary chain during selection was only
caught later, after VRF/KES signing, when `Chain.AddLocalBlock` rejected the
block at adoption.

## Fix

- Wrap the whole transaction-selection loop in `WithTxValidationSession`, so
  every transaction in a candidate block shares one pinned ledger
  generation and one repeatable-read transaction — the same mechanism
  mempool backend rebuilds and Leios endorser-block selection already use.
  Reject the candidate if the generation changes before selection finishes.
- Re-check the primary chain tip once selection finishes and reject the
  candidate before VRF/KES signing if it no longer matches the parent point
  the block already committed to. `Chain.AddLocalBlock`'s own tip check at
  adoption time remains as the final backstop.
- Document both mechanisms in `ARCHITECTURE.md`.

## Testing

- `go test -race ./ledger/forging/...`
- `go test -race -timeout 20m ./ledger/...`
- `go test ./internal/test/conformance/...` (SQLite backend)
- `go test ./internal/architecture/...` (import boundaries)
- `go test ./internal/docsparity/...`
- `golangci-lint run ./ledger/forging/...`, `nilaway ./ledger/forging/...`,
  `modernize ./ledger/forging/...`
- New regression tests confirmed to fail against the pre-fix behavior:
  reverting the session-pinning shows 4 sessions opened instead of 1 and a
  stale mid-loop generation change going undetected; removing the parent
  recheck shows the parent-change test passing when it should reject.

Not run: DevNet / `--conformance` end-to-end suite (this fixes a narrow,
microsecond-scale internal race between transaction validation and chain-tip
advancement; the race-enabled unit tests above exercise it deterministically,
which DevNet's real-time timing cannot reliably reproduce).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes forging's block transaction selection so a candidate block is built entirely against one pinned ledger snapshot, closing the race where a block or rollback landing mid-selection produced a block mixing transactions checked against different generations. Also rejects the candidate before signing if the chain tip moved away from the block's chosen parent.

**Bug Fixes**

- Wraps the whole transaction-selection loop in a single `WithTxValidationSession`, so every transaction in a candidate shares one snapshot and one repeatable-read transaction instead of opening a fresh one per transaction.
- Rejects the candidate if the ledger generation changes before selection finishes.
- Rechecks the primary chain tip after selection and rejects the candidate if its parent no longer matches, rather than relying solely on `Chain.AddLocalBlock`'s adoption-time check.
- Adds regression tests covering session pinning, stale-generation rejection, and parent-change rejection; they fail against the pre-fix behavior.
- Documents the mechanism in `ARCHITECTURE.md`.

Closes #3506.

<sup>Written for commit 24e6832838d7d1951ae6c0357bbe1cc65f9bff9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block forging reliability by validating all selected transactions against one consistent ledger snapshot.
  * Aborts block creation when the validation snapshot becomes outdated during transaction selection.
  * Detects changes to the chain tip during block assembly and prevents forging on an outdated parent.
* **Documentation**
  * Documented the updated transaction-selection and chain-tip validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->