### PR TITLE
fix(chainselection): verify header crypto before Genesis observation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2950,6 +2950,35 @@ it. Dingo implements this as a **corroboration gate**
   the historical default), preserving prior behavior for nodes that do not opt
   into the Genesis trust model. While the gate is disabled the per-peer hash
   frontier is not tracked, so normal Praos operation carries no extra state.
+- **Header-crypto verification gates observation, independent of
+  corroboration.** Density and the corroboration hash frontier are both
+  populated from `recordObservedPoint`, driven by `PeerTipUpdateEvent`
+  observation in the roll-forward handler — so with `corroborationPeers = 0`
+  (or before any corroboration state exists), density alone previously came
+  from peer-reported headers that had not passed any check. The roll-forward
+  handler now verifies a header's VRF/KES cryptography and, once local ledger
+  state has caught up, its leader eligibility
+  (`LedgerState.ValidateChainSelectionHeaderCrypto`, gated by
+  `ShouldVerifyChainSelectionHeaderCrypto`) *before* it is observed, for every
+  ingress-eligible peer — not only the currently apply-eligible one, since a
+  competing candidate's headers never reach the ledger's own chainsync
+  header-queue verification (that only runs for headers actually applied).
+  Verification is skipped under the same fast-sync/Mithril-import exemptions
+  the ledger's own header-queue path already applies, and a result showing
+  local state has not caught up to the header's slot (`IsHeaderVerification-
+  Deferred`) still leaves the header eligible — both preserve legitimate
+  catch-up behavior. Only a definite failure excludes the header from
+  observation and publishes `ledger.ConnectionRecycleRequestedEventType`
+  (`"header_verification_failure"`, translated to a connmanager recycle by
+  node composition, the same as the ledger's own header-queue failures).
+  The check is two derived closures on `Ouroboros`
+  (`chainSelectionShouldVerifyHeaderCrypto`/`chainSelectionVerifyHeaderCrypto`),
+  set from `ledgerState` the same way `chainsyncHeaderAdmission` already is —
+  so a test exercising the roll-forward handler alone can override either
+  seam directly instead of standing up a full `LedgerState`.
+  `chainselection/` itself is unchanged: the gate runs entirely in
+  `ouroboros/chainsync.go` before a header is ever handed to
+  `chainselection`.
 
 **Supported GSA-style configuration**: a trustable `localRoots` peer (the fast
 source) plus a ledger peer snapshot (`peerSnapshotFile`) that seeds

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2965,10 +2965,11 @@ it. Dingo implements this as a **corroboration gate**
   header-queue verification (that only runs for headers actually applied).
   Verification is skipped under the same fast-sync/Mithril-import exemptions
   the ledger's own header-queue path already applies, and a result showing
-  local state has not caught up to the header's slot (`IsHeaderVerification-
-  Deferred`) still leaves the header eligible — both preserve legitimate
-  catch-up behavior. Only a definite failure excludes the header from
-  observation and publishes `ledger.ConnectionRecycleRequestedEventType`
+  local state has not caught up to the header's slot
+  (`IsHeaderVerificationDeferred`) still leaves the header eligible — both
+  preserve legitimate catch-up behavior. Only a definite failure excludes the
+  header from observation and publishes
+  `ledger.ConnectionRecycleRequestedEventType`
   (`"header_verification_failure"`, translated to a connmanager recycle by
   node composition, the same as the ledger's own header-queue failures).
   The check is two derived closures on `Ouroboros`

--- a/ledger/verify_chain_selection_header_crypto_test.go
+++ b/ledger/verify_chain_selection_header_crypto_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateChainSelectionHeaderCryptoAcceptsVerifiedHeader proves that a
+// header whose crypto is valid and whose leader eligibility can already be
+// checked against local ledger state passes with no error -- the baseline
+// "fully verified" case chain selection must count toward Genesis density.
+func TestValidateChainSelectionHeaderCryptoAcceptsVerifiedHeader(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{70}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	seedBlockPoolRegistration(t, db, tb.block)
+	poolKeyHash := tb.block.IssuerVkey().Hash()
+	// Pool owns 100% of stake, matching createTestBlock's threshold
+	// assumption, at the epoch-5 block's "mark" snapshot (epoch 4).
+	seedPoolStakeSnapshot(t, db, 4, poolKeyHash[:], 1_000_000_000)
+	ls.publishSnapshotsLocked()
+
+	err := ls.ValidateChainSelectionHeaderCrypto(tb.block.Header())
+	require.NoError(
+		t,
+		err,
+		"a header with valid crypto and confirmed leader eligibility must verify",
+	)
+}
+
+// TestValidateChainSelectionHeaderCryptoRejectsTamperedProof proves that a
+// header with an internally-invalid VRF proof is a definite (non-deferred)
+// failure, even while local ledger state has not caught up to the header's
+// slot. An invalid header must never be counted toward Genesis density
+// regardless of local sync state (dingo #3517).
+func TestValidateChainSelectionHeaderCryptoRejectsTamperedProof(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{71}, 0, tamperVRFProof)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// Behind the block's slot, same as the deferred-eligibility fixtures
+	// below -- proves a real crypto failure is not masked by state-defer
+	// tolerance.
+	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
+	ls.publishSnapshotsLocked()
+
+	err := ls.ValidateChainSelectionHeaderCrypto(tb.block.Header())
+	require.Error(t, err)
+	assert.False(
+		t,
+		IsHeaderVerificationDeferred(err),
+		"a tampered VRF proof must be a definite failure, not deferred",
+	)
+}
+
+// TestValidateChainSelectionHeaderCryptoDefersAheadOfLocalState proves that a
+// header this node cannot yet confirm leader eligibility for -- because local
+// ledger application has not reached its slot -- is reported as deferred, not
+// rejected. This is the fast-sync/Genesis-bootstrap case the fix must
+// preserve: an honest peer legitimately racing ahead of local ledger apply
+// must still be eligible for chain-selection density.
+func TestValidateChainSelectionHeaderCryptoDefersAheadOfLocalState(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{72}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.currentTip.Point.Slot = tb.block.SlotNumber() - 1
+	ls.publishSnapshotsLocked()
+
+	err := ls.ValidateChainSelectionHeaderCrypto(tb.block.Header())
+	require.Error(t, err)
+	assert.True(
+		t,
+		IsHeaderVerificationDeferred(err),
+		"a header ahead of local ledger state must defer, not fail closed",
+	)
+}
+
+// TestValidateChainSelectionHeaderCryptoDoesNotAdvanceEpochCache proves that,
+// like ValidateBlockHeaderCrypto, verifying a header for chain selection
+// never mutates the shared epoch cache -- an unauthenticated peer header must
+// not be able to influence shared ledger state as a side effect of being
+// observed for density.
+func TestValidateChainSelectionHeaderCryptoDoesNotAdvanceEpochCache(
+	t *testing.T,
+) {
+	const futureSlot = uint64(1001)
+	ls := &LedgerState{
+		currentEra: eras.ConwayEraDesc,
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(500, []byte("tip"))},
+		epochCache: []models.Epoch{{
+			EpochId:       500,
+			StartSlot:     0,
+			SlotLength:    1_000,
+			LengthInSlots: 1_000,
+			EraId:         eras.ConwayEraDesc.Id,
+			Nonce:         []byte{0x01},
+		}},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	err := ls.ValidateChainSelectionHeaderCrypto(
+		&mockBabbageBlock{slot: futureSlot},
+	)
+	require.Error(t, err)
+	assert.Len(
+		t,
+		ls.loadConsensusSnapshot().epochCache,
+		1,
+		"chain-selection header validation must not advance the shared epoch cache",
+	)
+}
+
+// TestShouldVerifyChainSelectionHeaderCryptoMatchesChainsyncGate proves that
+// ShouldVerifyChainSelectionHeaderCrypto shares the same fast-sync/Mithril
+// exemptions as the ledger's own chainsync header-queue gate
+// (shouldVerifyChainsyncHeaderCrypto), so a competing peer's header is exempt
+// under exactly the same conditions the applied chain already is.
+func TestShouldVerifyChainSelectionHeaderCryptoMatchesChainsyncGate(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{73}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	slot := tb.block.SlotNumber()
+
+	assert.False(
+		t,
+		ls.ShouldVerifyChainSelectionHeaderCrypto(slot),
+		"verification must be skipped before live validation is enabled, "+
+			"matching shouldVerifyChainsyncHeaderCrypto",
+	)
+
+	ls.validationEnabled = true
+	ls.publishSnapshotsLocked()
+	assert.True(
+		t,
+		ls.ShouldVerifyChainSelectionHeaderCrypto(slot),
+		"verification must run once live validation is enabled and the "+
+			"epoch nonce is cached",
+	)
+
+	ls.mithrilLedgerSlot = slot
+	ls.publishSnapshotsLocked()
+	assert.False(
+		t,
+		ls.ShouldVerifyChainSelectionHeaderCrypto(slot),
+		"a Mithril-covered slot must be exempt, matching the applied-chain gate",
+	)
+}

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -142,6 +142,53 @@ func (ls *LedgerState) ValidateBlockHeaderCrypto(
 	)
 }
 
+// ShouldVerifyChainSelectionHeaderCrypto reports whether a header at the
+// given slot is eligible to have its cryptography verified right now via
+// ValidateChainSelectionHeaderCrypto. It mirrors the same exemptions the
+// ledger's own chainsync header-queue path already applies
+// (shouldVerifyChainsyncHeaderCrypto): verification is skipped while bulk
+// historical/catch-up loading has not yet enabled live validation, and for
+// slots already covered by an imported Mithril snapshot, since those slots
+// were authenticated by the certificate chain during import and the
+// restored database does not retain every historical epoch nonce. A caller
+// that skips verification because this returns false must still treat the
+// header as eligible, not reject it -- the same trust boundary the ledger's
+// own pipeline already extends to this data.
+func (ls *LedgerState) ShouldVerifyChainSelectionHeaderCrypto(
+	slot uint64,
+) bool {
+	return ls.shouldVerifyChainsyncHeaderCrypto(slot)
+}
+
+// ValidateChainSelectionHeaderCrypto verifies a header's VRF/KES cryptography
+// and, where the local ledger's stake/pool state has already caught up to
+// the header's epoch, its leader eligibility. It lets chain selection require
+// that a peer-reported header has passed the same checks as the applied
+// chain before the header is allowed to influence Genesis density or
+// corroboration (dingo #3517), independent of whether that header will ever
+// be applied to the ledger.
+//
+// It never advances the shared epoch cache (matching ValidateBlockHeaderCrypto's
+// no-mutation contract for header-only validation), but unlike
+// ValidateBlockHeaderCrypto it tolerates ledger state that has not yet caught
+// up to the header's slot: that is the normal condition for a peer
+// legitimately racing ahead of local ledger application during fast sync or
+// Genesis bootstrap. Use IsHeaderVerificationDeferred to distinguish that
+// case (the header must still be treated as eligible) from a header this
+// node can already prove is invalid.
+func (ls *LedgerState) ValidateChainSelectionHeaderCrypto(
+	header ledger.BlockHeader,
+) error {
+	if header == nil {
+		return errors.New("nil block header")
+	}
+	return ls.verifyBlockHeaderCryptoWithEpochAdvance(
+		headerOnlyBlock{header: header},
+		false,
+		true,
+	)
+}
+
 // verifyBlockHeader performs cryptographic verification of a block header.
 // This includes VRF proof verification and KES signature verification.
 // Byron-era blocks are skipped here because this helper has only Praos

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1045,6 +1045,58 @@ func (o *Ouroboros) chainsyncClientRollForwardAt(
 				return nil
 			}
 		}
+		// Verify header crypto (VRF/KES and, once local state has caught up,
+		// leader eligibility) before this header is allowed to influence
+		// Genesis chain-selection density or corroboration. Without this
+		// gate, an untrusted peer-reported header could steer fork selection
+		// using data that has not passed the same checks as the applied
+		// chain (dingo #3517). This runs for every ingress-eligible peer, not
+		// only the one currently apply-eligible: a competing candidate's
+		// headers never reach the ledger's own chainsync header-queue
+		// verification, since that only runs for headers actually applied.
+		//
+		// Verification is skipped under the same conditions the ledger's own
+		// header pipeline already skips it (bulk historical/catch-up
+		// loading, or a Mithril-covered slot), so fast sync and a
+		// Mithril-restored bootstrap are unaffected. A deferred result (local
+		// state has not caught up to this header's slot yet) also leaves the
+		// header eligible -- that is the normal shape of a peer legitimately
+		// racing ahead of local ledger application, not a peer fault. Only a
+		// definite crypto/eligibility failure excludes the header from
+		// observation and recycles the connection.
+		if ingressEligible && o.chainSelectionShouldVerifyHeaderCrypto != nil &&
+			o.chainSelectionShouldVerifyHeaderCrypto(blockSlot) {
+			if verifyErr := o.chainSelectionVerifyHeaderCrypto(v); verifyErr != nil {
+				if ledger.IsHeaderVerificationDeferred(verifyErr) {
+					o.config.Logger.Debug(
+						"chainsync: header verification deferred for chain selection",
+						"component", "ouroboros",
+						"slot", blockSlot,
+						"connection_id", ctx.ConnectionId.String(),
+						"error", verifyErr,
+					)
+				} else {
+					o.config.Logger.Warn(
+						"chainsync: excluding header from chain selection after verification failure",
+						"component", "ouroboros",
+						"slot", blockSlot,
+						"connection_id", ctx.ConnectionId.String(),
+						"error", verifyErr,
+					)
+					o.eventBus.Publish(
+						ledger.ConnectionRecycleRequestedEventType,
+						event.NewEvent(
+							ledger.ConnectionRecycleRequestedEventType,
+							ledger.ConnectionRecycleRequestedEvent{
+								ConnectionId: ctx.ConnectionId,
+								Reason:       "header_verification_failure",
+							},
+						),
+					)
+					ingressEligible = false
+				}
+			}
+		}
 		// Observe the tip for chain selection FIRST, so the apply-eligibility
 		// decision below reflects this header. Only ingress-eligible peers are
 		// observed; random inbound peers reporting ephemeral tips are filtered

--- a/ouroboros/chainsync_header_verification_test.go
+++ b/ouroboros/chainsync_header_verification_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chainselection"
+	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// nonByronTestHeader wraps testBlockHeader to report a post-Byron era so
+// header-crypto verification takes the Praos path (epoch/nonce lookup)
+// instead of the Byron PBFT path, which requires a concrete Byron header
+// type.
+type nonByronTestHeader struct {
+	*testBlockHeader
+}
+
+func (h nonByronTestHeader) Era() gledger.Era {
+	return babbage.EraBabbage
+}
+
+// TestChainsyncClientRollForwardExcludesHeaderFailingCryptoVerification
+// proves that a header whose crypto verification returns a definite (not
+// deferred) error is excluded from chain-selection observation and triggers
+// a connection recycle, instead of being allowed to influence Genesis
+// density or corroboration (dingo #3517).
+func TestChainsyncClientRollForwardExcludesHeaderFailingCryptoVerification(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	_, recycleCh := bus.Subscribe(ledger.ConnectionRecycleRequestedEventType)
+	state := dchainsync.NewState(bus, nil)
+	conn := newTestConnId("127.0.0.1:6010", "1.1.1.2:3001")
+	require.True(t, state.AddClientConnId(conn))
+
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncApplyEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.chainsyncState = state
+	o.eventBus = bus
+	o.chainSelectionShouldVerifyHeaderCrypto = func(uint64) bool { return true }
+	o.chainSelectionVerifyHeaderCrypto = func(gledger.BlockHeader) error {
+		return errors.New("boom: invalid VRF proof")
+	}
+
+	header := newTestBlockHeader(200, 1, 0xcc)
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(200, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: conn},
+		0,
+		header,
+		tip,
+	))
+
+	select {
+	case <-tipCh:
+		t.Fatal(
+			"a header failing crypto verification must not be observed " +
+				"for chain selection",
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	select {
+	case evt := <-recycleCh:
+		data, ok := evt.Data.(ledger.ConnectionRecycleRequestedEvent)
+		require.True(t, ok)
+		require.Equal(t, conn, data.ConnectionId)
+		require.Equal(t, "header_verification_failure", data.Reason)
+	case <-time.After(time.Second):
+		t.Fatal(
+			"expected a connection recycle request after crypto verification failure",
+		)
+	}
+}
+
+// TestChainsyncClientRollForwardObservesHeaderWithDeferredCryptoVerification
+// proves that a header this node cannot yet confirm (ValidateChainSelection-
+// HeaderCrypto returns a deferred error, e.g. because local ledger state has
+// not caught up to it) is still observed for chain selection. This preserves
+// legitimate fast-sync/Genesis-bootstrap behavior, where an honest peer
+// racing ahead of local ledger application must not be excluded.
+//
+// The verifier here is the real ledger.LedgerState.ValidateChainSelection-
+// HeaderCrypto (not a fake), driven into its deferred path by a bare ledger
+// with no cached epoch/nonce data -- proving the actual ledger method, not
+// just the branching around it.
+func TestChainsyncClientRollForwardObservesHeaderWithDeferredCryptoVerification(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	_, recycleCh := bus.Subscribe(ledger.ConnectionRecycleRequestedEventType)
+	state := dchainsync.NewState(bus, nil)
+	conn := newTestConnId("127.0.0.1:6011", "1.1.1.3:3001")
+	require.True(t, state.AddClientConnId(conn))
+
+	ls := newTestLedgerState(t)
+
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncApplyEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+	})
+	o.chainsyncState = state
+	o.eventBus = bus
+	// Force the readiness gate on and use the real verifier: a bare
+	// LedgerState with no cached epoch/nonce data for this slot deterministically
+	// returns a deferred error, matching what ShouldVerifyChainSelectionHeaderCrypto
+	// would itself have skipped verification for -- so a caller relying only on
+	// the real verifier's own error classification, without the readiness gate,
+	// must still get fast-sync-safe (deferred, not excluded) behavior.
+	o.chainSelectionShouldVerifyHeaderCrypto = func(uint64) bool { return true }
+	o.chainSelectionVerifyHeaderCrypto = ls.ValidateChainSelectionHeaderCrypto
+
+	var hash gledger.Blake2b256
+	hash[0] = 0xdd
+	header := nonByronTestHeader{&testBlockHeader{
+		hash:        hash,
+		blockNumber: 1,
+		slotNumber:  200,
+	}}
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(200, header.Hash().Bytes()),
+		BlockNumber: 1,
+	}
+
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: conn},
+		0,
+		header,
+		tip,
+	))
+
+	select {
+	case evt := <-tipCh:
+		_, ok := evt.Data.(chainselection.PeerTipUpdateEvent)
+		require.True(
+			t,
+			ok,
+			"a deferred verification result must still leave the header "+
+				"eligible for chain-selection observation",
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected PeerTipUpdateEvent despite deferred verification")
+	}
+	select {
+	case <-recycleCh:
+		t.Fatal(
+			"a deferred verification result must not recycle the connection",
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestChainsyncClientRollForwardCompetingPeersOnlyVerifiedHeaderCounted
+// proves the verification gate applies independently to every ingress-eligible
+// peer, not only the currently apply-eligible one -- covering the acceptance
+// criterion that competing (candidate) peers are subject to the same check as
+// the applied chain. Two peers deliver headers for the same round; one fails
+// crypto verification and must be excluded, the other passes and must be
+// observed.
+func TestChainsyncClientRollForwardCompetingPeersOnlyVerifiedHeaderCounted(
+	t *testing.T,
+) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	_, tipCh := bus.Subscribe(chainselection.PeerTipUpdateEventType)
+	state := dchainsync.NewState(bus, nil)
+	goodConn := newTestConnId("127.0.0.1:6012", "10.0.0.10:3001")
+	badConn := newTestConnId("127.0.0.1:6012", "10.0.0.11:3001")
+	require.True(t, state.AddClientConnId(goodConn))
+	require.True(t, state.AddClientConnId(badConn))
+
+	badHeader := newTestBlockHeader(300, 1, 0xee)
+
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		// Both peers are ingress-eligible candidates, e.g. competing during
+		// Genesis bootstrap -- neither is apply-eligible, matching a peer that
+		// has not yet won corroboration/selection.
+		ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool {
+			return true
+		},
+		ChainsyncApplyEligible: func(ouroboros.ConnectionId) bool {
+			return false
+		},
+	})
+	o.chainsyncState = state
+	o.eventBus = bus
+	o.chainSelectionShouldVerifyHeaderCrypto = func(uint64) bool { return true }
+	o.chainSelectionVerifyHeaderCrypto = func(h gledger.BlockHeader) error {
+		if h.Hash() == badHeader.Hash() {
+			return errors.New("boom: invalid VRF proof")
+		}
+		return nil
+	}
+
+	goodHeader := newTestBlockHeader(300, 1, 0xff)
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: badConn},
+		0,
+		badHeader,
+		ochainsync.Tip{
+			Point:       ocommon.NewPoint(300, badHeader.Hash().Bytes()),
+			BlockNumber: 1,
+		},
+	))
+	require.NoError(t, o.chainsyncClientRollForward(
+		ochainsync.CallbackContext{ConnectionId: goodConn},
+		0,
+		goodHeader,
+		ochainsync.Tip{
+			Point:       ocommon.NewPoint(300, goodHeader.Hash().Bytes()),
+			BlockNumber: 1,
+		},
+	))
+
+	select {
+	case evt := <-tipCh:
+		data, ok := evt.Data.(chainselection.PeerTipUpdateEvent)
+		require.True(t, ok)
+		require.Equal(
+			t,
+			goodConn,
+			data.ConnectionId,
+			"only the peer with a verified header may be observed",
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected the verified peer's header to be observed")
+	}
+	select {
+	case <-tipCh:
+		t.Fatal(
+			"the peer with a header failing crypto verification must not " +
+				"also be observed",
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -127,7 +127,16 @@ type Ouroboros struct {
 	// the connection; one earliest-onset timer is retained per connection.
 	chainsyncHeaderAdmission chainsyncHeaderAdmissionFunc
 	chainsyncHeaderSlotTime  func(uint64) (time.Time, error)
-	chainsyncScheduleAt      chainsyncScheduleAtFunc
+	// chainSelectionShouldVerifyHeaderCrypto and chainSelectionVerifyHeaderCrypto
+	// gate whether a peer-reported header may influence Genesis chain-selection
+	// density or corroboration before its VRF/KES cryptography (and, once local
+	// state has caught up, leader eligibility) has been checked (dingo #3517).
+	// Derived from ledgerState the same way chainsyncHeaderAdmission is, so
+	// tests exercising a single protocol handler can override either seam
+	// directly instead of standing up a full LedgerState.
+	chainSelectionShouldVerifyHeaderCrypto func(slot uint64) bool
+	chainSelectionVerifyHeaderCrypto       func(header gledger.BlockHeader) error
+	chainsyncScheduleAt                    chainsyncScheduleAtFunc
 	// chainsyncArrivalNow is an instance-local clock seam for deterministic
 	// arrival-order tests. Production instances use time.Now.
 	chainsyncArrivalNow      func() time.Time
@@ -442,6 +451,8 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 	if o.ledgerState != nil {
 		o.chainsyncHeaderAdmission = o.ledgerState.AwaitChainsyncHeaderAdmission
 		o.chainsyncHeaderSlotTime = o.ledgerState.SlotToTime
+		o.chainSelectionShouldVerifyHeaderCrypto = o.ledgerState.ShouldVerifyChainSelectionHeaderCrypto
+		o.chainSelectionVerifyHeaderCrypto = o.ledgerState.ValidateChainSelectionHeaderCrypto
 	}
 	// Initialize per-peer TxSubmission rate limiter
 	txRate := cfg.MaxTxSubmissionsPerSecond


### PR DESCRIPTION
Genesis density and the corroboration hash frontier were both populated
directly from peer-reported chainsync headers, before those headers had
passed any crypto verification, for every ingress-eligible peer — not
only the currently apply-eligible one. A competing candidate's headers
never reach the ledger's own chainsync header-queue verification, since
that only runs for headers actually applied, so with corroboration
disabled (the default) density comparisons had no readiness gate at all.

## Changes

- `ledger.LedgerState.ShouldVerifyChainSelectionHeaderCrypto` /
  `ValidateChainSelectionHeaderCrypto`: mirror the ledger's own chainsync
  header-queue verification and its fast-sync/Mithril-import exemptions,
  but tolerate ledger state that has not yet caught up to the header's
  slot (the normal shape of a peer legitimately racing ahead of local
  ledger application during fast sync or Genesis bootstrap).
- `ouroboros/chainsync.go`: verify a header before it is observed for
  chain selection, for every ingress-eligible peer. A definite failure
  excludes the header and requests a connection recycle
  (`header_verification_failure`); a deferred result still leaves the
  header eligible.
- `ARCHITECTURE.md`: documents the new gate under the Ouroboros Genesis
  trust model section.

## Testing

- `ledger`: new tests cover a fully verified header (accept), a tampered
  VRF proof (definite rejection, not deferred), a header ahead of local
  ledger state (deferred, not rejected), no epoch-cache mutation as a
  side effect, and the fast-sync/Mithril exemption parity with the
  ledger's existing chainsync gate.
- `ouroboros`: new tests cover exclusion + connection recycle on a
  definite verification failure, continued observation on a deferred
  result (using the real ledger method, not a fake), and two competing
  peers where only the one with a verified header is observed.
- All new tests were confirmed to fail without the fix.

## Validation

- `go build ./...`
- `golangci-lint run ./ledger/... ./ouroboros/...` — 0 issues
- `nilaway ./ledger/... ./ouroboros/...` — one pre-existing, unrelated
  finding in `ledger/leios/manager_test.go` (not touched by this change)
- `modernize ./ledger/... ./ouroboros/...` — clean
- `make import-boundaries`, `make docs-parity` — pass
- `go test ./ouroboros/... ./chainselection/...` and `-race` — pass
- `go test -race -timeout 20m ./ledger/...` — pass (719s)
- `go test ./internal/test/conformance/` — pass

Not run: DevNet (`internal/test/devnet/run-tests.sh`) and Antithesis —
no live devnet/Antithesis infrastructure in this session.

Fixes #3517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies header cryptography before peer-reported headers can influence Genesis chain-selection density or corroboration. Previously those headers were observed without any crypto check for non-applied peers; a definite verification failure now excludes the header and recycles its connection, while a deferred result (local ledger state not yet caught up) still leaves the header eligible.

**Changes**
- Adds `LedgerState.ShouldVerifyChainSelectionHeaderCrypto` and `ValidateChainSelectionHeaderCrypto`, mirroring the ledger's chainsync header-queue verification and its fast-sync/Mithril-import exemptions.
- Runs the check in the chainsync roll-forward handler ahead of tip observation for every ingress-eligible peer, not only the currently apply-eligible one.
- Excludes the header and publishes `ConnectionRecycleRequestedEvent` with reason `header_verification_failure` on a definite failure.
- Documents the new gate in `ARCHITECTURE.md`.

**Testing**
- New `ledger` tests cover accept, tampered VRF rejection, deferred-ahead-of-local-state, no epoch-cache mutation, and exemption parity.
- New `ouroboros` tests cover exclusion + recycle, deferred observation with the real ledger method, and two competing peers where only the verified one is observed.

Fixes #3517

<sup>Written for commit a2f2244651eadba9bb14650384db2d36ff5d13f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added cryptographic verification for peer-reported headers before they influence chain selection.
  * Invalid headers are excluded and the associated connection is recycled.
  * Headers that cannot yet be verified due to ledger synchronization are deferred rather than incorrectly rejected.
  * Verification respects existing fast-sync and snapshot-import exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->