### PR TITLE
fix(database): reject wrapped indexes and out-of-range asset values

### DIFF
--- a/database/block_indexer.go
+++ b/database/block_indexer.go
@@ -27,11 +27,16 @@ import (
 // safeIntToUint32 converts an int to uint32, clamping to math.MaxUint32 on overflow.
 // This is safe because we use this for byte offsets/lengths within blocks that
 // are bounded by Cardano's protocol limits (~90KB max block body).
+//
+// n is compared as int64 rather than directly against the untyped constant
+// math.MaxUint32: on a 32-bit platform int is 32 bits wide, and that
+// constant does not fit in it, so the naive comparison fails to compile.
+// int64 is wide enough to hold both n and math.MaxUint32 on every platform.
 func safeIntToUint32(n int) uint32 {
 	if n < 0 {
 		return 0
 	}
-	if n > math.MaxUint32 {
+	if int64(n) > math.MaxUint32 {
 		return math.MaxUint32
 	}
 	return uint32(n) // #nosec G115: bounds checked above

--- a/database/block_indexer_safe_conversion_test.go
+++ b/database/block_indexer_safe_conversion_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSafeIntToUint32 guards both the clamping behavior and the regression
+// this function was fixed for: comparing n directly against the untyped
+// constant math.MaxUint32 fails to compile on a 32-bit platform, where int
+// cannot represent that value. Comparing via int64(n) instead keeps the
+// same clamping behavior on every platform width.
+func TestSafeIntToUint32(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want uint32
+	}{
+		{name: "negative clamps to zero", n: -1, want: 0},
+		{name: "zero", n: 0, want: 0},
+		{name: "typical block offset", n: 90_000, want: 90_000},
+		{name: "exactly MaxUint32", n: math.MaxUint32, want: math.MaxUint32},
+		{
+			name: "beyond MaxUint32 clamps",
+			n:    math.MaxUint32 + 1,
+			want: math.MaxUint32,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, safeIntToUint32(tc.n))
+		})
+	}
+}

--- a/database/block_indexer_safe_conversion_test.go
+++ b/database/block_indexer_safe_conversion_test.go
@@ -16,35 +16,59 @@ package database
 
 import (
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type safeIntToUint32TestCase struct {
+	name string
+	n    int
+	want uint32
+}
 
 // TestSafeIntToUint32 guards both the clamping behavior and the regression
 // this function was fixed for: comparing n directly against the untyped
 // constant math.MaxUint32 fails to compile on a 32-bit platform, where int
 // cannot represent that value. Comparing via int64(n) instead keeps the
 // same clamping behavior on every platform width.
+//
+// The MaxUint32 and beyond-MaxUint32 cases only exist where int is wide
+// enough to hold them (64-bit platforms): assigning math.MaxUint32 to n
+// int would itself fail to compile as a 32-bit constant, exactly the bug
+// this test exists to catch in safeIntToUint32. They're appended via a
+// runtime int64->int conversion, guarded by strconv.IntSize, rather than
+// as int constants, so the test package still compiles on 32-bit.
 func TestSafeIntToUint32(t *testing.T) {
-	tests := []struct {
-		name string
-		n    int
-		want uint32
-	}{
+	tests := []safeIntToUint32TestCase{
 		{name: "negative clamps to zero", n: -1, want: 0},
 		{name: "zero", n: 0, want: 0},
 		{name: "typical block offset", n: 90_000, want: 90_000},
-		{name: "exactly MaxUint32", n: math.MaxUint32, want: math.MaxUint32},
-		{
-			name: "beyond MaxUint32 clamps",
-			n:    math.MaxUint32 + 1,
-			want: math.MaxUint32,
-		},
 	}
+	tests = append(tests, sixtyFourBitOnlySafeIntToUint32Cases()...)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, safeIntToUint32(tc.n))
 		})
+	}
+}
+
+func sixtyFourBitOnlySafeIntToUint32Cases() []safeIntToUint32TestCase {
+	if strconv.IntSize != 64 {
+		return nil
+	}
+	var maxUint32 int64 = math.MaxUint32
+	return []safeIntToUint32TestCase{
+		{
+			name: "exactly MaxUint32",
+			n:    int(maxUint32),
+			want: math.MaxUint32,
+		},
+		{
+			name: "beyond MaxUint32 clamps",
+			n:    int(maxUint32 + 1),
+			want: math.MaxUint32,
+		},
 	}
 }

--- a/database/lifecycle/blob_bulk_delete.go
+++ b/database/lifecycle/blob_bulk_delete.go
@@ -45,6 +45,22 @@ func blockIndexID(key []byte) (id uint64, ok bool) {
 	), true
 }
 
+// batchEnd returns the inclusive upper bound of the batch starting at start,
+// clamped to tipID. It avoids start+uint64(batchSize)-1 overflowing past
+// math.MaxUint64: that wraparound would silently produce an end below
+// start, corrupting the batch's iteration range instead of failing loudly.
+//
+// batchSize must be positive; DeleteBlocksAfter guarantees this by
+// substituting DefaultBlockDeleteBatchSize for any batchSize <= 0 before
+// calling in.
+func batchEnd(start, tipID uint64, batchSize int) uint64 {
+	size := uint64(batchSize) // #nosec G115 -- batchSize > 0, see doc comment
+	if tipID-start >= size-1 {
+		return start + size - 1
+	}
+	return tipID
+}
+
 // DeleteBlocksAfter removes every block whose internal, sequentially
 // assigned block ID (models.Block.ID — the basis of the blob store's "bi"
 // index, distinct from the chain's Number/height field) falls in
@@ -104,7 +120,7 @@ func DeleteBlocksAfter(
 		if err := ctx.Err(); err != nil {
 			return blocksDeleted, err
 		}
-		end := min(start+uint64(batchSize)-1, tipID)
+		end := batchEnd(start, tipID, batchSize)
 		var batchDeleted uint64
 		var batchIsIrreversible bool
 		txn := db.BlobTxn(true)

--- a/database/lifecycle/blob_bulk_delete.go
+++ b/database/lifecycle/blob_bulk_delete.go
@@ -261,6 +261,15 @@ func DeleteBlocksAfter(
 			return blocksDeleted, err
 		}
 		blocksDeleted += batchDeleted
+		// end == tipID marks the final batch. Testing that directly,
+		// rather than relying on the loop's start <= tipID condition to
+		// stop things, matters because tipID can itself be MaxUint64: in
+		// that case start = end + 1 would wrap to 0, which is <= tipID,
+		// and the loop would incorrectly run additional batches below
+		// afterID.
+		if end == tipID {
+			break
+		}
 		start = end + 1
 	}
 	return blocksDeleted, nil

