### PR TITLE
fix(mithril): preserve reward balances during historical backfill

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2486,3 +2486,9 @@ WHERE atx.payment_key = UNHEX(?)
 ORDER BY t.slot DESC, t.block_index DESC, t.id DESC
 LIMIT 50;
 ```
+# Historical API backfill withdrawals
+
+API-mode Mithril backfill replays historical withdrawal transactions after
+importing the snapshot's current reward balances. Its transaction-ingest
+option records the withdrawal history without applying the live-path
+balance-sufficiency check; normal ledger ingestion retains that validation.

--- a/database/batch.go
+++ b/database/batch.go
@@ -108,10 +108,28 @@ type BatchedTxIngestOpts struct {
 	// explicitly rather than assumed. Defaults to false here, preserving the
 	// unconditional write for any caller that does not opt in.
 	SkipWithdrawalWitnessWrite bool
+
+	// SkipWithdrawalBalanceValidation allows historical backfill to record
+	// withdrawals against the snapshot-boundary reward balance. Live ledger
+	// ingestion must leave this false so excessive withdrawals are rejected.
+	SkipWithdrawalBalanceValidation bool
 }
 
 type batchStatsSetter interface {
 	SetBackfillStats(*types.BackfillHotPathStats)
+}
+
+type transactionStoreWithdrawalOptions interface {
+	SetTransactionBatchedWithOpts(
+		lcommon.Transaction,
+		ocommon.Point,
+		uint32,
+		map[int]uint64,
+		bool,
+		bool,
+		BatchAccumulator,
+		types.Txn,
+	) error
 }
 
 // inFlightProducerLookup is implemented by accumulators that index the
@@ -285,10 +303,21 @@ func (d *Database) SetTransactionBatchedWithOpts(
 	if setter, ok := acc.(batchStatsSetter); ok {
 		setter.SetBackfillStats(opts.Stats)
 	}
-	if err := d.transactionStore().SetTransactionBatched(
-		tx, point, idx, certDeposits,
-		opts.SkipWithdrawalWitnessWrite, acc, metadataTxn,
-	); err != nil {
+	var metadataErr error
+	if store, ok := d.transactionStore().(transactionStoreWithdrawalOptions); ok {
+		metadataErr = store.SetTransactionBatchedWithOpts(
+			tx, point, idx, certDeposits,
+			opts.SkipWithdrawalWitnessWrite,
+			opts.SkipWithdrawalBalanceValidation,
+			acc, metadataTxn,
+		)
+	} else {
+		metadataErr = d.transactionStore().SetTransactionBatched(
+			tx, point, idx, certDeposits,
+			opts.SkipWithdrawalWitnessWrite, acc, metadataTxn,
+		)
+	}
+	if err := metadataErr; err != nil {
 		return fmt.Errorf(
 			"set transaction metadata for tx %s (batch idx %d, slot %d): %w",
 			tx.Hash(), idx, point.Slot, err,

--- a/database/batch.go
+++ b/database/batch.go
@@ -109,18 +109,18 @@ type BatchedTxIngestOpts struct {
 	// unconditional write for any caller that does not opt in.
 	SkipWithdrawalWitnessWrite bool
 
-	// SkipWithdrawalBalanceValidation allows historical backfill to record
-	// withdrawals against the snapshot-boundary reward balance. Live ledger
-	// ingestion must leave this false so excessive withdrawals are rejected.
-	SkipWithdrawalBalanceValidation bool
+	// HistoricalBackfill records already-ledger-validated historical
+	// withdrawals without replaying account state over the imported snapshot.
+	// Live ledger ingestion leaves this false and enforces balance sufficiency.
+	HistoricalBackfill bool
 }
 
 type batchStatsSetter interface {
 	SetBackfillStats(*types.BackfillHotPathStats)
 }
 
-type transactionStoreWithdrawalOptions interface {
-	SetTransactionBatchedWithOpts(
+type transactionStoreHistoricalBackfill interface {
+	SetTransactionBatchedHistorical(
 		lcommon.Transaction,
 		ocommon.Point,
 		uint32,
@@ -304,11 +304,11 @@ func (d *Database) SetTransactionBatchedWithOpts(
 		setter.SetBackfillStats(opts.Stats)
 	}
 	var metadataErr error
-	if store, ok := d.transactionStore().(transactionStoreWithdrawalOptions); ok {
-		metadataErr = store.SetTransactionBatchedWithOpts(
+	if store, ok := d.transactionStore().(transactionStoreHistoricalBackfill); ok {
+		metadataErr = store.SetTransactionBatchedHistorical(
 			tx, point, idx, certDeposits,
 			opts.SkipWithdrawalWitnessWrite,
-			opts.SkipWithdrawalBalanceValidation,
+			opts.HistoricalBackfill,
 			acc, metadataTxn,
 		)
 	} else {

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -35,7 +35,7 @@ type transactionWriteStore interface {
 		bool,
 		types.Txn,
 	) error
-	SetTransactionBatchedWithOpts(
+	SetTransactionBatchedHistorical(
 		lcommon.Transaction,
 		ocommon.Point,
 		uint32,
@@ -218,7 +218,7 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 		isValid:     true,
 		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(1235)},
 	}
-	require.NoError(t, store.SetTransactionBatchedWithOpts(
+	require.NoError(t, store.SetTransactionBatchedHistorical(
 		backfillTx,
 		ocommon.Point{Slot: 12, Hash: bytes.Repeat([]byte{0xd6}, 32)},
 		0,

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 type transactionWriteStore interface {
+	NewBatchAccumulator() types.MetadataBatchAccumulator
 	CreateAccount(types.Txn, *models.Account) error
 	CreateUtxo(types.Txn, *models.Utxo) error
 	SetTransaction(
@@ -32,6 +33,16 @@ type transactionWriteStore interface {
 		uint32,
 		map[int]uint64,
 		bool,
+		types.Txn,
+	) error
+	SetTransactionBatchedWithOpts(
+		lcommon.Transaction,
+		ocommon.Point,
+		uint32,
+		map[int]uint64,
+		bool,
+		bool,
+		types.MetadataBatchAccumulator,
 		types.Txn,
 	) error
 	GetTransactionByHash([]byte, types.Txn) (*models.Transaction, error)
@@ -198,6 +209,32 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 	require.ErrorContains(t, err, "reward withdrawal amount 1236 exceeds")
 	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
 	require.Equal(t, uint64(1234), uint64(account.Reward))
+
+	// Historical API backfill must retain the live snapshot balance while
+	// recording a withdrawal whose amount reflects an earlier chain state.
+	backfillHash := lcommon.Blake2b256{0xd5}
+	backfillTx := &mockTransaction{
+		hash:        backfillHash,
+		isValid:     true,
+		withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(1235)},
+	}
+	require.NoError(t, store.SetTransactionBatchedWithOpts(
+		backfillTx,
+		ocommon.Point{Slot: 12, Hash: bytes.Repeat([]byte{0xd6}, 32)},
+		0,
+		nil,
+		true,
+		true,
+		store.NewBatchAccumulator(),
+		nil,
+	))
+	account = requireTransactionWriteAccount(t, store, 0, stakeKey)
+	require.Equal(t, uint64(1234), uint64(account.Reward))
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM account_reward_delta WHERE tx_hash = ?",
+		backfillHash.Bytes(),
+	).Scan(&deltas))
+	require.Equal(t, 1, deltas)
 }
 
 func TestSharedSQLStoreWithdrawalCredentialTagsRemainDistinct(t *testing.T) {

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -73,12 +73,53 @@ func (s *Store) SetTransactionBatched(
 	)
 }
 
+// SetTransactionBatchedWithOpts is the historical-replay variant. It keeps
+// the public MetadataStore contract stable while allowing API backfill to
+// preserve snapshot-boundary reward balances instead of applying live-slot
+// withdrawal sufficiency checks.
+func (s *Store) SetTransactionBatchedWithOpts(
+	transaction lcommon.Transaction,
+	point ocommon.Point,
+	index uint32,
+	certDeposits map[int]uint64,
+	skipWithdrawalWitness bool,
+	skipWithdrawalBalanceValidation bool,
+	accumulator types.MetadataBatchAccumulator,
+	txn types.Txn,
+) error {
+	if _, ok := accumulator.(*immediateBatchAccumulator); !ok {
+		return fmt.Errorf(
+			"SetTransactionBatchedWithOpts: wrong accumulator type %T",
+			accumulator,
+		)
+	}
+	return s.setTransaction(
+		transaction, point, index, certDeposits,
+		skipWithdrawalWitness, skipWithdrawalBalanceValidation, txn,
+	)
+}
+
 func (s *Store) SetTransaction(
 	transaction lcommon.Transaction,
 	point ocommon.Point,
 	index uint32,
 	certDeposits map[int]uint64,
 	skipWithdrawalWitness bool,
+	txn types.Txn,
+) error {
+	return s.setTransaction(
+		transaction, point, index, certDeposits,
+		skipWithdrawalWitness, false, txn,
+	)
+}
+
+func (s *Store) setTransaction(
+	transaction lcommon.Transaction,
+	point ocommon.Point,
+	index uint32,
+	certDeposits map[int]uint64,
+	skipWithdrawalWitness bool,
+	skipWithdrawalBalanceValidation bool,
 	txn types.Txn,
 ) error {
 	if transaction == nil {
@@ -162,6 +203,7 @@ RETURNING id`,
 					point.Slot,
 					hash,
 					skipWithdrawalWitness,
