### PR TITLE
fix(chainsync): release NtC state when connections close

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1298,6 +1298,18 @@ All event types follow the `subsystem.snake_case_name` convention.
   than they drain and wedge the subscriber permanently — via exactly the
   two-topic coupling above — which silently stops the node from following the
   chain while it continues to forge
+- An NtC close still needs to release the chainsync server-side (N2C) client
+  state `chainsyncServerFindIntersect`/`chainsyncServerRequestNext` register
+  in `chainsync.State` via `AddClient` — most importantly, its live
+  `chain.ChainIterator`. Since that release can't ride the suppressed
+  `connmanager.conn_closed` event, `ConnectionManager` calls a separate,
+  unconditional `ConnClosedFunc(connId, isNtC, err)` for every connection
+  close (NtC and NtN alike) as a direct per-connection call rather than an
+  EventBus fan-out, so a reconnect storm costs no subscriber buffer capacity.
+  `Node.handleConnManagerClosed`, wired as `ConnClosedFunc`, calls
+  `chainsyncState.RemoveClient` only when `isNtC` is true — the NtN half of
+  cleanup still runs exactly once, through `Ouroboros.HandleConnClosedEvent`
+  on the `connmanager.conn_closed` subscription above
 - Prometheus metrics for event delivery tracking and latency, including
   `event_delivery_blocked_total{type,kind}` and
   `event_async_enqueue_blocked_total{type}` for backpressure

--- a/connmanager/connection_collision_test.go
+++ b/connmanager/connection_collision_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/stretchr/testify/require"
 )
@@ -104,5 +105,62 @@ func TestReplacedConnectionCloseDoesNotPublishStaleEvent(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
+	waitForConnectionManagerWatchers(t, cm)
+}
+
+// TestSameDirectionCollisionNotifiesEvictedConnection reproduces a gap a
+// CodeRabbit review of issue #3508's fix identified: a connection evicted by
+// a same-direction ConnectionId collision is closed directly by
+// addConnectionImpl, so its own error-watcher goroutine never observes a
+// live ErrorChan send -- and even if it did, RemoveConnection would already
+// find the replacement's entry under connId and reject it. Without an
+// explicit notification at the eviction site, ConnClosedFunc never fires for
+// the evicted connection, so an evicted NtC connection's chainsync
+// server-side client state (and its live chain iterator) would never be
+// released.
+func TestSameDirectionCollisionNotifiesEvictedConnection(t *testing.T) {
+	type call struct {
+		isNtC bool
+		err   error
+	}
+	calls := make(chan call, 2)
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		ConnClosedFunc: func(_ ouroboros.ConnectionId, isNtC bool, err error) {
+			calls <- call{isNtC: isNtC, err: err}
+		},
+	})
+	first := newUnstartedConnection(t)
+	second := newUnstartedConnection(t)
+
+	require.True(
+		t,
+		cm.addNtCConnectionWithIPKey(first, true, "127.0.0.1:3002", ""),
+	)
+	require.True(
+		t,
+		cm.addNtCConnectionWithIPKey(second, true, "127.0.0.1:3002", ""),
+	)
+	require.Same(t, second, cm.GetConnectionById(second.Id()))
+
+	c := testutil.RequireReceive(
+		t,
+		calls,
+		time.Second,
+		"expected a ConnClosedFunc call for the evicted connection",
+	)
+	require.True(t, c.isNtC, "evicted NtC connection must report isNtC=true")
+	require.ErrorIs(t, c.err, errConnectionReplaced)
+
+	// The evicted connection's own ErrorChan send must not produce a second,
+	// stale call once it is actually closed.
+	first.ErrorChan() <- errors.New("evicted connection closed")
+	testutil.RequireNoReceive(
+		t,
+		calls,
+		200*time.Millisecond,
+		"evicted connection's own close must not re-trigger ConnClosedFunc",
+	)
+
+	second.ErrorChan() <- nil
 	waitForConnectionManagerWatchers(t, cm)
 }

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -760,6 +760,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			existingConn := existing.conn
 			existingPeerAddr := existing.peerAddr
 			existingIPKey := existing.ipKey