--- a/database/lifecycle/blob_bulk_delete_internal_test.go
+++ b/database/lifecycle/blob_bulk_delete_internal_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBatchEndDoesNotWrapNearMaxUint64 guards against the regression this
+// function was extracted to fix: start+uint64(batchSize)-1 overflowing past
+// math.MaxUint64 and wrapping to a value below start, which would corrupt
+// the batch's iteration range instead of clamping to tipID.
+func TestBatchEndDoesNotWrapNearMaxUint64(t *testing.T) {
+	tipID := uint64(math.MaxUint64)
+	start := tipID - 5
+	end := batchEnd(start, tipID, 10_000)
+	assert.Equal(t, tipID, end)
+	assert.GreaterOrEqual(t, end, start)
+}
+
+func TestBatchEndClampsToTipIDWhenBatchSizeExceedsRemainder(t *testing.T) {
+	end := batchEnd(100, 105, 10_000)
+	assert.Equal(t, uint64(105), end)
+}
+
+func TestBatchEndStopsAtBatchSizeWhenTipIDIsFarther(t *testing.T) {
+	end := batchEnd(100, 1_000_000, 10_000)
+	assert.Equal(t, uint64(100+10_000-1), end)
+}
+
+func TestBatchEndSingleBlockBatch(t *testing.T) {
+	end := batchEnd(42, 1_000, 1)
+	assert.Equal(t, uint64(42), end)
+}

--- a/database/lifecycle/blob_bulk_delete_test.go
+++ b/database/lifecycle/blob_bulk_delete_test.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/lifecycle"
@@ -113,6 +115,32 @@ func TestDeleteBlocksAfterNoopWhenTipAtOrBelowThreshold(t *testing.T) {
 
 	_, err = db.BlockByIndex(1, nil)
 	require.NoError(t, err)
+}
+
+// TestDeleteBlocksAfterStopsAtMaxUint64TipWithoutWrapping guards a
+// regression batchEnd's extraction could reintroduce: once the batch
+// whose end equals tipID finishes, advancing via start = end + 1 wraps to
+// 0 when tipID is math.MaxUint64. An unguarded loop would then reopen a
+// batch spanning [0, batchSize-1] and keep walking upward indefinitely,
+// deleting blocks far below afterID along the way. Block 1 sits well
+// below afterID here and must survive; a bounded context turns a
+// reintroduced wraparound into a fast, clear failure instead of a hang.
+func TestDeleteBlocksAfterStopsAtMaxUint64TipWithoutWrapping(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.BlockCreate(testBlock(1, 0x01), nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tipID := uint64(math.MaxUint64)
+	blocksDeleted, err := lifecycle.DeleteBlocksAfter(
+		ctx, db, tipID-1, tipID, 0,
+	)
+	require.NoError(t, err)
+	require.Zero(t, blocksDeleted)
+
+	_, err = db.BlockByIndex(1, nil)
+	require.NoError(t, err, "block 1 is far below afterID and must survive")
 }
 
 // TestDeleteBlocksAfterRespectsSmallBatchSize verifies that a batch size

--- a/database/models/asset.go
+++ b/database/models/asset.go
@@ -16,6 +16,9 @@ package models
 
 import (
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -88,14 +91,31 @@ func ConvertMintToAssetMintBurnModels(
 	return rows
 }
 
+// checkedUint64FromBigInt converts amount to a uint64, rejecting negative
+// values and values that exceed math.MaxUint64. big.Int.Uint64 silently
+// keeps only the low 64 bits on overflow, which would otherwise let an
+// indexed asset amount wrap into an unrelated, much smaller value.
+func checkedUint64FromBigInt(amount *big.Int) (uint64, error) {
+	if amount == nil {
+		return 0, errors.New("asset amount is nil")
+	}
+	if !amount.IsUint64() {
+		return 0, fmt.Errorf(
+			"asset amount %s does not fit in uint64",
+			amount.String(),
+		)
+	}
+	return amount.Uint64(), nil
+}
+
 // ConvertMultiAssetToModels converts a MultiAsset structure into a slice of Asset models.
 // Each asset is populated with its name, hex-encoded name, policy ID, fingerprint, and amount.
 // Returns an empty slice if multiAsset is nil or contains no assets.
 func ConvertMultiAssetToModels(
 	multiAsset *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput],
-) []Asset {
+) ([]Asset, error) {
 	if multiAsset == nil {
-		return []Asset{}
+		return []Asset{}, nil
 	}
 	numAssets := 0
 	// Get all policy IDs
@@ -110,7 +130,17 @@ func ConvertMultiAssetToModels(
 		// Get asset names for this policy
 		assetNames := multiAsset.Assets(policyId)
 		for _, assetNameBytes := range assetNames {
-			amount := multiAsset.Asset(policyId, assetNameBytes)
+			amount, err := checkedUint64FromBigInt(
+				multiAsset.Asset(policyId, assetNameBytes),
+			)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"asset %x.%x: %w",
+					policyIdBytes,
+					assetNameBytes,
+					err,
+				)
+			}
 
 			// Calculate fingerprint
 			fingerprint := lcommon.NewAssetFingerprint(
@@ -123,11 +153,11 @@ func ConvertMultiAssetToModels(
 				NameHex:     []byte(hex.EncodeToString(assetNameBytes)),
 				PolicyId:    policyIdBytes,
 				Fingerprint: []byte(fingerprint.String()),
-				Amount:      types.Uint64(amount.Uint64()),
+				Amount:      types.Uint64(amount),
 			}
 			assets = append(assets, asset)
 		}
 	}
 
-	return assets
+	return assets, nil
 }

