### PR TITLE
fix(benchmark): repair setup failures before measurement

### DIFF
--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2367,13 +2367,24 @@ func BenchmarkVerifyBlockHeader(b *testing.B) {
 			},
 			epochNonceHexCache: make(map[uint64]string),
 		}
+		// The epoch cache is read through the published consensus snapshot,
+		// not the raw field, so it must be published before use even for
+		// this single-threaded literal construction.
+		ledgerState.publishSnapshotsLocked()
 
 		b.ReportAllocs()
 		b.ResetTimer()
 
 		for i := 0; b.Loop(); i++ {
-			if err := ledgerState.verifyBlockHeaderCrypto(
+			// verifyBlockHeaderStatelessCrypto isolates the cryptographic
+			// path this benchmark measures. verifyBlockHeaderCrypto also
+			// runs verifyBlockHeaderState, which looks up the pool's
+			// registered VRF key and stake snapshot through ls.db — an
+			// unrelated, database-backed concern this literal LedgerState
+			// has no database for.
+			if _, err := ledgerState.verifyBlockHeaderStatelessCrypto(
 				testBlocks[i%len(testBlocks)].block,
+				true,
 			); err != nil {
 				b.Fatal(err)
 			}

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2377,14 +2377,15 @@ func BenchmarkVerifyBlockHeader(b *testing.B) {
 
 		for i := 0; b.Loop(); i++ {
 			// verifyBlockHeaderStatelessCrypto isolates the cryptographic
-			// path this benchmark measures. verifyBlockHeaderCrypto also
-			// runs verifyBlockHeaderState, which looks up the pool's
-			// registered VRF key and stake snapshot through ls.db — an
-			// unrelated, database-backed concern this literal LedgerState
-			// has no database for.
+			// path this benchmark measures. Keep epoch cache advancement
+			// disabled because it also requires ls.db, which this literal
+			// LedgerState intentionally does not provide. Likewise,
+			// verifyBlockHeaderCrypto runs verifyBlockHeaderState, which
+			// looks up the pool's registered VRF key and stake snapshot
+			// through ls.db.
 			if _, err := ledgerState.verifyBlockHeaderStatelessCrypto(
 				testBlocks[i%len(testBlocks)].block,
-				true,
+				false,
 			); err != nil {
 				b.Fatal(err)
 			}

--- a/mempool/benchmark_test.go
+++ b/mempool/benchmark_test.go
@@ -577,8 +577,12 @@ func newBenchmarkPluginPool(
 		plugin.CapabilityMempool,
 		string(implementation),
 		map[string]any{
-			"capacity":           benchmarkCapacity,
-			"evictionWatermark":  1,
+			"capacity": benchmarkCapacity,
+			// Mempool construction requires evictionWatermark strictly
+			// below rejectionWatermark. 0 resolves to
+			// DefaultEvictionWatermark (disabled) and 1 is the maximum
+			// valid rejectionWatermark.
+			"evictionWatermark":  0,
 			"rejectionWatermark": 1,
 		},
 		ProviderDependencies{


### PR DESCRIPTION
## Summary

Two benchmark setups failed before measuring their target:

- `BenchmarkVerifyBlockHeader/ledger_state` built a `LedgerState` struct literal without publishing its consensus/tip snapshots, so `headerVerificationEpoch` dereferenced the nil result of `loadConsensusSnapshot()` and panicked before verification could run.
- `BenchmarkMempoolPlugins` and `BenchmarkMempoolPluginsDegenerate` configured `evictionWatermark`/`rejectionWatermark` both at `1`. Construction requires eviction strictly below rejection, so every FIFO/DAG scenario failed during setup.

Closes #3383

## Changes

### `ledger/benchmark_test.go`
- Publish the consensus/tip snapshot (`ledgerState.publishSnapshotsLocked()`) after building the `LedgerState` literal in `BenchmarkVerifyBlockHeader/ledger_state`, so `headerVerificationEpoch` reads a real epoch cache instead of a nil pointer.
- Switch that same sub-benchmark from `verifyBlockHeaderCrypto` to `verifyBlockHeaderStatelessCrypto`. `verifyBlockHeaderCrypto` also runs `verifyBlockHeaderState`, a database-backed VRF-key registration/stake-snapshot lookup this literal `LedgerState` has no database for (a second, distinct panic once the first was fixed) and one outside the cryptographic path this benchmark is documented to isolate.

### `mempool/benchmark_test.go`
- Change `newBenchmarkPluginPool`'s shared config from `evictionWatermark: 1, rejectionWatermark: 1` to `evictionWatermark: 0, rejectionWatermark: 1` — eviction `0` resolves to the disabled default, and rejection `1` is the maximum valid value, satisfying the constructor's requirement that eviction stay strictly below rejection.

`DATABASE.md`/`ARCHITECTURE.md`: checked, not affected (test-only change).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two benchmark setups that panicked before measuring their targets.

**Bug Fixes**
- `BenchmarkVerifyBlockHeader/ledger_state` now publishes its consensus/tip snapshot and calls `verifyBlockHeaderStatelessCrypto` with epoch cache advancement disabled, which avoids the nil pointer panic and database-backed lookups the literal `LedgerState` has no database for.
- `BenchmarkMempoolPlugins` and `BenchmarkMempoolPluginsDegenerate` now use `evictionWatermark: 0` and `rejectionWatermark: 1`, satisfying the constructor's strict-below requirement instead of failing during setup.

<sup>Written for commit 85ed93ce9ca2f5e9e03b00d096d7c394819613f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved ledger performance benchmarks for more focused and consistent cryptographic verification measurements.
  - Updated benchmark initialization to use published state snapshots before timing begins.
  - Corrected mempool benchmark configuration to use valid watermark settings and accurately represent the default eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->