### PR TITLE
feat(blockfrost): add transaction evaluation endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4886,8 +4886,12 @@ TLS and token authentication (including the `project_id` header alias) are
 configured through `plugins.api.blockfrost.config.tls`/`config.auth`; see
 "API security" above.
 
-A Blockfrost-compatible REST API that provides read access to chain data and
-transaction submission. The current router includes health/root, blocks,
+A Blockfrost-compatible REST API that provides read access to chain data,
+transaction evaluation, and transaction submission. `POST
+/api/v0/utils/txs/evaluate` accepts a serialized CBOR transaction and returns
+the ledger-calculated execution-unit map keyed by redeemer pointer; it does
+not submit or require a fully valid, balanced transaction. The current router
+includes health/root, blocks,
 epochs/parameters, network/eras, genesis, assets, pools list, pools/extended,
 retiring pools, pool detail, pool metadata, governance DRep list and lookup, address
 summary, address UTxOs and transactions, metadata label JSON/CBOR,

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -3717,6 +3717,53 @@ func (a *NodeAdapter) TransactionSubmit(
 	return tx.Hash().String(), nil
 }
 
+// TransactionEvaluate evaluates script execution units for raw transaction
+// CBOR without submitting the transaction.
+func (a *NodeAdapter) TransactionEvaluate(
+	txCbor []byte,
+) (TransactionEvaluationResponse, error) {
+	txType, err := gledger.DetermineTransactionType(txCbor)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: determine transaction type: %w",
+			ErrInvalidTransaction,
+			err,
+		)
+	}
+	tx, err := gledger.NewTransactionFromCbor(txType, txCbor)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: decode transaction: %w",
+			ErrInvalidTransaction,
+			err,
+		)
+	}
+	_, _, redeemerExUnits, err := a.ledgerState.EvaluateTx(tx)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: evaluate transaction: %w",
+			ErrInvalidTransaction,
+			err,
+		)
+	}
+	result := make(TransactionEvaluationResponse, len(redeemerExUnits))
+	for key, exUnits := range redeemerExUnits {
+		purpose := redeemerPurpose(key.Tag)
+		if purpose == "" {
+			return nil, fmt.Errorf(
+				"%w: unsupported redeemer tag %d",
+				ErrInvalidTransaction,
+				key.Tag,
+			)
+		}
+		result[fmt.Sprintf("%s:%d", purpose, key.Index)] = ExecutionUnitsResponse{
+			Memory: uint64(exUnits.Memory), // nolint:gosec
+			Steps:  uint64(exUnits.Steps),  // nolint:gosec
+		}
+	}
+	return result, nil
+}
+
 // TransactionCBOR returns raw signed transaction CBOR bytes for the requested
 // transaction hash.
 func (a *NodeAdapter) TransactionCBOR(

--- a/api/blockfrost/blockfrost.go
+++ b/api/blockfrost/blockfrost.go
@@ -179,6 +179,10 @@ func (b *Blockfrost) handler() http.Handler {
 		b.handleTransactionSubmit,
 	)
 	mux.HandleFunc(
+		"POST /api/v0/utils/txs/evaluate",
+		b.handleTransactionEvaluate,
+	)
+	mux.HandleFunc(
 		"GET /api/v0/txs/{hash}/cbor",
 		b.handleTransactionCBOR,
 	)

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -93,6 +93,7 @@ type mockNode struct {
 	metadataCBOR                  []MetadataTransactionCBORInfo
 	transaction                   TransactionInfo
 	transactionSubmitHash         string
+	transactionEvaluation         TransactionEvaluationResponse
 	transactionCBOR               []byte
 	transactionMetadata           []TransactionMetadataInfo
 	transactionMetadataCBOR       []TransactionMetadataCBORInfo
@@ -143,6 +144,7 @@ type mockNode struct {
 	metadataCBORErr               error
 	transactionErr                error
 	transactionSubmitErr          error
+	transactionEvaluationErr      error
 	transactionCBORErr            error
 	transactionMetadataErr        error
 	transactionMetadataCBORErr    error
@@ -332,6 +334,12 @@ func (m *mockNode) TransactionSubmit(
 	_ []byte,
 ) (string, error) {
 	return m.transactionSubmitHash, m.transactionSubmitErr
+}
+
+func (m *mockNode) TransactionEvaluate(
+	_ []byte,
+) (TransactionEvaluationResponse, error) {
+	return m.transactionEvaluation, m.transactionEvaluationErr
 }
 
 func (m *mockNode) TransactionCBOR(

--- a/api/blockfrost/evaluate_test.go
+++ b/api/blockfrost/evaluate_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package blockfrost
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleTransactionEvaluate(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{
+		transactionEvaluation: TransactionEvaluationResponse{
+			"spend:0": {Memory: 1700, Steps: 476468},
+			"mint:0":  {Memory: 42, Steps: 99},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/utils/txs/evaluate", strings.NewReader("\x84\x00"))
+	req.Header.Set("Content-Type", "application/cbor")
+	w := httptest.NewRecorder()
+	b.handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var got TransactionEvaluationResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, TransactionEvaluationResponse{
+		"spend:0": {Memory: 1700, Steps: 476468},
+		"mint:0":  {Memory: 42, Steps: 99},
+	}, got)
+}
+
+func TestHandleTransactionEvaluateRejectsInvalidTransaction(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{transactionEvaluationErr: ErrInvalidTransaction})
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/utils/txs/evaluate", strings.NewReader("\x84\x00"))
+	req.Header.Set("Content-Type", "application/cbor")
+	w := httptest.NewRecorder()
+	b.handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var got ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&got))
+	assert.Equal(t, "Invalid transaction CBOR.", got.Message)
+}
+
+func TestHandleTransactionEvaluateRequiresCBOR(t *testing.T) {
+	b := newTestBlockfrost(&mockNode{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/utils/txs/evaluate", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	b.handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+}

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -1287,6 +1287,74 @@ func (b *Blockfrost) handleTransactionSubmit(
 	writeJSON(w, http.StatusOK, hash)
 }
 
+// handleTransactionEvaluate handles POST /api/v0/utils/txs/evaluate and
+// evaluates script execution units without submitting the transaction.
+func (b *Blockfrost) handleTransactionEvaluate(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/cbor" {
+		writeError(
+			w,
+			http.StatusUnsupportedMediaType,
+			"Unsupported Media Type",
+			"Content-Type must be application/cbor.",
+		)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxTxBodySize)
+	txCbor, err := io.ReadAll(r.Body)
+	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			writeError(
+				w,
+				http.StatusRequestEntityTooLarge,
+				"Request Entity Too Large",
+				"transaction body exceeds maximum allowed size",
+			)
+			return
+		}
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"failed to read transaction body",
+		)
+		return
+	}
+	if len(txCbor) == 0 {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			"Bad Request",
+			"transaction body is empty",
+		)
+		return
+	}
+	result, err := b.node.TransactionEvaluate(txCbor)
+	if err != nil {
+		if errors.Is(err, ErrInvalidTransaction) {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				"Bad Request",
+				"Invalid transaction CBOR.",
+			)
+			return
+		}
+		b.logger.Error("failed to evaluate transaction", "error", err)
+		writeError(
+			w,
+			http.StatusInternalServerError,
+			"Internal Server Error",
+			"failed to evaluate transaction",
+		)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
 // handleTransactionCBOR handles GET /api/v0/txs/{hash}/cbor and returns
 // the raw signed transaction CBOR as a hex string.
 func (b *Blockfrost) handleTransactionCBOR(

--- a/api/blockfrost/node_interface.go
+++ b/api/blockfrost/node_interface.go
@@ -120,6 +120,10 @@ type BlockfrostNode interface {
 	// TransactionSubmit submits raw signed transaction CBOR to the mempool.
 	TransactionSubmit(txCbor []byte) (string, error)
 
+	// TransactionEvaluate evaluates script execution units for raw transaction
+	// CBOR without submitting the transaction.
+	TransactionEvaluate(txCbor []byte) (TransactionEvaluationResponse, error)
+
 	// TransactionCBOR returns raw signed transaction CBOR bytes.
 	TransactionCBOR(hash []byte) ([]byte, error)
 

--- a/api/blockfrost/types.go
+++ b/api/blockfrost/types.go
@@ -366,6 +366,18 @@ type ErrorResponse struct {
 	Message    string `json:"message"`
 }
 
+// TransactionEvaluationResponse contains the execution units calculated for
+// each redeemer in a transaction. Keys use redeemer pointers such as
+// "spend:0" and "mint:0".
+type TransactionEvaluationResponse map[string]ExecutionUnitsResponse
+
+// ExecutionUnitsResponse contains the execution units consumed by a
+// redeemer.
+type ExecutionUnitsResponse struct {
+	Memory uint64 `json:"memory"`
+	Steps  uint64 `json:"steps"`
+}
+
 // PoolExtendedResponse represents an extended stake pool list item,
 // following the Blockfrost OpenAPI 0.1.90 pool_list_extended schema
 // exactly. Neither vrf_key nor relays is part of that schema (vrf_key


### PR DESCRIPTION
## Summary

- add `POST /api/v0/utils/txs/evaluate` to the Blockfrost API
- evaluate serialized transactions through Dingo's existing ledger path without submission
- add route, error, and response-shape regression tests
- document the new API surface

Fixes #3587.

## Validation

- `go test ./api/blockfrost -count=1`
- `go test ./internal/test/conformance/`
- `golangci-lint run ./api/blockfrost`
- `make import-boundaries`
- `make docs-parity`
- `make golines`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `POST /api/v0/utils/txs/evaluate` endpoint to the Blockfrost API that returns ledger-calculated execution units keyed by redeemer pointer (e.g. `spend:0`) for serialized CBOR transactions, without submitting them or requiring a fully valid, balanced transaction. Fixes #3587.

**Details**
- Requires `Content-Type: application/cbor` and rejects other media types with 415.
- Returns 400 for invalid transaction CBOR and 413 for bodies over the allowed size.
- Adds route, error, and response-shape regression tests and updates the architecture docs.

<sup>Written for commit 08e6414bed7aed51e802b1b6e3378ded2e4c21e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