--- a/database/models/asset_test.go
+++ b/database/models/asset_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMultiAsset builds a single-policy, single-asset MultiAsset for a
+// caller-supplied amount, bypassing CBOR decoding's pruneZeroAssets so
+// out-of-range or negative values reach ConvertMultiAssetToModels untouched.
+func newTestMultiAsset(
+	policyId lcommon.Blake2b224,
+	assetName string,
+	amount *big.Int,
+) *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policyId: {
+				cbor.NewByteString([]byte(assetName)): amount,
+			},
+		},
+	)
+	return &multiAsset
+}
+
+// TestConvertMultiAssetToModelsMaxUint64 covers the maximum in-range value:
+// checkedUint64FromBigInt must not reject anything that legitimately fits
+// in a uint64.
+func TestConvertMultiAssetToModelsMaxUint64(t *testing.T) {
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xaa
+	amount := new(big.Int).SetUint64(math.MaxUint64)
+	multiAsset := newTestMultiAsset(policyId, "asset", amount)
+
+	assets, err := ConvertMultiAssetToModels(multiAsset)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	assert.Equal(t, types.Uint64(math.MaxUint64), assets[0].Amount)
+}
+
+// TestConvertMultiAssetToModelsRejectsOverflow guards the regression this
+// issue was filed for: one past math.MaxUint64, big.Int.Uint64 would
+// silently keep only the low 64 bits (wrapping to 0) instead of reporting
+// this.
+func TestConvertMultiAssetToModelsRejectsOverflow(t *testing.T) {
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xbb
+	amount := new(big.Int).SetUint64(math.MaxUint64)
+	amount.Add(amount, big.NewInt(1))
+	multiAsset := newTestMultiAsset(policyId, "asset", amount)
+
+	_, err := ConvertMultiAssetToModels(multiAsset)
+	assert.Error(t, err)
+}
+
+// TestConvertMultiAssetToModelsRejectsNegative covers a negative indexed
+// amount, which big.Int.Uint64 would otherwise reinterpret as a huge
+// positive value instead of reporting.
+func TestConvertMultiAssetToModelsRejectsNegative(t *testing.T) {
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xcc
+	amount := big.NewInt(-1)
+	multiAsset := newTestMultiAsset(policyId, "asset", amount)
+
+	_, err := ConvertMultiAssetToModels(multiAsset)
+	assert.Error(t, err)
+}
+
+// TestConvertMultiAssetToModelsNilMultiAsset covers the pre-existing nil
+// shortcut: it must keep returning an empty, non-nil slice with no error.
+func TestConvertMultiAssetToModelsNilMultiAsset(t *testing.T) {
+	assets, err := ConvertMultiAssetToModels(nil)
+	require.NoError(t, err)
+	assert.Empty(t, assets)
+}
+
+// TestCheckedUint64FromBigIntRejectsNil covers the defensive nil guard, so
+// a caller passing a nil *big.Int fails loudly instead of panicking inside
+// IsUint64/Uint64.
+func TestCheckedUint64FromBigIntRejectsNil(t *testing.T) {
+	_, err := checkedUint64FromBigInt(nil)
+	assert.Error(t, err)
+}

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -343,13 +343,17 @@ func (u *Utxo) Decode() (ledger.TransactionOutput, error) {
 func UtxoLedgerToModel(
 	utxo ledger.Utxo,
 	slot uint64,
-) Utxo {
+) (Utxo, error) {
 	outAddr := utxo.Output.Address()
+	amount, err := checkedUint64FromBigInt(utxo.Output.Amount())
+	if err != nil {
+		return Utxo{}, fmt.Errorf("utxo amount: %w", err)
+	}
 	ret := Utxo{
 		TxId:      utxo.Id.Id().Bytes(),
 		Cbor:      utxo.Output.Cbor(),
 		AddedSlot: slot,
-		Amount:    types.Uint64(utxo.Output.Amount().Uint64()),
+		Amount:    types.Uint64(amount),
 		OutputIdx: utxo.Id.Index(),
 	}
 	var zeroHash ledger.Blake2b224
@@ -376,10 +380,14 @@ func UtxoLedgerToModel(
 		ret.DatumHash = append([]byte(nil), dh[:]...)
 	}
 	if multiAsset := utxo.Output.Assets(); multiAsset != nil {
-		ret.Assets = ConvertMultiAssetToModels(multiAsset)
+		assets, err := ConvertMultiAssetToModels(multiAsset)
+		if err != nil {
+			return Utxo{}, fmt.Errorf("utxo assets: %w", err)
+		}
+		ret.Assets = assets
 	}
 
-	return ret
+	return ret, nil
 }
 
 func StakeCredentialTagFromAddress(addr ledger.Address) (uint8, bool) {

--- a/database/models/utxo_test.go
+++ b/database/models/utxo_test.go
@@ -16,10 +16,14 @@ package models
 
 import (
 	"bytes"
+	"math"
+	"math/big"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,12 +90,59 @@ func TestUtxoLedgerToModelPaymentScript(t *testing.T) {
 				},
 			}
 
-			model := UtxoLedgerToModel(utxo, 42)
+			model, err := UtxoLedgerToModel(utxo, 42)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantScript, model.PaymentScript)
 			// Payment hash is recorded regardless of credential type.
 			assert.Equal(t, payHash, model.PaymentKey)
 		})
 	}
