### PR TITLE
test: ignore agent worktree artifacts

### DIFF
--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -117,7 +117,7 @@ func filesMatching(
 		if rel == "" {
 			continue
 		}
-		rel = filepath.FromSlash(rel)
+		rel = filepath.ToSlash(filepath.FromSlash(rel))
 		if match(rel) {
 			found = append(found, rel)
 		}
@@ -154,6 +154,7 @@ func filesMatchingWalk(
 		if err != nil {
 			return err
 		}
+		rel = filepath.ToSlash(rel)
 		if match(rel) {
 			found = append(found, rel)
 		}
@@ -199,7 +200,7 @@ func workflowFiles(t *testing.T, root string) []string {
 	return filesMatching(t, root, func(rel string) bool {
 		return (strings.HasSuffix(rel, ".yml") ||
 			strings.HasSuffix(rel, ".yaml")) &&
-			filepath.Dir(rel) == filepath.Join(".github", "workflows")
+			filepath.ToSlash(filepath.Dir(rel)) == ".github/workflows"
 	})
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -134,6 +134,7 @@ func filesMatchingWalk(
 
 	skippedDirs := map[string]bool{
 		".git":         true,
+		".claude":      true,
 		".worktrees":   true,
 		".tools":       true,
 		"node_modules": true,


### PR DESCRIPTION
## Summary
- ignore generated `.claude` worktree artifacts in docs-parity fallback discovery
- restore clean platform test behavior without changing tracked-file discovery

Fixes #3594

## Validation
- `git diff --check`
- `gofmt`
- Focused test is blocked locally by the repository Go 1.26.7 toolchain download; the failing Windows/macOS CI output is reproduced in the issue and this change targets that path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores `.claude` worktree artifacts in docs-parity fallback discovery and normalizes discovered paths to slash format so platform tests no longer fail on generated agent files. Fixes #3594.

- Adds `.claude` to the skipped directories map.
- Converts paths to forward slashes so workflow file detection matches consistently across platforms.

<sup>Written for commit 77f34792438c4be6019682e416a09149b2d444b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation parity checks now correctly exclude files in the `.claude` directory when processing source archives without Git metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->