### PR TITLE
fix(ledger): close stopped slot clock subscriptions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7767,7 +7767,8 @@ block processing owns historical epoch transitions during catch-up.
 Slot-clock subscriptions are owned by that clock lifecycle: stopping the clock
 or cancelling its parent context closes every existing channel, and a
 subscription made after it has stopped is already closed. A later `Start`
-creates a new subscription lifecycle.
+creates a new subscription lifecycle; a concurrent `Stop` waits only for the
+generation it stopped, not for that replacement worker.
 
 The fallback capture runs outside the rollover transaction, so when its
 transaction tip has already passed the snapshot slot it must reconstruct the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7764,6 +7764,10 @@ Epoch transition events may come from block processing or the slot clock. The
 slot clock only emits proactive epoch transitions when the ledger tip is within
 the current era's stability window of the upstream tip; while farther behind,
 block processing owns historical epoch transitions during catch-up.
+Slot-clock subscriptions are owned by that clock lifecycle: stopping the clock
+or cancelling its parent context closes every existing channel, and a
+subscription made after it has stopped is already closed. A later `Start`
+creates a new subscription lifecycle.
 
 The fallback capture runs outside the rollover transaction, so when its
 transaction tip has already passed the snapshot slot it must reconstruct the

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2365,7 +2365,7 @@ func BenchmarkVerifyBlockHeader(b *testing.B) {
 				CardanoNodeConfig: newTestShelleyGenesisCfg(b),
 				Logger:            benchmarkDiscardLogger,
 			},
-			epochNonceHexCache: make(map[uint64]string),
+			epochNonceHexCache: make(map[uint64]epochNonceHexCacheEntry),
 		}
 
 		b.ReportAllocs()

