### PR TITLE
fix(ouroboros): contain decoder panics in the shared decode cache

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3055,12 +3055,15 @@ waiter-channel design (see Leios CertRB Serving below), applied to ordinary
 block/header decoding rather than Leios EB closures.
 
 A decode function that panics (adversarial/malformed peer bytes could in
-principle trigger this) does not strand the key: `getOrDecode` recovers the
-panic just long enough to record it as an ordinary cached failure and wake
-every waiter, then re-raises it, so the decoding goroutine's own
-crash-or-recover behavior is unchanged but no other connection is left
-permanently blocked on that key, and a later identical delivery fails fast
-from cache instead of panicking again.
+principle trigger this) does not strand the key and does not crash the
+decoding goroutine either: `getOrDecode` recovers the panic, records it as an
+ordinary cached failure, wakes every waiter, and returns it as its own
+`(value, err)` result instead of re-raising, so a decoder panic never escapes
+into `blockfetchClientBlockRaw`/`chainsyncClientRollForwardRaw` or the
+protocol worker that called them — it is handled exactly like any other
+decode error, on the leader's own path as well as every waiter's. A later
+identical delivery still fails fast from the cached failure instead of
+decoding (and therefore panicking) again. See dingo #3511.
 
 A waiting caller's decode outcome is delivered directly through its wait
 channel rather than by re-reading the shared entry map after waking: the