+}
+
+// TestUtxoLedgerToModelPropagatesAssetOverflowError exercises the asset
+// overflow guard end-to-end through a real ledger.TransactionOutput (a Mary
+// output, the era multi-asset was introduced in) rather than only unit
+// testing ConvertMultiAssetToModels/checkedUint64FromBigInt directly: it
+// confirms UtxoLedgerToModel itself surfaces the error and returns a
+// zero-value Utxo instead of a model with a wrapped asset amount.
+func TestUtxoLedgerToModelPropagatesAssetOverflowError(t *testing.T) {
+	payHash := bytes.Repeat([]byte{0xAB}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkMainnet,
+		payHash,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xdd
+	overflowAmount := new(big.Int).SetUint64(math.MaxUint64)
+	overflowAmount.Add(overflowAmount, big.NewInt(1))
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policyId: {
+				cbor.NewByteString([]byte("asset")): overflowAmount,
+			},
+		},
+	)
+
+	utxo := ledger.Utxo{
+		Id: shelley.NewShelleyTransactionInput(
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+			0,
+		),
+		Output: &mary.MaryTransactionOutput{
+			OutputAddress: addr,
+			OutputAmount: mary.MaryTransactionOutputValue{
+				Amount: 1_000_000,
+				Assets: &multiAsset,
+			},
+		},
+	}
+
+	_, err = UtxoLedgerToModel(utxo, 42)
+	assert.Error(t, err)
 }
 
 func TestMatchesUtxoAddressPatternsRejectsEmptyPattern(t *testing.T) {

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -1160,7 +1160,11 @@ type reverseKeyFile struct {
 }
 
 func writeReverseKey(file *os.File, key string) error {
-	if len(key) > math.MaxUint32 {
+	// len(key) is compared as int64 rather than directly against the
+	// untyped constant math.MaxUint32: on a 32-bit platform int is 32
+	// bits wide and that constant does not fit in it, so the naive
+	// comparison fails to compile.
+	if int64(len(key)) > math.MaxUint32 {
 		return fmt.Errorf("key length %d exceeds uint32 maximum", len(key))
 	}
 	length := make([]byte, 4)

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -1191,7 +1191,11 @@ type reverseKeyFile struct {
 }
 
 func writeReverseKey(file *os.File, key string) error {
-	if len(key) > math.MaxUint32 {
+	// len(key) is compared as int64 rather than directly against the
+	// untyped constant math.MaxUint32: on a 32-bit platform int is 32
+	// bits wide and that constant does not fit in it, so the naive
+	// comparison fails to compile.
+	if int64(len(key)) > math.MaxUint32 {
 		return fmt.Errorf("key length %d exceeds uint32 maximum", len(key))
 	}
 	length := make([]byte, 4)

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -795,12 +795,16 @@ func (s *Store) GetScript(
 	if err != nil {
 		return nil, fmt.Errorf("get script: %w", err)
 	}
+	scriptType, err := checkedUint8(row.Type.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("get script: %w", err)
+	}
 	return &models.Script{
 		Hash:        row.Hash,
 		Content:     row.Content,
 		ID:          uint(row.ID),
 		CreatedSlot: createdSlot,
-		Type:        uint8(row.Type.Int64),
+		Type:        scriptType,
 	}, nil
 }
 
@@ -1197,4 +1201,15 @@ func checkedUint64(value int64) (uint64, error) {
 		return 0, fmt.Errorf("signed SQL value %d is negative", value)
 	}
 	return uint64(value), nil
+}
+
+// checkedUint8 narrows a signed SQL column to uint8. script.type is an
+// unconstrained SQLite INTEGER, so a row corrupted or tampered with
+// outside normal writes can hold a value outside [0, 255]; converting
+// that directly would silently wrap instead of failing.
+func checkedUint8(value int64) (uint8, error) {
+	if value < 0 || value > math.MaxUint8 {
+		return 0, fmt.Errorf("signed SQL value %d does not fit in uint8", value)
+	}
+	return uint8(value), nil
 }

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -846,12 +846,16 @@ func (s *Store) GetPParams(
 		if err != nil {
 			return nil, fmt.Errorf("get pparams: %w", err)
 		}
+		eraId, err := checkedUint(row.EraID.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get pparams: %w", err)
+		}
 		ret = append(ret, models.PParams{
 			Cbor:      row.Cbor,
 			ID:        uint(row.ID),
 			AddedSlot: addedSlot,
 			Epoch:     epoch,
-			EraId:     uint(row.EraID.Int64),
+			EraId:     eraId,
 		})
 	}
 	return ret, nil
@@ -1171,6 +1175,18 @@ func epochFromValues(
 	if err != nil {
 		return nil, fmt.Errorf("epoch start slot: %w", err)
 	}
+	eraIdVal, err := checkedUint(eraID.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("epoch era id: %w", err)
+	}
+	slotLengthVal, err := checkedUint(slotLength.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("epoch slot length: %w", err)
+	}
+	lengthInSlotsVal, err := checkedUint(lengthInSlots.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("epoch length in slots: %w", err)
+	}
 	return &models.Epoch{
 		Nonce:               nonce,
 		EvolvingNonce:       evolvingNonce,
@@ -1179,9 +1195,9 @@ func epochFromValues(
 		ID:                  uint(id),
 		EpochId:             epochId,
 		StartSlot:           startSlotVal,
-		EraId:               uint(eraID.Int64),
-		SlotLength:          uint(slotLength.Int64),
-		LengthInSlots:       uint(lengthInSlots.Int64),
+		EraId:               eraIdVal,
+		SlotLength:          slotLengthVal,
+		LengthInSlots:       lengthInSlotsVal,
 	}, nil
 }
 
@@ -1212,4 +1228,21 @@ func checkedUint8(value int64) (uint8, error) {
 		return 0, fmt.Errorf("signed SQL value %d does not fit in uint8", value)
 	}
 	return uint8(value), nil
+}
+
+// checkedUint narrows a signed SQL column to uint. Several columns (era
+// id, slot length, length in slots) are unconstrained SQLite INTEGERs
+// read into a plain uint: a negative stored value would otherwise
+// reinterpret its bit pattern as unsigned (e.g. -1 silently becoming
+// MaxUint) instead of failing, and on a 32-bit build uint is only 32 bits
+// wide, so the upper bound is checked against this platform's actual
+// uint width (via ^uint(0), not a hardcoded 64-bit assumption).
+func checkedUint(value int64) (uint, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("signed SQL value %d is negative", value)
+	}
+	if uint64(value) > uint64(^uint(0)) {
+		return 0, fmt.Errorf("signed SQL value %d exceeds uint width", value)
+	}
+	return uint(value), nil
 }

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -48,9 +48,17 @@ func (s *Store) GetTip(txn types.Txn) (ochainsync.Tip, error) {
 	if err != nil {
 		return tip, fmt.Errorf("get tip: %w", err)
 	}
-	tip.Point.Slot = uint64(row.Slot.Int64)
+	slot, err := checkedUint64(row.Slot.Int64)
+	if err != nil {
+		return tip, fmt.Errorf("get tip slot: %w", err)
+	}
+	blockNumber, err := checkedUint64(row.BlockNumber.Int64)
+	if err != nil {
+		return tip, fmt.Errorf("get tip block number: %w", err)
+	}
+	tip.Point.Slot = slot
 	tip.Point.Hash = row.Hash
-	tip.BlockNumber = uint64(row.BlockNumber.Int64)
+	tip.BlockNumber = blockNumber
 	return tip, nil
 }
 
@@ -157,11 +165,15 @@ func (s *Store) GetNetworkState(
 	if err != nil {
 		return nil, fmt.Errorf("get network state reserves: %w", err)
 	}
+	slot, err := checkedUint64(row.Slot)
+	if err != nil {
+		return nil, fmt.Errorf("get network state slot: %w", err)
+	}
 	return &models.NetworkState{
 		ID:       uint(row.ID),
 		Treasury: types.Uint64(treasury),
 		Reserves: types.Uint64(reserves),
-		Slot:     uint64(row.Slot),
+		Slot:     slot,
 	}, nil
 }
 
@@ -246,7 +258,7 @@ func (s *Store) GetEpoch(
 	if err != nil {
 		return nil, fmt.Errorf("get epoch: %w", err)
 	}
-	return epochFromValues(
+	epoch, err := epochFromValues(
 		row.ID,
 		row.EpochID,
 		row.StartSlot,
@@ -257,7 +269,11 @@ func (s *Store) GetEpoch(
 		row.EraID,
 		row.SlotLength,
 		row.LengthInSlots,
-	), nil
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get epoch: %w", err)
+	}
+	return epoch, nil
 }
 
 func (s *Store) GetEpochsByEra(
@@ -282,7 +298,7 @@ func (s *Store) GetEpochsByEra(
 	}
 	ret := make([]models.Epoch, 0, len(rows))
 	for _, row := range rows {
-		ret = append(ret, *epochFromValues(
+		epoch, err := epochFromValues(
 			row.ID,
 			row.EpochID,
 			row.StartSlot,
@@ -293,7 +309,11 @@ func (s *Store) GetEpochsByEra(
 			row.EraID,
 			row.SlotLength,
 			row.LengthInSlots,
-		))
+		)
+		if err != nil {
+			return nil, fmt.Errorf("get epochs by era: %w", err)
+		}
+		ret = append(ret, *epoch)
 	}
 	return ret, nil
 }
@@ -310,7 +330,7 @@ func (s *Store) GetEpochs(txn types.Txn) ([]models.Epoch, error) {
 	}
 	ret := make([]models.Epoch, 0, len(rows))
 	for _, row := range rows {
-		ret = append(ret, *epochFromValues(
+		epoch, err := epochFromValues(
 			row.ID,
 			row.EpochID,
 			row.StartSlot,
@@ -321,7 +341,11 @@ func (s *Store) GetEpochs(txn types.Txn) ([]models.Epoch, error) {
 			row.EraID,
 			row.SlotLength,
 			row.LengthInSlots,
-		))
+		)
+		if err != nil {
+			return nil, fmt.Errorf("get epochs: %w", err)
+		}
+		ret = append(ret, *epoch)
 	}
 	return ret, nil
 }
@@ -355,7 +379,7 @@ func (s *Store) GetEpochBySlot(
 	if err != nil {
 		return nil, fmt.Errorf("get epoch by slot: %w", err)
 	}
-	return epochFromValues(
+	epoch, err := epochFromValues(
 		row.ID,
 		row.EpochID,
 		row.StartSlot,
@@ -366,7 +390,11 @@ func (s *Store) GetEpochBySlot(
 		row.EraID,
 		row.SlotLength,
 		row.LengthInSlots,
-	), nil
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get epoch by slot: %w", err)
+	}
+	return epoch, nil
 }
 
 func (s *Store) DeleteEpochsAfterSlot(slot uint64, txn types.Txn) error {
@@ -536,11 +564,15 @@ func (s *Store) GetBlockNoncesInSlotRange(
 	}
 	ret := make([]models.BlockNonce, 0, len(rows))
 	for _, row := range rows {
+		slot, err := checkedUint64(row.Slot.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get block nonces in slot range: %w", err)
+		}
 		ret = append(ret, models.BlockNonce{
 			Hash:         row.Hash,
 			Nonce:        row.Nonce,
 			ID:           uint(row.ID),
-			Slot:         uint64(row.Slot.Int64),
+			Slot:         slot,
 			IsCheckpoint: row.IsCheckpoint.Bool,
 		})
 	}
@@ -605,7 +637,14 @@ func (s *Store) GetLatestBlockNonce(
 		return models.BlockNonce{}, false, err
 	}
 	if slot.Valid {
-		ret.Slot = uint64(slot.Int64)
+		s, err := checkedUint64(slot.Int64)
+		if err != nil {
+			return models.BlockNonce{}, false, fmt.Errorf(
+				"get latest block nonce: %w",
+				err,
+			)
+		}
+		ret.Slot = s
 	}
 	if checkpoint.Valid {
 		ret.IsCheckpoint = checkpoint.Bool
@@ -696,11 +735,15 @@ func (s *Store) GetDatum(
 	if err != nil {
 		return nil, err
 	}
+	addedSlot, err := checkedUint64(row.AddedSlot)
+	if err != nil {
+		return nil, fmt.Errorf("get datum: %w", err)
+	}
 	return &models.Datum{
 		Hash:      row.Hash,
 		RawDatum:  row.RawDatum,
 		ID:        uint(row.ID),
-		AddedSlot: uint64(row.AddedSlot),
+		AddedSlot: addedSlot,
 	}, nil
 }
 
@@ -748,11 +791,15 @@ func (s *Store) GetScript(
 	if err != nil {
 		return nil, err
 	}
+	createdSlot, err := checkedUint64(row.CreatedSlot.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("get script: %w", err)
+	}
 	return &models.Script{
 		Hash:        row.Hash,
 		Content:     row.Content,
 		ID:          uint(row.ID),
-		CreatedSlot: uint64(row.CreatedSlot.Int64),
+		CreatedSlot: createdSlot,
 		Type:        uint8(row.Type.Int64),
 	}, nil
 }
@@ -787,11 +834,19 @@ func (s *Store) GetPParams(
 	}
 	ret := make([]models.PParams, 0, len(rows))
 	for _, row := range rows {
+		addedSlot, err := checkedUint64(row.AddedSlot.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get pparams: %w", err)
+		}
+		epoch, err := checkedUint64(row.Epoch.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get pparams: %w", err)
+		}
 		ret = append(ret, models.PParams{
 			Cbor:      row.Cbor,
 			ID:        uint(row.ID),
-			AddedSlot: uint64(row.AddedSlot.Int64),
-			Epoch:     uint64(row.Epoch.Int64),
+			AddedSlot: addedSlot,
+			Epoch:     epoch,
 			EraId:     uint(row.EraID.Int64),
 		})
 	}
@@ -833,12 +888,20 @@ func (s *Store) GetPParamUpdates(
 	}
 	ret := make([]models.PParamUpdate, 0, len(rows))
 	for _, row := range rows {
+		addedSlot, err := checkedUint64(row.AddedSlot.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get pparam updates: %w", err)
+		}
+		epoch, err := checkedUint64(row.Epoch.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("get pparam updates: %w", err)
+		}
 		ret = append(ret, models.PParamUpdate{
 			GenesisHash: row.GenesisHash,
 			Cbor:        row.Cbor,
 			ID:          uint(row.ID),
-			AddedSlot:   uint64(row.AddedSlot.Int64),
-			Epoch:       uint64(row.Epoch.Int64),
+			AddedSlot:   addedSlot,
+			Epoch:       epoch,
 		})
 	}
 	return ret, nil
@@ -1095,19 +1158,27 @@ func epochFromValues(
 	epochID, startSlot sql.NullInt64,
 	nonce, evolvingNonce, candidateNonce, lastEpochBlockNonce []byte,
 	eraID, slotLength, lengthInSlots sql.NullInt64,
-) *models.Epoch {
+) (*models.Epoch, error) {
+	epochId, err := checkedUint64(epochID.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("epoch id: %w", err)
+	}
+	startSlotVal, err := checkedUint64(startSlot.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("epoch start slot: %w", err)
+	}
 	return &models.Epoch{
 		Nonce:               nonce,
 		EvolvingNonce:       evolvingNonce,
 		CandidateNonce:      candidateNonce,
 		LastEpochBlockNonce: lastEpochBlockNonce,
 		ID:                  uint(id),
-		EpochId:             uint64(epochID.Int64),
-		StartSlot:           uint64(startSlot.Int64),
+		EpochId:             epochId,
+		StartSlot:           startSlotVal,
 		EraId:               uint(eraID.Int64),
 		SlotLength:          uint(slotLength.Int64),
 		LengthInSlots:       uint(lengthInSlots.Int64),
-	}
+	}, nil
 }
 
 func checkedInt64(value uint64) (int64, error) {
@@ -1115,4 +1186,15 @@ func checkedInt64(value uint64) (int64, error) {
 		return 0, fmt.Errorf("unsigned SQL value %d exceeds int64", value)
 	}
 	return int64(value), nil
+}
+
+// checkedUint64 is the reverse of checkedInt64: SQLite's INTEGER columns
+// are signed, so a row corrupted or tampered with outside normal writes can
+// surface a negative value here. Converting that directly to uint64 would
+// silently produce a near-MaxUint64 chain point instead of failing.
+func checkedUint64(value int64) (uint64, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("signed SQL value %d is negative", value)
+	}
+	return uint64(value), nil
 }

--- a/database/plugin/metadata/sqlstore/operational_test.go
+++ b/database/plugin/metadata/sqlstore/operational_test.go
@@ -103,6 +103,80 @@ func TestCheckedUint64(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCheckedUint unit-tests the helper directly: zero, a typical
+// positive value, and both out-of-range directions. The upper bound is
+// this platform's own uint width (via ^uint(0)), not a hardcoded 64-bit
+// assumption, so on a 32-bit build the same math.MaxInt64 input this test
+// accepts on 64-bit would correctly be rejected there instead.
+func TestCheckedUint(t *testing.T) {
+	t.Parallel()
+	v, err := checkedUint(42)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), v)
+
+	v, err = checkedUint(0)
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), v)
+
+	v, err = checkedUint(int64(^uint(0) >> 1))
+	require.NoError(t, err)
+	assert.Equal(t, uint(^uint(0)>>1), v)
+
+	_, err = checkedUint(-1)
+	require.Error(t, err)
+}
+
+// TestGetEpochRejectsNegativeStoredEraID reproduces the review finding on
+// this PR: GetEpoch filters only by epoch_id, so era_id, slot_length, and
+// length_in_slots are returned regardless of their stored value. A
+// negative era_id previously reinterpreted its bit pattern as unsigned in
+// epochFromValues (uint(int64(-1)) silently becomes MaxUint) instead of
+// failing.
+func TestGetEpochRejectsNegativeStoredEraID(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	_, err := store.writeDB.Exec(
+		"INSERT INTO epoch (epoch_id, start_slot, era_id, slot_length, length_in_slots) VALUES (?, ?, ?, ?, ?)",
+		1, 0, -1, 1, 432000,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetEpoch(1, nil)
+	require.Error(t, err)
+}
+
+// TestGetEpochRejectsNegativeStoredSlotLength covers the same regression
+// as TestGetEpochRejectsNegativeStoredEraID for the epoch's slot_length
+// column instead of its era_id column.
+func TestGetEpochRejectsNegativeStoredSlotLength(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	_, err := store.writeDB.Exec(
+		"INSERT INTO epoch (epoch_id, start_slot, era_id, slot_length, length_in_slots) VALUES (?, ?, ?, ?, ?)",
+		2, 0, 1, -1, 432000,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetEpoch(2, nil)
+	require.Error(t, err)
+}
+
+// TestGetEpochRejectsNegativeStoredLengthInSlots covers the same
+// regression as TestGetEpochRejectsNegativeStoredEraID for the epoch's
+// length_in_slots column instead of its era_id column.
+func TestGetEpochRejectsNegativeStoredLengthInSlots(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	_, err := store.writeDB.Exec(
+		"INSERT INTO epoch (epoch_id, start_slot, era_id, slot_length, length_in_slots) VALUES (?, ?, ?, ?, ?)",
+		3, 0, 1, 1, -1,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetEpoch(3, nil)
+	require.Error(t, err)
+}
+
 // TestGetScriptRejectsOutOfRangeStoredType covers script.type: an
 // unconstrained SQLite INTEGER, so a row corrupted outside normal writes
 // can hold a value outside uint8's [0, 255] range. Converting that

--- a/database/plugin/metadata/sqlstore/operational_test.go
+++ b/database/plugin/metadata/sqlstore/operational_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"math"
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetTipRejectsNegativeStoredSlot covers the regression this issue was
+// filed for: SQLite's INTEGER columns are signed, so a tip row corrupted
+// outside normal writes (SetTip already rejects out-of-range values via
+// checkedInt64) can surface a negative slot. Converting that directly to
+// uint64 would silently produce a near-MaxUint64 chain point instead of
+// failing.
+func TestGetTipRejectsNegativeStoredSlot(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	_, err := store.writeDB.Exec(
+		"INSERT INTO tip (id, hash, slot, block_number) VALUES (1, ?, ?, ?)",
+		[]byte{0x01},
+		-1,
+		5,
+	)
+	require.NoError(t, err)
+	_, err = store.GetTip(nil)
+	require.Error(t, err)
+}
+
+// TestGetTipRejectsNegativeStoredBlockNumber covers the same regression as
+// TestGetTipRejectsNegativeStoredSlot for the tip's block_number column
+// instead of its slot column.
+func TestGetTipRejectsNegativeStoredBlockNumber(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	_, err := store.writeDB.Exec(
+		"INSERT INTO tip (id, hash, slot, block_number) VALUES (1, ?, ?, ?)",
+		[]byte{0x01},
+		5,
+		-1,
+	)
+	require.NoError(t, err)
+	_, err = store.GetTip(nil)
+	require.Error(t, err)
+}
+
+// TestGetTipRoundTripsMaxInt64Slot covers the maximum in-range value:
+// checkedInt64/checkedUint64 must not reject anything that legitimately
+// fits in a signed 64-bit SQL column.
+func TestGetTipRoundTripsMaxInt64Slot(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	tip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: math.MaxInt64,
+			Hash: []byte{0x02},
+		},
+		BlockNumber: math.MaxInt64,
+	}
+	require.NoError(t, store.SetTip(tip, nil))
+	got, err := store.GetTip(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxInt64), got.Point.Slot)
+	assert.Equal(t, uint64(math.MaxInt64), got.BlockNumber)
+}
+
+// TestCheckedUint64 unit-tests the helper directly across the boundary
+// cases the GetTip tests exercise indirectly through SQLite: zero, a
+// typical positive value, the maximum signed 64-bit value, and negative.
+func TestCheckedUint64(t *testing.T) {
+	t.Parallel()
+	v, err := checkedUint64(42)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), v)
+
+	v, err = checkedUint64(0)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), v)
+
+	v, err = checkedUint64(math.MaxInt64)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxInt64), v)
+
+	_, err = checkedUint64(-1)
+	require.Error(t, err)
+}