+					skipWithdrawalBalanceValidation,
 				); err != nil {
 					return err
 				}
@@ -754,6 +796,7 @@ func (s *Store) applyTransactionWithdrawals(
 	slot uint64,
 	txHash []byte,
 	skipWithdrawalWitness bool,
+	skipWithdrawalBalanceValidation bool,
 ) error {
 	for address, amount := range transaction.Withdrawals() {
 		if address == nil || amount == nil {
@@ -826,7 +869,7 @@ SELECT EXISTS (
 		if err != nil {
 			return err
 		}
-		if amount.Uint64() > previous {
+		if !skipWithdrawalBalanceValidation && amount.Uint64() > previous {
 			return fmt.Errorf(
 				"reward withdrawal amount %s exceeds account balance %d",
 				amount.String(),
@@ -836,13 +879,18 @@ SELECT EXISTS (
 		if amount.Sign() == 0 {
 			continue
 		}
-		rewardAfter := previous - amount.Uint64()
-		if _, err := db.ExecContext(ctx, `
+		// Historical API backfill replays withdrawals before the imported
+		// snapshot balance's intervening credits are available. Record the
+		// withdrawal history, but leave that trusted boundary balance untouched.
+		if !skipWithdrawalBalanceValidation {
+			rewardAfter := previous - amount.Uint64()
+			if _, err := db.ExecContext(ctx, `
 UPDATE account SET reward = ? WHERE id = ?`,
-			strconv.FormatUint(rewardAfter, 10),
-			accountID,
-		); err != nil {
-			return err
+				strconv.FormatUint(rewardAfter, 10),
+				accountID,
+			); err != nil {
+				return err
+			}
 		}
 		if _, err := db.ExecContext(ctx, `
 INSERT INTO account_reward_delta (

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -73,29 +73,29 @@ func (s *Store) SetTransactionBatched(
 	)
 }
 
-// SetTransactionBatchedWithOpts is the historical-replay variant. It keeps
+// SetTransactionBatchedHistorical is the historical-replay variant. It keeps
 // the public MetadataStore contract stable while allowing API backfill to
 // preserve snapshot-boundary reward balances instead of applying live-slot
 // withdrawal sufficiency checks.
-func (s *Store) SetTransactionBatchedWithOpts(
+func (s *Store) SetTransactionBatchedHistorical(
 	transaction lcommon.Transaction,
 	point ocommon.Point,
 	index uint32,
 	certDeposits map[int]uint64,
 	skipWithdrawalWitness bool,
-	skipWithdrawalBalanceValidation bool,
+	historicalBackfill bool,
 	accumulator types.MetadataBatchAccumulator,
 	txn types.Txn,
 ) error {
 	if _, ok := accumulator.(*immediateBatchAccumulator); !ok {
 		return fmt.Errorf(
-			"SetTransactionBatchedWithOpts: wrong accumulator type %T",
+			"SetTransactionBatchedHistorical: wrong accumulator type %T",
 			accumulator,
 		)
 	}
 	return s.setTransaction(
 		transaction, point, index, certDeposits,
-		skipWithdrawalWitness, skipWithdrawalBalanceValidation, txn,
+		skipWithdrawalWitness, historicalBackfill, txn,
 	)
 }
 
@@ -119,7 +119,7 @@ func (s *Store) setTransaction(
 	index uint32,
 	certDeposits map[int]uint64,
 	skipWithdrawalWitness bool,
-	skipWithdrawalBalanceValidation bool,
+	historicalBackfill bool,
 	txn types.Txn,
 ) error {
 	if transaction == nil {
@@ -203,7 +203,7 @@ RETURNING id`,
 					point.Slot,
 					hash,
 					skipWithdrawalWitness,
-					skipWithdrawalBalanceValidation,
+					historicalBackfill,
 				); err != nil {
 					return err
 				}
@@ -796,7 +796,7 @@ func (s *Store) applyTransactionWithdrawals(
 	slot uint64,
 	txHash []byte,
 	skipWithdrawalWitness bool,
-	skipWithdrawalBalanceValidation bool,
+	historicalBackfill bool,
 ) error {
 	for address, amount := range transaction.Withdrawals() {
 		if address == nil || amount == nil {
@@ -869,7 +869,7 @@ SELECT EXISTS (
 		if err != nil {
 			return err
 		}
-		if !skipWithdrawalBalanceValidation && amount.Uint64() > previous {
+		if !historicalBackfill && amount.Uint64() > previous {
 			return fmt.Errorf(
 				"reward withdrawal amount %s exceeds account balance %d",
 				amount.String(),
@@ -882,7 +882,7 @@ SELECT EXISTS (
 		// Historical API backfill replays withdrawals before the imported
 		// snapshot balance's intervening credits are available. Record the
 		// withdrawal history, but leave that trusted boundary balance untouched.
-		if !skipWithdrawalBalanceValidation {
+		if !historicalBackfill {
 			rewardAfter := previous - amount.Uint64()
 			if _, err := db.ExecContext(ctx, `
 UPDATE account SET reward = ? WHERE id = ?`,

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -282,7 +282,8 @@ func (d *Database) SetTransactionWithOpts(
 	}
 	if err := d.transactionStore().SetTransaction(
 		tx, point, idx, certDeposits,
-		opts.SkipWithdrawalWitnessWrite, txn.Metadata(),
+		opts.SkipWithdrawalWitnessWrite,
+		txn.Metadata(),
 	); err != nil {
 		return fmt.Errorf(
 			"set transaction metadata for tx %s (block idx %d, slot %d): %w",

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -1162,7 +1162,7 @@ func (b *Backfill) processBlockTxsBatched(
 				// state, not the balance at each historical slot. Preserve
 				// withdrawal history without applying the live-path balance
 				// sufficiency check.
-				SkipWithdrawalBalanceValidation: true,
+				HistoricalBackfill: true,
 			},
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -1158,6 +1158,11 @@ func (b *Backfill) processBlockTxsBatched(
 				// checkMithrilInactivityCompat (cmd/dingo/serve.go) and
 				// errMithrilInactivityIncompatible (cmd/dingo/mithril.go).
 				SkipWithdrawalWitnessWrite: !b.delegatorInactivityEnabled,
+				// Historical replay follows the snapshot's complete reward
+				// state, not the balance at each historical slot. Preserve
+				// withdrawal history without applying the live-path balance
+				// sufficiency check.
+				SkipWithdrawalBalanceValidation: true,
 			},
 		); err != nil {
 			return fmt.Errorf("storing TX: %w", err)

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -718,6 +718,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 				"sync did not complete; "+
 					"re-run 'dingo mithril sync' to resume",
 				"component", "mithril",
+				"error", err,
 			)
 		}
 	}()

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -352,7 +352,7 @@ func markSyncInProgress(db *database.Database, storageMode string) error {
 // download + verify + extract a snapshot, import ledger state and immutable
 // blocks, close the volatile gap, backfill metadata, and mark the sync
 // complete. The resulting database is servable by dingo.Node.Run.
-func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
+func Sync(ctx context.Context, cfg SyncConfig) (result SyncResult, syncErr error) {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -718,7 +718,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, error) {
 				"sync did not complete; "+
 					"re-run 'dingo mithril sync' to resume",
 				"component", "mithril",
-				"error", err,
+				"error", syncErr,
 			)
 		}
 	}()

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -352,7 +352,7 @@ func markSyncInProgress(db *database.Database, storageMode string) error {
 // download + verify + extract a snapshot, import ledger state and immutable
 // blocks, close the volatile gap, backfill metadata, and mark the sync
 // complete. The resulting database is servable by dingo.Node.Run.
-func Sync(ctx context.Context, cfg SyncConfig) (result SyncResult, syncErr error) {
+func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()

--- a/mithril/sync.go
+++ b/mithril/sync.go
@@ -352,7 +352,7 @@ func markSyncInProgress(db *database.Database, storageMode string) error {
 // download + verify + extract a snapshot, import ledger state and immutable
 // blocks, close the volatile gap, backfill metadata, and mark the sync
 // complete. The resulting database is servable by dingo.Node.Run.
-func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
+func Sync(ctx context.Context, cfg SyncConfig) (syncResult SyncResult, syncErr error) {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -576,7 +576,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 	}
 
 	cfg.emit(SyncProgress{Phase: PhaseBootstrap, Active: true})
-	result, err := Bootstrap(
+	bootstrapResult, err := Bootstrap(
 		ctx,
 		BootstrapConfig{
 			OnChunkContiguous:      chunkHook,
@@ -658,8 +658,8 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 	// a run that keeps the tree for a later sync still must not leak the
 	// descriptors. This runs after the import errgroup is joined, which is what
 	// makes clearing the fields safe against the goroutines that read them.
-	defer result.CloseHandles()
-	certifiedImmutable, err := openBootstrappedImmutable(result)
+	defer bootstrapResult.CloseHandles()
+	certifiedImmutable, err := openBootstrappedImmutable(bootstrapResult)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -671,8 +671,8 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 	// database incomplete.
 	if catchUp {
 		targetImmutable := uint64(0)
-		if result.Snapshot != nil {
-			targetImmutable = result.Snapshot.Beacon.ImmutableFileNumber
+		if bootstrapResult.Snapshot != nil {
+			targetImmutable = bootstrapResult.Snapshot.Beacon.ImmutableFileNumber
 		}
 		// A resuming run (sync_status still in_progress) never maps
 		// local-ahead to up-to-date: it must fall through to the import so the
@@ -689,7 +689,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 		}
 		if upToDate {
 			if cfg.CleanupAfterLoad {
-				result.Cleanup(logger)
+				bootstrapResult.Cleanup(logger)
 			}
 			return SyncResult{}, nil
 		}
@@ -767,7 +767,7 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 		cfg.emit(SyncProgress{Phase: PhaseLedgerImport, Active: true})
 		defer cfg.emit(SyncProgress{Phase: PhaseLedgerImport, Active: false})
 		slot, hash, importErr := importLedgerState(
-			gctx, db, logger, nodeCfg, result, catchUp,
+			gctx, db, logger, nodeCfg, bootstrapResult, catchUp,
 			certifiedTip.Slot,
 			func(p ledgerstate.ImportProgress) {
 				cfg.emit(SyncProgress{
@@ -803,11 +803,11 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 		logger.Info(
 			"loading ImmutableDB blocks into blob store",
 			"component", "mithril",
-			"immutable_dir", result.ImmutableDir,
+			"immutable_dir", bootstrapResult.ImmutableDir,
 		)
 		var loadErr error
 		loadResult, loadErr = node.LoadBlobsWithDB(
-			gctx, nil, logger, result.ImmutableDir, db,
+			gctx, nil, logger, bootstrapResult.ImmutableDir, db,
 			node.WithImmutableDB(certifiedImmutable),
 			node.WithLoadBlobsProgress(func(p node.LoadBlobsProgress) {
 				cfg.emit(SyncProgress{
@@ -1200,9 +1200,9 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 	// skip already-present archives and anchor its intersection check. Written
 	// after updateMithrilReadyState clears sync_state, so it survives. Set on
 	// both bootstrap and catch-up. Non-fatal.
-	if result.Snapshot != nil {
+	if bootstrapResult.Snapshot != nil {
 		if markerErr := setImmutableImportMarker(
-			db, result.Snapshot.Beacon.ImmutableFileNumber,
+			db, bootstrapResult.Snapshot.Beacon.ImmutableFileNumber,
 		); markerErr != nil {
 			logger.Warn(
 				"failed to record Mithril immutable-import marker",
@@ -1215,20 +1215,20 @@ func Sync(ctx context.Context, cfg SyncConfig) (SyncResult, syncErr error) {
 
 	// Clean up temporary files after a successful complete load.
 	if cfg.CleanupAfterLoad {
-		result.Cleanup(logger)
+		bootstrapResult.Cleanup(logger)
 	}
 
 	logger.Info(
 		"Mithril bootstrap complete",
 		"component", "mithril",
-		"epoch", result.Snapshot.Beacon.Epoch,
-		"immutable_file_number", result.Snapshot.Beacon.ImmutableFileNumber,
+		"epoch", bootstrapResult.Snapshot.Beacon.Epoch,
+		"immutable_file_number", bootstrapResult.Snapshot.Beacon.ImmutableFileNumber,
 		"index_rebuild_elapsed", indexRebuildElapsed,
 		"lazy_index_rebuild_mode", "maintenance",
 	)
 
 	return SyncResult{
-		Snapshot:   result.Snapshot,
+		Snapshot:   bootstrapResult.Snapshot,
 		LedgerSlot: ledgerStateSlot,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Preserve imported Mithril snapshot reward balances while replaying historical withdrawal metadata during API-mode backfill. The historical replay path records already-ledger-validated withdrawals without applying historical account-state mutations; normal ledger ingestion retains full withdrawal balance validation.

This also keeps the underlying sync error in the incomplete-sync log so failed resumes are actionable.

Fixes #3605

## Validation

- `go test ./database ./database/plugin/metadata/sqlstore ./internal/node`
- `go test -race ./database/plugin/metadata/sqlite -run TestSharedSQLStoreWithdrawalRejectsExcessiveBalance`
- `git diff --check`