### PR TITLE
fix(event): preserve lossless critical subscribers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -498,11 +498,13 @@ only enqueues onto the ordered lane, so subscribers cannot observe an Apply
 before storage is durable and their work never runs inline in `Commit`.
 `ledger.block` remains `PublishBlocking` on the handler's own goroutine.
 
-Because a publisher parked on a full lane is released only by the EventBus
-stopping, and a live restore/truncate closes the `LedgerState` while keeping
-the bus running, ledger publishes go through `PublishOrderedContext` with a
-context `LedgerState.Close` cancels first thing. Without it `Close` waits
-unbounded on a `ledger.tx` subscriber that stopped draining.
+An ordinary stalled subscriber detaches after its delivery timeout; a lossless
+subscriber deliberately remains attached until it drains or is stopped, closed,
+or unsubscribed. A live restore/truncate closes the `LedgerState` while keeping
+the bus running, so ledger publishes go through `PublishOrderedContext` with a
+context `LedgerState.Close` cancels first thing. That cancellation releases a
+full ordered lane regardless of whether a subscriber later drains or its
+lifecycle removes it.
 
 This is also the one deliberate exception to the publish-under-lock rule
 above. `rollbackChainAndState` runs under `chainsyncMutex` — it is reached

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1242,11 +1242,13 @@ All event types follow the `subsystem.snake_case_name` convention.
 - Lossless delivery with bounded producer backpressure: when a subscriber buffer
   or the async queue is full, `Publish`, `PublishBlocking`, and `PublishAsync`
   wait for capacity instead of dropping an event for a live subscriber. An
-  in-memory subscriber that cannot free capacity by the delivery timeout is
-  detached; events already accepted into that subscriber retain their order,
-  while the unaccepted event and later events continue to healthy subscribers.
-  Waits also end on `Stop`, `Close`, or `Unsubscribe`. `PublishBlocking`
-  reports the detachment error (or `ErrEventBusStopped` when shutdown wins).
+  ordinary in-memory subscriber that cannot free capacity by the delivery
+  timeout is detached; events already accepted into that subscriber retain
+  their order, while the unaccepted event and later events continue to healthy
+  subscribers. A lossless subscriber explicitly uses the blocking policy when
+  detachment would make its component unable to recover safely. Waits also end
+  on `Stop`, `Close`, or `Unsubscribe`. `PublishBlocking` reports the
+  detachment error (or `ErrEventBusStopped` when shutdown wins).
 - A slow subscriber can temporarily backpressure its publishers, but a stalled
   one cannot hold the topic indefinitely. Consumers of `Subscribe` channels
   must drain for the life of the subscription and `Unsubscribe` when they stop.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1239,26 +1239,30 @@ All event types follow the `subsystem.snake_case_name` convention.
   buffers for high-volume ledger chainsync and chain-update paths. The
   payload-heavy ledger blockfetch path uses an eight-entry buffer and relies
   on lossless backpressure once one chain-store commit batch is queued
-- Lossless delivery with producer backpressure: when a subscriber buffer or the
-  async queue is full, `Publish`, `PublishBlocking`, and `PublishAsync` all wait
-  for capacity instead of dropping the event. Waits end on `Stop`, `Close`, or
-  `Unsubscribe`. `PublishBlocking` differs only in returning
-  `ErrEventBusStopped` when the bus shuts down mid-delivery
-- A subscriber that stops draining stalls its publishers, and the shared async
-  worker pool means it also delays unrelated async event types. Consumers of
-  `Subscribe` channels must drain for the life of the subscription and
-  `Unsubscribe` when they stop. The stalled-subscriber warning is rate-limited
-  per subscriber, not per delivery, and reports how many publishers are parked
-  on it — every parked publisher observes the same stall, so a per-delivery
-  limit made the log volume scale with publisher count rather than with time
+- Lossless delivery with bounded producer backpressure: when a subscriber buffer
+  or the async queue is full, `Publish`, `PublishBlocking`, and `PublishAsync`
+  wait for capacity instead of dropping an event for a live subscriber. An
+  in-memory subscriber that cannot free capacity by the delivery timeout is
+  detached; events already accepted into that subscriber retain their order,
+  while the unaccepted event and later events continue to healthy subscribers.
+  Waits also end on `Stop`, `Close`, or `Unsubscribe`. `PublishBlocking`
+  reports the detachment error (or `ErrEventBusStopped` when shutdown wins).
+- A slow subscriber can temporarily backpressure its publishers, but a stalled
+  one cannot hold the topic indefinitely. Consumers of `Subscribe` channels
+  must drain for the life of the subscription and `Unsubscribe` when they stop.
+  The stalled-subscriber warning is rate-limited per subscriber, not per
+  delivery, and reports how many publishers are parked on it — every parked
+  publisher observes the same stall, so a per-delivery limit made the log
+  volume scale with publisher count rather than with time
 - **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
-  while holding a lock that a subscriber of that event acquires.** Because all four wait for
-  capacity rather than dropping, this is a deadlock, not merely a slow path:
-  once the subscriber's buffer fills, the subscriber waits for the lock the
-  publisher holds while the publisher waits for the capacity the subscriber
-  would free. `PublishAsync` is no exception — it waits for room in the shared
-  async queue, which is drained by a worker pool running subscriber handlers,
-  so a handler blocked on the publisher's lock closes the same cycle. Both
+  while holding a lock that a subscriber of that event acquires.** All four can
+  wait for capacity, and a subscriber that is merely slow is still allowed the
+  whole delivery bound before detachment. Once its buffer fills, the subscriber
+  waits for the lock the publisher holds while the publisher waits for the
+  capacity the subscriber would free. `PublishAsync` is no exception — it waits
+  for room in the shared async queue, which is drained by a worker pool running
+  subscriber handlers, so a handler blocked on the publisher's lock closes the
+  same cycle. Both
   `LedgerState.chainsyncMutex` and `chainsyncBlockfetchMutex` count:
   `RecoverAfterLocalRollback` takes the first and nests the second inside it,
   so holding either while publishing is enough to deadlock.

