### PR TITLE
test(benchmark): preserve block numbers in processing fixture

### DIFF
--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 
@@ -2632,6 +2634,19 @@ func loadBatchProcessingFixture(
 	return seedModels, batchBlocks, rawBlocks, batchSize
 }
 
+// blockNumberFollowsParent mirrors chain.blockNumberContiguous, which is
+// unexported: a block number must be exactly parent+1, except a Byron-era
+// epoch boundary block which legitimately repeats its parent's number.
+func blockNumberFollowsParent(
+	eraId uint8,
+	blockNumber, parentNumber uint64,
+) bool {
+	if blockNumber == parentNumber+1 {
+		return true
+	}
+	return eraId == byron.EraIdByron && blockNumber == parentNumber
+}
+
 func loadBlockProcessingFixture(
 	b *testing.B,
 ) ([]models.Block, []*immutable.Block) {
@@ -2646,6 +2661,10 @@ func loadBlockProcessingFixture(
 
 	const seedCount = 5
 	const blockCount = blockProcessingBenchmarkFixtureBlockCount
+
+	var prevHash []byte
+	var prevNumber uint64
+	var havePrev bool
 
 	seedModels := make([]models.Block, 0, seedCount)
 	for len(seedModels) < seedCount {
@@ -2662,15 +2681,42 @@ func loadBlockProcessingFixture(
 		if err != nil {
 			continue
 		}
+		blockNumber := ledgerBlock.BlockNumber()
+		prevHashBytes := ledgerBlock.PrevHash().Bytes()
+		if havePrev {
+			if !bytes.Equal(prevHashBytes, prevHash) {
+				b.Fatalf(
+					"seed block %x has prev hash %x that does not match parent hash %x",
+					block.Hash,
+					prevHashBytes,
+					prevHash,
+				)
+			}
+			if !blockNumberFollowsParent(
+				ledgerBlock.Era().Id,
+				blockNumber,
+				prevNumber,
+			) {
+				b.Fatalf(
+					"seed block %x claims block number %d that is not contiguous with parent %d",
+					block.Hash,
+					blockNumber,
+					prevNumber,
+				)
+			}
+		}
 		seedModels = append(seedModels, models.Block{
 			ID:       uint64(len(seedModels) + 1),
 			Slot:     block.Slot,
 			Hash:     slices.Clone(block.Hash),
-			Number:   0,
+			Number:   blockNumber,
 			Type:     uint(ledgerBlock.Type()),
-			PrevHash: ledgerBlock.PrevHash().Bytes(),
+			PrevHash: prevHashBytes,
 			Cbor:     slices.Clone(block.Cbor),
 		})
+		prevHash = slices.Clone(block.Hash)
+		prevNumber = blockNumber
+		havePrev = true
 	}
 
 	blocks := make([]*immutable.Block, 0, blockCount)
@@ -2682,6 +2728,32 @@ func loadBlockProcessingFixture(
 		if block == nil {
 			b.Skip("insufficient blocks available for throughput benchmark")
 		}
+		ledgerBlock, err := ledger.NewBlockFromCbor(block.Type, block.Cbor)
+		if err != nil {
+			continue
+		}
+		blockNumber := ledgerBlock.BlockNumber()
+		prevHashBytes := ledgerBlock.PrevHash().Bytes()
+		if !bytes.Equal(prevHashBytes, prevHash) {
+			b.Fatalf(
+				"timed block %x has prev hash %x that does not match parent hash %x",
+				block.Hash,
+				prevHashBytes,
+				prevHash,
+			)
+		}
+		if !blockNumberFollowsParent(
+			ledgerBlock.Era().Id,
+			blockNumber,
+			prevNumber,
+		) {
+			b.Fatalf(
+				"timed block %x claims block number %d that is not contiguous with parent %d",
+				block.Hash,
+				blockNumber,
+				prevNumber,
+			)
+		}
 		tmpBlock := &immutable.Block{
 			Slot: block.Slot,
 			Type: block.Type,
@@ -2689,6 +2761,8 @@ func loadBlockProcessingFixture(
 			Hash: slices.Clone(block.Hash),
 		}
 		blocks = append(blocks, tmpBlock)
+		prevHash = slices.Clone(block.Hash)
+		prevNumber = blockNumber
 	}
 
 	return seedModels, blocks


### PR DESCRIPTION
## Summary
- `loadBlockProcessingFixture` stored every seeded block with `Number: 0` instead of its real decoded block number, leaving the post-seed chain tip reporting block number 0.
- The first timed block then failed `Chain.AddBlock`'s contiguity check against its real block number before the benchmark timer started.
- Preserve each block's decoded number, and validate that the seed and timed block streams are hash- and number-contiguous before the benchmark proceeds.

Fixes #3375

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l ledger/benchmark_test.go` (clean)
- [x] `golangci-lint run ./ledger/...`
- [x] `nilaway ./ledger/...`
- [x] `modernize ./ledger/...`
- [x] `go test ./internal/architecture/...` (import-boundaries)
- [x] `go test ./internal/docsparity/...` (docs-parity)
- [x] `go test -race ./ledger/...`
- [x] `go test -bench '^Benchmark(BlockProcessingThroughput|BlockProcessingThroughputPredecoded|BlockfetchNearTipThroughput)$' -count=2 ./ledger` — all pass against the real immutable fixture
- [ ] `make bench-ci` — not run in full (90m+30m curated suite); the two benchmarks named in the issue were validated directly above

`DATABASE.md`/`ARCHITECTURE.md`: checked, not affected (test-fixture-only change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `loadBlockProcessingFixture` storing every seeded block with `Number: 0` instead of its real decoded block number, which caused the first timed block to fail `Chain.AddBlock`'s contiguity check before the benchmark timer started. Preserves each block's decoded number and validates that seed and timed block streams are hash- and number-contiguous before the benchmark proceeds.

<sup>Written for commit 2a8fb4b1bfaa240031d8fcefeb565d3f733bda60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved benchmark fixture validation to detect broken parent references and inconsistent block numbering.
  * Added support for valid block-number behavior at historical epoch boundaries.
  * Updated benchmark data handling to reflect actual block numbers, improving test accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->