### PR TITLE
fix(leios): bind fetched transactions to manifest references

### DIFF
--- a/ouroboros/leios_eb_zero_refs_test.go
+++ b/ouroboros/leios_eb_zero_refs_test.go
@@ -23,6 +23,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type recordingLeiosPipelineHandler struct {
+	observed int
+}
+
+func (h *recordingLeiosPipelineHandler) ObserveEndorserBlock(
+	uint64,
+	lcommon.Blake2b256,
+) {
+	h.observed++
+}
+
 // Investigation for dingo #2729.
 //
 // A from-genesis musashi Leios sync stalls in the epoch-15 endorser-block
@@ -187,6 +198,10 @@ func TestStoreLeiosEndorserBlockGenuinelyEmptyEbStillRejected(t *testing.T) {
 	point := ocommon.NewPoint(15, hash.Bytes())
 
 	o := newOuroboros(OuroborosConfig{EnableLeios: true})
+	votes := &fakeLeiosVoteHandler{}
+	pipeline := &recordingLeiosPipelineHandler{}
+	o.leiosVotes = votes
+	o.leiosPipeline = pipeline
 	err := o.storeLeiosEndorserBlock(point, emptyManifest, nil)
 	require.Error(t, err)
 	require.ErrorContains(
@@ -194,6 +209,10 @@ func TestStoreLeiosEndorserBlockGenuinelyEmptyEbStillRejected(t *testing.T) {
 		err,
 		"must contain at least one transaction reference",
 	)
+	_, cached := o.lookupLeiosEndorserBlock(point.Hash)
+	require.False(t, cached)
+	require.Empty(t, votes.ebs)
+	require.Zero(t, pipeline.observed)
 }
 
 // TestStoreLeiosEndorserBlockValidManifestStillStores confirms the reordered

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -246,6 +246,9 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	if err != nil {
 		return fmt.Errorf("decode leios endorser block: %w", err)
 	}
+	if err := block.Validate(); err != nil {
+		return fmt.Errorf("validate leios endorser block: %w", err)
+	}
 	cacheKeys := []string{leiosBlockKey(point.Hash)}
 	data := &leiosEndorserBlockData{
 		point:      point,

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -124,6 +124,9 @@ func validateLeiosEndorserBlockTxs(
 	if err != nil {
 		return fmt.Errorf("decode leios endorser block: %w", err)
 	}
+	if err := block.Validate(); err != nil {
+		return fmt.Errorf("validate leios endorser block references: %w", err)
+	}
 	if len(txsRaw) != len(block.TransactionReferences) {
 		return fmt.Errorf(
 			"leios endorser block transaction count mismatch: got %d, want %d",
@@ -192,6 +195,9 @@ func leiosEndorserBlockTxValidator(
 	block, err := lcommon.NewLeiosEndorserBlockFromCbor(manifestRaw)
 	if err != nil {
 		return nil, fmt.Errorf("decode leios endorser block: %w", err)
+	}
+	if err := block.Validate(); err != nil {
+		return nil, fmt.Errorf("validate leios endorser block references: %w", err)
 	}
 	if len(block.TransactionReferences) != txCount {
 		return nil, fmt.Errorf(
@@ -390,16 +396,27 @@ func mergeLeiosPartialTxs(
 // by an earlier caller); partialTxs is sparse.
 func (data *leiosEndorserBlockData) seedLeiosPartialTxsLocked(
 	result []cbor.RawMessage,
+	validate func(int, cbor.RawMessage) error,
 ) {
 	for idx, raw := range data.txsRaw {
 		if idx >= len(result) || raw == nil {
 			break
+		}
+		if validate != nil {
+			if err := validate(idx, raw); err != nil {
+				continue
+			}
 		}
 		result[idx] = raw
 	}
 	for idx, raw := range data.partialTxs {
 		if idx >= len(result) || raw == nil || result[idx] != nil {
 			continue
+		}
+		if validate != nil {
+			if err := validate(idx, raw); err != nil {
+				continue
+			}
 		}
 		result[idx] = raw
 	}
@@ -413,6 +430,7 @@ func (data *leiosEndorserBlockData) seedLeiosPartialTxsLocked(
 func (o *Ouroboros) seedLeiosPartialTxs(
 	hash []byte,
 	result []cbor.RawMessage,
+	validate func(int, cbor.RawMessage) error,
 ) {
 	if len(result) == 0 {
 		return
@@ -423,7 +441,7 @@ func (o *Ouroboros) seedLeiosPartialTxs(
 	if !ok || data == nil || data.expired(time.Now()) {
 		return
 	}
-	data.seedLeiosPartialTxsLocked(result)
+	data.seedLeiosPartialTxsLocked(result, validate)
 }
 
 // retainLeiosPartialTxs merges an incomplete fetch result into the cached

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -467,12 +467,14 @@ func (o *Ouroboros) retainLeiosPartialTxs(
 	}
 	held := existing.partialTxs
 	add := partial
+	removedHeld := false
 	if validate != nil {
 		held = cloneRawMessages(held)
 		for idx, raw := range held {
 			if raw != nil {
 				if err := validate(idx, raw); err != nil {
 					held[idx] = nil
+					removedHeld = true
 				}
 			}
 		}
@@ -490,7 +492,7 @@ func (o *Ouroboros) retainLeiosPartialTxs(
 		add,
 		existing.txCount,
 	)
-	if added == 0 {
+	if added == 0 && !removedHeld {
 		return
 	}
 	// Cached entries are replaced, never mutated in place: lookups hand out the
@@ -500,6 +502,9 @@ func (o *Ouroboros) retainLeiosPartialTxs(
 	// indefinitely.
 	updated := *existing
 	updated.partialTxs = merged
+	if updated.partialTxCount() == 0 {
+		updated.partialTxs = nil
+	}
 	for _, cacheKey := range existing.cacheKeys {
 		if o.leiosEndorserBlocks[cacheKey] == existing {
 			o.leiosEndorserBlocks[cacheKey] = &updated

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -452,6 +452,7 @@ func (o *Ouroboros) seedLeiosPartialTxs(
 func (o *Ouroboros) retainLeiosPartialTxs(
 	hash []byte,
 	partial []cbor.RawMessage,
+	validate func(int, cbor.RawMessage) error,
 ) {
 	if len(partial) == 0 {
 		return
@@ -464,9 +465,29 @@ func (o *Ouroboros) retainLeiosPartialTxs(
 		existing.txCount <= 0 {
 		return
 	}
+	held := existing.partialTxs
+	add := partial
+	if validate != nil {
+		held = cloneRawMessages(held)
+		for idx, raw := range held {
+			if raw != nil {
+				if err := validate(idx, raw); err != nil {
+					held[idx] = nil
+				}
+			}
+		}
+		add = cloneRawMessages(add)
+		for idx, raw := range add {
+			if raw != nil {
+				if err := validate(idx, raw); err != nil {
+					add[idx] = nil
+				}
+			}
+		}
+	}
 	merged, added := mergeLeiosPartialTxs(
-		existing.partialTxs,
-		partial,
+		held,
+		add,
 		existing.txCount,
 	)
 	if added == 0 {

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -246,9 +246,6 @@ func (o *Ouroboros) storeLeiosEndorserBlock(
 	if err != nil {
 		return fmt.Errorf("decode leios endorser block: %w", err)
 	}
-	if err := block.Validate(); err != nil {
-		return fmt.Errorf("validate leios endorser block: %w", err)
-	}
 	cacheKeys := []string{leiosBlockKey(point.Hash)}
 	data := &leiosEndorserBlockData{
 		point:      point,

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -243,7 +243,11 @@ func TestLeiosNotifyBlockTxsOfferCacheMissIsNonFatal(t *testing.T) {
 		conn.ErrorChan() <- errors.New("test connection closed")
 	}()
 
-	o := newOuroboros(OuroborosConfig{ConnManager: cm, EnableLeios: true})
+	o := newOuroboros(OuroborosConfig{
+		ConnManager:        cm,
+		EnableLeios:        true,
+		EnableLeiosTxFetch: true,
+	})
 	err = o.leiosnotifyClientNotification(
 		oleiosnotify.CallbackContext{ConnectionId: conn.Id()},
 		oleiosnotify.NewMsgBlockTxsOffer(
@@ -728,6 +732,62 @@ func TestValidateLeiosEndorserBlockTxsBindsManifestOrder(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := validateLeiosEndorserBlockTxs(manifestRaw, txs)
 			require.ErrorContains(t, err, "endorser tx 0 body hash mismatch")
+		})
+	}
+}
+
+func TestValidateLeiosEndorserBlockTxsRejectsMalformedManifest(t *testing.T) {
+	tx, ref := testLeiosManifestTx(t, 1)
+	hashRaw, err := cbor.Encode(ref.TransactionHash)
+	require.NoError(t, err)
+	sizeRaw, err := cbor.Encode(uint16(ref.TransactionSize))
+	require.NoError(t, err)
+
+	duplicateManifest := append([]byte{0x81, 0xa2}, hashRaw...)
+	duplicateManifest = append(duplicateManifest, sizeRaw...)
+	duplicateManifest = append(duplicateManifest, hashRaw...)
+	duplicateManifest = append(duplicateManifest, sizeRaw...)
+	zeroSizeManifest := append([]byte{0x81, 0xa1}, hashRaw...)
+	zeroSizeManifest = append(zeroSizeManifest, 0x00)
+
+	for name, manifest := range map[string][]byte{
+		"missing references":   {0x81, 0xa0},
+		"duplicate references": duplicateManifest,
+		"zero reference size":  zeroSizeManifest,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateLeiosEndorserBlockTxs(manifest, []cbor.RawMessage{tx})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateLeiosEndorserBlockTxsRejectsWrongSizeAndMalformedBody(
+	t *testing.T,
+) {
+	tx, ref := testLeiosManifestTx(t, 1)
+	manifestRaw, err := lcommon.LeiosEndorserBlock{
+		TransactionReferences: []lcommon.LeiosTransactionReference{ref},
+	}.MarshalCBOR()
+	require.NoError(t, err)
+
+	tests := map[string]cbor.RawMessage{
+		"wrong size":     append(cbor.RawMessage(nil), tx...),
+		"malformed body": {0xff},
+		"trailing bytes": append(append(cbor.RawMessage(nil), tx...), 0x00),
+	}
+	for name, candidate := range tests {
+		t.Run(name, func(t *testing.T) {
+			manifest := manifestRaw
+			candidateRef := ref
+			if name == "wrong size" {
+				candidateRef.TransactionSize++
+				manifest, err = lcommon.LeiosEndorserBlock{
+					TransactionReferences: []lcommon.LeiosTransactionReference{candidateRef},
+				}.MarshalCBOR()
+				require.NoError(t, err)
+			}
+			require.Error(t, validateLeiosEndorserBlockTxs(manifest, []cbor.RawMessage{candidate}))
 		})
 	}
 }

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -811,6 +811,58 @@ func (r manifestTxRequester) BlockTxsRequest(
 	return oleiosfetch.NewMsgBlockTxsFull(point, bitmaps, txs), nil
 }
 
+type recordingManifestTxRequester struct {
+	txs       []cbor.RawMessage
+	requested []int
+}
+
+func (r *recordingManifestTxRequester) BlockTxsRequest(
+	_ context.Context,
+	point ocommon.Point,
+	bitmaps map[uint16]uint64,
+) (protocol.Message, error) {
+	indices := leiosBitmapTxIndices(bitmaps)
+	r.requested = append(r.requested, indices...)
+	txs := make([]cbor.RawMessage, 0, len(indices))
+	for _, index := range indices {
+		if index >= 0 && index < len(r.txs) {
+			txs = append(txs, r.txs[index])
+		}
+	}
+	return oleiosfetch.NewMsgBlockTxsFull(point, bitmaps, txs), nil
+}
+
+func TestFetchLeiosEbTxsBatchedRefetchesMismatchedRetainedPartial(t *testing.T) {
+	tx1, ref1 := testLeiosManifestTx(t, 1)
+	tx2, ref2 := testLeiosManifestTx(t, 2)
+	manifestRaw, err := lcommon.LeiosEndorserBlock{
+		TransactionReferences: []lcommon.LeiosTransactionReference{ref1, ref2},
+	}.MarshalCBOR()
+	require.NoError(t, err)
+	point := ocommon.NewPoint(123, lcommon.Blake2b256Hash(manifestRaw).Bytes())
+	o := newOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(t, o.storeLeiosEndorserBlock(point, manifestRaw, nil))
+
+	// Seed index 0 with the body for index 1. A resumed fetch must discard it
+	// before computing its request bitmap, then replace it in the retained set.
+	o.retainLeiosPartialTxs(point.Hash, []cbor.RawMessage{tx2, nil}, nil)
+	requester := &recordingManifestTxRequester{
+		txs: []cbor.RawMessage{tx1, tx2},
+	}
+	txs, err := o.fetchLeiosEbTxsBatched(requester, point, 2, manifestRaw)
+	require.NoError(t, err)
+	require.Contains(t, requester.requested, 0)
+	require.NoError(t, validateLeiosEndorserBlockTxs(manifestRaw, txs))
+
+	cached, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	require.True(t, ok)
+	require.Equal(t, 2, cached.partialTxCount())
+	require.NoError(t, validateLeiosEndorserBlockTxs(
+		manifestRaw,
+		leiosCollectTxs(cached.partialTxs),
+	))
+}
+
 func TestValidatedLeiosFetchRejectsMismatchBeforePartialRetention(t *testing.T) {
 	tx1, ref1 := testLeiosManifestTx(t, 1)
 	tx2, ref2 := testLeiosManifestTx(t, 2)

--- a/ouroboros/leios_partial_tail_test.go
+++ b/ouroboros/leios_partial_tail_test.go
@@ -194,12 +194,12 @@ func TestRetainLeiosPartialTxsUnionsAcrossAttempts(t *testing.T) {
 			tail[i] = cbor.RawMessage(enc)
 		}
 	}
-	o.retainLeiosPartialTxs(point.Hash, head)
+	o.retainLeiosPartialTxs(point.Hash, head, nil)
 	data, ok := o.lookupLeiosEndorserBlock(point.Hash)
 	require.True(t, ok)
 	require.Equal(t, 60, data.partialTxCount())
 
-	o.retainLeiosPartialTxs(point.Hash, tail)
+	o.retainLeiosPartialTxs(point.Hash, tail, nil)
 	data, ok = o.lookupLeiosEndorserBlock(point.Hash)
 	require.True(t, ok)
 	require.Equal(t, txCount, data.partialTxCount())
@@ -219,7 +219,7 @@ func TestRetainLeiosPartialTxsIgnoresUnknownBlock(t *testing.T) {
 	o := newOuroboros(OuroborosConfig{EnableLeios: true})
 	o.retainLeiosPartialTxs([]byte{0xde, 0xad}, []cbor.RawMessage{
 		mustCbor(t, "tx0"),
-	})
+	}, nil)
 	_, ok := o.lookupLeiosEndorserBlock([]byte{0xde, 0xad})
 	require.False(t, ok)
 }

--- a/ouroboros/leios_partial_tail_test.go
+++ b/ouroboros/leios_partial_tail_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
@@ -211,6 +212,34 @@ func TestRetainLeiosPartialTxsUnionsAcrossAttempts(t *testing.T) {
 	require.NoError(t, err)
 	requireTxsInIndexOrder(t, txs, txCount)
 	require.Zero(t, requester.calls)
+}
+
+// Retention validation can invalidate bodies that were already cached. Even
+// when the current fetch contributes no replacement body, the sanitized union
+// must replace the old cache entry so a later fetch cannot reuse the invalid
+// body.
+func TestRetainLeiosPartialTxsPublishesSanitizedHeldEntries(t *testing.T) {
+	_, ref1 := testLeiosManifestTx(t, 1)
+	tx2, ref2 := testLeiosManifestTx(t, 2)
+	manifestRaw, err := lcommon.LeiosEndorserBlock{
+		TransactionReferences: []lcommon.LeiosTransactionReference{ref1, ref2},
+	}.MarshalCBOR()
+	require.NoError(t, err)
+	point := ocommon.NewPoint(23, lcommon.Blake2b256Hash(manifestRaw).Bytes())
+	o := newOuroboros(OuroborosConfig{EnableLeios: true})
+	require.NoError(t, o.storeLeiosEndorserBlock(point, manifestRaw, nil))
+
+	// Seed index 0 with the body for index 1. The validation callback below
+	// must clear it even though this attempt offers no replacement body.
+	o.retainLeiosPartialTxs(point.Hash, []cbor.RawMessage{tx2, nil}, nil)
+	validate, err := leiosEndorserBlockTxValidator(manifestRaw, 2)
+	require.NoError(t, err)
+	o.retainLeiosPartialTxs(point.Hash, []cbor.RawMessage{tx2, nil}, validate)
+
+	cached, ok := o.lookupLeiosEndorserBlock(point.Hash)
+	require.True(t, ok)
+	require.Empty(t, cached.partialTxs)
+	require.Zero(t, cached.partialTxCount())
 }
 
 // Retention is scoped to endorser blocks dingo is actually tracking: a partial

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -1099,7 +1099,7 @@ func (o *Ouroboros) fetchLeiosEbTxsBatchedUntilWithValidator(
 	// connection free while its progress survives for the next offer. A
 	// completing attempt's caller stores the whole set, which clears this.
 	defer func() {
-		o.retainLeiosPartialTxs(point.Hash, result)
+		o.retainLeiosPartialTxs(point.Hash, result, validate)
 	}()
 	// The no-progress guard below guarantees termination (each non-final round
 	// places at least one new transaction, and there are txCount of them); this

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -1093,7 +1093,7 @@ func (o *Ouroboros) fetchLeiosEbTxsBatchedUntilWithValidator(
 	// against the cached block (below) and seeded back here, so a re-offer
 	// requests only the still-missing tail instead of re-fetching transactions
 	// dingo already has (issue #2629).
-	o.seedLeiosPartialTxs(point.Hash, result)
+	o.seedLeiosPartialTxs(point.Hash, result, validate)
 	// Retain whatever this attempt ends up holding, so an attempt that stops
 	// short (tail budget, per-attempt deadline, protocol error) leaves the
 	// connection free while its progress survives for the next offer. A


### PR DESCRIPTION
## Summary

- bind fetched Leios transaction bodies to manifest hashes, encoded sizes, and
  positions before retaining or using them
- reject malformed or mismatched manifest references across both fresh and
  retained fetch paths
- refetch a retained transaction when it does not match the current manifest

## Checks

- focused manifest-binding and retained-refetch regressions with race detection
- full `ouroboros` tests with race detection
- conformance tests with race detection
- `make lint`
- documentation parity and import-boundary checks

Closes #3557

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Leios transaction integrity by binding every fetched transaction body to its manifest reference (hash, size, position) before retaining or using it.

- Rejects malformed or mismatched manifest references in both fresh and retained fetch paths, validates cached endorser manifests, and clears invalid bodies already held in the partial cache so the sanitized set is published.
- Re-fetches a retained transaction when its body no longer matches the current manifest.

Closes #3557.

<sup>Written for commit d38b145c55dc903c52da113d6d098a5ec0c79980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transactions received from Leios endorser blocks.
  * Invalid, malformed, duplicated, or mismatched transactions are now rejected during fetching and cache retention.
  * Batched transaction refetching now replaces invalid retained data and requests the correct missing transactions.
  * Added safer handling for malformed block manifests and transaction payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->