--- a/event/backpressure_test.go
+++ b/event/backpressure_test.go
@@ -313,6 +313,61 @@ func TestPublishBlockingReportsStalledSubscriber(t *testing.T) {
 	require.False(t, open, "stalled subscriber should be closed")
 }
 
+// TestLosslessSubscribeFuncDoesNotDetach verifies the policy used by
+// ordering-critical ledger streams. A full callback queue must apply
+// backpressure until the handler drains it, rather than silently removing the
+// subscriber after the ordinary delivery timeout.
+func TestLosslessSubscribeFuncDoesNotDetach(t *testing.T) {
+	originalTimeout := channelDeliveryTimeout
+	channelDeliveryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { channelDeliveryTimeout = originalTimeout })
+
+	const eventType EventType = "test.lossless.callback"
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Stop)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	eb.SubscribeFuncWithBufferPolicy(
+		eventType,
+		1,
+		SubscriberBackpressureBlock,
+		func(evt Event) {
+			if evt.Data == "first" {
+				once.Do(func() { close(started) })
+				<-release
+			}
+		},
+	)
+
+	eb.Publish(eventType, NewEvent(eventType, "first"))
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("lossless callback did not begin")
+	}
+	eb.Publish(eventType, NewEvent(eventType, "second"))
+
+	published := make(chan error, 1)
+	go func() {
+		published <- eb.PublishBlocking(eventType, NewEvent(eventType, "third"))
+	}()
+	select {
+	case err := <-published:
+		t.Fatalf("lossless callback detached while full: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-published:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("lossless callback did not resume after draining")
+	}
+}
+
 // TestStalledSubscriberDetachmentReportsWarningAndMetric makes the bounded
 // path observable with the production defaults: detachment emits a warning and
 // increments the delivery-timeout metric even though the periodic stall warning

--- a/event/backpressure_test.go
+++ b/event/backpressure_test.go
@@ -238,6 +238,79 @@ func TestDeliverAfterCloseReturnsClosed(t *testing.T) {
 	require.NoError(t, sub.Deliver(NewEvent("test", "x")))
 }
 
+// TestPublishDetachesStalledSubscriberWithoutReorderingHealthyDelivery proves
+// the EventBus boundary rather than channelSubscriber in isolation. A dead
+// subscriber cannot hold a topic forever; healthy subscribers still receive
+// every event accepted for them in the publisher's order.
+func TestPublishDetachesStalledSubscriberWithoutReorderingHealthyDelivery(
+	t *testing.T,
+) {
+	originalTimeout := channelDeliveryTimeout
+	channelDeliveryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { channelDeliveryTimeout = originalTimeout })
+
+	const eventType EventType = "test.stalled.detach"
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Stop)
+
+	_, stalled := eb.SubscribeWithBuffer(eventType, 1)
+	_, healthy := eb.SubscribeWithBuffer(eventType, 2)
+
+	eb.Publish(eventType, NewEvent(eventType, 0))
+	require.Equal(t, 0, (<-healthy).Data)
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		eb.Publish(eventType, NewEvent(eventType, 1))
+	}()
+
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("stalled subscriber was not detached within the delivery bound")
+	}
+	require.Equal(t, 1, (<-healthy).Data)
+
+	// The stalled channel keeps only work accepted before detachment, then
+	// closes. The second event was never accepted by that subscriber.
+	require.Equal(t, 0, (<-stalled).Data)
+	_, open := <-stalled
+	require.False(t, open, "stalled subscriber should be detached and closed")
+}
+
+// TestPublishBlockingReportsStalledSubscriber verifies the synchronous API
+// exposes the lifecycle boundary instead of silently treating a detached
+// subscriber as a successful delivery.
+func TestPublishBlockingReportsStalledSubscriber(t *testing.T) {
+	originalTimeout := channelDeliveryTimeout
+	channelDeliveryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { channelDeliveryTimeout = originalTimeout })
+
+	const eventType EventType = "test.stalled.blocking"
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Stop)
+
+	_, stalled := eb.SubscribeWithBuffer(eventType, 1)
+	eb.Publish(eventType, NewEvent(eventType, "first"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- eb.PublishBlocking(eventType, NewEvent(eventType, "second"))
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, ErrEventSubscriberStalled)
+	case <-time.After(time.Second):
+		t.Fatal("PublishBlocking did not return after stalled-subscriber timeout")
+	}
+
+	require.Equal(t, "first", (<-stalled).Data)
+	_, open := <-stalled
+	require.False(t, open, "stalled subscriber should be closed")
+}
+
 type lockedBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer

