### PR TITLE
docs: record Mithril bootstrap timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,20 @@ Performance (preview network, ~4M blocks):
 | Backfill historical metadata | — | ~varies |
 | Total | ~50 min | ~50 min + backfill |
 
+### Observed Mithril Bootstrap Timings
+
+The following timings were measured during profiled `core`-mode validation
+runs on 2026-08-26 and 2026-08-28, from bootstrap start through completion:
+
+| Network | Snapshot ready | Bootstrap complete |
+|---------|-----------------|--------------------|
+| mainnet | 41m 51s | 9h 10m 56s |
+| preprod | 4m 07s | 37m 56s |
+| preview | 12m 11s | 46m 22s |
+
+Mainnet's total includes its index rebuild; subsequent restarts reused the
+completed database rather than repeating the bootstrap.
+
 ### Disk Space Requirements
 
 Bootstrapping requires temporary disk space for both the downloaded snapshot and the Dingo database:


### PR DESCRIPTION
Document measured profiled core-mode Mithril bootstrap durations for mainnet, preprod, and preview, including snapshot-ready and total completion times.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records observed Mithril bootstrap timings for mainnet, preprod, and preview in the README performance docs. Mainnet's total includes its index rebuild; later restarts reuse the completed database.

<sup>Written for commit a52eb20d6246b3df3ac571b43f8c1b214638249c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Observed Mithril Bootstrap Timings” section to the README.
  * Documented snapshot-ready and bootstrap-complete timings for mainnet, preprod, and preview environments.
  * Added context about mainnet index rebuilding and subsequent database reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->