--- a/database/plugin/metadata/sqlstore/operational_test.go
+++ b/database/plugin/metadata/sqlstore/operational_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"testing"
 
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -99,5 +100,64 @@ func TestCheckedUint64(t *testing.T) {
 	assert.Equal(t, uint64(math.MaxInt64), v)
 
 	_, err = checkedUint64(-1)
+	require.Error(t, err)
+}
+
+// TestGetScriptRejectsOutOfRangeStoredType covers script.type: an
+// unconstrained SQLite INTEGER, so a row corrupted outside normal writes
+// can hold a value outside uint8's [0, 255] range. Converting that
+// directly would silently wrap instead of failing.
+func TestGetScriptRejectsOutOfRangeStoredType(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	hash := lcommon.NewBlake2b224([]byte{0x03})
+	_, err := store.writeDB.Exec(
+		"INSERT INTO script (hash, content, created_slot, type) VALUES (?, ?, ?, ?)",
+		hash[:],
+		[]byte{0x80},
+		1,
+		256,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetScript(hash, nil)
+	require.Error(t, err)
+}
+
+// TestGetScriptRejectsNegativeStoredType covers the same regression as
+// TestGetScriptRejectsOutOfRangeStoredType for a negative script.type.
+func TestGetScriptRejectsNegativeStoredType(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+	hash := lcommon.NewBlake2b224([]byte{0x04})
+	_, err := store.writeDB.Exec(
+		"INSERT INTO script (hash, content, created_slot, type) VALUES (?, ?, ?, ?)",
+		hash[:],
+		[]byte{0x80},
+		1,
+		-1,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetScript(hash, nil)
+	require.Error(t, err)
+}
+
+// TestCheckedUint8 unit-tests the helper directly: zero, the maximum
+// in-range value, and both out-of-range directions (negative and > 255).
+func TestCheckedUint8(t *testing.T) {
+	t.Parallel()
+	v, err := checkedUint8(0)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(0), v)
+
+	v, err = checkedUint8(255)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(255), v)
+
+	_, err = checkedUint8(256)
+	require.Error(t, err)
+
+	_, err = checkedUint8(-1)
 	require.Error(t, err)
 }

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -194,7 +194,14 @@ RETURNING id`,
 			)
 			producedStakeRefs := make([]models.StakeCredentialRef, 0)
 			for _, produced := range transaction.Produced() {
-				model := models.UtxoLedgerToModel(produced, point.Slot)
+				model, err := models.UtxoLedgerToModel(produced, point.Slot)
+				if err != nil {
+					return fmt.Errorf(
+						"convert output %d: %w",
+						produced.Id.Index(),
+						err,
+					)
+				}
 				if collateralReturn != nil &&
 					produced.Output == collateralReturn {
 					id := uint(transactionID)
@@ -365,7 +372,14 @@ RETURNING id`,
 			collateralReturn := transaction.CollateralReturn()
 			stakeRefs := make([]models.StakeCredentialRef, 0)
 			for _, produced := range transaction.Produced() {
-				model := models.UtxoLedgerToModel(produced, point.Slot)
+				model, err := models.UtxoLedgerToModel(produced, point.Slot)
+				if err != nil {
+					return fmt.Errorf(
+						"convert output %d: %w",
+						produced.Id.Index(),
+						err,
+					)
+				}
 				id := uint(transactionID)
 				if collateralReturn != nil &&
 					produced.Output == collateralReturn {

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -339,7 +339,15 @@ func (s *Store) AddUtxos(
 	}
 	items := make([]models.Utxo, len(utxos))
 	for i := range utxos {
-		items[i] = models.UtxoLedgerToModel(utxos[i].Utxo, utxos[i].Slot)
+		item, err := models.UtxoLedgerToModel(utxos[i].Utxo, utxos[i].Slot)
+		if err != nil {
+			return fmt.Errorf(
+				"convert utxo %d: %w",
+				utxos[i].Utxo.Id.Index(),
+				err,
+			)
+		}
+		items[i] = item
 	}
 	return s.importUtxos(items, txn, false)
 }

--- a/database/plugin/metadata/sqlstore/utxo_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_test.go
@@ -15,9 +15,16 @@
 package sqlstore
 
 import (
+	"math"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +79,55 @@ func TestDedupeUtxoIDs_CrossChunkDuplicate(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, count, "duplicate ref must appear exactly once")
+}
+
+// TestAddUtxosRejectsOverflowAssetWithoutMutation covers the acceptance
+// criterion that a rejected conversion must not mutate metadata: given a
+// UTxO carrying a native-asset amount that overflows uint64,
+// AddUtxos must fail and leave the utxo/asset tables empty, not insert a
+// row with a silently wrapped amount.
+func TestAddUtxosRejectsOverflowAssetWithoutMutation(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xee
+	overflowAmount := new(big.Int).SetUint64(math.MaxUint64)
+	overflowAmount.Add(overflowAmount, big.NewInt(1))
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policyId: {
+				cbor.NewByteString([]byte("asset")): overflowAmount,
+			},
+		},
+	)
+
+	utxo := ledger.Utxo{
+		Id: shelley.NewShelleyTransactionInput(
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+			0,
+		),
+		Output: &mary.MaryTransactionOutput{
+			OutputAmount: mary.MaryTransactionOutputValue{
+				Amount: 1_000_000,
+				Assets: &multiAsset,
+			},
+		},
+	}
+
+	err := store.AddUtxos(
+		[]models.UtxoSlot{{Utxo: utxo, Slot: 1}},
+		nil,
+	)
+	require.Error(t, err)
+
+	var utxoCount, assetCount int
+	require.NoError(t, store.writeDB.QueryRow(
+		"SELECT COUNT(*) FROM utxo",
+	).Scan(&utxoCount))
+	require.NoError(t, store.writeDB.QueryRow(
+		"SELECT COUNT(*) FROM asset",
+	).Scan(&assetCount))
+	require.Equal(t, 0, utxoCount)
+	require.Equal(t, 0, assetCount)
 }

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -986,13 +986,16 @@ func (d *Database) recoverConsumedUtxo(
 	if err != nil {
 		return nil, fmt.Errorf("decode transaction output: %w", err)
 	}
-	ret := models.UtxoLedgerToModel(
+	ret, err := models.UtxoLedgerToModel(
 		lcommon.Utxo{
 			Id:     input,
 			Output: output,
 		},
 		addedSlot,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("convert recovered utxo: %w", err)
+	}
 	// Populate the producer transaction FK so that joins on
 	// utxo.transaction_id and Preload("Outputs") from the producer
 	// Transaction see this row after a rollback reanimates it. The
@@ -1079,7 +1082,16 @@ func (d *Database) SetGenesisTransaction(
 		}
 
 		// Build model for metadata store
-		utxoModels[i] = models.UtxoLedgerToModel(utxo, 0)
+		model, err := models.UtxoLedgerToModel(utxo, 0)
+		if err != nil {
+			return fmt.Errorf(
+				"convert genesis utxo %x:%d: %w",
+				bytePrefix(txId),
+				outputIdx,
+				err,
+			)
+		}
+		utxoModels[i] = model
 	}
 
 	// Store transaction in metadata


### PR DESCRIPTION
## Summary

Several Dingo numeric conversions accepted values outside their target
width and produced wrapped or architecture-dependent state. This closes
#3385 by checking sign, width, and arithmetic overflow before conversion
or range construction, and by returning an error instead of mutating
metadata or selecting a wrapped range.

## Changes

**`database/lifecycle/blob_bulk_delete.go`**
Extracted the batch-end computation into a new `batchEnd(start, tipID uint64, batchSize int) uint64` helper. The old `start+uint64(batchSize)-1` could wrap past `math.MaxUint64` before `min()` clamped it, so a persisted block index near `MaxUint64` produced an `end` below `start` and corrupted the deletion range. The helper computes `tipID-start` first (always safe, since the loop guarantees `start <= tipID`) and only adds `batchSize` once that's proven not to overflow.

**`database/plugin/metadata/sqlstore/operational.go`**
Added `checkedUint64(value int64) (uint64, error)`, the mirror of the existing `checkedInt64`. Applied it everywhere a signed SQL column was being cast straight to `uint64`: `GetTip` (the case named in the issue — a negative stored slot/block number previously became a near-`MaxUint64` chain point), `GetNetworkState`, `GetBlockNoncesInSlotRange`, `GetLatestBlockNonce`, `GetDatum`, `GetScript`, `GetPParams`, `GetPParamUpdates`, and `epochFromValues` (shared by the `GetEpoch*` family). All of these already returned `error`, so no interface changes were needed; `epochFromValues` gained an `error` return and its 4 callers picked up one more check each.

**`database/block_indexer.go`**
`safeIntToUint32` compared a plain `int` against the untyped constant `math.MaxUint32`, which doesn't fit in a 32-bit `int` — a compile-time "constant overflows int" error on 32-bit platforms. Fixed by comparing via `int64(n)` instead, which is wide enough on every platform while preserving the existing clamp-to-`MaxUint32` behavior.

**`database/plugin/blob/aws/database.go`, `database/plugin/blob/gcs/database.go`**
Not named in the issue, but `writeReverseKey` in both files had the identical `len(key) > math.MaxUint32` pattern and the same 32-bit compile failure. Fixed the same way, since leaving them would mean the module still didn't build on 32-bit.

**`database/models/asset.go`**
Added `checkedUint64FromBigInt(amount *big.Int) (uint64, error)`, guarded by `big.Int.IsUint64()` (false for both negative values and values ≥ 2⁶⁴). `ConvertMultiAssetToModels` now calls this instead of `amount.Uint64()` directly and returns `([]Asset, error)` instead of `[]Asset`.

**`database/models/utxo.go`**
`UtxoLedgerToModel`'s signature changed from `Utxo` to `(Utxo, error)` to propagate `ConvertMultiAssetToModels`'s new error, and it applies the same `checkedUint64FromBigInt` guard to the UTxO's own lovelace amount.

**`database/models/utxo_test.go`, `database/plugin/metadata/sqlstore/transaction_write.go`, `database/plugin/metadata/sqlstore/utxo.go`, `database/transaction.go`**
Mechanical fallout at the 5 call sites of `UtxoLedgerToModel` (`recoverConsumedUtxo`, `SetGenesisTransaction`, `SetTransaction`, `SetGapBlockTransaction`, `AddUtxos`, plus the existing unit test): each already sat inside a function/closure returning `error`, so each picked up `model, err := models.UtxoLedgerToModel(...)` and an `if err != nil` check.

**New test files**
- `database/lifecycle/blob_bulk_delete_internal_test.go` — `batchEnd` at/near `MaxUint64`.
- `database/block_indexer_safe_conversion_test.go` — `safeIntToUint32` at negative, zero, `MaxUint32`, and `MaxUint32+1`.
- `database/models/asset_test.go` — `ConvertMultiAssetToModels`/`UtxoLedgerToModel` at `MaxUint64`, one past it, and negative, plus nil-input cases.
- `database/plugin/metadata/sqlstore/operational_test.go` — `GetTip` against a hand-inserted row with a negative slot/block number, a `MaxInt64` round-trip, and direct `checkedUint64` unit tests.
- `database/plugin/metadata/sqlstore/utxo_test.go` — `AddUtxos` given an overflowing asset amount, asserting it errors and leaves the `utxo`/`asset` tables empty (no partial mutation).

Closes #3385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented numeric overflow and truncation when converting asset amounts, UTxO data, and stored metadata values.
  - Invalid negative or oversized values now return clear errors instead of producing corrupted data.
  - Improved deletion batching to safely handle maximum numeric boundaries.
  - Added compatibility fixes for 32-bit platforms.

- **Validation**
  - Expanded regression coverage for overflow handling, boundary values, corrupted metadata, and failed UTxO conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->