+			existingIsNtC := existing.isNtC
 			// Remove the old entry so the evicted connection's
 			// error-watcher goroutine cannot double-decrement
 			// metrics via RemoveConnection.
@@ -774,6 +775,13 @@ func (c *ConnectionManager) addConnectionImpl(
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)
 			}
+			// The evicted connection's own error-watcher goroutine cannot
+			// deliver this: by the time its ErrorChan fires, RemoveConnection
+			// finds either no entry or the replacement's entry for connId
+			// and returns false without calling ConnClosedFunc. Without this
+			// call, an evicted NtC connection's chainsync server-side client
+			// state (and its live chain iterator) would never be released.
+			c.notifyEvictedConnectionClosed(connId, existingIsNtC)
 			c.connectionsMutex.Lock()
 
 		default:
@@ -799,6 +807,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			existingConn := existing.conn
 			existingPeerAddr := existing.peerAddr
 			existingIPKey := existing.ipKey
+			existingIsNtC := existing.isNtC
 			delete(c.connections, connId)
 			c.connectionsMutex.Unlock()
 			closeConnAndLog(
@@ -810,6 +819,7 @@ func (c *ConnectionManager) addConnectionImpl(
 			if existingIPKey != "" {
 				c.releaseIPSlot(existingIPKey)
 			}
+			c.notifyEvictedConnectionClosed(connId, existingIsNtC)
 			c.connectionsMutex.Lock()
 		}
 	}
@@ -871,6 +881,33 @@ func (c *ConnectionManager) addConnectionImpl(
 		}
 	}()
 	return true
+}
+
+// errConnectionReplaced is the error reported to ConnClosedFunc for a
+// connection evicted by a ConnectionId collision, rather than a closed
+// transport.
+var errConnectionReplaced = errors.New(
+	"connection replaced by a new connection with the same identity",
+)
+
+// notifyEvictedConnectionClosed calls ConnClosedFunc for a connection just
+// evicted by a ConnectionId collision (addConnectionImpl's replacement
+// branches). The evicted connection's own error-watcher goroutine cannot
+// deliver this itself: by the time its ErrorChan fires, RemoveConnection
+// finds either no entry or the replacement's entry for connId and returns
+// false without calling ConnClosedFunc, so without this call an evicted NtC
+// connection's chainsync server-side client state (and its live chain
+// iterator) would never be released. Called synchronously, before the
+// replacement connection is registered in c.connections, so it cannot race
+// the replacement's own state registration.
+func (c *ConnectionManager) notifyEvictedConnectionClosed(
+	connId ouroboros.ConnectionId,
+	isNtC bool,
+) {
+	if c.config.ConnClosedFunc == nil {
+		return
+	}
+	c.config.ConnClosedFunc(connId, isNtC, errConnectionReplaced)
 }
 
 func (c *ConnectionManager) RemoveConnection(

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -30,8 +30,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// ConnectionManagerConnClosedFunc is a function that takes a connection ID and an optional error
-type ConnectionManagerConnClosedFunc func(ouroboros.ConnectionId, error)
+// ConnectionManagerConnClosedFunc is a function that takes a connection ID,
+// whether the closed connection was node-to-client (local), and an optional
+// error. Unlike ConnectionClosedEventType, it fires for every closed
+// connection regardless of isNtC — see the call site below for why the
+// broad EventBus event stays NtN-only.
+type ConnectionManagerConnClosedFunc func(ouroboros.ConnectionId, bool, error)
 
 const (
 	// metricNamePrefix is the common prefix for all connection manager metrics
@@ -857,9 +861,13 @@ func (c *ConnectionManager) addConnectionImpl(
 				),
 			)
 		}
-		// Call configured connection closed callback func
+		// Call configured connection closed callback func. Fires for both
+		// NtN and NtC closes -- unlike the EventBus event above, this is a
+		// direct per-connection call rather than a fan-out to multiple
+		// subscribers, so it carries no reconnect-storm risk. It is the
+		// only close notification an NtC connection gets.
 		if c.config.ConnClosedFunc != nil {
-			c.config.ConnClosedFunc(connId, err)
+			c.config.ConnClosedFunc(connId, isNtC, err)
 		}
 	}()
 	return true