--- a/ledger/heal_mithril_gap_nonce_test.go
+++ b/ledger/heal_mithril_gap_nonce_test.go
@@ -50,7 +50,7 @@ func newGapHealTestLedgerState(
 		currentTip: ochainsync.Tip{
 			Point: ocommon.Point{Slot: tipSlot, Hash: tipHash},
 		},
-		epochNonceHexCache: map[uint64]string{},
+		epochNonceHexCache: map[uint64]epochNonceHexCacheEntry{},
 		config: LedgerStateConfig{
 			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		},
@@ -128,7 +128,10 @@ func TestHealMithrilGapBlockNonces_ReconstructsGapAndRefreshesTip(
 	ls := newGapHealTestLedgerState(t, db, boundary, tipSlot, tipHash)
 	ls.config.CardanoNodeConfig = newConwayBootstrapStabilityCfg(t)
 	ls.currentTipBlockNonce = bytes.Clone(staleTipNonce)
-	ls.epochNonceHexCache[42] = "stale"
+	ls.epochNonceHexCache[42] = epochNonceHexCacheEntry{
+		nonce: []byte("stale"),
+		hex:   "stale",
+	}
 
 	expected := bytes.Clone(anchorNonce)
 	expectedBySlot := map[uint64][]byte{}

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -95,8 +95,8 @@ type SlotClock struct {
 	subscribers []chan SlotTick
 	mu          sync.RWMutex
 	cancel      context.CancelFunc
-	ctx         context.Context
 	running     bool
+	stopped     bool
 	wg          sync.WaitGroup
 
 	// Track last emitted epoch to avoid duplicates and detect discrepancies
@@ -152,17 +152,20 @@ func waitForDuration(ctx context.Context, delay time.Duration) error {
 // The clock will emit SlotTick notifications at each slot boundary.
 // Returns immediately; the tick loop runs in a goroutine.
 func (sc *SlotClock) Start(ctx context.Context) {
+	clockCtx, cancel := context.WithCancel(ctx)
 	sc.mu.Lock()
 	if sc.running {
+		cancel()
 		sc.mu.Unlock()
 		return
 	}
 	sc.running = true
-	sc.ctx, sc.cancel = context.WithCancel(ctx)
+	sc.stopped = false
+	sc.cancel = cancel
+	sc.wg.Add(1)
 	sc.mu.Unlock()
 
-	sc.wg.Add(1)
-	go sc.run()
+	go sc.run(clockCtx)
 }
 
 // Stop halts the slot clock and waits for the tick loop to exit.
@@ -171,18 +174,17 @@ func (sc *SlotClock) Start(ctx context.Context) {
 func (sc *SlotClock) Stop() {
 	sc.mu.Lock()
 	if !sc.running {
+		sc.stopped = true
+		sc.closeSubscribersLocked()
 		sc.mu.Unlock()
+		sc.wg.Wait()
 		return
 	}
-	sc.running = false
+	sc.stopped = true
 	if sc.cancel != nil {
 		sc.cancel()
 	}
-	// Close all subscriber channels to unblock any goroutines waiting on them
-	for _, ch := range sc.subscribers {
-		close(ch)
-	}
-	sc.subscribers = nil
+	sc.closeSubscribersLocked()
 	sc.mu.Unlock()
 
 	sc.wg.Wait()
@@ -194,9 +196,21 @@ func (sc *SlotClock) Stop() {
 func (sc *SlotClock) Subscribe() <-chan SlotTick {
 	ch := make(chan SlotTick, 1)
 	sc.mu.Lock()
+	if sc.stopped {
+		close(ch)
+		sc.mu.Unlock()
+		return ch
+	}
 	sc.subscribers = append(sc.subscribers, ch)
 	sc.mu.Unlock()
 	return ch
+}
+
+func (sc *SlotClock) closeSubscribersLocked() {
+	for _, ch := range sc.subscribers {
+		close(ch)
+	}
+	sc.subscribers = nil
 }
 
 // Unsubscribe removes a subscriber channel from the notification list.
@@ -341,15 +355,22 @@ func (sc *SlotClock) SetLastEmittedEpoch(epoch uint64) {
 // =============================================================================
 
 // run is the main tick loop
-func (sc *SlotClock) run() {
-	defer sc.wg.Done()
+func (sc *SlotClock) run(ctx context.Context) {
+	defer func() {
+		sc.mu.Lock()
+		sc.running = false
+		sc.stopped = true
+		sc.closeSubscribersLocked()
+		sc.mu.Unlock()
+		sc.wg.Done()
+	}()
 
 	logger := sc.config.Logger.With("component", "slot_clock")
 
 	for {
 		// Check context first
 		select {
-		case <-sc.ctx.Done():
+		case <-ctx.Done():
 			return
 		default:
 		}
@@ -367,7 +388,7 @@ func (sc *SlotClock) run() {
 						"error", slotErr,
 					)
 					select {
-					case <-sc.ctx.Done():
+					case <-ctx.Done():
 						return
 					case <-time.After(time.Second):
 						continue
@@ -383,7 +404,7 @@ func (sc *SlotClock) run() {
 					"wait", waitDur.Round(time.Second),
 				)
 				select {
-				case <-sc.ctx.Done():
+				case <-ctx.Done():
 					return
 				case <-time.After(waitDur):
 					continue
@@ -392,7 +413,7 @@ func (sc *SlotClock) run() {
 			logger.Error("failed to get current slot", "error", err)
 			// Sleep briefly and retry
 			select {
-			case <-sc.ctx.Done():
+			case <-ctx.Done():
 				return
 			case <-time.After(100 * time.Millisecond):
 				continue
@@ -411,7 +432,7 @@ func (sc *SlotClock) run() {
 				nextSlot,
 			)
 			select {
-			case <-sc.ctx.Done():
+			case <-ctx.Done():
 				return
 			case <-time.After(100 * time.Millisecond):
 				continue
@@ -422,7 +443,7 @@ func (sc *SlotClock) run() {
 		sleepDuration := nextSlotTime.Sub(now)
 		if sleepDuration > 0 {
 			select {
-			case <-sc.ctx.Done():
+			case <-ctx.Done():
 				return
 			case <-time.After(sleepDuration):
 			}

--- a/ledger/slot_clock.go
+++ b/ledger/slot_clock.go
@@ -95,9 +95,10 @@ type SlotClock struct {
 	subscribers []chan SlotTick
 	mu          sync.RWMutex
 	cancel      context.CancelFunc
+	done        chan struct{}
+	generation  uint64
 	running     bool
 	stopped     bool
-	wg          sync.WaitGroup
 
 	// Track last emitted epoch to avoid duplicates and detect discrepancies
 	lastEmittedEpoch uint64
@@ -112,6 +113,9 @@ type SlotClock struct {
 	// For testing: allow injection of custom time source
 	nowFunc  func() time.Time
 	waitFunc func(context.Context, time.Duration) error
+	// beforeRunDone is a test hook that runs after a worker releases its
+	// lifecycle state but before it reports completion. It is nil in production.
+	beforeRunDone func()
 }
 
 // NewSlotClock creates a new SlotClock with the given provider and configuration
@@ -162,10 +166,13 @@ func (sc *SlotClock) Start(ctx context.Context) {
 	sc.running = true
 	sc.stopped = false
 	sc.cancel = cancel
-	sc.wg.Add(1)
+	sc.generation++
+	generation := sc.generation
+	done := make(chan struct{})
+	sc.done = done
 	sc.mu.Unlock()
 
-	go sc.run(clockCtx)
+	go sc.run(clockCtx, generation, done)
 }
 
 // Stop halts the slot clock and waits for the tick loop to exit.
@@ -173,21 +180,17 @@ func (sc *SlotClock) Start(ctx context.Context) {
 // on receiving from them to exit cleanly.
 func (sc *SlotClock) Stop() {
 	sc.mu.Lock()
-	if !sc.running {
-		sc.stopped = true
-		sc.closeSubscribersLocked()
-		sc.mu.Unlock()
-		sc.wg.Wait()
-		return
-	}
 	sc.stopped = true
-	if sc.cancel != nil {
+	if sc.running && sc.cancel != nil {
 		sc.cancel()
 	}
 	sc.closeSubscribersLocked()
+	done := sc.done
 	sc.mu.Unlock()
 
-	sc.wg.Wait()
+	if done != nil {
+		<-done
+	}
 }
 
 // Subscribe returns a channel that will receive SlotTick notifications.
@@ -355,14 +358,25 @@ func (sc *SlotClock) SetLastEmittedEpoch(epoch uint64) {
 // =============================================================================
 
 // run is the main tick loop
-func (sc *SlotClock) run(ctx context.Context) {
+func (sc *SlotClock) run(
+	ctx context.Context,
+	generation uint64,
+	done chan struct{},
+) {
 	defer func() {
 		sc.mu.Lock()
-		sc.running = false
-		sc.stopped = true
-		sc.closeSubscribersLocked()
+		if sc.generation == generation {
+			sc.running = false
+			sc.stopped = true
+			sc.cancel = nil
+			sc.closeSubscribersLocked()
+		}
+		beforeRunDone := sc.beforeRunDone
 		sc.mu.Unlock()
-		sc.wg.Done()
+		if beforeRunDone != nil {
+			beforeRunDone()
+		}
+		close(done)
 	}()
 
 	logger := sc.config.Logger.With("component", "slot_clock")

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -326,6 +326,66 @@ func TestSlotClockStartStop(t *testing.T) {
 	clock.mu.RUnlock()
 }
 
+func TestSlotClockStartOverlappingStopWaitsOnlyForStoppedGeneration(
+	t *testing.T,
+) {
+	provider := newMockSlotTimeProvider(time.Now(), time.Second, 100)
+	clock := NewSlotClock(provider, DefaultSlotClockConfig())
+	oldStateReleased := make(chan struct{})
+	allowOldCompletion := make(chan struct{})
+	var hookCalls atomic.Uint32
+	clock.beforeRunDone = func() {
+		if hookCalls.Add(1) != 1 {
+			return
+		}
+		close(oldStateReleased)
+		<-allowOldCompletion
+	}
+
+	var releaseOnce sync.Once
+	releaseOld := func() {
+		releaseOnce.Do(func() { close(allowOldCompletion) })
+	}
+	defer clock.Stop()
+	defer releaseOld()
+
+	clock.Start(context.Background())
+	stopDone := make(chan struct{})
+	go func() {
+		clock.Stop()
+		close(stopDone)
+	}()
+
+	testutil.RequireReceive(
+		t,
+		oldStateReleased,
+		time.Second,
+		"stopped generation should release its lifecycle state",
+	)
+	replacementCtx, cancelReplacement := context.WithCancel(context.Background())
+	defer cancelReplacement()
+	clock.Start(replacementCtx)
+	releaseOld()
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
+	defer cancelWait()
+	select {
+	case <-stopDone:
+	case <-waitCtx.Done():
+		cancelReplacement()
+		<-stopDone
+		t.Fatal("Stop waited for a replacement slot-clock generation")
+	}
+
+	clock.mu.RLock()
+	replacementRunning := clock.running
+	clock.mu.RUnlock()
+	require.True(t, replacementRunning, "overlapping Start should remain running")
+
+	cancelReplacement()
+	clock.Stop()
+}
+
 func TestSlotClockReceivesTicks(t *testing.T) {
 	// Use short slot length for faster test
 	systemStart := time.Now()
@@ -491,12 +551,9 @@ func TestSlotClockContextCancellation(t *testing.T) {
 	// Cancel context
 	cancel()
 
-	// Wait briefly for goroutine to exit
-	done := make(chan struct{})
-	go func() {
-		clock.wg.Wait()
-		close(done)
-	}()
+	clock.mu.RLock()
+	done := clock.done
+	clock.mu.RUnlock()
 
 	select {
 	case <-done:

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -485,6 +485,7 @@ func TestSlotClockContextCancellation(t *testing.T) {
 	clock := NewSlotClock(provider, DefaultSlotClockConfig())
 
 	ctx, cancel := context.WithCancel(context.Background())
+	existing := clock.Subscribe()
 	clock.Start(ctx)
 
 	// Cancel context
@@ -502,6 +503,36 @@ func TestSlotClockContextCancellation(t *testing.T) {
 		// Good, clock stopped
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("clock did not stop after context cancellation")
+	}
+
+	// A cancelled clock has stopped just as surely as one stopped explicitly:
+	// its existing subscriber and any later subscription must be closed.
+	_, ok := <-existing
+	assert.False(t, ok, "cancellation must close existing subscriptions")
+	_, ok = <-clock.Subscribe()
+	assert.False(t, ok, "cancellation must close later subscriptions")
+}
+
+func TestSlotClockSubscriptionAfterStopIsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		start bool
+	}{
+		{name: "before_start"},
+		{name: "after_start", start: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			systemStart := time.Now()
+			provider := newMockSlotTimeProvider(systemStart, time.Second, 100)
+			clock := NewSlotClock(provider, DefaultSlotClockConfig())
+			if tc.start {
+				clock.Start(t.Context())
+			}
+			clock.Stop()
+
+			_, ok := <-clock.Subscribe()
+			assert.False(t, ok, "subscriptions registered after Stop must be closed")
+		})
 	}
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -809,7 +809,7 @@ type LedgerState struct {
 	chainsyncState                     ChainsyncState
 	currentTipBlockNonce               []byte
 	epochCache                         []models.Epoch
-	epochNonceHexCache                 map[uint64]string
+	epochNonceHexCache                 map[uint64]epochNonceHexCacheEntry
 	checkpoints                        map[uint64]string // configured chain checkpoints keyed by block number (height)
 	slotsPerKESPeriod                  atomic.Uint64
 	forgedBlockChecker                 atomic.Pointer[forgedBlockCheckerHolder]
@@ -1161,7 +1161,7 @@ func NewLedgerState(cfg LedgerStateConfig) (*LedgerState, error) {
 		chainsyncState:     InitChainsyncState,
 		db:                 cfg.Database,
 		chain:              cfg.ChainManager.PrimaryChain(),
-		epochNonceHexCache: make(map[uint64]string),
+		epochNonceHexCache: make(map[uint64]epochNonceHexCacheEntry),
 		validationEnabled:  cfg.ValidateHistorical,
 		byronPBFT:          byronPBFT,
 	}

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1406,20 +1406,34 @@ func (ls *LedgerState) maxKESEvolutions() uint64 {
 	return uint64(shelleyGenesis.MaxKESEvolutions) // #nosec G115 -- guarded > 0
 }
 
+// epochNonceHexCacheEntry keeps the nonce that produced its hexadecimal form.
+// The nonce is copied at insertion because callers can reuse their backing
+// storage after verification returns.
+type epochNonceHexCacheEntry struct {
+	nonce []byte
+	hex   string
+}
+
 func (ls *LedgerState) epochNonceHex(epochId uint64, nonce []byte) string {
-	nonceHex := hex.EncodeToString(nonce)
 	ls.RLock()
 	cachedNonce, ok := ls.epochNonceHexCache[epochId]
 	ls.RUnlock()
-	if ok && cachedNonce == nonceHex {
-		return cachedNonce
+	if ok && bytes.Equal(cachedNonce.nonce, nonce) {
+		return cachedNonce.hex
 	}
 	ls.Lock()
 	defer ls.Unlock()
-	if ls.epochNonceHexCache == nil {
-		ls.epochNonceHexCache = make(map[uint64]string)
+	if cachedNonce, ok := ls.epochNonceHexCache[epochId]; ok && bytes.Equal(cachedNonce.nonce, nonce) {
+		return cachedNonce.hex
 	}
-	ls.epochNonceHexCache[epochId] = nonceHex
+	nonceHex := hex.EncodeToString(nonce)
+	if ls.epochNonceHexCache == nil {
+		ls.epochNonceHexCache = make(map[uint64]epochNonceHexCacheEntry)
+	}
+	ls.epochNonceHexCache[epochId] = epochNonceHexCacheEntry{
+		nonce: slices.Clone(nonce),
+		hex:   nonceHex,
+	}
 	return nonceHex
 }
 

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -68,6 +68,31 @@ func verifyBlockHeader(
 	)
 }
 
+func TestEpochNonceHexCachesMatchingRawNonce(t *testing.T) {
+	ls := &LedgerState{
+		epochNonceHexCache: make(map[uint64]epochNonceHexCacheEntry),
+	}
+	nonce := []byte{0x00, 0x11, 0x22, 0x33}
+
+	first := ls.epochNonceHex(42, nonce)
+	require.Equal(t, "00112233", first)
+
+	// A cached nonce must return without allocating another hexadecimal string.
+	var cached string
+	allocs := testing.AllocsPerRun(100, func() {
+		cached = ls.epochNonceHex(42, nonce)
+	})
+	require.Equal(t, first, cached)
+	require.Zero(t, allocs)
+
+	// The cache retains an independent nonce copy, so a reused caller buffer
+	// invalidates the old entry instead of returning stale text for this epoch.
+	nonce[0] = 0xff
+	second := ls.epochNonceHex(42, nonce)
+	require.Equal(t, "ff112233", second)
+	require.NotEqual(t, first, second)
+}
+
 // tamperOption controls which part of a test block to corrupt.
 type tamperOption int
 


### PR DESCRIPTION
Part of #3529.

- Cache epoch nonce text only after a raw-nonce match.
- Close slot-clock subscriptions when the clock stops or its context is cancelled.
- Keep overlapping slot-clock lifecycle generations independently stoppable.