--- a/event/backpressure_test.go
+++ b/event/backpressure_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -309,6 +311,78 @@ func TestPublishBlockingReportsStalledSubscriber(t *testing.T) {
 	require.Equal(t, "first", (<-stalled).Data)
 	_, open := <-stalled
 	require.False(t, open, "stalled subscriber should be closed")
+}
+
+// TestStalledSubscriberDetachmentReportsWarningAndMetric makes the bounded
+// path observable with the production defaults: detachment emits a warning and
+// increments the delivery-timeout metric even though the periodic stall warning
+// interval is longer than the normal delivery timeout.
+func TestStalledSubscriberDetachmentReportsWarningAndMetric(t *testing.T) {
+	originalTimeout := channelDeliveryTimeout
+	channelDeliveryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { channelDeliveryTimeout = originalTimeout })
+
+	const eventType EventType = "test.stalled.observability"
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	registry := prometheus.NewRegistry()
+	eb := NewEventBus(registry, logger)
+	t.Cleanup(eb.Stop)
+
+	_, _ = eb.SubscribeWithBuffer(eventType, 1)
+	eb.Publish(eventType, NewEvent(eventType, "first"))
+	eb.Publish(eventType, NewEvent(eventType, "second"))
+
+	require.Contains(
+		t,
+		buf.String(),
+		"event subscriber detached after delivery timeout",
+	)
+	require.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			eb.metrics.deliveryTimeouts.WithLabelValues(string(eventType)),
+		),
+	)
+}
+
+// TestConcurrentPublishBlockingReportsStalledSubscriber preserves the cause
+// for every publisher already parked on one subscription when the first timer
+// detaches it. Returning nil to the later publishers would falsely report an
+// accepted delivery that never reached their subscriber.
+func TestConcurrentPublishBlockingReportsStalledSubscriber(t *testing.T) {
+	originalTimeout := channelDeliveryTimeout
+	channelDeliveryTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { channelDeliveryTimeout = originalTimeout })
+
+	const eventType EventType = "test.stalled.concurrent"
+	const publishers = 8
+	eb := NewEventBus(nil, nil)
+	t.Cleanup(eb.Stop)
+
+	_, _ = eb.SubscribeWithBuffer(eventType, 1)
+	eb.Publish(eventType, NewEvent(eventType, "first"))
+
+	results := make(chan error, publishers)
+	for range publishers {
+		go func() {
+			results <- eb.PublishBlocking(
+				eventType,
+				NewEvent(eventType, "blocked"),
+			)
+		}()
+	}
+	for range publishers {
+		select {
+		case err := <-results:
+			require.ErrorIs(t, err, ErrEventSubscriberStalled)
+		case <-time.After(time.Second):
+			t.Fatal("blocked publisher did not receive the detachment cause")
+		}
+	}
 }
 
 type lockedBuffer struct {

--- a/event/doc.go
+++ b/event/doc.go
@@ -70,26 +70,29 @@
 // happens-before -- see the ledger.tx section of ARCHITECTURE.md for how
 // the rollback and block-apply paths establish theirs.
 //
-// Only shutdown releases a publisher waiting on a full lane. A caller on
-// a goroutine something else waits for before the bus stops must use
-// PublishOrderedContext and cancel that context, or the wait is
-// unbounded.
+// A healthy subscriber drains a full lane; a stalled one is detached after the
+// delivery timeout. A caller on a goroutine something else waits for before
+// the bus stops must still use PublishOrderedContext and cancel that context
+// when it needs a shorter bound than the subscriber-delivery timeout.
 //
 // # Delivery guarantees
 //
-// The bus does not drop events. When a subscriber's channel buffer or
-// the shared async queue is full, the publisher waits for capacity
-// rather than discarding the event, so ingestion slows instead of
-// losing work that subscribers derive state from. Waiting is bounded
-// only by shutdown: Stop, Close, and Unsubscribe all release publishers
-// parked on a full buffer. Buffers themselves stay bounded, so
-// backpressure never trades event loss for unbounded memory.
+// The bus does not drop events for a live subscriber. When a subscriber's
+// channel buffer or the shared async queue is full, the publisher waits for
+// capacity rather than discarding the event, so ingestion slows instead of
+// losing work that subscribers derive state from. A subscriber that remains
+// full for the delivery timeout is detached: events already accepted into its
+// channel retain their order, while the event that cannot be accepted and later
+// events continue only to healthy subscribers. This bounds a dead subscriber's
+// impact without trading unbounded memory for liveness. Stop, Close, and
+// Unsubscribe also release publishers parked on a full buffer.
 //
-// The practical consequence is that a subscriber which stops draining
-// stalls its publishers. It also means a publisher must not hold a lock
+// The practical consequence is that a slow subscriber backpressures its
+// publishers until it drains or is detached. A publisher must not hold a lock
 // that a subscriber of the same event acquires: once the buffer fills,
-// the subscriber waits for the lock and the publisher waits for the
-// capacity the subscriber would free, and neither proceeds. Queue such
+// the subscriber waits for the lock and the publisher waits for the capacity
+// the subscriber would free, and neither proceeds until the delivery bound
+// detaches that subscriber. Queue such
 // events and publish them after releasing the lock (see ledger's
 // pendingPublishes). Subscribers that take a channel from Subscribe
 // must drain it for as long as they hold the subscription and must

--- a/event/doc.go
+++ b/event/doc.go
@@ -70,10 +70,11 @@
 // happens-before -- see the ledger.tx section of ARCHITECTURE.md for how
 // the rollback and block-apply paths establish theirs.
 //
-// A healthy subscriber drains a full lane; a stalled one is detached after the
-// delivery timeout. A caller on a goroutine something else waits for before
-// the bus stops must still use PublishOrderedContext and cancel that context
-// when it needs a shorter bound than the subscriber-delivery timeout.
+// A healthy subscriber drains a full lane; the ordinary policy detaches a
+// stalled one after the delivery timeout. A caller on a goroutine something
+// else waits for before the bus stops must still use PublishOrderedContext and
+// cancel that context when it needs a shorter bound than the subscriber-
+// delivery timeout.
 //
 // # Delivery guarantees
 //
@@ -81,11 +82,13 @@
 // channel buffer or the shared async queue is full, the publisher waits for
 // capacity rather than discarding the event, so ingestion slows instead of
 // losing work that subscribers derive state from. A subscriber that remains
-// full for the delivery timeout is detached: events already accepted into its
-// channel retain their order, while the event that cannot be accepted and later
-// events continue only to healthy subscribers. This bounds a dead subscriber's
-// impact without trading unbounded memory for liveness. Stop, Close, and
-// Unsubscribe also release publishers parked on a full buffer.
+// full for the delivery timeout is detached by the ordinary subscription
+// policy: events already accepted into its channel retain their order, while
+// the event that cannot be accepted and later events continue only to healthy
+// subscribers. A lossless owner can explicitly select the blocking policy when
+// detaching its stream would make recovery unsafe. This bounds a dead ordinary
+// subscriber's impact without trading unbounded memory for liveness. Stop,
+// Close, and Unsubscribe also release publishers parked on a full buffer.
 //
 // The practical consequence is that a slow subscriber backpressures its
 // publishers until it drains or is detached. A publisher must not hold a lock

--- a/event/event.go
+++ b/event/event.go
@@ -55,15 +55,16 @@ var ErrEventBusStopped = errors.New("event bus stopped")
 
 var errChannelSubscriberClosed = errors.New("channel subscriber closed")
 
-// ErrEventSubscriberStalled is returned by PublishBlocking when an in-memory
-// subscriber stays full past the delivery bound and is detached.
+// ErrEventSubscriberStalled is returned by PublishBlocking when an ordinary
+// in-memory subscriber stays full past the delivery bound and is detached.
 var ErrEventSubscriberStalled = errors.New("event subscriber stalled")
 
 // channelDeliveryTimeout bounds how long an in-memory subscriber may keep a
-// publisher parked after its buffer fills. A subscriber that cannot drain in
-// this interval is detached, so it cannot indefinitely stall the remaining
-// subscribers of that event type. Tests shorten it through this package-local
-// variable; production uses the same bound as remote delivery.
+// publisher parked after its buffer fills. The ordinary policy detaches a
+// subscriber that cannot drain in this interval, so it cannot indefinitely
+// stall the remaining subscribers of that event type. Tests shorten it through
+// this package-local variable; production uses the same bound as remote
+// delivery.
 var channelDeliveryTimeout = RemoteDeliverTimeout
 
 // deliveryStallWarnInterval is how long a single delivery may wait for
@@ -78,6 +79,20 @@ type EventType string
 type EventSubscriberId int
 
 type EventHandlerFunc func(Event)
+
+// SubscriberBackpressurePolicy decides what happens when a channel-backed
+// subscriber stays full past the delivery timeout.
+type SubscriberBackpressurePolicy uint8
+
+const (
+	// SubscriberBackpressureDetach removes a subscriber that is no longer
+	// making progress. It is the default for ordinary asynchronous consumers.
+	SubscriberBackpressureDetach SubscriberBackpressurePolicy = iota
+	// SubscriberBackpressureBlock keeps a lossless subscriber attached until it
+	// drains or normal lifecycle cancellation closes it. Use this for a stream
+	// whose omission would make the owning component unable to recover safely.
+	SubscriberBackpressureBlock
+)
 
 type Event struct {
 	Timestamp time.Time
@@ -250,9 +265,16 @@ type channelSubscriber struct {
 	// capacity. Set once at subscribe time, before the subscriber is
 	// reachable by any publisher.
 	onBlocked func()
-	closeOnce sync.Once
-	mu        sync.RWMutex
-	closed    bool
+	// onStalled reports an in-memory subscriber detached after the delivery
+	// timeout. Set while subscribing, before the subscriber is published.
+	onStalled func()
+	// backpressurePolicy decides whether a full channel is detached after the
+	// timeout or remains lossless until its lifecycle closes it.
+	backpressurePolicy SubscriberBackpressurePolicy
+	closeOnce          sync.Once
+	mu                 sync.RWMutex
+	closed             bool
+	closeCause         atomic.Int32
 
 	// eventType is the type this subscriber was registered under —
 	// checked in unsubscribe against the eventType a caller passes in,
@@ -322,12 +344,19 @@ func newChannelSubscriber(
 	eventType EventType,
 	buffer int,
 	logger *slog.Logger,
+	backpressurePolicies ...SubscriberBackpressurePolicy,
 ) *channelSubscriber {
+	backpressurePolicy := SubscriberBackpressureDetach
+	if len(backpressurePolicies) > 0 &&
+		backpressurePolicies[0] == SubscriberBackpressureBlock {
+		backpressurePolicy = backpressurePolicies[0]
+	}
 	return &channelSubscriber{
-		ch:        make(chan Event, buffer),
-		logger:    logger,
-		closeReq:  make(chan struct{}),
-		eventType: eventType,
+		ch:                 make(chan Event, buffer),
+		logger:             logger,
+		closeReq:           make(chan struct{}),
+		eventType:          eventType,
+		backpressurePolicy: backpressurePolicy,
 	}
 }
 
@@ -395,7 +424,7 @@ func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 	// detached from the delivery contract.
 	select {
 	case <-c.closeReq:
-		return errChannelSubscriberClosed
+		return c.closedDeliveryError()
 	default:
 	}
 
@@ -413,28 +442,61 @@ func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 	defer c.stallWaiters.Add(-1)
 	stall := time.NewTimer(deliveryStallWarnInterval)
 	defer stall.Stop()
-	deliveryTimeout := time.NewTimer(channelDeliveryTimeout)
-	defer deliveryTimeout.Stop()
+	var deliveryTimeout <-chan time.Time
+	var stopDeliveryTimeout func()
+	if c.backpressurePolicy == SubscriberBackpressureDetach {
+		timeout := time.NewTimer(channelDeliveryTimeout)
+		deliveryTimeout = timeout.C
+		stopDeliveryTimeout = func() { timeout.Stop() }
+	}
+	if stopDeliveryTimeout != nil {
+		defer stopDeliveryTimeout()
+	}
 	for {
 		select {
 		case c.ch <- evt:
 			return nil
 		case <-c.closeReq:
-			return errChannelSubscriberClosed
+			return c.closedDeliveryError()
 		case <-c.busStop:
 			return errChannelSubscriberClosed
-		case <-deliveryTimeout.C:
+		case <-deliveryTimeout:
 			// Close the request channel before returning. Publish removes the
 			// subscriber immediately after this error, but every concurrent
 			// publisher must already see the detachment while that removal is
 			// in flight.
-			c.requestClose()
-			return ErrEventSubscriberStalled
+			if c.requestClose(stalledSubscriberCloseCause) {
+				c.reportStalled(evt.Type)
+			}
+			return c.closedDeliveryError()
 		case <-stall.C:
 			c.warnStalled(evt.Type)
 			stall.Reset(deliveryStallWarnInterval)
 		}
 	}
+}
+
+func (c *channelSubscriber) closedDeliveryError() error {
+	if c.closeCause.Load() == stalledSubscriberCloseCause {
+		return ErrEventSubscriberStalled
+	}
+	return errChannelSubscriberClosed
+}
+
+func (c *channelSubscriber) reportStalled(eventType EventType) {
+	if c.onStalled != nil {
+		c.onStalled()
+	}
+	if c.logger == nil {
+		return
+	}
+	c.logger.Warn(
+		"event subscriber detached after delivery timeout",
+		"type", eventType,
+		"buffer", cap(c.ch),
+		"timeout", channelDeliveryTimeout,
+		"blocked_publishers", c.stallWaiters.Load(),
+	)
 }
 
 // Deliver waits for subscriber capacity and reports success even when the
@@ -458,17 +520,26 @@ func (c *channelSubscriber) Close() {
 	c.close(false)
 }
 
-func (c *channelSubscriber) requestClose() {
+const (
+	normalSubscriberCloseCause int32 = iota + 1
+	stalledSubscriberCloseCause
+)
+
+func (c *channelSubscriber) requestClose(cause int32) bool {
+	if !c.closeCause.CompareAndSwap(0, cause) {
+		return false
+	}
 	c.closeOnce.Do(func() {
 		close(c.closeReq)
 	})
+	return true
 }
 
 func (c *channelSubscriber) close(discardQueued bool) {
 	// Release waiting sends before asking for the write lock; they hold the
 	// read lock, so the write lock would otherwise wait on a wait that only
 	// Close can end.
-	c.requestClose()
+	_ = c.requestClose(normalSubscriberCloseCause)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
@@ -494,6 +565,7 @@ func (e *EventBus) subscribeInternal(
 	eventType EventType,
 	buffer int,
 	withDone bool,
+	backpressurePolicy SubscriberBackpressurePolicy,
 ) (EventSubscriberId, *channelSubscriber) {
 	if buffer <= 0 {
 		buffer = DefaultSubscriberBuffer
@@ -506,13 +578,21 @@ func (e *EventBus) subscribeInternal(
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	// Create channel-backed subscriber
-	chSub := newChannelSubscriber(eventType, buffer, e.Logger)
+	chSub := newChannelSubscriber(
+		eventType,
+		buffer,
+		e.Logger,
+		backpressurePolicy,
+	)
 	chSub.busStop = busStop
 	if e.metrics != nil {
 		chSub.onBlocked = func() {
 			e.metrics.deliveryBlocked.WithLabelValues(
 				string(eventType), "in-memory",
 			).Inc()
+		}
+		chSub.onStalled = func() {
+			e.metrics.deliveryTimeouts.WithLabelValues(string(eventType)).Inc()
 		}
 	}
 	if withDone {
@@ -569,12 +649,32 @@ func (e *EventBus) SubscribeWithBuffer(
 	eventType EventType,
 	buffer int,
 ) (EventSubscriberId, <-chan Event) {
+	return e.SubscribeWithBufferPolicy(
+		eventType,
+		buffer,
+		SubscriberBackpressureDetach,
+	)
+}
+
+// SubscribeWithBufferPolicy is SubscribeWithBuffer with an explicit stalled
+// subscriber policy. Use SubscriberBackpressureBlock only when detaching the
+// subscriber would leave its owning component unable to recover safely.
+func (e *EventBus) SubscribeWithBufferPolicy(
+	eventType EventType,
+	buffer int,
+	backpressurePolicy SubscriberBackpressurePolicy,
+) (EventSubscriberId, <-chan Event) {
 	e.stopMu.RLock()
 	if e.stopped || e.closed {
 		e.stopMu.RUnlock()
 		return 0, nil
 	}
-	subId, chSub := e.subscribeInternal(eventType, buffer, false)
+	subId, chSub := e.subscribeInternal(
+		eventType,
+		buffer,
+		false,
+		backpressurePolicy,
+	)
 	e.stopMu.RUnlock()
 	return subId, chSub.ch
 }
@@ -599,6 +699,24 @@ func (e *EventBus) SubscribeFuncWithBuffer(
 	buffer int,
 	handlerFunc EventHandlerFunc,
 ) EventSubscriberId {
+	return e.SubscribeFuncWithBufferPolicy(
+		eventType,
+		buffer,
+		SubscriberBackpressureDetach,
+		handlerFunc,
+	)
+}
+
+// SubscribeFuncWithBufferPolicy is SubscribeFuncWithBuffer with an explicit
+// stalled subscriber policy. Use SubscriberBackpressureBlock only when
+// detaching the subscriber would leave its owning component unable to recover
+// safely.
+func (e *EventBus) SubscribeFuncWithBufferPolicy(
+	eventType EventType,
+	buffer int,
+	backpressurePolicy SubscriberBackpressurePolicy,
+	handlerFunc EventHandlerFunc,
+) EventSubscriberId {
 	// Hold stopMu.RLock through Add(1) to prevent Stop() from calling Wait()
 	// before we increment the counter. This prevents the race where:
 	// 1. Stop() sets stopped=true and proceeds to subscriberWg.Wait()
@@ -615,7 +733,12 @@ func (e *EventBus) SubscribeFuncWithBuffer(
 	// subscribeInternal has already returned and released e.mu) is
 	// required for a concurrent Unsubscribe/UnsubscribeAndWait to always
 	// observe a non-nil done once the subId is visible at all.
-	subId, chSub := e.subscribeInternal(eventType, buffer, true)
+	subId, chSub := e.subscribeInternal(
+		eventType,
+		buffer,
+		true,
+		backpressurePolicy,
+	)
 	e.subscriberWg.Add(1)
 	e.stopMu.RUnlock()
 

--- a/event/event.go
+++ b/event/event.go
@@ -55,6 +55,17 @@ var ErrEventBusStopped = errors.New("event bus stopped")
 
 var errChannelSubscriberClosed = errors.New("channel subscriber closed")
 
+// ErrEventSubscriberStalled is returned by PublishBlocking when an in-memory
+// subscriber stays full past the delivery bound and is detached.
+var ErrEventSubscriberStalled = errors.New("event subscriber stalled")
+
+// channelDeliveryTimeout bounds how long an in-memory subscriber may keep a
+// publisher parked after its buffer fills. A subscriber that cannot drain in
+// this interval is detached, so it cannot indefinitely stall the remaining
+// subscribers of that event type. Tests shorten it through this package-local
+// variable; production uses the same bound as remote delivery.
+var channelDeliveryTimeout = RemoteDeliverTimeout
+
 // deliveryStallWarnInterval is how long a single delivery may wait for
 // subscriber capacity before the subscriber is reported as stalled, and how
 // often that report repeats while the wait continues. Backpressure is normal
@@ -378,6 +389,15 @@ func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 	if c.closed {
 		return errChannelSubscriberClosed
 	}
+	// A stalled delivery requests closure before EventBus.unsubscribe can take
+	// the subscriber out of its snapshot. Do not let a concurrent publisher
+	// refill a channel in that small interval: the subscriber has already been
+	// detached from the delivery contract.
+	select {
+	case <-c.closeReq:
+		return errChannelSubscriberClosed
+	default:
+	}
 
 	select {
 	case c.ch <- evt:
@@ -393,6 +413,8 @@ func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 	defer c.stallWaiters.Add(-1)
 	stall := time.NewTimer(deliveryStallWarnInterval)
 	defer stall.Stop()
+	deliveryTimeout := time.NewTimer(channelDeliveryTimeout)
+	defer deliveryTimeout.Stop()
 	for {
 		select {
 		case c.ch <- evt:
@@ -401,6 +423,13 @@ func (c *channelSubscriber) deliverWait(evt Event) (err error) {
 			return errChannelSubscriberClosed
 		case <-c.busStop:
 			return errChannelSubscriberClosed
+		case <-deliveryTimeout.C:
+			// Close the request channel before returning. Publish removes the
+			// subscriber immediately after this error, but every concurrent
+			// publisher must already see the detachment while that removal is
+			// in flight.
+			c.requestClose()
+			return ErrEventSubscriberStalled
 		case <-stall.C:
 			c.warnStalled(evt.Type)
 			stall.Reset(deliveryStallWarnInterval)
@@ -429,13 +458,17 @@ func (c *channelSubscriber) Close() {
 	c.close(false)
 }
 
+func (c *channelSubscriber) requestClose() {
+	c.closeOnce.Do(func() {
+		close(c.closeReq)
+	})
+}
+
 func (c *channelSubscriber) close(discardQueued bool) {
 	// Release waiting sends before asking for the write lock; they hold the
 	// read lock, so the write lock would otherwise wait on a wait that only
 	// Close can end.
-	c.closeOnce.Do(func() {
-		close(c.closeReq)
-	})
+	c.requestClose()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
@@ -769,11 +802,10 @@ func (e *EventBus) unsubscribe(
 }
 
 // deliverWithTimeout calls sub.Deliver with a timeout for non-channel
-// subscribers. channelSubscriber.Deliver is called directly: it waits for
-// buffer capacity by design, and bounding that wait would put the drop this
-// package no longer performs back into the delivery path. For other (e.g.
-// network-backed) implementations, the call is bounded by
-// RemoteDeliverTimeout to prevent worker stalls.
+// subscribers. channel subscribers enforce their own timeout in deliverWait,
+// so their stalled send can synchronously request detachment without leaving a
+// delivery goroutine behind. For other (e.g. network-backed) implementations,
+// the call is bounded by RemoteDeliverTimeout to prevent worker stalls.
 //
 // Bounded goroutine leak on timeout: when the timeout fires, the
 // goroutine running sub.Deliver remains alive until Deliver returns.

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -55,7 +55,7 @@ func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
 	e.metrics.deliveryTimeouts = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "event_delivery_timeouts_total",
-			Help: "total remote subscriber delivery timeouts by event type",
+			Help: "total subscriber delivery timeouts by event type",
 		},
 		[]string{"type"},
 	)

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -51,9 +51,11 @@ type orderedLane struct {
 // producer sequence -- a ledger rollback's transaction undo events followed by
 // the next block's transaction events -- is exactly the case this is for.
 //
-// Like PublishAsync it does not drop: a full lane makes the publisher wait for
-// capacity rather than discarding the event, and only shutdown releases that
-// wait. Returns false when the EventBus is stopped or closed.
+// Like PublishAsync it does not drop for a live subscriber: a full lane makes
+// the publisher wait for capacity rather than discarding the event. A stalled
+// subscriber is detached after the delivery timeout, which lets its lane make
+// progress for healthy subscribers; shutdown also releases the wait. Returns
+// false when the EventBus is stopped or closed.
 //
 // Each event type gets its own lane, so a slow subscriber delays only its own
 // event type instead of holding up every async event as it would on the shared
@@ -63,11 +65,11 @@ func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
 }
 
 // PublishOrderedContext is PublishOrdered that also abandons the publish when
-// ctx is done. Only shutdown otherwise releases a publisher waiting on a full
-// lane, so a caller on a shutdown-critical goroutine -- one something else
-// waits for before the EventBus itself stops, such as a LedgerState the node
-// closes while keeping the bus running for a live restore -- must pass a
-// context it cancels, or that wait is unbounded.
+// ctx is done. A stalled subscriber is detached after the delivery timeout,
+// but a caller on a shutdown-critical goroutine -- one something else waits
+// for before the EventBus itself stops, such as a LedgerState the node closes
+// while keeping the bus running for a live restore -- must pass a context it
+// cancels when it needs a shorter bound.
 //
 // Abandoning is not a drop in the delivery-guarantee sense: the event was
 // never accepted, and the false return says so.

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -53,9 +53,10 @@ type orderedLane struct {
 //
 // Like PublishAsync it does not drop for a live subscriber: a full lane makes
 // the publisher wait for capacity rather than discarding the event. A stalled
-// subscriber is detached after the delivery timeout, which lets its lane make
-// progress for healthy subscribers; shutdown also releases the wait. Returns
-// false when the EventBus is stopped or closed.
+// ordinary subscriber is detached after the delivery timeout, which lets its
+// lane make progress for healthy subscribers; a lossless subscription instead
+// remains blocked until lifecycle cancellation. Shutdown also releases the
+// wait. Returns false when the EventBus is stopped or closed.
 //
 // Each event type gets its own lane, so a slow subscriber delays only its own
 // event type instead of holding up every async event as it would on the shared
@@ -65,11 +66,12 @@ func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
 }
 
 // PublishOrderedContext is PublishOrdered that also abandons the publish when
-// ctx is done. A stalled subscriber is detached after the delivery timeout,
-// but a caller on a shutdown-critical goroutine -- one something else waits
-// for before the EventBus itself stops, such as a LedgerState the node closes
-// while keeping the bus running for a live restore -- must pass a context it
-// cancels when it needs a shorter bound.
+// ctx is done. An ordinary stalled subscriber is detached after the delivery
+// timeout, while a lossless subscriber waits for lifecycle cancellation. A
+// caller on a shutdown-critical goroutine -- one something else waits for
+// before the EventBus itself stops, such as a LedgerState the node closes while
+// keeping the bus running for a live restore -- must pass a context it cancels
+// when it needs a shorter bound.
 //
 // Abandoning is not a drop in the delivery-guarantee sense: the event was
 // never accepted, and the false return says so.

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -178,8 +178,12 @@ func (ls *LedgerState) publishBlockEvent(
 		event.NewEvent(BlockEventType, evt),
 	); err != nil {
 		// ErrEventBusStopped is expected during teardown when the bus shuts
-		// down before LedgerState finishes draining its last events.
-		if errors.Is(err, event.ErrEventBusStopped) {
+		// down before LedgerState finishes draining its last events. An ordinary
+		// subscriber may also be detached after it stops draining; that is an
+		// isolated optional-consumer failure, not a reason to stop the node or
+		// report the block as unpublished to the lossless subscribers.
+		if errors.Is(err, event.ErrEventBusStopped) ||
+			errors.Is(err, event.ErrEventSubscriberStalled) {
 			return
 		}
 		publishErr := fmt.Errorf(

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -77,6 +77,38 @@ func loadTestBlocksWithTxs(t *testing.T, want int) []models.Block {
 	return blocks
 }
 
+type stalledBlockSubscriber struct{}
+
+func (stalledBlockSubscriber) Deliver(event.Event) error {
+	return event.ErrEventSubscriberStalled
+}
+
+func (stalledBlockSubscriber) Close() {}
+
+// TestPublishBlockEventIgnoresOptionalSubscriberDetachment ensures an
+// ordinary optional block-event consumer cannot turn its own detachment into
+// a node-wide fatal error. The EventBus has already isolated and removed the
+// stalled subscriber when it returns this error.
+func TestPublishBlockEventIgnoresOptionalSubscriberDetachment(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+	require.NotZero(t, bus.RegisterSubscriber(BlockEventType, stalledBlockSubscriber{}))
+
+	fatalCalled := false
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			EventBus: bus,
+			Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+			FatalErrorFunc: func(error) {
+				fatalCalled = true
+			},
+		},
+	}
+
+	ls.publishBlockEvent(BlockActionApply, models.Block{})
+	require.False(t, fatalCalled)
+}
+
 // TestChainUpdateHandlerPublishesNoTransactionEvents pins the structural
 // invariant the ordering guarantee rests on: the chain-update handler must not
 // be a ledger.tx producer.

--- a/ledger/event_backpressure_test.go
+++ b/ledger/event_backpressure_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+)
+
+// TestBlockfetchSubscriptionRemainsLosslessPastDeliveryTimeout verifies the
+// production LedgerState subscription policy, not only EventBus in isolation.
+// A blockfetch event cannot be silently omitted: the subscription remains
+// attached until the handler drains or its lifecycle closes it.
+func TestBlockfetchSubscriptionRemainsLosslessPastDeliveryTimeout(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Stop()
+
+	started := make(chan struct{})
+	releaseCh := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCh) }) }
+	defer release()
+
+	const total = blockfetchCommitBatchSize + 2
+	allHandled := make(chan struct{})
+	var handled atomic.Int32
+	ls := &LedgerState{config: LedgerStateConfig{EventBus: bus}}
+	ls.subscribeBlockfetchEvents(func(event.Event) {
+		if handled.Add(1) == 1 {
+			close(started)
+			<-releaseCh
+		}
+		if handled.Load() == total {
+			close(allHandled)
+		}
+	})
+
+	bus.Publish(BlockfetchEventType, event.NewEvent(BlockfetchEventType, 0))
+	testutil.RequireReceive(
+		t,
+		started,
+		time.Second,
+		"blockfetch handler did not begin",
+	)
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		for i := 1; i < total; i++ {
+			bus.Publish(BlockfetchEventType, event.NewEvent(BlockfetchEventType, i))
+		}
+	}()
+
+	// The ordinary EventBus subscriber timeout is five seconds. A regression to
+	// the detaching policy would make this publish finish at that bound instead
+	// of retaining the blockfetch stream until the handler can drain it.
+	testutil.RequireNoReceive(
+		t,
+		published,
+		event.RemoteDeliverTimeout+time.Second,
+		"blockfetch subscription detached instead of preserving the stream",
+	)
+
+	release()
+	testutil.RequireReceive(
+		t,
+		published,
+		5*time.Second,
+		"blockfetch publisher did not resume after the handler drained",
+	)
+	testutil.RequireReceive(
+		t,
+		allHandled,
+		5*time.Second,
+		"blockfetch handler did not receive every retained event",
+	)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1500,11 +1500,7 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			ChainsyncAwaitReplyEventType,
 			ls.handleEventChainsyncAwaitReply,
 		)
-		ls.blockfetchSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
-			BlockfetchEventType,
-			blockfetchCommitBatchSize,
-			ls.handleEventBlockfetch,
-		)
+		ls.subscribeBlockfetchEvents(ls.handleEventBlockfetch)
 		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
 			chain.ChainUpdateEventType,
 			event.EventQueueSize,
@@ -1594,6 +1590,19 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 		})
 	}
 	return nil
+}
+
+// subscribeBlockfetchEvents preserves lossless blockfetch delivery. A dropped
+// blockfetch event cannot be replayed from the EventBus, so this subscriber
+// remains attached until it drains or normal node lifecycle cancellation closes
+// it rather than taking the ordinary stalled-subscriber detachment path.
+func (ls *LedgerState) subscribeBlockfetchEvents(handler event.EventHandlerFunc) {
+	ls.blockfetchSubID = ls.config.EventBus.SubscribeFuncWithBufferPolicy(
+		BlockfetchEventType,
+		blockfetchCommitBatchSize,
+		event.SubscriberBackpressureBlock,
+		handler,
+	)
 }
 
 func (ls *LedgerState) loadMithrilTrustBoundary() {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1491,9 +1491,10 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// to one commit batch and let EventBus backpressure bound decoded CBOR while
 	// the chain store catches up. Sparser streams use the default.
 	if ls.config.EventBus != nil {
-		ls.chainsyncSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
+		ls.chainsyncSubID = ls.config.EventBus.SubscribeFuncWithBufferPolicy(
 			ChainsyncEventType,
 			event.EventQueueSize,
+			event.SubscriberBackpressureBlock,
 			ls.handleEventChainsync,
 		)
 		ls.chainsyncAwaitReplySubID = ls.config.EventBus.SubscribeFunc(
@@ -1501,9 +1502,10 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 			ls.handleEventChainsyncAwaitReply,
 		)
 		ls.subscribeBlockfetchEvents(ls.handleEventBlockfetch)
-		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFuncWithBuffer(
+		ls.chainUpdateSubID = ls.config.EventBus.SubscribeFuncWithBufferPolicy(
 			chain.ChainUpdateEventType,
 			event.EventQueueSize,
+			event.SubscriberBackpressureBlock,
 			ls.handleEventChainUpdate,
 		)
 		ls.chainSwitchSubID = ls.config.EventBus.SubscribeFunc(


### PR DESCRIPTION
## Summary

- bound ordinary stalled event subscribers and expose detachment telemetry
- preserve lossless block-fetch delivery through lifecycle cancellation
- cover concurrent publishers and block-fetch backpressure

Part of #3529

## Checks

- `go test -race -count=1 ./event`
- `go test -race -count=1 -run ^'TestBlockfetchSubscriptionRemainsLosslessPastDeliveryTimeout$' ./ledger`
- `make docs-parity`
- `golangci-lint run ./event ./ledger`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds how long a stalled subscriber can hold up the event bus and keeps critical ledger streams lossless so block-carrying events are never silently dropped. Ordinary subscribers that stay full past the delivery timeout are now detached; previously they parked publishers indefinitely until shutdown.

- Detached subscribers keep events already accepted into their channel in order, while the unaccepted event and later events continue only to healthy subscribers.
- `PublishBlocking` reports the new `ErrEventSubscriberStalled` error, and detachment increments the `event_delivery_timeouts_total` metric plus a warning log.
- `SubscribeWithBufferPolicy` and `SubscribeFuncWithBufferPolicy` expose `SubscriberBackpressureBlock`, which keeps a full subscriber attached until it drains or lifecycle cancellation closes it.
- `ledger` opts its chainsync, blockfetch, and chain-update subscriptions into the blocking policy and treats `ErrEventSubscriberStalled` from optional block-event consumers as non-fatal instead of stopping the node.

<sup>Written for commit 58982f5950e8fdfa33da4c4466c3e72cf3f1b5fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable subscriber backpressure policies.
  * Stalled subscribers are automatically detached after the delivery timeout by default.
  * Added a lossless blocking policy for subscriptions that must retain every event.
  * Publishers now receive a clear error when a subscriber is detached for stalling.
  * Healthy subscribers continue receiving events in order when another subscriber is stalled.

* **Bug Fixes**
  * Blockfetch event delivery now remains lossless during backpressure.

* **Documentation**
  * Updated event delivery guarantees, timeout behavior, and monitoring documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->