### PR TITLE
fix(chainsync): synchronize server client-state snapshots

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -334,8 +334,9 @@ func (s *State) AddClient(
 	return s.clients[connId], nil
 }
 
-// LookupClient returns the registered server-side (N2C) chainsync client
-// state for a connection, or false if no client is registered for it.
+// LookupClient returns a snapshot of the registered server-side (N2C)
+// chainsync client state for a connection, or false if no client is registered
+// for it.
 //
 // Unlike AddClient, this is a pure read: it never registers a client as a
 // side effect of being asked about one. Callers that need to assert whether
@@ -350,7 +351,9 @@ func (s *State) LookupClient(
 	if !ok || clientState == nil {
 		return nil, false
 	}
-	return clientState, true
+	clientStateSnapshot := *clientState
+	clientStateSnapshot.Cursor.Hash = cloneBytes(clientState.Cursor.Hash)
+	return &clientStateSnapshot, true
 }
 
 // RemoveClient unregisters a server-side (N2C) chainsync

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -98,6 +98,34 @@ type ChainsyncClientState struct {
 	ChainIter            *chain.ChainIterator
 	Cursor               ocommon.Point
 	NeedsInitialRollback bool
+	// mu guards NeedsInitialRollback so chainsyncServerRequestNext's
+	// read-send-clear sequence and LookupClient's snapshot read never
+	// observe a torn value. It is scoped to this one client rather than
+	// State's map-wide lock so a slow send to one peer cannot stall
+	// AddClient/LookupClient/RemoveClient for every other connection.
+	mu sync.Mutex
+}
+
+// LockRollbackState and UnlockRollbackState serialize access to
+// NeedsInitialRollback for this client. Callers outside this package (the
+// chainsync server's request-next handler) use these instead of reaching
+// into an unexported field.
+func (cs *ChainsyncClientState) LockRollbackState() {
+	cs.mu.Lock()
+}
+
+func (cs *ChainsyncClientState) UnlockRollbackState() {
+	cs.mu.Unlock()
+}
+
+// ChainsyncClientStateSnapshot is an immutable, point-in-time copy of a
+// registered server-side chainsync client's mutable state. It intentionally
+// omits ChainIter: callers only need Cursor and NeedsInitialRollback, and
+// exposing the shared iterator would let a caller cancel or advance the
+// live client's iterator through what looks like a read-only value.
+type ChainsyncClientStateSnapshot struct {
+	Cursor               ocommon.Point
+	NeedsInitialRollback bool
 }
 
 // TrackedClient holds per-connection state for a tracked
@@ -335,8 +363,8 @@ func (s *State) AddClient(
 }
 
 // LookupClient returns a snapshot of the registered server-side (N2C)
-// chainsync client state for a connection, or false if no client is registered
-// for it.
+// chainsync client state for a connection, or false if no client is
+// registered for it.
 //
 // Unlike AddClient, this is a pure read: it never registers a client as a
 // side effect of being asked about one. Callers that need to assert whether
