### PR TITLE
fix(docs): ignore generated worktrees in parity discovery

### DIFF
--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -107,12 +107,12 @@ func filesMatching(
 	}
 	topLevel, err := exec.Command("git", "-C", root, "rev-parse", "--show-toplevel").Output()
 	if err != nil || !sameDiscoveryRoot(rootAbs, strings.TrimSpace(string(topLevel))) {
-		return filesMatchingWalk(t, root, match)
+		return filesMatchingWalk(t, rootAbs, match)
 	}
 	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
 	output, err := cmd.Output()
 	if err != nil {
-		return filesMatchingWalk(t, root, match)
+		return filesMatchingWalk(t, rootAbs, match)
 	}
 	for rel := range strings.SplitSeq(string(output), "\x00") {
 		if rel == "" {
@@ -434,6 +434,31 @@ func TestDocumentationDiscoveryRecognizesAliasedRepositoryRoot(t *testing.T) {
 	}
 	if got, want := workflowFiles(t, alias), []string{".github/workflows/tracked.yml"}; !slices.Equal(got, want) {
 		t.Errorf("aliased workflowFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestDocumentationDiscoveryFollowsAliasedSourceArchive(t *testing.T) {
+	archive := t.TempDir()
+	writeTestFile(t, archive, "docs/source.md")
+	writeTestFile(t, archive, "Dockerfile")
+	writeTestFile(t, archive, ".github/workflows/source.yml")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/Dockerfile")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/.github/workflows/ignored.yml")
+
+	alias := filepath.Join(t.TempDir(), "archive-alias")
+	if err := os.Symlink(archive, alias); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+
+	if got, want := markdownFiles(t, alias), []string{"docs/source.md"}; !slices.Equal(got, want) {
+		t.Errorf("aliased archive markdownFiles() = %v, want %v", got, want)
+	}
+	if got, want := dockerfiles(t, alias), []string{"Dockerfile"}; !slices.Equal(got, want) {
+		t.Errorf("aliased archive dockerfiles() = %v, want %v", got, want)
+	}
+	if got, want := workflowFiles(t, alias), []string{".github/workflows/source.yml"}; !slices.Equal(got, want) {
+		t.Errorf("aliased archive workflowFiles() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -41,7 +41,7 @@ var contributorDocs = []string{
 	"ARCHITECTURE.md",
 	"DATABASE.md",
 	"GENESIS_SYNC.md",
-	filepath.Join("internal", "test", "devnet", "README.md"),
+	"internal/test/devnet/README.md",
 }
 
 // historicalDocs record past measurements or shipped releases. They describe
@@ -101,12 +101,12 @@ func filesMatching(
 	t.Helper()
 
 	var found []string
-	rootAbs, err := filepath.Abs(root)
+	rootAbs, err := canonicalDiscoveryPath(root)
 	if err != nil {
 		return filesMatchingWalk(t, root, match)
 	}
 	topLevel, err := exec.Command("git", "-C", root, "rev-parse", "--show-toplevel").Output()
-	if err != nil || filepath.Clean(strings.TrimSpace(string(topLevel))) != filepath.Clean(rootAbs) {
+	if err != nil || !sameDiscoveryRoot(rootAbs, strings.TrimSpace(string(topLevel))) {
 		return filesMatchingWalk(t, root, match)
 	}
 	cmd := exec.Command("git", "-C", root, "ls-files", "-z")
@@ -124,6 +124,41 @@ func filesMatching(
 		}
 	}
 	return found
+}
+
+// canonicalDiscoveryPath resolves aliases and symlinks before comparing
+// repository roots. os.SameFile is used by sameDiscoveryRoot when possible,
+// which handles aliases whose spelling differs even after filepath.Clean.
+func canonicalDiscoveryPath(root string) (string, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func sameDiscoveryRoot(canonicalRoot, gitRoot string) bool {
+	canonicalGitRoot, err := canonicalDiscoveryPath(gitRoot)
+	if err != nil {
+		return false
+	}
+	if rootInfo, err := os.Stat(canonicalRoot); err == nil {
+		if gitInfo, err := os.Stat(canonicalGitRoot); err == nil {
+			return os.SameFile(rootInfo, gitInfo)
+		}
+	}
+	// Windows paths are case-insensitive. EqualFold also makes the fallback
+	// comparison robust when Git and the process use different path casing.
+	left := filepath.ToSlash(filepath.Clean(canonicalRoot))
+	right := filepath.ToSlash(filepath.Clean(canonicalGitRoot))
+	if filepath.Separator == '\\' {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
 }
 
 func filesMatchingWalk(
@@ -302,7 +337,7 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 		t.Errorf("dockerfiles() = %v, want %v", got, want)
 	}
 	got, want = workflowFiles(t, root), []string{
-		filepath.Join(".github", "workflows", "tracked.yml"),
+		".github/workflows/tracked.yml",
 	}
 	if !slices.Equal(got, want) {
 		t.Errorf("workflowFiles() = %v, want %v", got, want)
@@ -312,9 +347,22 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	runGit(t, parent, "init")
 	nested := filepath.Join(parent, "nested")
 	writeTestFile(t, nested, "docs/archive.md")
+	writeTestFile(t, nested, "Dockerfile")
+	writeTestFile(t, nested, ".github/workflows/archive.yml")
+	writeTestFile(t, nested, ".claude/worktrees/scratch/ignored.md")
+	writeTestFile(t, nested, ".claude/worktrees/scratch/Dockerfile")
+	writeTestFile(t, nested, ".claude/worktrees/scratch/ignored.yml")
 	got, want = markdownFiles(t, nested), []string{"docs/archive.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("nested markdownFiles() = %v, want %v", got, want)
+	}
+	got, want = dockerfiles(t, nested), []string{"Dockerfile"}
+	if !slices.Equal(got, want) {
+		t.Errorf("nested dockerfiles() = %v, want %v", got, want)
+	}
+	got, want = workflowFiles(t, nested), []string{".github/workflows/archive.yml"}
+	if !slices.Equal(got, want) {
+		t.Errorf("nested workflowFiles() = %v, want %v", got, want)
 	}
 
 	archive := t.TempDir()
@@ -327,6 +375,31 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	got, want = markdownFiles(t, archive), []string{"docs/tracked.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("archive markdownFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestDocumentationDiscoveryRecognizesAliasedRepositoryRoot(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init")
+	writeTestFile(t, root, "docs/tracked.md")
+	writeTestFile(t, root, ".github/workflows/tracked.yml")
+	writeTestFile(t, root, "Dockerfile")
+	writeTestFile(t, root, ".codex/worktrees/ignored.md")
+	runGit(t, root, "add", "docs/tracked.md", ".github/workflows/tracked.yml", "Dockerfile")
+
+	alias := filepath.Join(t.TempDir(), "repo-alias")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+
+	if got, want := markdownFiles(t, alias), []string{"docs/tracked.md"}; !slices.Equal(got, want) {
+		t.Errorf("aliased markdownFiles() = %v, want %v", got, want)
+	}
+	if got, want := dockerfiles(t, alias), []string{"Dockerfile"}; !slices.Equal(got, want) {
+		t.Errorf("aliased dockerfiles() = %v, want %v", got, want)
+	}
+	if got, want := workflowFiles(t, alias), []string{".github/workflows/tracked.yml"}; !slices.Equal(got, want) {
+		t.Errorf("aliased workflowFiles() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -117,7 +118,7 @@ func filesMatching(
 		if rel == "" {
 			continue
 		}
-		rel = filepath.ToSlash(filepath.FromSlash(rel))
+		rel = normalizeDiscoveryPath(rel)
 		if match(rel) {
 			found = append(found, rel)
 		}
@@ -132,29 +133,25 @@ func filesMatchingWalk(
 ) []string {
 	t.Helper()
 
-	skippedDirs := map[string]bool{
-		".git":         true,
-		".claude":      true,
-		".worktrees":   true,
-		".tools":       true,
-		"node_modules": true,
-	}
 	var found []string
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if entry.IsDir() {
-			if skippedDirs[entry.Name()] {
-				return filepath.SkipDir
-			}
-			return nil
-		}
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
-		rel = filepath.ToSlash(rel)
+		rel = normalizeDiscoveryPath(rel)
+		if entry.IsDir() {
+			if isExcludedDiscoveryPath(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if isExcludedDiscoveryPath(rel) {
+			return nil
+		}
 		if match(rel) {
 			found = append(found, rel)
 		}
@@ -166,6 +163,43 @@ func filesMatchingWalk(
 	return found
 }
 
+// excludedDiscoveryRoots are generated or dependency trees that are not part
+// of a source checkout's documentation/configuration surface. They are
+// expressed with slash separators because repository-relative paths use Git's
+// format regardless of the host platform.
+var excludedDiscoveryRoots = []string{
+	".agents/worktrees",
+	".claude/worktrees",
+	".codex/worktrees",
+	".git",
+	".tools",
+	".worktrees",
+	"node_modules",
+}
+
+// normalizeDiscoveryPath converts a repository-relative path to the stable
+// slash-separated form used by every discovery predicate. Replacing both
+// separators before path.Clean keeps synthetic Windows paths testable on Unix
+// and avoids filepath semantics changing the parity contract by host OS.
+func normalizeDiscoveryPath(rel string) string {
+	rel = strings.ReplaceAll(rel, `\`, "/")
+	rel = path.Clean(rel)
+	if rel == "." {
+		return ""
+	}
+	return strings.TrimPrefix(rel, "./")
+}
+
+func isExcludedDiscoveryPath(rel string) bool {
+	rel = normalizeDiscoveryPath(rel)
+	for _, root := range excludedDiscoveryRoots {
+		if rel == root || strings.HasPrefix(rel, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // markdownFiles returns every non-historical markdown document in the tree.
 func markdownFiles(t *testing.T, root string) []string {
 	t.Helper()
@@ -175,7 +209,7 @@ func markdownFiles(t *testing.T, root string) []string {
 	})
 	kept := make([]string, 0, len(all))
 	for _, rel := range all {
-		if historicalDocs[filepath.Base(rel)] {
+		if historicalDocs[path.Base(rel)] {
 			continue
 		}
 		kept = append(kept, rel)
@@ -188,7 +222,7 @@ func dockerfiles(t *testing.T, root string) []string {
 	t.Helper()
 
 	return filesMatching(t, root, func(rel string) bool {
-		name := filepath.Base(rel)
+		name := path.Base(rel)
 		return name == "Dockerfile" || strings.HasPrefix(name, "Dockerfile.")
 	})
 }
@@ -200,8 +234,39 @@ func workflowFiles(t *testing.T, root string) []string {
 	return filesMatching(t, root, func(rel string) bool {
 		return (strings.HasSuffix(rel, ".yml") ||
 			strings.HasSuffix(rel, ".yaml")) &&
-			filepath.ToSlash(filepath.Dir(rel)) == ".github/workflows"
+			path.Dir(rel) == ".github/workflows"
 	})
+}
+
+func TestNormalizeDiscoveryPathIsPlatformIndependent(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		excluded bool
+	}{
+		"windows agent worktree": {
+			input:    `.codex\\worktrees\\scratch\\notes.md`,
+			excluded: true,
+		},
+		"unix agent worktree": {
+			input:    `.claude/worktrees/scratch/notes.md`,
+			excluded: true,
+		},
+		"similar name remains": {
+			input:    `.codex/worktree-notes/notes.md`,
+			excluded: false,
+		},
+		"tracked repository file": {
+			input:    `docs\\guide.md`,
+			excluded: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := isExcludedDiscoveryPath(tt.input); got != tt.excluded {
+				t.Fatalf("isExcludedDiscoveryPath(%q) = %v, want %v", tt.input, got, tt.excluded)
+			}
+		})
+	}
 }
 
 func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
@@ -213,17 +278,22 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	writeTestFile(t, root, ".github/workflows/tracked.yml")
 	writeTestFile(t, root, ".claude/worktrees/scratch/ignored.md")
 	writeTestFile(t, root, ".claude/worktrees/scratch/Dockerfile")
+	writeTestFile(t, root, ".codex/worktrees/tracked.md")
 	writeTestFile(t, root, ".github/workflows/ignored.yaml")
 	runGit(
 		t,
 		root,
 		"add",
+		".codex/worktrees/tracked.md",
 		"docs/tracked.md",
 		"Dockerfile",
 		".github/workflows/tracked.yml",
 	)
 
-	got, want := markdownFiles(t, root), []string{"docs/tracked.md"}
+	got, want := markdownFiles(t, root), []string{
+		".codex/worktrees/tracked.md",
+		"docs/tracked.md",
+	}
 	if !slices.Equal(got, want) {
 		t.Errorf("markdownFiles() = %v, want %v", got, want)
 	}
@@ -245,6 +315,18 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	got, want = markdownFiles(t, nested), []string{"docs/archive.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("nested markdownFiles() = %v, want %v", got, want)
+	}
+
+	archive := t.TempDir()
+	writeTestFile(t, archive, "docs/tracked.md")
+	writeTestFile(t, archive, ".claude/worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".agents/worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".tools/scratch/ignored.md")
+	got, want = markdownFiles(t, archive), []string{"docs/tracked.md"}
+	if !slices.Equal(got, want) {
+		t.Errorf("archive markdownFiles() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -206,9 +206,15 @@ var excludedDiscoveryRoots = []string{
 	".agents/worktrees",
 	".claude/worktrees",
 	".codex/worktrees",
-	".git",
 	".tools",
 	".worktrees",
+}
+
+// excludedDiscoveryDirectories are generic dependency and VCS directories
+// that may occur below any fallback-discovery root. Unlike generated worktree
+// roots, these must be excluded recursively at every path depth.
+var excludedDiscoveryDirectories = []string{
+	".git",
 	"node_modules",
 }
 
@@ -227,6 +233,11 @@ func normalizeDiscoveryPath(rel string) string {
 
 func isExcludedDiscoveryPath(rel string) bool {
 	rel = normalizeDiscoveryPath(rel)
+	for _, component := range strings.Split(rel, "/") {
+		if slices.Contains(excludedDiscoveryDirectories, component) {
+			return true
+		}
+	}
 	for _, root := range excludedDiscoveryRoots {
 		if rel == root || strings.HasPrefix(rel, root+"/") {
 			return true
@@ -374,6 +385,10 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	writeTestFile(t, archive, ".agents/worktrees/scratch/ignored.md")
 	writeTestFile(t, archive, ".worktrees/scratch/ignored.md")
 	writeTestFile(t, archive, ".tools/scratch/ignored.md")
+	writeTestFile(t, archive, "vendor/project/.git/config")
+	writeTestFile(t, archive, "vendor/project/.git/README.md")
+	writeTestFile(t, archive, "vendor/project/node_modules/pkg/README.md")
+	writeTestFile(t, archive, "vendor/project/node_modules/pkg/Dockerfile")
 	got, want = markdownFiles(t, archive), []string{"docs/tracked.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("archive markdownFiles() = %v, want %v", got, want)

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -233,7 +233,7 @@ func normalizeDiscoveryPath(rel string) string {
 
 func isExcludedDiscoveryPath(rel string) bool {
 	rel = normalizeDiscoveryPath(rel)
-	for _, component := range strings.Split(rel, "/") {
+	for component := range strings.SplitSeq(rel, "/") {
 		if slices.Contains(excludedDiscoveryDirectories, component) {
 			return true
 		}

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -369,12 +369,28 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	writeTestFile(t, archive, "docs/tracked.md")
 	writeTestFile(t, archive, ".claude/worktrees/scratch/ignored.md")
 	writeTestFile(t, archive, ".codex/worktrees/scratch/ignored.md")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/Dockerfile")
+	writeTestFile(t, archive, ".codex/worktrees/scratch/.github/workflows/ignored.yml")
 	writeTestFile(t, archive, ".agents/worktrees/scratch/ignored.md")
 	writeTestFile(t, archive, ".worktrees/scratch/ignored.md")
 	writeTestFile(t, archive, ".tools/scratch/ignored.md")
 	got, want = markdownFiles(t, archive), []string{"docs/tracked.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("archive markdownFiles() = %v, want %v", got, want)
+	}
+	got, want = dockerfiles(t, archive), []string{}
+	if !slices.Equal(got, want) {
+		t.Errorf("archive dockerfiles() = %v, want %v", got, want)
+	}
+
+	// Use a matcher broader than workflowFiles so the fallback walk reaches a
+	// workflow nested inside a generated worktree. The parent implementation
+	// walked this path and returned it because it did not exclude .codex.
+	got, want = filesMatching(t, archive, func(rel string) bool {
+		return strings.HasSuffix(rel, "/.github/workflows/ignored.yml")
+	}), []string{}
+	if !slices.Equal(got, want) {
+		t.Errorf("archive nested workflow files = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docsparity/parity_helpers_test.go
+++ b/internal/docsparity/parity_helpers_test.go
@@ -351,7 +351,7 @@ func TestDocumentationDiscoveryIgnoresUntrackedFiles(t *testing.T) {
 	writeTestFile(t, nested, ".github/workflows/archive.yml")
 	writeTestFile(t, nested, ".claude/worktrees/scratch/ignored.md")
 	writeTestFile(t, nested, ".claude/worktrees/scratch/Dockerfile")
-	writeTestFile(t, nested, ".claude/worktrees/scratch/ignored.yml")
+	writeTestFile(t, nested, ".codex/worktrees/scratch/.github/workflows/ignored.yml")
 	got, want = markdownFiles(t, nested), []string{"docs/archive.md"}
 	if !slices.Equal(got, want) {
 		t.Errorf("nested markdownFiles() = %v, want %v", got, want)
@@ -385,6 +385,9 @@ func TestDocumentationDiscoveryRecognizesAliasedRepositoryRoot(t *testing.T) {
 	writeTestFile(t, root, ".github/workflows/tracked.yml")
 	writeTestFile(t, root, "Dockerfile")
 	writeTestFile(t, root, ".codex/worktrees/ignored.md")
+	writeTestFile(t, root, "untracked.md")
+	writeTestFile(t, root, ".github/workflows/untracked.yaml")
+	writeTestFile(t, root, ".codex/worktrees/scratch/.github/workflows/ignored.yml")
 	runGit(t, root, "add", "docs/tracked.md", ".github/workflows/tracked.yml", "Dockerfile")
 
 	alias := filepath.Join(t.TempDir(), "repo-alias")


### PR DESCRIPTION
## Summary
- make documentation, Dockerfile, and workflow discovery stable across generated agent worktrees and fallback archives
- preserve recursive exclusions and handle canonicalized symlinked source roots
- add regression coverage for nested exclusions, path normalization, and non-Git archives

Closes #3594

## Validation
- go test -race ./internal/docsparity
- make docs-parity
- go test ./internal/test/conformance/
- go vet ./internal/docsparity
- Windows/amd64 and macOS/arm64 cross-compilation
- gofmt and git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes docs-parity discovery stable across symlinked checkouts, generated agent worktrees, and fallback archives so parity checks no longer scan files that aren't part of the source checkout.

- Excludes generated worktree roots (`.agents`, `.claude`, `.codex`, `.worktrees`, `.tools`) and nested `.git`/`node_modules` directories recursively at any depth.
- Canonicalizes symlinked source roots so Git-tracked file listings are used even when the discovery path is an alias to the repository or archive.
- Normalizes repository-relative paths with slash separators so discovery behavior is identical on Windows and Unix.
- Adds regression coverage for nested exclusions, aliased roots and archives, and platform-independent path handling.

<sup>Written for commit 1b24e58ded1e47178060f90cfad4c516f7d01a5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation file detection across operating systems.
  * Correctly handles symlinked, aliased, nested, and archived repository locations.
  * Improved exclusion handling for directories and repository paths.
  * Added coverage for untracked files and other edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->