--- a/ouroboros/decode_cache.go
+++ b/ouroboros/decode_cache.go
@@ -133,10 +133,16 @@ func newDecodeCache[T any]() *decodeCache[T] {
 // bookkeeping, never the decode itself, so concurrent decodes for different
 // keys never serialize against each other.
 //
-// A decodeFn that panics does not strand this key: the panic is recovered
-// long enough to record it as a normal cached failure and release every
-// waiter, then re-raised so the calling goroutine's own crash-or-recover
-// behavior is unchanged from before this cache existed. See finishDecode.
+// A decodeFn that panics does not strand this key, and does not crash the
+// calling goroutine either: the panic is recovered and recorded as a normal
+// cached failure via finishDecode, exactly like an ordinary decode error, so
+// the leader gets back a plain (zero value, err, true) result instead of a
+// re-raised panic. This makes the leader's own outcome symmetric with every
+// other caller for the same key -- an in-flight waiter, or a later lookup of
+// the now-cached failure -- which were already returned a clean error before
+// this fix. See dingo #3511: a decoder panic used to escape uncontained into
+// the leader's calling protocol worker even though the cache had already
+// recorded it as a normal decode failure. See finishDecode.
 func (c *decodeCache[T]) getOrDecode(
 	key decodeCacheKey,
 	decodeFn func() (T, error),
@@ -174,12 +180,16 @@ func (c *decodeCache[T]) getOrDecode(
 	// principle, panic instead of erroring -- gouroboros' own cbor.Value
 	// decoder recovers only one specific panic class and re-panics for
 	// every other one) must not leave this key's claim held and its
-	// waiters parked forever. Recover, record the panic as a normal
-	// (cacheable) decode failure via finishDecode -- exactly like any
-	// other failure, so every current waiter is woken and any future
-	// submission of the identical bytes fails fast instead of panicking
-	// again -- then re-panic so this goroutine's own crash-or-recover
-	// behavior is unchanged from before this cache existed.
+	// waiters parked forever, and must not crash the caller either: a
+	// decode failure -- panic or ordinary error -- is a contained result
+	// about these bytes, not a fault in the calling protocol worker.
+	// Recover, and record the panic as a normal (cacheable) decode failure
+	// via finishDecode -- exactly like any other failure, so every current
+	// waiter is woken and any future submission of the identical bytes
+	// fails fast instead of panicking again -- then return it as this
+	// call's own (value, err) result instead of re-raising. value is still
+	// its zero value here: the panic happened before decodeFn's return
+	// values were ever assigned to it.
 	//
 	// completed (not recover()'s return value) is what decides whether
 	// decodeFn panicked: recover() returns nil both when there is no panic
@@ -200,7 +210,8 @@ func (c *decodeCache[T]) getOrDecode(
 			panicErr = fmt.Errorf("decode panicked: %v", r)
 		}
 		c.finishDecode(key, value, panicErr)
-		panic(r)
+		err = panicErr
+		decoded = true
 	}()
 
 	value, err = decodeFn()
@@ -210,45 +221,31 @@ func (c *decodeCache[T]) getOrDecode(
 }
 
 // decodeWithPanicSafeMetrics wraps getOrDecode and owns recording its
-// hit/miss outcome entirely, covering three cases in one place so a future
-// change to one can't drift out of sync with the others:
+// hit/miss outcome entirely, covering two cases in one place so a future
+// change to one can't drift out of sync with the other. A decodeFn panic
+// needs no case of its own here: getOrDecode fully contains it and always
+// returns a normal (value, err, decoded) result (see its own doc comment),
+// so a panicked decode reaches this function as an ordinary failed err,
+// indistinguishable from one decodeFn returned directly.
 //
-//   - decodeFn panics: getOrDecode's own panic recovery re-raises after
-//     cleaning up the cache (see its doc comment), so this call never
-//     returns normally -- recordOutcome(true) runs from a recover here,
-//     before the panic is re-raised again.
-//   - decodeFn returns an error, or a waiter/cached-hit shares an
-//     already-failed outcome: recordOutcome(true). A failed delivery never
-//     represents an actual decode being successfully reused, whether this
-//     call ran decodeFn itself or reused another caller's failure, so it
-//     must never be counted as a hit -- getOrDecode's own decoded flag
-//     alone would undercount this, since it is false for every hit
-//     (including a hit on a cached failure) and every waiter (including one
-//     woken by a failing in-flight decode).
+//   - decodeFn returns an error (including one recovered from a decodeFn
+//     panic), or a waiter/cached-hit shares an already-failed outcome:
+//     recordOutcome(true). A failed delivery never represents an actual
+//     decode being successfully reused, whether this call ran decodeFn
+//     itself or reused another caller's failure, so it must never be
+//     counted as a hit -- getOrDecode's own decoded flag alone would
+//     undercount this, since it is false for every hit (including a hit on
+//     a cached failure) and every waiter (including one woken by a failing
+//     in-flight decode).
 //   - a genuine successful decode or hit: recordOutcome(decoded), matching
 //     getOrDecode's own contract exactly.
-//
-// completed, not recover()'s return value, decides whether getOrDecode
-// panicked -- see getOrDecode's own doc comment on why testing "r == nil"
-// alone would mistake a bare panic(nil) for normal completion.
 func decodeWithPanicSafeMetrics[T any](
 	cache *decodeCache[T],
 	key decodeCacheKey,
 	decodeFn func() (T, error),
 	recordOutcome func(isMiss bool),
 ) (value T, err error) {
-	completed := false
-	defer func() {
-		if completed {
-			return
-		}
-		r := recover()
-		recordOutcome(true)
-		panic(r)
-	}()
-	var decoded bool
-	value, err, decoded = cache.getOrDecode(key, decodeFn)
-	completed = true
+	value, err, decoded := cache.getOrDecode(key, decodeFn)
 	recordOutcome(decoded || err != nil)
 	return value, err
 }

--- a/ouroboros/decode_cache_test.go
+++ b/ouroboros/decode_cache_test.go
@@ -427,17 +427,18 @@ func TestDecodeCacheNoGoroutineLeakOnFailure(t *testing.T) {
 }
 
 // TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey is the regression
-// test for a real bug found by proactively auditing this file for remaining
-// gaps: decodeFn panicking (CBOR decode on adversarial bytes can, in
-// principle, panic instead of erroring) used to leave the key's in-flight
-// claim held and any concurrent waiters parked forever, since nothing ever
-// closed their channels or released the claim. This confirms the fix: the
-// leader's own panic still propagates to its immediate caller (unchanged
-// crash-or-recover behavior for that goroutine), but every concurrent
-// waiter is woken with a normal error instead of hanging, the in-flight
-// claim is released, and -- since the panic is now a cached failure like
-// any other -- a later call for the identical bytes fails fast without
-// invoking decodeFn (and therefore without panicking) again.
+// test for dingo #3511: decodeFn panicking (CBOR decode on adversarial bytes
+// can, in principle, panic instead of erroring) used to leave the key's
+// in-flight claim held and any concurrent waiters parked forever, since
+// nothing ever closed their channels or released the claim; a later fix made
+// getOrDecode recover and release waiters but still re-raised the panic to
+// the leader's own caller, letting a decoder panic escape uncontained into
+// the calling protocol worker. This confirms the current behavior: every
+// caller -- the leader that actually ran decodeFn included -- gets back a
+// normal error instead of a panic, the in-flight claim is released, and --
+// since the panic is now a cached failure like any other -- a later call for
+// the identical bytes fails fast without invoking decodeFn (and therefore
+// without panicking) again.
 func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 	c := newDecodeCache[int]()
 	key := decodeCacheKey{0x06}
@@ -449,20 +450,9 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 	results := make([]error, numWaiters)
 	var wg sync.WaitGroup
 	wg.Add(numWaiters)
-	leaderPanicked := make(chan struct{})
 	for i := range numWaiters {
 		go func(idx int) {
 			defer wg.Done()
-			defer func() {
-				// Only the leader (the one goroutine that actually calls
-				// decodeFn) observes the panic here; recovering it mimics
-				// whatever, if anything, sits upstream of the cache in
-				// production, and lets this test assert on the effect on
-				// the OTHER waiters without crashing the test binary.
-				if r := recover(); r != nil {
-					close(leaderPanicked)
-				}
-			}()
 			_, err, _ := c.getOrDecode(key, func() (int, error) {
 				leaderOnce.Do(func() { close(leaderStarted) })
 				<-release
@@ -488,21 +478,13 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("a waiter never woke up after the in-flight decode panicked")
+		t.Fatal("a caller never returned after the in-flight decode panicked")
 	}
-	<-leaderPanicked
 
-	nonLeaderErrs := 0
 	for _, err := range results {
-		if err != nil {
-			nonLeaderErrs++
-			require.Contains(t, err.Error(), "decode panicked")
-		}
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "decode panicked")
 	}
-	require.Equal(
-		t, numWaiters-1, nonLeaderErrs,
-		"every non-leader waiter must be woken with the recorded panic error",
-	)
 	require.Zero(
 		t,
 		len(c.inFlight),
@@ -529,28 +511,25 @@ func TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey(t *testing.T) {
 // completion -- the recovery branch would never run, this key's in-flight
 // claim would never be released, and every current and future waiter for
 // these exact bytes would block forever. This confirms a panic(nil)
-// decodeFn is still detected, still finishes the entry and wakes waiters,
-// and still re-raises to the caller, exactly like panicking with any other
-// value.
+// decodeFn is still detected and still finishes the entry and wakes waiters,
+// exactly like panicking with any other value, and (dingo #3511) that
+// getOrDecode itself returns a normal error instead of re-raising.
 func TestDecodeCachePanicNilDuringDecodeDoesNotStrandWaitersOrKey(
 	t *testing.T,
 ) {
 	c := newDecodeCache[int]()
 	key := decodeCacheKey{0x0E}
 
-	func() {
-		defer func() {
-			// recover() here returns the runtime's substituted, non-nil
-			// *runtime.PanicNilError on modern Go rather than literal nil,
-			// but the fix does not depend on that: it is unconditional on
-			// completed, not on recover()'s value, so this holds either way.
-			_ = recover()
-		}()
-		_, _, _ = c.getOrDecode(key, func() (int, error) {
-			panic(nil)
-		})
-		t.Fatal("getOrDecode must still panic for a panic(nil) decodeFn")
-	}()
+	_, err, decoded := c.getOrDecode(key, func() (int, error) {
+		panic(nil)
+	})
+	require.True(t, decoded)
+	require.Error(
+		t,
+		err,
+		"a panic(nil) decodeFn must be detected and returned as a normal error, not left undetected",
+	)
+	require.Contains(t, err.Error(), "decode panicked")
 
 	require.Zero(
 		t,
@@ -558,50 +537,39 @@ func TestDecodeCachePanicNilDuringDecodeDoesNotStrandWaitersOrKey(
 		"the in-flight claim must be released even when decodeFn panics with nil",
 	)
 
-	_, err, decoded := c.getOrDecode(key, func() (int, error) {
+	_, err2, decoded2 := c.getOrDecode(key, func() (int, error) {
 		t.Fatal("decodeFn must not run again for an already-cached panic")
 		return 0, nil
 	})
-	require.False(t, decoded)
+	require.False(t, decoded2)
 	require.Error(
 		t,
-		err,
+		err2,
 		"the panic(nil) must still be recorded as a cached failure",
 	)
-	require.Contains(t, err.Error(), "decode panicked")
+	require.Contains(t, err2.Error(), "decode panicked")
 }
 
 // TestDecodeWithPanicSafeMetricsRecordsMissOnPanic is the regression test for
-// a real bug found in code review: getOrDecode's own panic recovery
-// re-raises after cleaning up the cache (see
-// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey above), so it
-// never returns normally to blockfetchClientBlockRaw/
-// chainsyncClientRollForwardRaw -- their usual "record the outcome based on
-// the returned decoded bool" line never runs, and a genuine decode attempt
-// (a miss) that happened to panic went uncounted in the hit/miss metrics.
-// This confirms decodeWithPanicSafeMetrics -- the helper both wrappers now
-// call through -- invokes recordOutcome(true) exactly once before
-// re-raising the panic, and that the panic still propagates to the caller
-// unchanged.
+// dingo #3511: a decodeFn panic must be fully contained by getOrDecode (see
+// TestDecodeCachePanicDuringDecodeDoesNotStrandWaitersOrKey above), so
+// decodeWithPanicSafeMetrics returns normally to
+// blockfetchClientBlockRaw/chainsyncClientRollForwardRaw with a plain error
+// instead of letting the panic escape into the calling protocol worker, and
+// still records the outcome as a miss.
 func TestDecodeWithPanicSafeMetricsRecordsMissOnPanic(t *testing.T) {
 	c := newDecodeCache[int]()
 	key := decodeCacheKey{0x08}
 	var outcomes []bool
 
-	func() {
-		defer func() {
-			r := recover()
-			require.NotNil(t, r, "the panic must still propagate to the caller")
-			require.Equal(t, "simulated decode panic", r)
-		}()
-		_, _ = decodeWithPanicSafeMetrics(
-			c,
-			key,
-			func() (int, error) { panic("simulated decode panic") },
-			func(isMiss bool) { outcomes = append(outcomes, isMiss) },
-		)
-		t.Fatal("decodeWithPanicSafeMetrics must not return normally on panic")
-	}()
+	_, err := decodeWithPanicSafeMetrics(
+		c,
+		key,
+		func() (int, error) { panic("simulated decode panic") },
+		func(isMiss bool) { outcomes = append(outcomes, isMiss) },
+	)
+	require.Error(t, err, "a decodeFn panic must be returned as a normal error, not propagated")
+	require.Contains(t, err.Error(), "decode panicked")
 
 	require.Equal(
 		t,
@@ -615,7 +583,7 @@ func TestDecodeWithPanicSafeMetricsRecordsMissOnPanic(t *testing.T) {
 	// call for the same key must not invoke decodeFn again, but must still
 	// be recorded as a miss (not a hit) -- see
 	// TestDecodeWithPanicSafeMetricsNeverRecordsAFailureAsAHit.
-	_, err := decodeWithPanicSafeMetrics(
+	_, err = decodeWithPanicSafeMetrics(
 		c,
 		key,
 		func() (int, error) {


### PR DESCRIPTION
Fixes #3511.

`getOrDecode` recovered a decoder panic long enough to cache it and wake
in-flight waiters, but then re-raised the panic to the leader goroutine's own
caller. Every waiter and later cache hit already got a clean error; only the
leader — the goroutine that actually ran `decodeFn` — still crashed its
calling protocol worker (`blockfetchClientBlockRaw` /
`chainsyncClientRollForwardRaw`).

`getOrDecode` now returns the recovered panic as a normal `(value, err)`
result instead of re-raising, matching every other caller for the same key.
`decodeWithPanicSafeMetrics`'s own defer/recover is removed since it existed
only to catch that re-raise.

## Checks

- `go test -race ./ouroboros/...` — pass
- `go test ./internal/architecture/...` (import-boundaries) — pass
- `go test ./internal/docsparity/...` (docs-parity) — pass
- `golangci-lint run ./ouroboros/...` — 0 issues
- `nilaway ./ouroboros/...` — clean
- `modernize ./ouroboros/...` — no findings
- `gofmt`/`golines` — clean

DevNet/conformance not run: this change only alters what a decode-panic
returns on the leader's own path (a normal error instead of a crash); it does
not change decode results, block/header validity, or consensus behavior.

`ARCHITECTURE.md`'s "Shared Block/Header Decode Cache" section updated to
match. `DATABASE.md` checked, not affected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain decoder panics in the shared decode cache so a panicking `decodeFn` returns a normal error to the leader goroutine instead of re-raising and crashing the calling protocol worker (`blockfetchClientBlockRaw` / `chainsyncClientRollForwardRaw`). Fixes #3511.

**Bug Fixes**
- The leader goroutine now receives the same clean error that in-flight waiters and later cache hits on the same key already received.
- Removed `decodeWithPanicSafeMetrics`'s defer/recover, which existed only to catch the re-raise.
- Updated `ARCHITECTURE.md`'s decode-cache section and the regression tests to match the contained behavior.

<sup>Written for commit 3a9019e459e305c7ba91ad4d2ed771b90878b92a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decode failures caused by panics are now handled as regular errors instead of crashing protocol processing.
  * All callers receive a consistent error, including the original request and waiting requests.
  * Repeated deliveries with the same failed data fail quickly using the cached failure.
  * Panic-related decode metrics are now recorded as cache misses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->