### PR TITLE
fix(devnet): stabilize accelerated tx propagation and stake-key cleanup

### DIFF
--- a/internal/test/antithesis/internal/txpump/pump.go
+++ b/internal/test/antithesis/internal/txpump/pump.go
@@ -67,6 +67,13 @@ func (p *Pump) Run(ctx context.Context) error {
 		startup = startupTimer.C
 	}
 	ready := false
+	// A healthy node can accept an N2C connection before the network's
+	// configured system start. Keep the first submission behind the genesis
+	// boundary so an accepted pre-genesis transaction is not later discarded
+	// when forging and ledger revalidation begin.
+	if err := p.waitForGenesis(ctx, startup); err != nil {
+		return err
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -131,6 +138,33 @@ func (p *Pump) Run(ctx context.Context) error {
 		if !p.cooldown(ctx) {
 			return ctx.Err()
 		}
+	}
+}
+
+// waitForGenesis blocks transaction generation until the configured network
+// start. The startup deadline remains active while waiting, so a bad runtime
+// genesis timestamp fails readiness instead of leaving txpump hung forever.
+func (p *Pump) waitForGenesis(
+	ctx context.Context,
+	startup <-chan time.Time,
+) error {
+	delay := time.Until(p.genesisTime)
+	if delay <= 0 {
+		return nil
+	}
+	p.logger.Info("waiting for genesis start", "delay", delay)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-startup:
+		return fmt.Errorf(
+			"txpump readiness timeout after %s: genesis has not started",
+			p.cfg.StartupTimeout,
+		)
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -202,12 +236,16 @@ func enabledTypes(
 	return enabled
 }
 
-// currentSlot returns the number of 1-second slots elapsed since the Pump was
-// created.  Using elapsed time (rather than Unix epoch seconds) ensures that
-// the slot counter starts near 0 and epoch gating works correctly for devnet
-// testing, where epochs are only 500 slots long.
+// currentSlot returns the number of 1-second slots elapsed since genesis.
+// Using elapsed time (rather than Unix epoch seconds) ensures that the slot
+// counter starts near 0 and epoch gating works correctly for devnet testing,
+// where epochs are only 500 slots long. Before genesis, report slot 0 rather
+// than converting a negative duration to a near-MaxUint64 slot.
 func (p *Pump) currentSlot() uint64 {
 	elapsed := time.Since(p.genesisTime)
+	if elapsed <= 0 {
+		return 0
+	}
 	return uint64(elapsed.Seconds())
 }
 

--- a/internal/test/antithesis/internal/txpump/pump_test.go
+++ b/internal/test/antithesis/internal/txpump/pump_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txpump
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testPump(genesisTime time.Time, startupTimeout time.Duration) *Pump {
+	return NewPump(
+		&Config{StartupTimeout: startupTimeout},
+		NewWallet(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		genesisTime,
+	)
+}
+
+// TestWaitForGenesis proves that node connectivity cannot release transaction
+// generation before the network start boundary.
+func TestWaitForGenesis(t *testing.T) {
+	pump := testPump(time.Now().Add(25*time.Millisecond), time.Second)
+	started := time.Now()
+	require.NoError(t, pump.waitForGenesis(context.Background(), nil))
+	require.GreaterOrEqual(t, time.Since(started), 20*time.Millisecond)
+}
+
+// TestWaitForGenesisHonorsStartupTimeout ensures a malformed future runtime
+// start surfaces as a readiness failure instead of hanging the workload.
+func TestWaitForGenesisHonorsStartupTimeout(t *testing.T) {
+	pump := testPump(time.Now().Add(time.Hour), time.Millisecond)
+	startup := make(chan time.Time, 1)
+	startup <- time.Now()
+	err := pump.waitForGenesis(context.Background(), startup)
+	require.ErrorContains(t, err, "genesis has not started")
+}
+
+// TestCurrentSlotBeforeGenesisIsZero guards the signed-duration to uint64
+// conversion that previously produced an architecture-independent wrap.
+func TestCurrentSlotBeforeGenesisIsZero(t *testing.T) {
+	pump := testPump(time.Now().Add(time.Hour), time.Second)
+	require.Zero(t, pump.currentSlot())
+}

--- a/internal/test/devnet/configurator.sh
+++ b/internal/test/devnet/configurator.sh
@@ -163,6 +163,17 @@ config_topology_json "$number_of_pools"
 compute_start_time
 echo "system start: ${SYSTEM_START_ISO} (unix: ${SYSTEM_START_UNIX})"
 
+# Publish the actual runtime start (which overrides the generator's short
+# delay) for txpump. Docker can mark every node healthy before this timestamp,
+# so service health alone is not a safe transaction-submission barrier. The
+# shared UTxO volume carries this generated file to txpump without introducing
+# another volume solely for runtime metadata.
+cp /testnet.yaml /configs/utxo-keys/runtime-genesis
+# genesis.Load reads systemStartUnix from the first YAML document. Preserve the
+# original testnet specification and add the exact timestamp used above.
+sed -i "/^systemStartDelay:/a systemStartUnix: ${SYSTEM_START_UNIX}" \
+  /configs/utxo-keys/runtime-genesis
+
 for pool in $pools; do
   echo "pool: $pool"
   set_start_time "$pool"

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -260,6 +260,9 @@ services:
       TXPUMP_COOLDOWN_MAX: "15000"
       TXPUMP_TYPES: "payment"
       TXPUMP_LOG_DIR: "/logs"
+      # The configurator writes the effective system start here. txpump waits
+      # for it even when Docker reports all Dingo services healthy earlier.
+      TXPUMP_GENESIS_FILE: "/utxo-keys/runtime-genesis"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
       - logs:/logs
@@ -394,6 +397,9 @@ services:
       TXPUMP_COOLDOWN_MAX: "15000"
       TXPUMP_TYPES: "payment"
       TXPUMP_LOG_DIR: "/logs"
+      # Use the configurator's effective start rather than treating an early
+      # healthy N2C endpoint as permission to submit transactions.
+      TXPUMP_GENESIS_FILE: "/utxo-keys/runtime-genesis"
       TXPUMP_GENESIS_UTXO_FILE: "/utxo-keys"
     volumes:
       - logs:/logs

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -107,6 +107,7 @@ export DEVNET_COMPOSE_FILE="${COMPOSE_FILE}"
 # script created is cleaned up on success, so a passing run cannot destroy
 # a shared or pre-existing path.
 ARTIFACT_DIR_IS_OURS=false
+STAKE_KEYS_HOST_DIR_IS_OURS=false
 if [[ -z "${DEVNET_ARTIFACT_DIR:-}" ]]; then
   DEVNET_ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-artifacts.XXXXXX")"
   ARTIFACT_DIR_IS_OURS=true
@@ -173,7 +174,8 @@ cleanup() {
   fi
   log "Tearing down DevNet..."
   docker compose -f "${COMPOSE_FILE}" down -v 2>/dev/null || true
-  if [[ -n "${STAKE_KEYS_HOST_DIR:-}" ]]; then
+  if [[ "${STAKE_KEYS_HOST_DIR_IS_OURS}" == "true" ]] &&
+    [[ -n "${STAKE_KEYS_HOST_DIR:-}" ]]; then
     rm -rf "${STAKE_KEYS_HOST_DIR}"
   fi
   exit "${exit_code}"
@@ -268,6 +270,7 @@ if [[ "${MODE}" == "dingo" ]]; then
     UTXO_KEYS_VOLUME=$(docker volume ls --filter label=com.docker.compose.volume=utxo-keys --format '{{.Name}}' | head -n1)
   fi
   STAKE_KEYS_HOST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-stake-keys.XXXXXX")"
+  STAKE_KEYS_HOST_DIR_IS_OURS=true
   if [[ -z "${UTXO_KEYS_VOLUME}" ]]; then
     warn "Unable to locate the utxo-keys Docker volume; skipping stake-keys copy"
   else

--- a/internal/test/devnet/run_tests_script_test.go
+++ b/internal/test/devnet/run_tests_script_test.go
@@ -147,10 +147,43 @@ func TestRunTestsCleansContainerCreatedTemporaryFiles(t *testing.T) {
 	}
 }
 
+// TestRunTestsPreservesCallerOwnedStakeDirectory verifies cleanup ownership:
+// the runner may inherit STAKE_KEYS_HOST_DIR from its caller, but it must only
+// remove a stake-key directory that this invocation created with mktemp.
+func TestRunTestsPreservesCallerOwnedStakeDirectory(t *testing.T) {
+	callerDir := t.TempDir()
+	marker := filepath.Join(callerDir, "keep")
+	require.NoError(t, os.WriteFile(marker, []byte("caller-owned"), 0o600))
+
+	result := runFakeDevnetWithEnv(t, 0, false, map[string]string{
+		"MODE":                "conformance",
+		"STAKE_KEYS_HOST_DIR": callerDir,
+	})
+	require.Equal(t, 0, result.exitCode, result.output)
+	contents, err := os.ReadFile(marker)
+	require.NoError(t, err, "runner removed a stake directory it did not create")
+	assert.Equal(t, "caller-owned", string(contents))
+}
+
 func runFakeDevnet(
 	t *testing.T,
 	testExit int,
 	failRm bool,
+	runnerArgs ...string,
+) fakeDevnetResult {
+	t.Helper()
+	return runFakeDevnetWithEnv(t, testExit, failRm, nil, runnerArgs...)
+}
+
+// runFakeDevnetWithEnv runs the shell harness against fake Docker and Go
+// binaries while allowing a test to model inherited runner state. Keeping the
+// overrides inside cleanRunnerEnv prevents the developer's real environment
+// from accidentally deciding which directory the cleanup trap removes.
+func runFakeDevnetWithEnv(
+	t *testing.T,
+	testExit int,
+	failRm bool,
+	envOverrides map[string]string,
 	runnerArgs ...string,
 ) fakeDevnetResult {
 	t.Helper()
@@ -184,13 +217,17 @@ func runFakeDevnet(
 	args = append(args, runnerArgs...)
 	cmd := exec.CommandContext(ctx, "bash", args...)
 	cmd.Dir = root
-	cmd.Env = cleanRunnerEnv(map[string]string{
+	env := map[string]string{
 		"FAKE_DOCKER_LOG": filepath.Join(tempRoot, "docker.log"),
 		"FAKE_GO_EXIT":    strconv.Itoa(testExit),
 		"MODE":            "dingo",
 		"PATH":            fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"TMPDIR":          tempRoot,
-	})
+	}
+	for key, value := range envOverrides {
+		env[key] = value
+	}
+	cmd.Env = cleanRunnerEnv(env)
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -242,6 +279,7 @@ func cleanRunnerEnv(overrides map[string]string) []string {
 		"FAKE_GO_EXIT":        {},
 		"MODE":                {},
 		"PATH":                {},
+		"STAKE_KEYS_HOST_DIR": {},
 		"TMPDIR":              {},
 	}
 	env := make([]string, 0, len(os.Environ())+len(overrides))


### PR DESCRIPTION
### Summary

- Restrict stake-key cleanup to temporary directories created by the current runner invocation.
- Preserve caller-provided stake-key directories and failure artifacts.
- Publish the effective runtime genesis timestamp to txpump.
- Prevent txpump from submitting transactions before genesis, even when Docker reports nodes healthy.
- Clamp pre-genesis slot calculations to slot zero.

### Changes by file

- `internal/test/devnet/run-tests.sh`
  - Tracks whether the runner created the stake-key directory.
  - Removes the directory only when owned by that invocation.
  - Preserves inherited or caller-provided paths.

- `internal/test/devnet/run_tests_script_test.go`
  - Adds coverage proving caller-owned directories are preserved.
  - Adds environment override support to the fake runner.
  - Documents the cleanup ownership invariant.

- `internal/test/devnet/configurator.sh`
  - Writes the effective runtime genesis timestamp into shared runtime configuration.
  - Documents why Docker health is insufficient as a submission barrier.

- `internal/test/devnet/docker-compose.yml`
  - Provides runtime genesis configuration to txpump in Dingo and conformance profiles.

- `internal/test/antithesis/internal/txpump/pump.go`
  - Waits for genesis before starting transaction generation.
  - Keeps the startup deadline active during the wait.
  - Returns slot zero before genesis instead of wrapping a negative duration.

- `internal/test/antithesis/internal/txpump/pump_test.go`
  - Tests genesis waiting.
  - Tests startup timeout propagation.
  - Tests safe pre-genesis slot calculation.

Closes #3265 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes devnet runs by waiting for the real genesis timestamp before txpump submits transactions and by restricting stake-key cleanup to directories the runner itself created.

- txpump now waits for the runtime genesis time even when Docker reports nodes healthy, and reports slot zero before genesis instead of a wrapped negative duration.
- The devnet runner now only removes stake-key directories it created itself; caller-provided and inherited paths are preserved on cleanup.

<sup>Written for commit 00704ea30e9ed1fc5b2e4caa3bf5782fff84ad68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transaction submission now waits for the network’s actual genesis time before starting.
  - Prevented incorrect slot calculations before genesis.
  - Startup timeout and cancellation conditions now report appropriate readiness errors.
  - Devnet test cleanup preserves stake-key directories supplied by the caller.

- **Tests**
  - Added coverage for genesis waiting, startup timeouts, pre-genesis slot handling, and directory preservation.

- **Chores**
  - Devnet services now use the effective runtime genesis configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->