### PR TITLE
fix(chainsync): bound FindIntersect work per request

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -48,6 +48,21 @@ const (
 	// headroom so legitimate sync is never rejected.
 	chainsyncMaxFindIntersectPoints = 1000
 
+	// chainsyncFindIntersectBudgetRate bounds the sustained rate (points per
+	// second) of database lookup work a single ChainSync peer connection may
+	// trigger via repeated FindIntersect requests. Cost is charged per point
+	// actually looked up, after deduplication, so this bounds cumulative
+	// work across many requests, not just the size of one request. Honest
+	// clients issue FindIntersect rarely — on connect, and on resync after a
+	// rollback we cannot follow — so this is far above legitimate use.
+	chainsyncFindIntersectBudgetRate = 200
+
+	// chainsyncFindIntersectBudgetBurst allows a peer to spend its entire
+	// FindIntersect work budget on one immediate request up to
+	// chainsyncMaxFindIntersectPoints, matching the point-count cap above so
+	// a single in-bounds request is never rejected by the budget alone.
+	chainsyncFindIntersectBudgetBurst = float64(chainsyncMaxFindIntersectPoints)
+
 	// chainsyncRestartTimeout bounds how long the restart of a
 	// chainsync client can take before we give up and close the
 	// connection. Increase this for slow or congested networks.
@@ -575,6 +590,27 @@ func (o *Ouroboros) chainsyncServerFindIntersect(
 			"connection_id", ctx.ConnectionId.String(),
 			"num_points", len(points),
 			"max_points", chainsyncMaxFindIntersectPoints,
+		)
+		return retPoint, tip, ochainsync.ErrIntersectNotFound
+	}
+	// Deduplicate before charging the work budget or performing any lookup.
+	// GetIntersectPoint's running-best-match scan only skips a point once a
+	// higher-or-equal-slot match has already been found, so a peer resending
+	// the same point many times (or an equal-slot point with a different
+	// hash) would otherwise force one redundant database lookup per repeat.
+	// The intersection result is independent of point order (the highest
+	// matching slot always wins), so deduplicating here changes no outcome.
+	points = normalizeIntersectPoints(points)
+	if o.chainsyncFindIntersectLimiter != nil &&
+		!o.chainsyncFindIntersectLimiter.Allow(ctx.ConnectionId, len(points)) {
+		o.config.Logger.Warn(
+			"chainsync server: rejecting FindIntersect over per-connection work budget",
+			"component",
+			"ouroboros",
+			"connection_id",
+			ctx.ConnectionId.String(),
+			"num_points",
+			len(points),
 		)
 		return retPoint, tip, ochainsync.ErrIntersectNotFound
 	}

--- a/ouroboros/chainsync_rate_limiter.go
+++ b/ouroboros/chainsync_rate_limiter.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"sync"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+)
+
+// chainsyncFindIntersectRateLimiter bounds the database lookup work a single
+// ChainSync peer connection can trigger via repeated FindIntersect requests.
+// Unlike the point-count cap in chainsyncServerFindIntersect, which only
+// rejects a single oversized request, this tracks cumulative work across a
+// connection's lifetime: a peer that repeatedly resends smaller, in-bounds
+// point lists is bounded the same way as one that sends occasional large
+// ones. Cost is charged per point actually looked up (post-deduplication),
+// so resending duplicate points cannot inflate the charge.
+//
+// Reuses the tokenBucket implementation from txsubmission_rate_limiter.go
+// and the sync.Map-per-peer shape for lock-free reads on the hot path.
+type chainsyncFindIntersectRateLimiter struct {
+	peers   sync.Map // map[string]*tokenBucket keyed by connIdKey
+	rate    float64  // points per second per peer
+	burst   float64  // max burst per peer
+	nowFunc func() time.Time
+}
+
+// newChainsyncFindIntersectRateLimiter creates a new per-peer FindIntersect
+// work-budget limiter. rate is the sustained points-per-second budget per
+// peer; burst is the maximum immediately available budget.
+func newChainsyncFindIntersectRateLimiter(
+	rate float64,
+	burst float64,
+) *chainsyncFindIntersectRateLimiter {
+	return &chainsyncFindIntersectRateLimiter{
+		rate:    rate,
+		burst:   burst,
+		nowFunc: time.Now,
+	}
+}
+
+// Allow reports whether n points of FindIntersect lookup work from the given
+// peer are within budget, consuming that budget if so.
+func (rl *chainsyncFindIntersectRateLimiter) Allow(
+	connId ouroboros.ConnectionId,
+	n int,
+) bool {
+	key := connIdKey(connId)
+	val, ok := rl.peers.Load(key)
+	if !ok {
+		bucket := newTokenBucket(rl.rate, rl.burst, rl.nowFunc())
+		val, _ = rl.peers.LoadOrStore(key, bucket)
+	}
+	return val.(*tokenBucket).allow(float64(n), rl.nowFunc())
+}
+
+// RemovePeer removes rate limiting state for the given connection. This
+// should be called when a connection is closed.
+func (rl *chainsyncFindIntersectRateLimiter) RemovePeer(
+	connId ouroboros.ConnectionId,
+) {
+	rl.peers.Delete(connIdKey(connId))
+}

