### PR TITLE
fix(node): serialize startup cleanup and shutdown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1128,6 +1128,13 @@ Phase 4: Cleanup resources
   Registered shutdown functions
 ```
 
+`Node.Run` holds a startup lifecycle gate from entry until startup either
+completes or has unwound its LIFO rollback stack. Normal shutdown takes the
+same gate before its phase-ordered teardown begins. A SIGINT/SIGTERM received
+while components are still starting can therefore cancel startup without
+letting `Node.Stop` concurrently close a partially initialized component; the
+normal shutdown waits until rollback has finished.
+
 The node creates one shutdown context from the configured `shutdownTimeout`
 and passes it through every phase. PeerGovernor shutdown cancels its internal
 run context, which interrupts ledger-peer DNS discovery and outbound work,

--- a/node.go
+++ b/node.go
@@ -104,19 +104,24 @@ type Node struct {
 	// ouroborosConfig retains the settings half of the config Run built, so a
 	// live restore can reconstruct ouroboros against rebuilt dependencies
 	// without recomputing them and drifting from Run.
-	ouroborosConfig                  ouroborosPkg.OuroborosConfig
-	blockForger                      *forging.BlockForger
-	leaderElection                   *leader.Election
-	rtsMetrics                       *rtsMetrics
-	shutdownFuncs                    []func(context.Context) error
-	deferredIndexMaintenanceDone     chan struct{}
-	config                           Config
-	ctx                              context.Context
-	cancel                           context.CancelFunc
-	fatalErrMu                       sync.Mutex
-	fatalErr                         error
-	shutdownOnce                     sync.Once
-	shutdownErr                      error
+	ouroborosConfig              ouroborosPkg.OuroborosConfig
+	blockForger                  *forging.BlockForger
+	leaderElection               *leader.Election
+	rtsMetrics                   *rtsMetrics
+	shutdownFuncs                []func(context.Context) error
+	deferredIndexMaintenanceDone chan struct{}
+	config                       Config
+	ctx                          context.Context
+	cancel                       context.CancelFunc
+	fatalErrMu                   sync.Mutex
+	fatalErr                     error
+	shutdownOnce                 sync.Once
+	shutdownErr                  error
+	// startupLifecycleMu keeps the startup rollback and normal shutdown from
+	// operating on the same partially initialized component concurrently. Run
+	// holds it until startup has either completed or unwound its LIFO cleanup;
+	// shutdown takes it before it begins its phase-ordered teardown.
+	startupLifecycleMu               sync.Mutex
 	chainsyncStallRecycler           *chainsyncrecycler.Recycler
 	chainsyncIngressEligibilityMu    sync.RWMutex
 	chainsyncIngressEligibilityCache map[ouroboros.ConnectionId]bool
@@ -443,6 +448,24 @@ var _ mempool.TxValidationSessionProvider = (*ledger.LedgerState)(nil)
 
 //nolint:contextcheck // Run is the lifecycle boundary and derives n.ctx from the caller context.
 func (n *Node) Run(ctx context.Context) (runErr error) {
+	// A signal can cancel ctx while this function is still constructing
+	// components. Hold the lifecycle gate until either the startup cleanup has
+	// finished or every component has started, so the command layer's Stop
+	// cannot tear down a component while the rollback is doing the same.
+	n.startupLifecycleMu.Lock()
+	startupGateHeld := true
+	var started []func()
+	defer func() {
+		if !startupGateHeld {
+			return
+		}
+		r := recover()
+		n.cleanupFailedStartup(started)
+		if r != nil {
+			panic(r)
+		}
+	}()
+
 	// Configure tracing
 	n.warnIfTracingMisconfigured()
 	if n.config.tracing {
@@ -462,7 +485,6 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 	go n.runRTSMetricsUpdater(n.ctx, rtsMetricsUpdateInterval)
 
 	// Track started components for cleanup on failure
-	var started []func()
 	stopPluginCapability := func(capability plugin.Capability) func() {
 		return func() {
 			if err := n.pluginHost.StopCapability(
@@ -479,29 +501,6 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 			}
 		}
 	}
-	success := false
-	defer func() {
-		r := recover()
-		if r != nil {
-			if n.cancel != nil {
-				n.cancel()
-			}
-			// Cleanup on panic, then re-panic
-			for _, s := range slices.Backward(started) {
-				s()
-			}
-			panic(r)
-		} else if !success {
-			if n.cancel != nil {
-				n.cancel()
-			}
-			// Cleanup on failure (non-panic)
-			for _, s := range slices.Backward(started) {
-				s()
-			}
-		}
-	}()
-
 	// Register eventBus cleanup (created in New(), has background goroutines).
 	// Close (not Stop): startup-failure cleanup is terminal, and Stop restarts
 	// the async-worker pool, leaking those goroutines.
@@ -1667,7 +1666,8 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 	}
 
 	// All components started successfully
-	success = true
+	n.startupLifecycleMu.Unlock()
+	startupGateHeld = false
 
 	// Only now -- every component above has actually started against
 	// n.config.dataDir -- is a pre-restore backup left over from an
@@ -1677,6 +1677,19 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 	n.removeConfirmedRestoreBackup()
 
 	return n.waitForShutdown()
+}
+
+// cleanupFailedStartup completes a failed startup while Run owns the startup
+// lifecycle gate. The gate is released only after every started component has
+// stopped, so shutdown cannot overlap the LIFO rollback on a startup signal.
+func (n *Node) cleanupFailedStartup(started []func()) {
+	defer n.startupLifecycleMu.Unlock()
+	if n.cancel != nil {
+		n.cancel()
+	}
+	for _, stop := range slices.Backward(started) {
+		stop()
+	}
 }
 
 // cancelForFatal records the first component failure before cancelling the

--- a/node_shutdown.go
+++ b/node_shutdown.go
@@ -87,6 +87,13 @@ func (n *Node) configuredShutdownTimeout() time.Duration {
 }
 
 func (n *Node) shutdown() error {
+	// Run holds this gate until startup has either completed or rolled back.
+	// In particular, a signal can reach Stop while Run is still unwinding a
+	// failed startup; waiting here keeps the phase-ordered shutdown from
+	// concurrently closing a component the startup stack is stopping.
+	n.startupLifecycleMu.Lock()
+	defer n.startupLifecycleMu.Unlock()
+
 	shutdownStart := time.Now()
 	shutdownTimeout := n.configuredShutdownTimeout()
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)

--- a/node_test.go
+++ b/node_test.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -353,6 +354,81 @@ func TestStopReturnsSameShutdownErrorAfterFirstCall(t *testing.T) {
 	require.ErrorIs(t, firstErr, wantErr)
 	require.ErrorIs(t, secondErr, wantErr)
 	require.Equal(t, firstErr, secondErr)
+}
+
+// TestStartupFailureCleanupCancelsBeforeAllowingShutdown verifies the
+// signal-during-startup lifecycle boundary. Run owns startupLifecycleMu while
+// it unwinds its LIFO stack; shutdown must wait for that rollback rather than
+// closing the same partially initialized resource concurrently.
+func TestStartupFailureCleanupCancelsBeforeAllowingShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rollbackStarted := make(chan struct{})
+	releaseRollback := make(chan struct{})
+	var releaseRollbackOnce sync.Once
+	release := func() { releaseRollbackOnce.Do(func() { close(releaseRollback) }) }
+	defer release()
+	rollbackDone := make(chan struct{})
+	shutdownFuncStarted := make(chan struct{})
+	shutdownDone := make(chan error, 1)
+
+	n := &Node{
+		config: Config{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		ctx:    ctx,
+		cancel: cancel,
+		shutdownFuncs: []func(context.Context) error{
+			func(context.Context) error {
+				close(shutdownFuncStarted)
+				return nil
+			},
+		},
+	}
+
+	// Match Run's startup section: cleanupFailedStartup owns the gate until
+	// every started component's rollback completes.
+	n.startupLifecycleMu.Lock()
+	go func() {
+		defer close(rollbackDone)
+		n.cleanupFailedStartup([]func(){func() {
+			close(rollbackStarted)
+			<-releaseRollback
+		}})
+	}()
+	testutil.RequireReceive(
+		t,
+		rollbackStarted,
+		time.Second,
+		"startup rollback to begin",
+	)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+
+	go func() {
+		shutdownDone <- n.shutdown()
+	}()
+	// If shutdown did not take the same gate, its phase-four callback would
+	// run while the startup rollback is intentionally blocked above.
+	testutil.RequireNoReceive(
+		t,
+		shutdownFuncStarted,
+		50*time.Millisecond,
+		"normal shutdown while startup rollback owns the lifecycle gate",
+	)
+
+	release()
+	testutil.RequireReceive(
+		t,
+		rollbackDone,
+		time.Second,
+		"startup rollback completion",
+	)
+	testutil.RequireReceive(
+		t,
+		shutdownFuncStarted,
+		time.Second,
+		"normal shutdown after startup rollback completion",
+	)
+	require.NoError(t, <-shutdownDone)
 }
 
 func TestShutdownClosesEventBusBeforeFinalCleanup(t *testing.T) {


### PR DESCRIPTION
Fixes #3529.

- Serialize startup rollback and normal shutdown.
- Cover signal cancellation while startup cleanup is in progress.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3529 by serializing startup rollback and normal shutdown so a SIGINT/SIGTERM during startup cannot tear down a partially initialized component twice.

- `Node.Run` now holds a lifecycle gate until startup completes or its LIFO cleanup finishes; `Node.Stop` waits on the same gate before beginning teardown.
- Adds a test covering signal cancellation while startup cleanup is in progress.

<sup>Written for commit 88ec2fef9bb68b92a531cc1db36aa407fe543bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

