### PR TITLE
test(docsparity): resolve symlinked repository paths

### DIFF
--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -104,8 +104,16 @@ func filesMatching(
 	if err != nil {
 		return filesMatchingWalk(t, root, match)
 	}
+	rootResolved, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return filesMatchingWalk(t, root, match)
+	}
 	topLevel, err := exec.Command("git", "-C", root, "rev-parse", "--show-toplevel").Output()
-	if err != nil || filepath.Clean(strings.TrimSpace(string(topLevel))) != filepath.Clean(rootAbs) {
+	if err != nil {
+		return filesMatchingWalk(t, root, match)
+	}
+	topLevelResolved, err := filepath.EvalSymlinks(strings.TrimSpace(string(topLevel)))
+	if err != nil || filepath.Clean(topLevelResolved) != filepath.Clean(rootResolved) {
 		return filesMatchingWalk(t, root, match)
 	}
 	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
@@ -237,6 +245,16 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Errorf("workflowFiles() = %v, want %v", got, want)
 	}
+	t.Run("through symlink", func(t *testing.T) {
+		linkedRoot := filepath.Join(t.TempDir(), "repo")
+		if err := os.Symlink(root, linkedRoot); err != nil {
+			t.Skipf("create repository symlink: %v", err)
+		}
+		got := workflowFiles(t, linkedRoot)
+		if !slices.Equal(got, want) {
+			t.Errorf("workflowFiles() through symlink = %v, want %v", got, want)
+		}
+	})
 
 	parent := t.TempDir()
 	runGit(t, parent, "init")


### PR DESCRIPTION
## Summary

- normalize Git repository roots before selecting index-backed discovery
- cover discovery through a directory symlink

Closes #3598

## Checks

- `GOWORK=off GOCACHE=/tmp/dingo-3598-gocache go test -race -count=1 -run "^TestDocumentationDiscoveryIgnoresUntrackedFiles$" ./internal/docsparity`
- `GOWORK=off GOCACHE=/tmp/dingo-3598-gocache go test -race -count=1 ./internal/docsparity`
- `GOWORK=off GOCACHE=/tmp/dingo-3598-darwin-gocache GOOS=darwin GOARCH=arm64 go test -c -o /tmp/dingo-3598-docsparity-darwin.test ./internal/docsparity`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `docsparity` discovery so index-backed file lists are used even when the repository path is accessed through a symlink. Previously, the unresolved root path was compared to Git's resolved toplevel, causing fallback to the slower walk method. Now both paths are resolved before comparison. Adds a regression test for symlinked repo roots. Closes #3598.

<sup>Written for commit 196906187198af37ddfa07b0139986a2527791b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