--- a/ouroboros/chainsync_rate_limiter_test.go
+++ b/ouroboros/chainsync_rate_limiter_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainsyncFindIntersectRateLimiter_NormalUse(t *testing.T) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	peer := testConnIdWithPort(4001)
+
+	// A well-behaved client's occasional, in-bounds FindIntersect requests
+	// stay well within the burst.
+	assert.True(t, rl.Allow(peer, 100), "first request should be allowed")
+	assert.True(t, rl.Allow(peer, 100), "second request should be allowed")
+	assert.True(t, rl.Allow(peer, 100), "third request should be allowed")
+}
+
+func TestChainsyncFindIntersectRateLimiter_BoundaryAtBurst(t *testing.T) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+	peer := testConnIdWithPort(4001)
+
+	// A single request exactly at the burst (matching
+	// chainsyncMaxFindIntersectPoints) must be allowed in full.
+	assert.True(
+		t,
+		rl.Allow(peer, 1000),
+		"a request exactly at the burst must be allowed",
+	)
+	// The very next point, with no time elapsed, must be rejected: the
+	// budget is now exhausted.
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"a request one point past the exhausted burst must be rejected",
+	)
+}
+
+func TestChainsyncFindIntersectRateLimiter_RepeatedRequestsExhaustBudget(
+	t *testing.T,
+) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+	peer := testConnIdWithPort(4001)
+
+	// Several smaller, individually in-bounds requests must draw from the
+	// same cumulative budget as one large request.
+	for i := range 4 {
+		assert.True(
+			t,
+			rl.Allow(peer, 250),
+			"request %d within the cumulative budget should be allowed",
+			i,
+		)
+	}
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"a request after the cumulative budget is spent must be rejected",
+	)
+}
+
+func TestChainsyncFindIntersectRateLimiter_PerPeerIsolation(t *testing.T) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+
+	peerA := testConnIdWithPort(4001)
+	peerB := testConnIdWithPort(4002)
+
+	assert.True(t, rl.Allow(peerA, 1000), "peer A burst allowed")
+	assert.False(t, rl.Allow(peerA, 1), "peer A should be over budget")
+
+	// Peer B has an independent budget, unaffected by peer A's requests.
+	assert.True(t, rl.Allow(peerB, 1000), "peer B should be unaffected")
+	assert.False(t, rl.Allow(peerB, 1), "peer B should now be over budget")
+}
+
+func TestChainsyncFindIntersectRateLimiter_Recovery(t *testing.T) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+	peer := testConnIdWithPort(4001)
+
+	assert.True(t, rl.Allow(peer, 1000), "burst allowed")
+	assert.False(t, rl.Allow(peer, 1), "should be over budget")
+
+	// Advance time: the budget refills at the configured rate.
+	now = now.Add(1 * time.Second) // +200 points at rate=200/s
+	assert.True(
+		t,
+		rl.Allow(peer, 200),
+		"should allow a request within the refilled budget",
+	)
+	assert.False(
+		t,
+		rl.Allow(peer, 1),
+		"should reject again once the refill is spent",
+	)
+}
+
+func TestChainsyncFindIntersectRateLimiter_ZeroPointRequestAlwaysAllowed(
+	t *testing.T,
+) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+	peer := testConnIdWithPort(4001)
+
+	require.True(t, rl.Allow(peer, 1000), "exhaust the budget")
+	// An empty (post-deduplication) point list costs nothing and must
+	// never be rejected by the budget, matching how GetIntersectPoint
+	// treats an empty list.
+	assert.True(
+		t,
+		rl.Allow(peer, 0),
+		"a zero-point request must always be allowed",
+	)
+}
+
+func TestChainsyncFindIntersectRateLimiter_RemovePeer(t *testing.T) {
+	rl := newChainsyncFindIntersectRateLimiter(200, 1000)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl.nowFunc = func() time.Time { return now }
+	peer := testConnIdWithPort(4001)
+
+	require.True(t, rl.Allow(peer, 1000), "burst allowed")
+	require.False(t, rl.Allow(peer, 1), "should be over budget")
+
+	rl.RemovePeer(peer)
+
+	// Removing the peer drops its bucket; the next request starts with a
+	// fresh burst rather than inheriting the exhausted state.
+	assert.True(
+		t,
+		rl.Allow(peer, 1000),
+		"a fresh bucket should be created after RemovePeer",
+	)
+}
+
+func TestNewOuroboros_ChainsyncFindIntersectLimiterAlwaysEnabled(t *testing.T) {
+	// Unlike TxSubmission, FindIntersect is entirely peer-driven rather than
+	// paced by our own request loop, so this limiter is not configurable
+	// off; it must always be present.
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := newOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+
+	require.NotNil(t, o.chainsyncFindIntersectLimiter)
+	assert.Equal(
+		t,
+		float64(chainsyncFindIntersectBudgetRate),
+		o.chainsyncFindIntersectLimiter.rate,
+	)
+	assert.Equal(
+		t,
+		chainsyncFindIntersectBudgetBurst,
+		o.chainsyncFindIntersectLimiter.burst,
+	)
+}
+
+func TestHandleConnClosedEvent_CleansUpChainsyncFindIntersectLimiter(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	o := newOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+
+	peer := testConnIdWithPort(4001)
+
+	o.chainsyncFindIntersectLimiter.Allow(peer, 1)
+	_, exists := o.chainsyncFindIntersectLimiter.peers.Load(connIdKey(peer))
+	require.True(t, exists, "peer should exist in the limiter")
+
+	evt := event.NewEvent(
+		connmanager.ConnectionClosedEventType,
+		connmanager.ConnectionClosedEvent{
+			ConnectionId: peer,
+		},
+	)
+	o.HandleConnClosedEvent(evt)
+
+	_, exists = o.chainsyncFindIntersectLimiter.peers.Load(connIdKey(peer))
+	assert.False(
+		t,
+		exists,
+		"peer should be removed from the limiter after connection closed event",
+	)
+}

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -454,6 +454,74 @@ func TestChainsyncServerFindIntersectAcceptsNormalPointList(t *testing.T) {
 	require.True(t, msg.IsIntersectFound())
 }
 