@@ -344,16 +372,25 @@ func (s *State) AddClient(
 // the question cannot create its own answer.
 func (s *State) LookupClient(
 	connId connection.ConnectionId,
-) (*ChainsyncClientState, bool) {
+) (*ChainsyncClientStateSnapshot, bool) {
 	s.Lock()
-	defer s.Unlock()
 	clientState, ok := s.clients[connId]
+	s.Unlock()
 	if !ok || clientState == nil {
 		return nil, false
 	}
-	clientStateSnapshot := *clientState
-	clientStateSnapshot.Cursor.Hash = cloneBytes(clientState.Cursor.Hash)
-	return &clientStateSnapshot, true
+	// clientState's mutable fields are guarded by its own lock, not
+	// State's, so this only serializes against chainsyncServerRequestNext
+	// for this one connection instead of blocking every other connection's
+	// AddClient/LookupClient/RemoveClient.
+	clientState.LockRollbackState()
+	defer clientState.UnlockRollbackState()
+	cursor := clientState.Cursor
+	cursor.Hash = cloneBytes(clientState.Cursor.Hash)
+	return &ChainsyncClientStateSnapshot{
+		Cursor:               cursor,
+		NeedsInitialRollback: clientState.NeedsInitialRollback,
+	}, true
 }
 
 // RemoveClient unregisters a server-side (N2C) chainsync

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1474,6 +1474,40 @@ func (m *mockChainProvider) StabilityWindow() uint64 {
 	return m.stabilityWin
 }
 
+// TestLookupClientReturnsSnapshot guards against the race fixed in issue
+// 3267: a caller could take the pointer LookupClient returned and read its
+// fields later while the server goroutine mutated the same live
+// ChainsyncClientState (e.g. clearing NeedsInitialRollback), so the read and
+// the write were unsynchronized.
+//
+// It registers a client, takes a snapshot via LookupClient, then mutates the
+// real client state returned by AddClient (flipping NeedsInitialRollback and
+// overwriting a byte of the cursor hash). The snapshot must still show the
+// pre-mutation values, proving LookupClient copied the data — including a
+// deep copy of the Cursor.Hash byte slice — rather than handing back a
+// pointer an observer could see change underneath it.
+func TestLookupClientReturnsSnapshot(t *testing.T) {
+	provider := &mockChainProvider{}
+	s := chainsync.NewStateWithConfig(nil, provider, chainsync.DefaultConfig())
+	conn := newTestConnId(1)
+	point := ocommon.NewPoint(1, []byte{0x01})
+	clientState, err := s.AddClient(conn, point)
+	require.NoError(t, err)
+
+	// Snapshot must be taken before the mutation below to prove it isn't
+	// affected by changes made to the live state afterward.
+	snapshot, ok := s.LookupClient(conn)
+	require.True(t, ok)
+
+	// Mutate the live client state the same way the server does in
+	// production (clearing NeedsInitialRollback) plus a cursor byte, to
+	// confirm neither field aliases the snapshot.
+	clientState.NeedsInitialRollback = false
+	clientState.Cursor.Hash[0] = 0x02
+	require.True(t, snapshot.NeedsInitialRollback)
+	require.Equal(t, []byte{0x01}, snapshot.Cursor.Hash)
+}
+
 // TestAddClient_NilChainProvider_ReturnsError verifies that AddClient returns
 // an error rather than panicking when no ChainProvider has been wired.
 func TestAddClient_NilChainProvider_ReturnsError(t *testing.T) {

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1508,6 +1508,44 @@ func TestLookupClientReturnsSnapshot(t *testing.T) {
 	require.Equal(t, []byte{0x01}, snapshot.Cursor.Hash)
 }
 
+// TestLookupClientPerClientLockDoesNotBlockOtherClients guards against a
+// second issue found in review of the 3267 fix: an earlier version of the
+// rollback-state lock reused chainsync.State's map-wide mutex, so a slow
+// RollBackward send on one connection (chainsyncServerRequestNext holds the
+// lock across that send) would stall LookupClient and RemoveClient for every
+// other connection too.
+//
+// It locks one client's rollback state to simulate a send in flight, then
+// proves LookupClient and RemoveClient on a different client complete almost
+// immediately rather than waiting on that lock.
+func TestLookupClientPerClientLockDoesNotBlockOtherClients(t *testing.T) {
+	provider := &mockChainProvider{}
+	s := chainsync.NewStateWithConfig(nil, provider, chainsync.DefaultConfig())
+	slowConn := newTestConnId(1)
+	otherConn := newTestConnId(2)
+	slowClient, err := s.AddClient(slowConn, ocommon.NewPoint(1, []byte{0x01}))
+	require.NoError(t, err)
+	_, err = s.AddClient(otherConn, ocommon.NewPoint(2, []byte{0x02}))
+	require.NoError(t, err)
+
+	slowClient.LockRollbackState()
+	defer slowClient.UnlockRollbackState()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, ok := s.LookupClient(otherConn)
+		require.True(t, ok)
+		s.RemoveClient(otherConn)
+	}()
+	testutil.RequireReceive(
+		t,
+		done,
+		200*time.Millisecond,
+		"LookupClient/RemoveClient for another connection must not wait on a different client's rollback lock",
+	)
+}
+
 // TestAddClient_NilChainProvider_ReturnsError verifies that AddClient returns
 // an error rather than panicking when no ChainProvider has been wired.
 func TestAddClient_NilChainProvider_ReturnsError(t *testing.T) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -678,10 +678,13 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 			err,
 		)
 	}
-	// LookupClient snapshots this state under the same lock. Keep the lock
-	// through the send and state transition so observers cannot read the
-	// pending flag after RollBackward is visible but before it is cleared.
-	o.chainsyncState.Lock()
+	// LookupClient snapshots this same field under clientState's own lock,
+	// scoped to this one connection rather than the whole chainsync State,
+	// so a slow RollBackward send here cannot stall AddClient/LookupClient/
+	// RemoveClient for other connections. Held through the send and state
+	// transition so observers cannot read the pending flag after
+	// RollBackward is visible but before it is cleared.
+	clientState.LockRollbackState()
 	if clientState.NeedsInitialRollback {
 		o.config.Logger.Debug(
 			"chainsync server: initial rollback",
@@ -693,14 +696,14 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 			tip,
 		)
 		if err != nil {
-			o.chainsyncState.Unlock()
+			clientState.UnlockRollbackState()
 			return err
 		}
 		clientState.NeedsInitialRollback = false
-		o.chainsyncState.Unlock()
+		clientState.UnlockRollbackState()
 		return nil
 	}