--- a/connmanager/connection_manager_test.go
+++ b/connmanager/connection_manager_test.go
@@ -62,7 +62,7 @@ func TestConnectionManagerConnError(t *testing.T) {
 	var doneOnce sync.Once
 	connManager := connmanager.NewConnectionManager(
 		connmanager.ConnectionManagerConfig{
-			ConnClosedFunc: func(connId ouroboros.ConnectionId, err error) {
+			ConnClosedFunc: func(connId ouroboros.ConnectionId, isNtC bool, err error) {
 				if err != nil && connId == expectedConnId {
 					doneOnce.Do(func() { close(doneChan) })
 				}
@@ -148,7 +148,7 @@ func TestConnectionManagerConnClosed(t *testing.T) {
 	doneChan := make(chan any)
 	connManager := connmanager.NewConnectionManager(
 		connmanager.ConnectionManagerConfig{
-			ConnClosedFunc: func(connId ouroboros.ConnectionId, err error) {
+			ConnClosedFunc: func(connId ouroboros.ConnectionId, isNtC bool, err error) {
 				if connId != expectedConnId {
 					t.Fatalf(
 						"did not receive closed signal from expected connection: got %d, wanted %d",

--- a/connmanager/ntc_conn_closed_callback_test.go
+++ b/connmanager/ntc_conn_closed_callback_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/stretchr/testify/require"
 )
@@ -55,13 +56,14 @@ func TestConnClosedFunc_ReceivesIsNtCTrueForNtCClose(t *testing.T) {
 	conn.ErrorChan() <- closeErr
 	waitForConnectionManagerWatchers(t, cm)
 
-	select {
-	case c := <-calls:
-		require.True(t, c.isNtC, "NtC connection close must report isNtC=true")
-		require.ErrorIs(t, c.err, closeErr)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for ConnClosedFunc call")
-	}
+	c := testutil.RequireReceive(
+		t,
+		calls,
+		time.Second,
+		"expected a ConnClosedFunc call for the NtC connection",
+	)
+	require.True(t, c.isNtC, "NtC connection close must report isNtC=true")
+	require.ErrorIs(t, c.err, closeErr)
 }
 
 func TestConnClosedFunc_ReceivesIsNtCFalseForNtNClose(t *testing.T) {
@@ -82,11 +84,12 @@ func TestConnClosedFunc_ReceivesIsNtCFalseForNtNClose(t *testing.T) {
 	conn.ErrorChan() <- closeErr
 	waitForConnectionManagerWatchers(t, cm)
 
-	select {
-	case c := <-calls:
-		require.False(t, c.isNtC, "NtN connection close must report isNtC=false")
-		require.ErrorIs(t, c.err, closeErr)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for ConnClosedFunc call")
-	}
+	c := testutil.RequireReceive(
+		t,
+		calls,
+		time.Second,
+		"expected a ConnClosedFunc call for the NtN connection",
+	)
+	require.False(t, c.isNtC, "NtN connection close must report isNtC=false")
+	require.ErrorIs(t, c.err, closeErr)
 }

--- a/connmanager/ntc_conn_closed_callback_test.go
+++ b/connmanager/ntc_conn_closed_callback_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmanager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/stretchr/testify/require"
+)
+
+// ConnClosedFunc is the only close notification an NtC connection gets --
+// ConnectionClosedEventType is published for NtN closes only (see
+// ntc_conn_closed_test.go). This pair of tests proves the callback
+// distinguishes the two: before issue #3508's fix, ConnClosedFunc carried no
+// isNtC parameter at all, so nothing downstream could tell an NtC close from
+// an NtN one and wire NtC-specific chainsync teardown to it.
+//
+// Each test gets its own ConnectionManager: newUnstartedConnection returns
+// connections whose ConnectionId is the zero value, so two of them
+// registered with one manager would collide (see ntc_conn_closed_test.go).
+
+func TestConnClosedFunc_ReceivesIsNtCTrueForNtCClose(t *testing.T) {
+	type call struct {
+		isNtC bool
+		err   error
+	}
+	calls := make(chan call, 1)
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		ConnClosedFunc: func(_ ouroboros.ConnectionId, isNtC bool, err error) {
+			calls <- call{isNtC: isNtC, err: err}
+		},
+	})
+	conn := newUnstartedConnection(t)
+	require.True(
+		t,
+		cm.addNtCConnectionWithIPKey(conn, true, "127.0.0.1:3002", ""),
+	)
+
+	closeErr := errors.New("ntc connection closed")
+	conn.ErrorChan() <- closeErr
+	waitForConnectionManagerWatchers(t, cm)
+
+	select {
+	case c := <-calls:
+		require.True(t, c.isNtC, "NtC connection close must report isNtC=true")
+		require.ErrorIs(t, c.err, closeErr)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ConnClosedFunc call")
+	}
+}
+
+func TestConnClosedFunc_ReceivesIsNtCFalseForNtNClose(t *testing.T) {
+	type call struct {
+		isNtC bool
+		err   error
+	}
+	calls := make(chan call, 1)
+	cm := NewConnectionManager(ConnectionManagerConfig{
+		ConnClosedFunc: func(_ ouroboros.ConnectionId, isNtC bool, err error) {
+			calls <- call{isNtC: isNtC, err: err}
+		},
+	})
+	conn := newUnstartedConnection(t)
+	require.True(t, cm.AddConnection(conn, false, "1.2.3.4:3001"))
+
+	closeErr := errors.New("ntn connection closed")
+	conn.ErrorChan() <- closeErr
+	waitForConnectionManagerWatchers(t, cm)
+
+	select {
+	case c := <-calls:
+		require.False(t, c.isNtC, "NtN connection close must report isNtC=false")
+		require.ErrorIs(t, c.err, closeErr)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ConnClosedFunc call")
+	}
+}

--- a/node.go
+++ b/node.go
@@ -1122,6 +1122,7 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 			PromRegistry:        n.config.promRegistry,
 			MaxConnectionsPerIP: n.config.maxConnectionsPerIP,
 			MaxInboundConns:     n.config.maxInboundConns,
+			ConnClosedFunc:      n.handleConnManagerClosed,
 		},
 	)
 	// Wire connection-manager and inbound/outbound connection events.
@@ -1742,6 +1743,31 @@ func taintValue(relaxed bool) string {
 		return nodesettings.LatchOn
 	}
 	return nodesettings.LatchOff
+}
+
+// handleConnManagerClosed releases the chainsync server-side (N2C) client
+// state -- including its live chain iterator -- for a node-to-client
+// connection that just closed.
+//
+// NtC closes are deliberately excluded from the ConnectionClosedEventType
+// fan-out (see the connection manager's publish site) because every current
+// subscriber does node-to-node work and a local client reconnecting in a
+// tight loop would otherwise wedge the EventBus. This callback is the NtC
+// counterpart to HandleConnClosedEvent, which already performs the
+// equivalent RemoveClient cleanup for NtN closes via that event. Guarding on
+// isNtC here keeps the release exactly-once: an NtN close still cleans up
+// only through HandleConnClosedEvent.
+func (n *Node) handleConnManagerClosed(
+	connId ouroboros.ConnectionId,
+	isNtC bool,
+	_ error,
+) {
+	if !isNtC {
+		return
+	}
+	if n.chainsyncState != nil {
+		n.chainsyncState.RemoveClient(connId)
+	}
 }
 
 // subscribeConnectionEvents wires the connection-manager side of the EventBus:

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -923,6 +923,7 @@ func (n *Node) reinitializeNetworkingCore(ctx context.Context) error {
 			PromRegistry:        n.config.promRegistry,
 			MaxConnectionsPerIP: n.config.maxConnectionsPerIP,
 			MaxInboundConns:     n.config.maxInboundConns,
+			ConnClosedFunc:      n.handleConnManagerClosed,
 		},
 	)
 	n.connManagerRecycleSubId = n.eventBus.SubscribeFunc(

--- a/node_ntc_conn_closed_test.go
+++ b/node_ntc_conn_closed_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// nilIterChainProvider satisfies chainsync.ChainProvider without requiring a
+// real database-backed chain. It hands AddClient a nil *chain.ChainIterator,
+// which is enough to register server-side (N2C) client state -- the object
+// under test here is whether that state is released, not the iterator's own
+// Cancel behavior.
+type nilIterChainProvider struct{}
+
+func (nilIterChainProvider) GetChainFromPoint(
+	_ ocommon.Point,
+	_ bool,
+) (*chain.ChainIterator, error) {
+	return nil, nil
+}
+
+func (nilIterChainProvider) StabilityWindow() uint64 { return 0 }
+
+func newNtCTestConnId(port int) ouroboros.ConnectionId {
+	return ouroboros.ConnectionId{
+		LocalAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 3001,
+		},
+		RemoteAddr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: port,
+		},
+	}
+}
+
+func newHandleConnManagerClosedTestNode(t *testing.T) *Node {
+	t.Helper()
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	return &Node{
+		chainsyncState: chainsync.NewStateWithConfig(
+			bus,
+			nilIterChainProvider{},
+			chainsync.DefaultConfig(),
+		),
+	}
+}
+
+// TestHandleConnManagerClosed_NtC_ReleasesChainsyncClientState reproduces
+// issue #3508: NtC connections never received any close notification (the
+// EventBus's ConnectionClosedEventType is intentionally NtN-only), so
+// chainsync.State.RemoveClient -- which cancels the live chain iterator and
+// deletes the per-connection client state -- was never invoked for a closed
+// NtC connection. Without handleConnManagerClosed wired as the connection
+// manager's ConnClosedFunc, this assertion fails: the client state
+// registered by AddClient is still present after the simulated close.
+func TestHandleConnManagerClosed_NtC_ReleasesChainsyncClientState(t *testing.T) {
+	n := newHandleConnManagerClosedTestNode(t)
+	connId := newNtCTestConnId(1)
+
+	_, err := n.chainsyncState.AddClient(connId, ocommon.Point{})
+	require.NoError(t, err)
+	_, ok := n.chainsyncState.LookupClient(connId)
+	require.True(t, ok, "precondition: server-side client state registered")
+
+	n.handleConnManagerClosed(connId, true, nil)
+
+	_, ok = n.chainsyncState.LookupClient(connId)
+	require.False(
+		t,
+		ok,
+		"NtC close must release the chainsync server-side client state and its chain iterator",
+	)
+}
+
+// TestHandleConnManagerClosed_NtN_LeavesStateForEventBusPath guards the
+// "exactly once" half of the fix: NtN connections are already cleaned up via
+// Ouroboros.HandleConnClosedEvent, subscribed to the EventBus's
+// ConnectionClosedEventType. If handleConnManagerClosed also released state
+// for isNtC=false, an NtN close would race two independent RemoveClient
+// calls instead of exactly one.
+func TestHandleConnManagerClosed_NtN_LeavesStateForEventBusPath(t *testing.T) {
+	n := newHandleConnManagerClosedTestNode(t)
+	connId := newNtCTestConnId(2)
+
+	_, err := n.chainsyncState.AddClient(connId, ocommon.Point{})
+	require.NoError(t, err)
+
+	n.handleConnManagerClosed(connId, false, nil)
+
+	_, ok := n.chainsyncState.LookupClient(connId)
+	require.True(
+		t,
+		ok,
+		"NtN close must not be released through the NtC-only callback",
+	)
+}
+
+// TestHandleConnManagerClosed_NilChainsyncState guards the shutdown/restore
+// window (node_lifecycle.go nils n.chainsyncState while rebuilding it) so a
+// late NtC close callback cannot panic.
+func TestHandleConnManagerClosed_NilChainsyncState(t *testing.T) {
+	n := &Node{}
+	require.NotPanics(t, func() {
+		n.handleConnManagerClosed(newNtCTestConnId(3), true, nil)
+	})
+}


### PR DESCRIPTION
## Summary

`connmanager` suppresses `connmanager.conn_closed` for node-to-client
connections to avoid wedging NtN-only subscribers, but no other close
notification existed. The chainsync server-side (N2C) client state
`AddClient` registers per connection — including the live chain
iterator — was therefore never released when an NtC connection
closed, and repeated short-lived connections accumulated it
indefinitely.

## Change

- `ConnectionManagerConnClosedFunc` gains an `isNtC` parameter. This
  callback already fires for every connection close as a direct
  per-connection call rather than an EventBus fan-out, so it carries no
  reconnect-storm risk.
- `Node.handleConnManagerClosed`, wired as `ConnClosedFunc` at both
  connection-manager construction sites (`node.go`, `node_lifecycle.go`),
  releases chainsync client state via `chainsyncState.RemoveClient` only
  when `isNtC` is true. NtN cleanup still runs exactly once, through the
  existing `Ouroboros.HandleConnClosedEvent` subscription on
  `connmanager.conn_closed`.
- Normal close, protocol error, and shutdown all resolve through the same
  connection-manager watcher goroutine, so all three are covered by this
  one fix.
- Documented the mechanism in `ARCHITECTURE.md`.

## Testing

- `go test ./connmanager/...`, `go test .`, `go test ./chainsync/...`,
  `go test ./ouroboros/...` (all `-race`)
- `make import-boundaries`, `make docs-parity`, `make gorm-check`
- `golangci-lint run ./...`, `nilaway -tags dingo_extra_plugins ./...`,
  `modernize`, `golines` — no new findings
- New regression tests confirmed to fail without the fix:
  - `connmanager/ntc_conn_closed_callback_test.go`:
    `TestConnClosedFunc_ReceivesIsNtCTrueForNtCClose` /
    `...FalseForNtNClose` — fails to compile against the pre-fix 2-arg
    `ConnClosedFunc` signature
  - `node_ntc_conn_closed_test.go`:
    `TestHandleConnManagerClosed_NtC_ReleasesChainsyncClientState` —
    fails to compile without `Node.handleConnManagerClosed`, and fails
    behaviorally (verified by temporarily neutering the method's body)
    if the release logic itself regresses

DATABASE.md is unaffected — no schema, query, or storage-provider changes.

Fixes #3508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NtC connections leaking chainsync client state (including their live chain iterators) when they close. `connmanager` suppressed close events for NtC connections, so the per-connection state `AddClient` registered was never released and short-lived connections accumulated it indefinitely. The connection-closed callback now distinguishes NtC closes, and `chainsyncState.RemoveClient` runs only for them.

- Adds an `isNtC` parameter to `ConnectionManagerConnClosedFunc`; this callback already fires for every close as a direct per-connection call, avoiding the reconnect-storm risk that motivated suppressing the EventBus event.
- Wires `Node.handleConnManagerClosed` as `ConnClosedFunc` at both connection manager construction sites (`node.go`, `node_lifecycle.go`).
- Connections evicted by a same-direction ConnectionId collision now also trigger `ConnClosedFunc` (with `errConnectionReplaced`), since their own error watcher can't report the eviction.
- NtN cleanup still runs exactly once through the existing `Ouroboros.HandleConnClosedEvent` subscription on `connmanager.conn_closed`.
- Covers normal close, protocol error, collision eviction, and shutdown.
- Adds regression tests that fail without the fix and documents the mechanism in `ARCHITECTURE.md`.

Fixes #3508.

<sup>Written for commit 7a52cff5aea1b705437ce97352f963f5a3321682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup when node-to-client connections close.
  * Ensured associated synchronization state and iterators are released correctly.
  * Prevented duplicate cleanup for node-to-node connections.
  * Added safeguards for connection closures when synchronization state is unavailable.

* **Tests**
  * Added coverage verifying connection type, error propagation, cleanup behavior, and safe handling of missing state.

* **Documentation**
  * Documented connection-close cleanup behavior in the architecture guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->