+// TestChainsyncServerFindIntersectDeduplicatesRepeatedPointsForBudget verifies
+// duplicate points within one request are deduplicated before the
+// per-connection work budget is charged. A list of chainsyncMaxFindIntersectPoints
+// copies of the same point is at the point-count limit but collapses to a
+// single point after deduplication, so it must be charged as 1 point of work,
+// not chainsyncMaxFindIntersectPoints.
+func TestChainsyncServerFindIntersectDeduplicatesRepeatedPointsForBudget(
+	t *testing.T,
+) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+
+	// An empty chain intersects any in-bounds request at origin, so
+	// IntersectFound here only tells us the request wasn't rejected — the
+	// assertion that matters is the second request below.
+	point := makeFindIntersectPoints(1)[0]
+	dup := make([]ocommon.Point, chainsyncMaxFindIntersectPoints)
+	for i := range dup {
+		dup[i] = point
+	}
+	require.NoError(t, f.h.FindIntersect(dup))
+	require.True(t, f.observe(t).IsIntersectFound())
+
+	// Had the duplicate-heavy request above been charged its full
+	// un-deduplicated size, it would have exhausted the entire work budget
+	// on its own, and this distinct-point request — within both the
+	// point-count and work-budget limits by itself — would be rejected too.
+	require.NoError(
+		t,
+		f.h.FindIntersect(
+			makeFindIntersectPoints(chainsyncMaxFindIntersectPoints-1),
+		),
+	)
+	require.True(
+		t,
+		f.observe(t).IsIntersectFound(),
+		"a duplicate-heavy request must not exhaust the work budget meant for distinct points",
+	)
+}
+
+// TestChainsyncServerFindIntersectRateLimitsRepeatedRequests verifies the
+// per-connection work budget bounds cumulative work across many in-bounds
+// requests, not just the size of a single request: a second full-size
+// request immediately following the first must be rejected even though
+// each is within the point-count limit on its own. The gap between the two
+// requests is a single wire round trip — far too short for
+// chainsyncFindIntersectBudgetRate to refill another full burst — so this
+// is deterministic rather than timing-sensitive.
+func TestChainsyncServerFindIntersectRateLimitsRepeatedRequests(
+	t *testing.T,
+) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+
+	points := makeFindIntersectPoints(chainsyncMaxFindIntersectPoints)
+	require.NoError(t, f.h.FindIntersect(points))
+	require.True(
+		t,
+		f.observe(t).IsIntersectFound(),
+		"first full-size request should be within the work budget",
+	)
+
+	require.NoError(t, f.h.FindIntersect(points))
+	require.True(
+		t,
+		f.observe(t).IsIntersectNotFound(),
+		"a repeated full-size request over the per-connection work budget must be rejected",
+	)
+}
+
 // =============================================================================
 // RequestNext (synchronous replies)
 // =============================================================================

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -497,14 +497,18 @@ func TestChainsyncServerFindIntersectDeduplicatesRepeatedPointsForBudget(
 // per-connection work budget bounds cumulative work across many in-bounds
 // requests, not just the size of a single request: a second full-size
 // request immediately following the first must be rejected even though
-// each is within the point-count limit on its own. The gap between the two
-// requests is a single wire round trip — far too short for
-// chainsyncFindIntersectBudgetRate to refill another full burst — so this
-// is deterministic rather than timing-sensitive.
+// each is within the point-count limit on its own. The limiter's clock is
+// pinned so the assertion holds regardless of how long the wire round trips
+// actually take, rather than relying on them staying under the 5s a full
+// burst would need to refill at chainsyncFindIntersectBudgetRate.
 func TestChainsyncServerFindIntersectRateLimitsRepeatedRequests(
 	t *testing.T,
 ) {
 	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	f.o.chainsyncFindIntersectLimiter.nowFunc = func() time.Time {
+		return now
+	}
 
 	points := makeFindIntersectPoints(chainsyncMaxFindIntersectPoints)
 	require.NoError(t, f.h.FindIntersect(points))

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -136,6 +136,8 @@ type Ouroboros struct {
 	restartMu sync.Map // ouroboros.ConnectionId → *sync.Mutex
 	// Per-peer rate limiter for TxSubmission server
 	txSubmissionRateLimiter *txSubmissionRateLimiter
+	// Per-peer work-budget limiter for ChainSync FindIntersect
+	chainsyncFindIntersectLimiter *chainsyncFindIntersectRateLimiter
 	// Cached Leios EB material fetched from peers. This lets NtC
 	// ChainSync serve merged RB+EB blocks without coupling the chain
 	// package to Leios prototype protocols.
@@ -425,6 +427,14 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 			burst,
 		)
 	}
+	// Initialize per-peer ChainSync FindIntersect work-budget limiter.
+	// Unlike TxSubmission, FindIntersect is driven entirely by the peer
+	// rather than paced by us, so this always runs; see the constants'
+	// doc comments in chainsync.go for the sizing rationale.
+	o.chainsyncFindIntersectLimiter = newChainsyncFindIntersectRateLimiter(
+		chainsyncFindIntersectBudgetRate,
+		chainsyncFindIntersectBudgetBurst,
+	)
 	if cfg.PromRegistry != nil {
 		o.initBlockfetchMetrics()
 		o.initProtocolMetrics()
@@ -697,6 +707,10 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	// Clean up TxSubmission rate limiter state
 	if o.txSubmissionRateLimiter != nil {
 		o.txSubmissionRateLimiter.RemovePeer(connId)
+	}
+	// Clean up ChainSync FindIntersect work-budget limiter state
+	if o.chainsyncFindIntersectLimiter != nil {
+		o.chainsyncFindIntersectLimiter.RemovePeer(connId)
 	}
 	// Clean up Leios vote serving state
 	if o.leiosVotes != nil {


### PR DESCRIPTION
Fixes #3510

## Changes

- Deduplicate `FindIntersect` points (`normalizeIntersectPoints`) before the intersection lookup, so a peer resending the same point cannot force one redundant database lookup per repeat. The intersection result is order-independent (highest matching slot wins), so deduplication changes no outcome.
- Add a per-connection token-bucket work budget (`chainsyncFindIntersectRateLimiter`), charged per point looked up after deduplication. This bounds cumulative work across many requests on one connection, not just the size of a single request — closing the gap left by the existing `chainsyncMaxFindIntersectPoints` per-request cap.
- Over-budget requests return the existing `IntersectNotFound` protocol result, matching how over-limit requests are already handled, rather than tearing down the connection.

## Tests

- `chainsync_rate_limiter_test.go`: unit tests for the new limiter (normal use, boundary at burst, repeated requests exhausting budget, per-peer isolation, refill/recovery, zero-point requests, peer removal, wiring into `Ouroboros`/`HandleConnClosedEvent`).
- `chainsync_server_fixture_test.go`: wire-level tests proving duplicate points don't inflate the work-budget charge, and that a second full-size request immediately following the first is rejected.

## Validation

- `go build ./...`
- `go test -race ./ouroboros/...`
- `golangci-lint run ./ouroboros/...`
- `nilaway -tags dingo_extra_plugins ./ouroboros/...`
- `modernize -tags dingo_extra_plugins ./ouroboros/...`
- `go test ./internal/architecture` (import-boundaries)
- `go test ./internal/docsparity` (docs-parity)
- `make gorm-check`

`DATABASE.md`/`ARCHITECTURE.md` checked and not affected — this is an internal protocol-callback hardening detail at the same level as the existing `chainsyncMaxFindIntersectPoints` cap and `txSubmissionRateLimiter`, neither of which is documented there either.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3510 by bounding the database lookup work a single ChainSync peer connection can trigger via FindIntersect. Points are now deduplicated before lookup, and a per-connection token-bucket budget caps cumulative work, closing the gap where a peer could resend duplicate points or many smaller in-bounds requests to force unbounded lookups. Over-budget requests return `IntersectNotFound` rather than closing the connection.

**Changes**
- Deduplicating points changes no result because intersection is order-independent and the highest matching slot wins.
- The budget allows a burst of 1000 points (matching the existing per-request cap) and refills at 200 points/second, so legitimate sync is never rejected.
- Each peer gets an independent bucket, and limiter state is removed when the connection closes.

<sup>Written for commit 60d5dc8a81d5eac7e1f1c09aad6bb1b3ae8c78e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-connection work limits for ChainSync intersection requests.
  * Duplicate intersection points are now counted only once, preventing unnecessary budget usage.
  * Excessive repeated requests are rejected more consistently.
  * Connection-specific rate-limit state is cleaned up when connections close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->