-	o.chainsyncState.Unlock()
+	clientState.UnlockRollbackState()
 	// Check for available block
 	next, err := clientState.ChainIter.Next(false)
 	if err != nil {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -678,6 +678,10 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 			err,
 		)
 	}
+	// LookupClient snapshots this state under the same lock. Keep the lock
+	// through the send and state transition so observers cannot read the
+	// pending flag after RollBackward is visible but before it is cleared.
+	o.chainsyncState.Lock()
 	if clientState.NeedsInitialRollback {
 		o.config.Logger.Debug(
 			"chainsync server: initial rollback",
@@ -689,11 +693,14 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 			tip,
 		)
 		if err != nil {
+			o.chainsyncState.Unlock()
 			return err
 		}
 		clientState.NeedsInitialRollback = false
+		o.chainsyncState.Unlock()
 		return nil
 	}
+	o.chainsyncState.Unlock()
 	// Check for available block
 	next, err := clientState.ChainIter.Next(false)
 	if err != nil {

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -269,7 +269,7 @@ func (f *chainsyncServerFixture) setTip(
 // state being asserted on.
 func (f *chainsyncServerFixture) registeredClient(
 	t *testing.T,
-) (*dchainsync.ChainsyncClientState, bool) {
+) (*dchainsync.ChainsyncClientStateSnapshot, bool) {
 	t.Helper()
 	connId, ok := f.observedConnId()
 	if !ok {


### PR DESCRIPTION
## Summary

Fixes #3267. `LookupClient` returned a live pointer into the registered-client
map, so a caller reading its fields after the lock was released could race
against `chainsyncServerRequestNext` mutating `NeedsInitialRollback` on the
same object. `LookupClient` now returns a locked snapshot, and the server
holds the same lock for the full read-modify-clear sequence.

## Changes

- `chainsync/chainsync.go`: `LookupClient` copies the `ChainsyncClientState`
  under the existing lock and deep-copies `Cursor.Hash` before returning it,
  instead of returning a pointer into `s.clients`.
- `ouroboros/chainsync.go`: `chainsyncServerRequestNext` holds
  `o.chainsyncState.Lock()` across the `RollBackward` send and the
  `NeedsInitialRollback = false` clear, so the write is synchronized with
  `LookupClient` reads under the same lock.
- `chainsync/chainsync_test.go`: adds `TestLookupClientReturnsSnapshot`,
  which mutates the live client state after taking a snapshot and asserts
  the snapshot is unaffected.

No changes were needed in `ouroboros/chainsync_server_fixture_test.go`; its
assertions already read through `LookupClient` and inherit the fix.

## Testing

- `go build ./...`
- `go test ./ouroboros/... -run TestChainsyncServerRequestNextEmitsInitialRollbackToIntersect -race -count=20` (20/20 pass)
- `go test ./chainsync/... ./ouroboros/... -race`
- `go test ./chainsync/... -run TestLookupClientReturnsSnapshot -race`
- `golangci-lint run ./chainsync/... ./ouroboros/...` — 0 issues
- `nilaway ./chainsync/... ./ouroboros/...` — clean
- `go vet ./chainsync/... ./ouroboros/...`
- `modernize ./chainsync/... ./ouroboros/...` — 1 pre-existing, unrelated hit in `ouroboros/txsubmission.go` (not touched by this change)
- `make golines`, `make import-boundaries` — no drift / pass

Skipped: `make docs-parity` fails identically on unmodified `main` in this
environment (an untracked-file discovery test dependent on this machine's
global git-excludes config) — unrelated to this change. No `DATABASE.md` or
`ARCHITECTURE.md` update is needed; this is an internal locking fix with no
schema, API, or component-boundary impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in chainsync server client-state handling: `LookupClient` returned a live pointer, so a caller could read `NeedsInitialRollback` while the server mutated it. `LookupClient` now returns an immutable snapshot (deep-copying `Cursor.Hash`, omitting `ChainIter`), and `chainsyncServerRequestNext` holds a per-client lock across the `RollBackward` send and flag clear so a slow send can't stall other connections' `AddClient`/`LookupClient`/`RemoveClient`.

- Adds `TestLookupClientReturnsSnapshot` and `TestLookupClientPerClientLockDoesNotBlockOtherClients`.
- Race tests pass with `-race`; no migration or rollout steps required.

<sup>Written for commit d162eb28031d706fae59a0b4af9c4875a14069eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client state lookups by returning independent snapshots, preventing accidental changes to registered state.
  - Ensured cursor data is safely copied when retrieving client information.
  - Improved synchronization during rollback handling so state updates appear consistently to observers.
- **Tests**
  - Added coverage confirming snapshots remain unchanged after the underlying client state is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->