### PR TITLE
fix(blockfrost): bound pagination and address UTxO loading

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1766,6 +1766,38 @@ index. Full-address transaction reads resolve participating UTxO CBOR, compare
 complete address bytes, and scan candidate pages before applying the requested
 offset and limit.
 
+`UtxoWithOrderingQuery.Offset` and `.Descending` give `GetUtxosByAddressWithOrdering`
+page-number pagination (SQL `OFFSET` and a reversed `ORDER BY`) as an
+alternative to keyset (`After`) pagination. `Offset` is rejected whenever the
+address patterns require CBOR-based exact-address filtering
+(`RequiresExactAddressFilter`): the coarse SQL predicate over-matches address
+forms sharing a credential (pointer addresses), so `OFFSET` would skip a
+different set of rows than skipping exact matches would. `Descending` is
+rejected combined with `After`, since the cursor's comparison operators
+assume ascending order. `SkipAssets` omits a row's native assets from the
+result, for a candidate scan whose rows are discarded or only used to
+confirm a match and never returned to a caller reading `Utxo.Assets`.
+
+`CountUtxosByAddressWithOrdering` returns a plain `COUNT(*)` over the coarse
+predicate and is rejected for exact-address patterns, since the coarse
+predicate over-counts them. Blockfrost's `AccountUTXOs` adapter
+(`api/blockfrost/adapter_account_activity.go`) uses `Offset`, `Descending`,
+and this count for a stake credential's UTxOs, since a credential-only
+pattern never needs exact-address filtering.
+
+`AddressUTXOs` (exact address) cannot use `Offset`/`Count`, since an exact
+total requires CBOR-decoding every coarse candidate either way. Instead
+`MatchingUtxoRefsByAddressWithOrdering` scans coarse candidates in keyset
+batches (mirroring `GetUtxosByAddressWithOrdering`'s own exact-filter loop)
+with `SkipAssets` set, CBOR-decodes each only to confirm the match, and
+returns bare `(TxId, OutputIdx)` references rather than full rows — the
+result's length is the accurate total, and the caller slices it for one
+page's worth of references and fetches full rows (with assets) for just
+that page via `GetUtxosByRefs`. This bounds the expensive part (asset
+loading, full-row retention) to one page instead of the address's entire
+live UTxO history, while the CBOR-decode-only candidate scan remains
+unavoidable for the total.
+
 ### `GetTransactionsByMetadataLabel`
 
 Transactions by metadata label:

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1772,11 +1772,15 @@ alternative to keyset (`After`) pagination. `Offset` is rejected whenever the
 address patterns require CBOR-based exact-address filtering
 (`RequiresExactAddressFilter`): the coarse SQL predicate over-matches address
 forms sharing a credential (pointer addresses), so `OFFSET` would skip a
-different set of rows than skipping exact matches would. `Descending` is
-rejected combined with `After`, since the cursor's comparison operators
-assume ascending order. `SkipAssets` omits a row's native assets from the
-result, for a candidate scan whose rows are discarded or only used to
-confirm a match and never returned to a caller reading `Utxo.Assets`.
+different set of rows than skipping exact matches would. `Descending` and
+`Offset` are each rejected combined with `After`: `Descending` because the
+cursor's comparison operators assume ascending order, and `Offset` because
+applying both would filter to rows after the cursor and then additionally
+skip `Offset` rows within that filtered set, silently returning a page
+shifted by both controls instead of the one either alone describes.
+`SkipAssets` omits a row's native assets from the result, for a candidate
+scan whose rows are discarded or only used to confirm a match and never
+returned to a caller reading `Utxo.Assets`.
 
 `CountUtxosByAddressWithOrdering` returns a plain `COUNT(*)` over the coarse
 predicate and is rejected for exact-address patterns, since the coarse
@@ -1797,6 +1801,16 @@ that page via `GetUtxosByRefs`. This bounds the expensive part (asset
 loading, full-row retention) to one page instead of the address's entire
 live UTxO history, while the CBOR-decode-only candidate scan remains
 unavoidable for the total.
+
+Both `AccountUTXOs` and `AddressUTXOs` open one read `Txn`
+(`Database.Transaction(false)`) and pass it to both their count/scan call
+and their page-fetch call, rather than leaving each to open its own
+(`Transaction`/`ReadTransaction` begin the underlying SQL transaction
+eagerly, so the shared `Txn` fixes a single snapshot at that point). Two
+separate implicit transactions would each see whatever was most recently
+committed independently, so a write landing between them (a live node
+adding or spending a UTxO for the same address mid-request) could make the
+reported total and the returned page describe different UTxO sets.
 
 ### `GetTransactionsByMetadataLabel`
 

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -3306,7 +3306,13 @@ func (a *NodeAdapter) AddressUTXOs(
 	if err != nil {
 		return nil, 0, err
 	}
-	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(
+	// Exact-address matching requires decoding output CBOR (see
+	// models.RequiresExactAddressFilter), so getting an accurate total
+	// requires visiting every coarse candidate either way. Fetch only
+	// references (no assets, no full rows) for that pass, and materialize
+	// full UTxO data via UtxosByRefs for just the requested page, instead
+	// of loading the address's entire UTxO history in full.
+	refs, err := a.ledgerState.MatchingUtxoRefsByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
 			AddressPatterns: []models.UtxoAddressPattern{pattern},
 		},
@@ -3318,14 +3324,29 @@ func (a *NodeAdapter) AddressUTXOs(
 			err,
 		)
 	}
-	total := len(utxos)
+	total := len(refs)
+	start, end := paginationRange(total, params)
+	var pageRefs []models.UtxoId
 	if params.Order == PaginationOrderDesc {
-		for left, right := 0, len(utxos)-1; left < right; left, right = left+1, right-1 {
-			utxos[left], utxos[right] = utxos[right], utxos[left]
-		}
+		// Page N in descending order is ascending index range
+		// [total-end, total-start), reversed.
+		pageRefs = append(
+			[]models.UtxoId(nil),
+			refs[total-end:total-start]...,
+		)
+		slices.Reverse(pageRefs)
+	} else {
+		pageRefs = refs[start:end]
 	}
 
-	paged := paginateUtxos(utxos, params)
+	paged, err := a.orderedUtxosByRefs(pageRefs)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"get address UTxOs for %q: %w",
+			address,
+			err,
+		)
+	}
 	txBlockHashes, err := a.addressUtxoBlockHashes(paged)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
@@ -3372,6 +3393,47 @@ func (a *NodeAdapter) AddressUTXOs(
 		})
 	}
 	return ret, total, nil
+}
+
+// orderedUtxosByRefs fetches full UTxO rows (including assets) for refs in
+// a single batch and returns them in refs' order. A ref whose UTxO was
+// spent between the reference scan and this fetch is simply omitted, the
+// same "missing entries degrade" tolerance the rest of this file applies to
+// concurrently-changing chain state. The returned ordering metadata
+// (TxSlot, TxBlockIndex) is left zero-valued: callers of this helper only
+// need it for its embedded Utxo fields, which UtxosByRefs already
+// populates in full.
+func (a *NodeAdapter) orderedUtxosByRefs(
+	refs []models.UtxoId,
+) ([]models.UtxoWithOrdering, error) {
+	if len(refs) == 0 {
+		return []models.UtxoWithOrdering{}, nil
+	}
+	utxos, err := a.ledgerState.UtxosByRefs(refs)
+	if err != nil {
+		return nil, err
+	}
+	byRef := make(map[database.UtxoRef]models.Utxo, len(utxos))
+	for _, utxo := range utxos {
+		byRef[utxoRef(utxo)] = utxo
+	}
+	ret := make([]models.UtxoWithOrdering, 0, len(refs))
+	for _, ref := range refs {
+		utxo, ok := byRef[utxoIdRef(ref)]
+		if !ok {
+			continue
+		}
+		ret = append(ret, models.UtxoWithOrdering{Utxo: utxo})
+	}
+	return ret, nil
+}
+
+// utxoIdRef converts a models.UtxoId to the database.UtxoRef key shape
+// utxoRef uses, so results keyed by one can be looked up by the other.
+func utxoIdRef(id models.UtxoId) database.UtxoRef {
+	var txID [32]byte
+	copy(txID[:], id.Hash)
+	return database.UtxoRef{TxId: txID, OutputIdx: id.Idx}
 }
 
 // addressUtxoCbor resolves the raw output CBOR for the given UTxOs in a single
@@ -5184,17 +5246,6 @@ func bigIntString(v *big.Int) string {
 		return "0"
 	}
 	return v.String()
-}
-
-func paginateUtxos(
-	utxos []models.UtxoWithOrdering,
-	params PaginationParams,
-) []models.UtxoWithOrdering {
-	start, end := paginationRange(len(utxos), params)
-	if start >= end {
-		return []models.UtxoWithOrdering{}
-	}
-	return utxos[start:end]
 }
 
 func paginationRange(

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -3306,16 +3306,24 @@ func (a *NodeAdapter) AddressUTXOs(
 	if err != nil {
 		return nil, 0, err
 	}
+	// Shared between the reference scan and the page fetch below so the
+	// total and the returned page describe the same snapshot: two
+	// separate (nil-txn) calls could otherwise straddle a concurrent
+	// commit and return a page inconsistent with the reported total.
+	txn := a.ledgerState.Database().Transaction(false)
+	defer txn.Release()
+
 	// Exact-address matching requires decoding output CBOR (see
 	// models.RequiresExactAddressFilter), so getting an accurate total
 	// requires visiting every coarse candidate either way. Fetch only
 	// references (no assets, no full rows) for that pass, and materialize
 	// full UTxO data via UtxosByRefs for just the requested page, instead
 	// of loading the address's entire UTxO history in full.
-	refs, err := a.ledgerState.MatchingUtxoRefsByAddressWithOrdering(
+	refs, err := a.ledgerState.Database().MatchingUtxoRefsByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
 			AddressPatterns: []models.UtxoAddressPattern{pattern},
 		},
+		txn,
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
@@ -3339,7 +3347,7 @@ func (a *NodeAdapter) AddressUTXOs(
 		pageRefs = refs[start:end]
 	}
 
-	paged, err := a.orderedUtxosByRefs(pageRefs)
+	paged, err := a.orderedUtxosByRefs(pageRefs, txn)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
 			"get address UTxOs for %q: %w",
@@ -3396,20 +3404,23 @@ func (a *NodeAdapter) AddressUTXOs(
 }
 
 // orderedUtxosByRefs fetches full UTxO rows (including assets) for refs in
-// a single batch and returns them in refs' order. A ref whose UTxO was
-// spent between the reference scan and this fetch is simply omitted, the
-// same "missing entries degrade" tolerance the rest of this file applies to
-// concurrently-changing chain state. The returned ordering metadata
-// (TxSlot, TxBlockIndex) is left zero-valued: callers of this helper only
-// need it for its embedded Utxo fields, which UtxosByRefs already
-// populates in full.
+// a single batch, within txn (pass the same transaction the caller
+// resolved refs from, so this reads the identical snapshot rather than a
+// later one that may have since spent one of them), and returns them in
+// refs' order. A ref whose UTxO was spent before txn's snapshot was taken
+// is simply omitted, the same "missing entries degrade" tolerance the
+// rest of this file applies to concurrently-changing chain state. The
+// returned ordering metadata (TxSlot, TxBlockIndex) is left zero-valued:
+// callers of this helper only need it for its embedded Utxo fields, which
+// UtxosByRefs already populates in full.
 func (a *NodeAdapter) orderedUtxosByRefs(
 	refs []models.UtxoId,
+	txn *database.Txn,
 ) ([]models.UtxoWithOrdering, error) {
 	if len(refs) == 0 {
 		return []models.UtxoWithOrdering{}, nil
 	}
-	utxos, err := a.ledgerState.UtxosByRefs(refs)
+	utxos, err := a.ledgerState.Database().UtxosByRefs(refs, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/api/blockfrost/adapter_account_activity.go
+++ b/api/blockfrost/adapter_account_activity.go
@@ -42,8 +42,15 @@ func (a *NodeAdapter) AccountUTXOs(
 	if err != nil {
 		return nil, 0, err
 	}
+	// Shared across the existence check, count, and page fetch below so
+	// the total and the returned page describe the same snapshot: two
+	// separate (nil-txn) calls could otherwise straddle a concurrent
+	// commit and return a page inconsistent with the reported total.
+	txn := a.ledgerState.Database().Transaction(false)
+	defer txn.Release()
+
 	if _, err := a.ledgerState.Database().
-		GetAccountByCredential(credentialTag, stakeKey, true, nil); err != nil {
+		GetAccountByCredential(credentialTag, stakeKey, true, txn); err != nil {
 		return nil, 0, err
 	}
 
@@ -56,8 +63,9 @@ func (a *NodeAdapter) AccountUTXOs(
 	addressPatterns := []models.UtxoAddressPattern{
 		{DelegationPart: stakeKey},
 	}
-	total, err := a.ledgerState.CountUtxosByAddressWithOrdering(
+	total, err := a.ledgerState.Database().CountUtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{AddressPatterns: addressPatterns},
+		txn,
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(
@@ -71,13 +79,14 @@ func (a *NodeAdapter) AccountUTXOs(
 		return []AccountUTXOInfo{}, total, nil
 	}
 
-	paged, err := a.ledgerState.UtxosByAddressWithOrdering(
+	paged, err := a.ledgerState.Database().UtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
 			AddressPatterns: addressPatterns,
 			Limit:           params.Count,
 			Offset:          offset,
 			Descending:      params.Order == PaginationOrderDesc,
 		},
+		txn,
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf(

--- a/api/blockfrost/adapter_account_activity.go
+++ b/api/blockfrost/adapter_account_activity.go
@@ -47,11 +47,36 @@ func (a *NodeAdapter) AccountUTXOs(
 		return nil, 0, err
 	}
 
-	utxos, err := a.ledgerState.UtxosByAddressWithOrdering(
+	// A stake credential's UTxO set is matched entirely by SQL (payment_key
+	// is irrelevant; staking_key alone is exact), so it does not need the
+	// CBOR-based exact-address filtering that AddressUTXOs does. That makes
+	// a cheap SQL COUNT and a LIMIT/OFFSET-bound fetch safe: unlike
+	// AddressUTXOs, this query never has to materialize the full UTxO
+	// history to page or total a large stake account.
+	addressPatterns := []models.UtxoAddressPattern{
+		{DelegationPart: stakeKey},
+	}
+	total, err := a.ledgerState.CountUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{AddressPatterns: addressPatterns},
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf(
+			"count account UTxOs for %q: %w",
+			stakeAddress,
+			err,
+		)
+	}
+	offset, ok := paginationOffset(params)
+	if !ok || offset >= total {
+		return []AccountUTXOInfo{}, total, nil
+	}
+
+	paged, err := a.ledgerState.UtxosByAddressWithOrdering(
 		&models.UtxoWithOrderingQuery{
-			AddressPatterns: []models.UtxoAddressPattern{
-				{DelegationPart: stakeKey},
-			},
+			AddressPatterns: addressPatterns,
+			Limit:           params.Count,
+			Offset:          offset,
+			Descending:      params.Order == PaginationOrderDesc,
 		},
 	)
 	if err != nil {
@@ -61,14 +86,7 @@ func (a *NodeAdapter) AccountUTXOs(
 			err,
 		)
 	}
-	total := len(utxos)
-	if params.Order == PaginationOrderDesc {
-		for left, right := 0, len(utxos)-1; left < right; left, right = left+1, right-1 {
-			utxos[left], utxos[right] = utxos[right], utxos[left]
-		}
-	}
 
-	paged := paginateUtxos(utxos, params)
 	txBlockHashes, err := a.addressUtxoBlockHashes(paged)
 	if err != nil {
 		return nil, 0, fmt.Errorf(

--- a/api/blockfrost/adapter_account_utxos_test.go
+++ b/api/blockfrost/adapter_account_utxos_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/binary"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedStakeCredentialUtxos registers a stake credential's account row, then
+// seeds numUtxos live UTxOs against it (each at a distinct payment address
+// and slot, so ascending/descending order is unambiguous), returning the
+// bech32 stake address and the underlying staking key bytes.
+func seedStakeCredentialUtxos(
+	t *testing.T,
+	adapter *NodeAdapter,
+	raw *sql.DB,
+	db *database.Database,
+	numUtxos int,
+) (string, []byte) {
+	t.Helper()
+	stakeKey := bytes.Repeat([]byte{0x77}, lcommon.AddressHashSize)
+	stakeAddr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeKey,
+	)
+	require.NoError(t, err)
+	require.NoError(t, adapter.ledgerState.Database().CreateAccount(
+		nil,
+		&models.Account{StakingKey: stakeKey, Active: true},
+	))
+
+	for i := range numUtxos {
+		payment := make([]byte, lcommon.AddressHashSize)
+		binary.BigEndian.PutUint32(payment, uint32(i)+1)
+		txHash := make([]byte, 32)
+		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+		slot := uint64(i) + 1
+		amount := (uint64(i) + 1) * 1_000_000
+		insertAdapterTransaction(t, raw, &models.Transaction{
+			Hash:       txHash,
+			Slot:       slot,
+			BlockIndex: 0,
+			Outputs: []models.Utxo{{
+				TxId:       txHash,
+				OutputIdx:  0,
+				PaymentKey: payment,
+				StakingKey: stakeKey,
+				AddedSlot:  slot,
+				Amount:     types.Uint64(amount),
+			}},
+		})
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			lcommon.AddressNetworkTestnet,
+			payment,
+			stakeKey,
+		)
+		require.NoError(t, err)
+		storePointerOutputCbor(t, db, txHash, 0, addr, amount)
+	}
+	return stakeAddr.String(), stakeKey
+}
+
+// TestNodeAdapterAccountUTXOsLargeResultSetPagination proves AccountUTXOs
+// pages a large stake account's UTxOs without materializing more than the
+// requested window (see dingo/3520): it exercises a large result set, an
+// ascending and a descending page, and an out-of-range page landing past
+// the end.
+func TestNodeAdapterAccountUTXOsLargeResultSetPagination(t *testing.T) {
+	adapter, raw, db := newDBBackedAdapter(t)
+	const total = 250
+	stakeAddr, _ := seedStakeCredentialUtxos(t, adapter, raw, db, total)
+
+	t.Run("ascending page stops at the requested window", func(t *testing.T) {
+		items, gotTotal, err := adapter.AccountUTXOs(
+			stakeAddr,
+			PaginationParams{Count: 10, Page: 3, Order: PaginationOrderAsc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, total, gotTotal)
+		require.Len(t, items, 10)
+		// Page 3 with count 10 is items 21..30 (slot order == insertion
+		// order); item 21's amount is (21 * 1_000_000).
+		assert.Equal(t, "21000000", items[0].Amount[0].Quantity)
+		assert.Equal(t, "30000000", items[len(items)-1].Amount[0].Quantity)
+	})
+
+	t.Run("descending page returns newest first", func(t *testing.T) {
+		items, gotTotal, err := adapter.AccountUTXOs(
+			stakeAddr,
+			PaginationParams{Count: 10, Page: 1, Order: PaginationOrderDesc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, total, gotTotal)
+		require.Len(t, items, 10)
+		assert.Equal(t, "250000000", items[0].Amount[0].Quantity)
+		assert.Equal(t, "241000000", items[len(items)-1].Amount[0].Quantity)
+	})
+
+	t.Run("a page past the end is empty but reports the real total", func(t *testing.T) {
+		items, gotTotal, err := adapter.AccountUTXOs(
+			stakeAddr,
+			PaginationParams{Count: 100, Page: 4, Order: PaginationOrderAsc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, total, gotTotal)
+		assert.Empty(t, items)
+	})
+
+	t.Run("a page far beyond the address history is empty, not an error", func(t *testing.T) {
+		items, gotTotal, err := adapter.AccountUTXOs(
+			stakeAddr,
+			PaginationParams{
+				Count: MaxPaginationCount,
+				Page:  MaxPaginationPage,
+				Order: PaginationOrderAsc,
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, total, gotTotal)
+		assert.Empty(t, items)
+	})
+}
+
+// TestNodeAdapterAccountUTXOsEmpty proves a registered stake credential with
+// no live UTxOs returns an empty page and a zero total rather than an error.
+func TestNodeAdapterAccountUTXOsEmpty(t *testing.T) {
+	adapter, raw, db := newDBBackedAdapter(t)
+	stakeAddr, _ := seedStakeCredentialUtxos(t, adapter, raw, db, 0)
+
+	items, total, err := adapter.AccountUTXOs(
+		stakeAddr,
+		PaginationParams{Count: 100, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Empty(t, items)
+}

--- a/api/blockfrost/adapter_address_utxos_pagination_test.go
+++ b/api/blockfrost/adapter_address_utxos_pagination_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeAdapterAddressUTXOsLargeResultSetPagination seeds one address with
+// a large number of live UTxOs and proves ascending and descending
+// pagination both return the correct window. It exercises the windowed
+// reverse in NodeAdapter.AddressUTXOs (adapter.go): descending pagination
+// used to swap-reverse the address's entire UTxO history before slicing out
+// a page; reversing only the requested window must produce the identical
+// ordering for a large result set (see dingo/3520).
+func TestNodeAdapterAddressUTXOsLargeResultSetPagination(t *testing.T) {
+	adapter, raw, db := newDBBackedAdapter(t)
+
+	payment := bytes.Repeat([]byte{0x99}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	const total = 250
+	for i := range total {
+		txHash := make([]byte, 32)
+		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+		slot := uint64(i) + 1
+		amount := (uint64(i) + 1) * 1_000_000
+		insertAdapterTransaction(t, raw, &models.Transaction{
+			Hash:       txHash,
+			Slot:       slot,
+			BlockIndex: 0,
+			Outputs: []models.Utxo{{
+				TxId:       txHash,
+				OutputIdx:  0,
+				PaymentKey: payment,
+				AddedSlot:  slot,
+				Amount:     types.Uint64(amount),
+			}},
+		})
+		storePointerOutputCbor(t, db, txHash, 0, addr, amount)
+	}
+
+	t.Run("ascending page stops at the requested window", func(t *testing.T) {
+		items, total, err := adapter.AddressUTXOs(
+			addr.String(),
+			PaginationParams{Count: 10, Page: 3, Order: PaginationOrderAsc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 250, total)
+		require.Len(t, items, 10)
+		assert.Equal(t, "21000000", items[0].Amount[0].Quantity)
+		assert.Equal(t, "30000000", items[len(items)-1].Amount[0].Quantity)
+	})
+
+	t.Run("descending page matches a full-history reverse", func(t *testing.T) {
+		items, total, err := adapter.AddressUTXOs(
+			addr.String(),
+			PaginationParams{Count: 10, Page: 5, Order: PaginationOrderDesc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 250, total)
+		require.Len(t, items, 10)
+		// Descending page 5 (count 10) is the 41st-newest through the
+		// 50th-newest UTxO: amounts 210000000 down to 201000000.
+		assert.Equal(t, "210000000", items[0].Amount[0].Quantity)
+		assert.Equal(t, "201000000", items[len(items)-1].Amount[0].Quantity)
+	})
+
+	t.Run("descending page past the end is empty", func(t *testing.T) {
+		items, total, err := adapter.AddressUTXOs(
+			addr.String(),
+			PaginationParams{Count: 10, Page: 26, Order: PaginationOrderDesc},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 250, total)
+		assert.Empty(t, items)
+	})
+}
+
+// TestNodeAdapterAddressUTXOsAssetsSurviveRefFetch proves native assets
+// still attach to the returned page: AddressUTXOs now resolves its total
+// via a reference-only scan (no assets loaded) and fetches full rows for
+// just the requested page via UtxosByRefs, a different path than before
+// (see dingo/3520) that must not drop asset data along the way.
+func TestNodeAdapterAddressUTXOsAssetsSurviveRefFetch(t *testing.T) {
+	adapter, store, db := newDBBackedAdapter(t)
+
+	payment := bytes.Repeat([]byte{0x33}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	policyID := bytes.Repeat([]byte{0x44}, lcommon.AddressHashSize)
+	assetName := []byte("TOKEN")
+
+	txHash := fill32(0x50)
+	insertAdapterTransaction(t, store, &models.Transaction{
+		Hash: txHash,
+		Slot: 1,
+		Outputs: []models.Utxo{{
+			TxId:       txHash,
+			OutputIdx:  0,
+			PaymentKey: payment,
+			AddedSlot:  1,
+			Amount:     types.Uint64(1_000_000),
+			Assets: []models.Asset{{
+				PolicyId: policyID,
+				Name:     assetName,
+				Amount:   types.Uint64(9),
+			}},
+		}},
+	})
+	storePointerOutputCbor(t, db, txHash, 0, addr, 1_000_000)
+
+	items, total, err := adapter.AddressUTXOs(
+		addr.String(),
+		PaginationParams{Count: 10, Page: 1, Order: PaginationOrderAsc},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, items, 1)
+	require.Len(t, items[0].Amount, 2)
+	assert.Equal(t, "lovelace", items[0].Amount[0].Unit)
+	assert.Equal(
+		t,
+		hex.EncodeToString(policyID)+hex.EncodeToString(assetName),
+		items[0].Amount[1].Unit,
+	)
+	assert.Equal(t, "9", items[0].Amount[1].Quantity)
+}

--- a/api/blockfrost/pagination.go
+++ b/api/blockfrost/pagination.go
@@ -16,6 +16,7 @@ package blockfrost
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -90,6 +91,9 @@ func ParsePagination(r *http.Request) (PaginationParams, error) {
 	}
 	if params.Page < 1 {
 		params.Page = 1
+	}
+	if params.Page > MaxPaginationPage {
+		params.Page = MaxPaginationPage
 	}
 
 	return params, nil
@@ -177,4 +181,19 @@ func SetPaginationHeaders(
 		"X-Pagination-Page-Total",
 		strconv.Itoa(totalPages),
 	)
+}
+
+// paginationOffset computes the zero-based SQL OFFSET for params, i.e.
+// (params.Page-1)*params.Count. The second return value is false if
+// params.Page or params.Count is out of range or the product would
+// overflow int, in which case the caller should treat the page as empty
+// rather than compute a nonsensical offset.
+func paginationOffset(params PaginationParams) (int, bool) {
+	if params.Page < 1 || params.Count < 1 {
+		return 0, false
+	}
+	if params.Page-1 > math.MaxInt/params.Count {
+		return 0, false
+	}
+	return (params.Page - 1) * params.Count, true
 }

--- a/api/blockfrost/pagination_test.go
+++ b/api/blockfrost/pagination_test.go
@@ -62,6 +62,80 @@ func TestParsePaginationClampBounds(t *testing.T) {
 	assert.Equal(t, PaginationOrderAsc, params.Order)
 }
 
+func TestParsePaginationClampsUnboundedPage(t *testing.T) {
+	// The largest value strconv.Atoi accepts on a 64-bit platform: large
+	// enough to have overflowed a naive offset calculation (page-1)*count
+	// before this was bounded, without itself overflowing int parsing.
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/test?page=9223372036854775807",
+		nil,
+	)
+	params, err := ParsePagination(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, MaxPaginationPage, params.Page)
+}
+
+func TestParsePaginationClampsPageAboveMax(t *testing.T) {
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/test?page=21474837",
+		nil,
+	)
+	params, err := ParsePagination(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, MaxPaginationPage, params.Page)
+}
+
+func TestPaginationOffset(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     PaginationParams
+		wantOffset int
+		wantOK     bool
+	}{
+		{
+			name:       "first page",
+			params:     PaginationParams{Page: 1, Count: 100},
+			wantOffset: 0,
+			wantOK:     true,
+		},
+		{
+			name:       "third page",
+			params:     PaginationParams{Page: 3, Count: 25},
+			wantOffset: 50,
+			wantOK:     true,
+		},
+		{
+			name:       "max page and count does not overflow",
+			params:     PaginationParams{Page: MaxPaginationPage, Count: MaxPaginationCount},
+			wantOffset: (MaxPaginationPage - 1) * MaxPaginationCount,
+			wantOK:     true,
+		},
+		{
+			name:   "zero page is invalid",
+			params: PaginationParams{Page: 0, Count: 100},
+			wantOK: false,
+		},
+		{
+			name:   "zero count is invalid",
+			params: PaginationParams{Page: 1, Count: 0},
+			wantOK: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			offset, ok := paginationOffset(test.params)
+			assert.Equal(t, test.wantOK, ok)
+			if test.wantOK {
+				assert.Equal(t, test.wantOffset, offset)
+			}
+		})
+	}
+}
+
 func TestParsePaginationInvalid(t *testing.T) {
 	tests := []struct {
 		name string

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -35,6 +35,12 @@ var (
 	ErrExactAddressRequiresCbor = errors.New(
 		"exact address matching requires output CBOR",
 	)
+	ErrDescendingKeysetUnsupported = errors.New(
+		"keyset pagination (After) does not support Descending",
+	)
+	ErrOffsetRequiresCoarseMatch = errors.New(
+		"offset requires address patterns that do not need exact-address CBOR filtering",
+	)
 )
 
 // UtxoAddressPattern carries explicit address-match intent through the shared
@@ -322,7 +328,26 @@ type UtxoOrderingCursor struct {
 //     satisfy any pattern. Fields within a pattern are ANDed; patterns are ORed.
 //
 // After + Limit: keyset pagination; Limit <= 0 means no SQL LIMIT. SearchUtxos sets Limit to
-// effective page size + 1.
+// effective page size + 1. Mutually exclusive with Offset and Descending (both page-number
+// pagination controls); GetUtxosByAddressWithOrdering errors if After is combined with
+// Descending.
+//
+// Offset: page-number pagination; > 0 means SQL OFFSET. Only valid when the address
+// patterns do not require CBOR-based exact-address filtering (see
+// RequiresExactAddressFilter): the coarse SQL predicate over-matches address forms sharing
+// a payment/delegation credential (for example pointer addresses), so skipping rows in SQL
+// would skip a different set of rows than skipping exact matches. Combine with Limit for a
+// bounded page; GetUtxosByAddressWithOrdering errors if Offset is set on a query that
+// requires exact-address filtering.
+//
+// Descending: reverses SQL ORDER BY direction (newest first) instead of the default
+// ascending (oldest first) producing-transaction-position order.
+//
+// SkipAssets: when true, GetUtxosByAddressWithOrdering does not load each
+// row's native assets. Set this for a candidate scan whose rows are
+// discarded or only used to confirm an exact-address match (see
+// RequiresExactAddressFilter) and never returned to a caller that reads
+// Utxo.Assets, to avoid materializing asset data that is thrown away.
 //
 // FilterByAsset: when true, AssetPolicyID is required; AssetName nil matches any name under
 // the policy (same semantics as GetUtxosByAssets).
@@ -331,6 +356,9 @@ type UtxoWithOrderingQuery struct {
 	AddressPatterns   []UtxoAddressPattern
 	After             *UtxoOrderingCursor
 	Limit             int
+	Offset            int
+	Descending        bool
+	SkipAssets        bool
 	FilterByAsset     bool
 	AssetPolicyID     []byte
 	AssetName         []byte

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -38,6 +38,9 @@ var (
 	ErrDescendingKeysetUnsupported = errors.New(
 		"keyset pagination (After) does not support Descending",
 	)
+	ErrOffsetKeysetUnsupported = errors.New(
+		"keyset pagination (After) does not support Offset",
+	)
 	ErrOffsetRequiresCoarseMatch = errors.New(
 		"offset requires address patterns that do not need exact-address CBOR filtering",
 	)
@@ -330,7 +333,7 @@ type UtxoOrderingCursor struct {
 // After + Limit: keyset pagination; Limit <= 0 means no SQL LIMIT. SearchUtxos sets Limit to
 // effective page size + 1. Mutually exclusive with Offset and Descending (both page-number
 // pagination controls); GetUtxosByAddressWithOrdering errors if After is combined with
-// Descending.
+// either one.
 //
 // Offset: page-number pagination; > 0 means SQL OFFSET. Only valid when the address
 // patterns do not require CBOR-based exact-address filtering (see

--- a/database/plugin/metadata/domain_stores_test.go
+++ b/database/plugin/metadata/domain_stores_test.go
@@ -121,6 +121,7 @@ var utxoStoreMethods = []string{
 	"GetUtxosDeletedBeforeSlot",
 	"GetUtxosByAddress",
 	"GetUtxosByAddressWithOrdering",
+	"CountUtxosByAddressWithOrdering",
 	"GetUtxosByAddressAtSlot",
 	"GetControlledAmountByCredential",
 	"GetUtxoPaymentScriptByCredential",

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -1089,6 +1089,12 @@ func (s *Store) GetUtxosByAddressWithOrdering(
 			models.ErrDescendingKeysetUnsupported,
 		)
 	}
+	if query.After != nil && query.Offset > 0 {
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrOffsetKeysetUnsupported,
+		)
+	}
 	if query.Offset > 0 && models.RequiresExactAddressFilter(query.AddressPatterns) {
 		return nil, fmt.Errorf(
 			"GetUtxosByAddressWithOrdering: %w",

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -1025,20 +1025,13 @@ func (s *Store) GetUtxosByAddress(
 	return ret, nil
 }
 
-func (s *Store) GetUtxosByAddressWithOrdering(
+// utxoOrderingPredicate builds the WHERE predicate shared by
+// GetUtxosByAddressWithOrdering and CountUtxosByAddressWithOrdering. The
+// returned predicate excludes any keyset (query.After) bound, which only
+// GetUtxosByAddressWithOrdering applies.
+func utxoOrderingPredicate(
 	query *models.UtxoWithOrderingQuery,
-	txn types.Txn,
-) ([]models.UtxoWithOrdering, error) {
-	if query == nil {
-		return nil, fmt.Errorf(
-			"GetUtxosByAddressWithOrdering: %w",
-			models.ErrNilUtxoWithOrderingQuery,
-		)
-	}
-	db, ctx, err := s.readDBFromTxn(txn)
-	if err != nil {
-		return nil, err
-	}
+) (string, []any, error) {
 	predicate := "utxo.deleted_slot = 0"
 	args := []any{}
 	switch {
@@ -1053,10 +1046,7 @@ func (s *Store) GetUtxosByAddressWithOrdering(
 				&args,
 				pattern,
 			); err != nil {
-				return nil, fmt.Errorf(
-					"GetUtxosByAddressWithOrdering: %w",
-					err,
-				)
+				return "", nil, err
 			}
 		}
 		if len(branches) == 0 {
@@ -1067,11 +1057,7 @@ func (s *Store) GetUtxosByAddressWithOrdering(
 	}
 	if query.FilterByAsset {
 		if len(query.AssetPolicyID) == 0 {
-			return nil, fmt.Errorf(
-				"GetUtxosByAddressWithOrdering: "+
-					"asset filter requires non-empty policy id: %w",
-				models.ErrEmptyAssetPolicyID,
-			)
+			return "", nil, models.ErrEmptyAssetPolicyID
 		}
 		predicate += `
  AND EXISTS (
@@ -1083,6 +1069,39 @@ func (s *Store) GetUtxosByAddressWithOrdering(
 			args = append(args, query.AssetName)
 		}
 		predicate += ")"
+	}
+	return predicate, args, nil
+}
+
+func (s *Store) GetUtxosByAddressWithOrdering(
+	query *models.UtxoWithOrderingQuery,
+	txn types.Txn,
+) ([]models.UtxoWithOrdering, error) {
+	if query == nil {
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrNilUtxoWithOrderingQuery,
+		)
+	}
+	if query.After != nil && query.Descending {
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrDescendingKeysetUnsupported,
+		)
+	}
+	if query.Offset > 0 && models.RequiresExactAddressFilter(query.AddressPatterns) {
+		return nil, fmt.Errorf(
+			"GetUtxosByAddressWithOrdering: %w",
+			models.ErrOffsetRequiresCoarseMatch,
+		)
+	}
+	db, ctx, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return nil, err
+	}
+	predicate, args, err := utxoOrderingPredicate(query)
+	if err != nil {
+		return nil, fmt.Errorf("GetUtxosByAddressWithOrdering: %w", err)
 	}
 	slotExpr := `COALESCE("transaction".slot, utxo.added_slot)`
 	blockIndexExpr := `COALESCE("transaction".block_index, 0)`
@@ -1110,18 +1129,19 @@ func (s *Store) GetUtxosByAddressWithOrdering(
 			query.After.TxId,
 		)
 	}
+	orderDir := "ASC"
+	if query.Descending {
+		orderDir = "DESC"
+	}
 	statement := `
 SELECT ` + qualifiedSQLiteUtxoColumns + `,
        ` + slotExpr + `, ` + blockIndexExpr + `
 FROM utxo
 LEFT JOIN "transaction" ON utxo.transaction_id = "transaction".id
 WHERE ` + predicate + `
-ORDER BY ` + slotExpr + ` ASC, ` + blockIndexExpr + ` ASC,
-         utxo.output_idx ASC, utxo.tx_id ASC`
-	if query.Limit > 0 {
-		statement += " LIMIT ?"
-		args = append(args, query.Limit)
-	}
+ORDER BY ` + slotExpr + ` ` + orderDir + `, ` + blockIndexExpr + ` ` + orderDir + `,
+         utxo.output_idx ` + orderDir + `, utxo.tx_id ` + orderDir
+	statement, args = addLimitOffset(statement, args, query.Limit, query.Offset)
 	rows, err := db.QueryContext(
 		ctx,
 		s.dialect.Rebind(statement),
@@ -1143,6 +1163,9 @@ ORDER BY ` + slotExpr + ` ASC, ` + blockIndexExpr + ` ASC,
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	if query.SkipAssets {
+		return ret, nil
+	}
 	for i := range ret {
 		pointers = append(pointers, &ret[i].Utxo)
 	}
@@ -1150,6 +1173,51 @@ ORDER BY ` + slotExpr + ` ASC, ` + blockIndexExpr + ` ASC,
 		return nil, err
 	}
 	return ret, nil
+}
+
+// CountUtxosByAddressWithOrdering returns the number of live UTxOs matching
+// query's coarse SQL predicate (address patterns and asset filter), without
+// materializing rows. It rejects a query whose address patterns require
+// CBOR-based exact-address filtering (see RequiresExactAddressFilter):
+// the coarse predicate alone over-matches address forms that share a
+// payment/delegation credential (for example pointer addresses), so a count
+// against it would not equal the exact-match total.
+func (s *Store) CountUtxosByAddressWithOrdering(
+	query *models.UtxoWithOrderingQuery,
+	txn types.Txn,
+) (int, error) {
+	if query == nil {
+		return 0, fmt.Errorf(
+			"CountUtxosByAddressWithOrdering: %w",
+			models.ErrNilUtxoWithOrderingQuery,
+		)
+	}
+	if models.RequiresExactAddressFilter(query.AddressPatterns) {
+		return 0, fmt.Errorf(
+			"CountUtxosByAddressWithOrdering: %w",
+			models.ErrExactAddressRequiresCbor,
+		)
+	}
+	db, ctx, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return 0, err
+	}
+	predicate, args, err := utxoOrderingPredicate(query)
+	if err != nil {
+		return 0, fmt.Errorf("CountUtxosByAddressWithOrdering: %w", err)
+	}
+	var count int
+	err = db.QueryRowContext(
+		ctx,
+		s.dialect.Rebind(
+			"SELECT COUNT(*) FROM utxo WHERE "+predicate,
+		),
+		args...,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count utxos by address: %w", err)
+	}
+	return count, nil
 }
 
 func (s *Store) GetUtxosByAddressAtSlot(

--- a/database/plugin/metadata/sqlstore/utxo_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_test.go
@@ -131,3 +131,60 @@ func TestAddUtxosRejectsOverflowAssetWithoutMutation(t *testing.T) {
 	require.Equal(t, 0, utxoCount)
 	require.Equal(t, 0, assetCount)
 }
+
+// TestGetUtxosByAddressWithOrderingSkipAssets proves SkipAssets omits a
+// row's native assets from the result without affecting which rows are
+// returned. Callers that only need row identity or ordering (an
+// exact-address candidate scan, a reference-only lookup) use this to avoid
+// paying for asset joins that would be immediately discarded.
+func TestGetUtxosByAddressWithOrderingSkipAssets(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+
+	var policyId lcommon.Blake2b224
+	policyId[0] = 0xaa
+	multiAsset := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policyId: {
+				cbor.NewByteString([]byte("token")): big.NewInt(5),
+			},
+		},
+	)
+	utxo := ledger.Utxo{
+		Id: shelley.NewShelleyTransactionInput(
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+			0,
+		),
+		Output: &mary.MaryTransactionOutput{
+			OutputAmount: mary.MaryTransactionOutputValue{
+				Amount: 1_000_000,
+				Assets: &multiAsset,
+			},
+		},
+	}
+	require.NoError(
+		t,
+		store.AddUtxos([]models.UtxoSlot{{Utxo: utxo, Slot: 1}}, nil),
+	)
+
+	withAssets, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{MatchAllAddresses: true},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, withAssets, 1)
+	require.Len(t, withAssets[0].Assets, 1)
+
+	skipped, err := store.GetUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			MatchAllAddresses: true,
+			SkipAssets:        true,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, skipped, 1)
+	require.Empty(t, skipped[0].Assets)
+	// Row identity is unaffected by SkipAssets.
+	require.Equal(t, withAssets[0].TxId, skipped[0].TxId)
+}

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -649,6 +649,16 @@ type UtxoStore interface {
 		types.Txn,
 	) ([]models.UtxoWithOrdering, error)
 
+	// CountUtxosByAddressWithOrdering returns the number of live UTxOs
+	// matching q's coarse SQL predicate, without materializing rows. It
+	// errors if q's address patterns require CBOR-based exact-address
+	// filtering (see models.RequiresExactAddressFilter), since the coarse
+	// predicate alone would over-count. See models.UtxoWithOrderingQuery.
+	CountUtxosByAddressWithOrdering(
+		*models.UtxoWithOrderingQuery,
+		types.Txn,
+	) (int, error)
+
 	// GetUtxosByAddressAtSlot retrieves all UTxOs for a given address at a specific slot.
 	GetUtxosByAddressAtSlot(
 		models.UtxoAddressPattern,

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -723,6 +723,133 @@ func (d *Database) UtxosByAddressWithOrdering(
 	return ret, nil
 }
 
+// MatchingUtxoRefsByAddressWithOrdering returns the (TxId, OutputIdx)
+// references of every live UTxO matching q's address patterns, in ascending
+// producing-transaction-position order, without loading assets or
+// retaining full rows. Unlike CountUtxosByAddressWithOrdering, this works
+// for exact-address patterns too: it scans coarse SQL candidates in keyset
+// batches (see UtxosByAddressWithOrdering's identical loop) and CBOR-decodes
+// each to confirm the match, which is the same per-candidate cost the
+// coarse predicate alone cannot avoid, but skips the asset loading and full
+// UtxoWithOrdering retention a straight fetch would pay for every candidate
+// instead of only the page a caller goes on to request via UtxosByRefs.
+//
+// The result both is the accurate total (its length) and can be sliced for
+// a page's worth of references to pass to UtxosByRefs, letting a caller
+// avoid materializing more than one page of an address's UTxO history.
+func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
+	q *models.UtxoWithOrderingQuery,
+	txn *Txn,
+) ([]models.UtxoId, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	if q == nil {
+		return nil, models.ErrNilUtxoWithOrderingQuery
+	}
+	if q.MatchAllAddresses || !models.RequiresExactAddressFilter(q.AddressPatterns) {
+		scanQuery := *q
+		scanQuery.SkipAssets = true
+		utxos, err := d.utxoStore().GetUtxosByAddressWithOrdering(
+			&scanQuery,
+			txn.Metadata(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		refs := make([]models.UtxoId, len(utxos))
+		for i := range utxos {
+			refs[i] = models.UtxoId{Hash: utxos[i].TxId, Idx: utxos[i].OutputIdx}
+		}
+		return refs, nil
+	}
+
+	scanQuery := *q
+	scanQuery.Limit = 1024
+	scanQuery.SkipAssets = true
+	scanQuery.Offset = 0
+	scanQuery.Descending = false
+	refs := []models.UtxoId{}
+	candidatesProcessed := 0
+	for {
+		remainingCandidates := exactAddressCandidateScanLimit -
+			candidatesProcessed
+		if remainingCandidates <= 0 {
+			return refs, errExactAddressCandidateScanLimit
+		}
+		scanQuery.Limit = min(1024, remainingCandidates)
+		batch, err := d.utxoStore().GetUtxosByAddressWithOrdering(
+			&scanQuery,
+			txn.Metadata(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		candidatesProcessed += len(batch)
+		for i := range batch {
+			if err := loadCbor(&batch[i].Utxo, txn); err != nil {
+				return nil, err
+			}
+			output, err := batch[i].Decode()
+			if err != nil {
+				return nil, fmt.Errorf(
+					"decode UTxO %x#%d for exact address match: %w",
+					batch[i].TxId,
+					batch[i].OutputIdx,
+					err,
+				)
+			}
+			match, err := models.MatchesUtxoAddressPatterns(
+				output.Address(),
+				q.AddressPatterns,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				refs = append(refs, models.UtxoId{
+					Hash: batch[i].TxId,
+					Idx:  batch[i].OutputIdx,
+				})
+			}
+		}
+		if len(batch) < scanQuery.Limit || len(batch) == 0 {
+			break
+		}
+		last := batch[len(batch)-1]
+		scanQuery.After = &models.UtxoOrderingCursor{
+			Slot:       last.TxSlot,
+			BlockIndex: last.TxBlockIndex,
+			OutputIdx:  last.OutputIdx,
+		}
+	}
+	return refs, nil
+}
+
+// CountUtxosByAddressWithOrdering returns the number of live UTxOs matching
+// q's coarse SQL predicate. See MetadataStore.CountUtxosByAddressWithOrdering:
+// it errors if q's address patterns require CBOR-based exact-address
+// filtering, since Dingo has no cheap way to compute an exact-address total
+// without decoding every coarse candidate's output CBOR.
+func (d *Database) CountUtxosByAddressWithOrdering(
+	q *models.UtxoWithOrderingQuery,
+	txn *Txn,
+) (int, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	if q == nil {
+		return 0, models.ErrNilUtxoWithOrderingQuery
+	}
+	count, err := d.utxoStore().CountUtxosByAddressWithOrdering(q, txn.Metadata())
+	if err != nil {
+		return 0, fmt.Errorf("count utxos by address: %w", err)
+	}
+	return count, nil
+}
+
 func (d *Database) UtxosByAddressAtSlot(
 	addr lcommon.Address,
 	slot uint64,

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -765,20 +765,21 @@ func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
 		return refs, nil
 	}
 
+	// Unlike UtxosByAddressWithOrdering's page-fill scan, this loop must
+	// visit every coarse candidate to produce an accurate total and cannot
+	// stop early once a page's worth of matches is found, so it does not
+	// apply exactAddressCandidateScanLimit: that cap bounds work spent
+	// filling one bounded page, and applying it here would turn a valid
+	// high-cardinality address listing into a server error instead of
+	// bounding cost, which SkipAssets and the reference-only result
+	// already do.
 	scanQuery := *q
 	scanQuery.Limit = 1024
 	scanQuery.SkipAssets = true
 	scanQuery.Offset = 0
 	scanQuery.Descending = false
 	refs := []models.UtxoId{}
-	candidatesProcessed := 0
 	for {
-		remainingCandidates := exactAddressCandidateScanLimit -
-			candidatesProcessed
-		if remainingCandidates <= 0 {
-			return refs, errExactAddressCandidateScanLimit
-		}
-		scanQuery.Limit = min(1024, remainingCandidates)
 		batch, err := d.utxoStore().GetUtxosByAddressWithOrdering(
 			&scanQuery,
 			txn.Metadata(),
@@ -786,7 +787,6 @@ func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
 		if err != nil {
 			return nil, err
 		}
-		candidatesProcessed += len(batch)
 		for i := range batch {
 			if err := loadCbor(&batch[i].Utxo, txn); err != nil {
 				return nil, err
@@ -822,6 +822,7 @@ func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
 			Slot:       last.TxSlot,
 			BlockIndex: last.TxBlockIndex,
 			OutputIdx:  last.OutputIdx,
+			TxId:       last.TxId,
 		}
 	}
 	return refs, nil

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -718,6 +718,7 @@ func (d *Database) UtxosByAddressWithOrdering(
 			Slot:       last.TxSlot,
 			BlockIndex: last.TxBlockIndex,
 			OutputIdx:  last.OutputIdx,
+			TxId:       last.TxId,
 		}
 	}
 	return ret, nil
@@ -748,7 +749,8 @@ func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
 	if q == nil {
 		return nil, models.ErrNilUtxoWithOrderingQuery
 	}
-	if q.MatchAllAddresses || !models.RequiresExactAddressFilter(q.AddressPatterns) {
+	if q.MatchAllAddresses ||
+		!models.RequiresExactAddressFilter(q.AddressPatterns) {
 		scanQuery := *q
 		scanQuery.SkipAssets = true
 		utxos, err := d.utxoStore().GetUtxosByAddressWithOrdering(
@@ -760,7 +762,10 @@ func (d *Database) MatchingUtxoRefsByAddressWithOrdering(
 		}
 		refs := make([]models.UtxoId, len(utxos))
 		for i := range utxos {
-			refs[i] = models.UtxoId{Hash: utxos[i].TxId, Idx: utxos[i].OutputIdx}
+			refs[i] = models.UtxoId{
+				Hash: utxos[i].TxId,
+				Idx:  utxos[i].OutputIdx,
+			}
 		}
 		return refs, nil
 	}
@@ -844,7 +849,8 @@ func (d *Database) CountUtxosByAddressWithOrdering(
 	if q == nil {
 		return 0, models.ErrNilUtxoWithOrderingQuery
 	}
-	count, err := d.utxoStore().CountUtxosByAddressWithOrdering(q, txn.Metadata())
+	count, err := d.utxoStore().
+		CountUtxosByAddressWithOrdering(q, txn.Metadata())
 	if err != nil {
 		return 0, fmt.Errorf("count utxos by address: %w", err)
 	}

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -677,6 +677,190 @@ func TestMatchingUtxoRefsByAddressWithOrderingCrossesBatchBoundary(t *testing.T)
 	assert.Equal(t, wantHashes, gotHashes)
 }
 
+// seedExactAddressImportedUtxo seeds an exact-address UTxO with no producing
+// transaction row, so GetUtxosByAddressWithOrdering's COALESCE falls back to
+// added_slot and block index zero -- the snapshot-import case described on
+// UtxoOrderingCursor. Real snapshot imports can share slot, block index, and
+// output index across many rows, differing only by tx_id.
+func seedExactAddressImportedUtxo(
+	t *testing.T,
+	raw *sql.DB,
+	addr lcommon.Address,
+	slot uint64,
+	outputIdx uint32,
+	txHash []byte,
+) {
+	t.Helper()
+	var paymentKey any = addr.PaymentKeyHash().Bytes()
+	if addr.PaymentKeyHash() == lcommon.NewBlake2b224(nil) {
+		paymentKey = nil
+	}
+	var stakingKey any
+	if stake := addr.StakeKeyHash(); stake != lcommon.NewBlake2b224(nil) {
+		stakingKey = stake.Bytes()
+	}
+	_, err := raw.Exec(`
+INSERT INTO utxo (
+    transaction_id, tx_id, payment_key, staking_key, credential_tag,
+    added_slot, deleted_slot, amount, output_idx, payment_script
+) VALUES (NULL, ?, ?, ?, 0, ?, 0, ?, ?, FALSE)`,
+		txHash,
+		paymentKey,
+		stakingKey,
+		slot,
+		strconv.FormatUint(slot*1_000_000, 10),
+		outputIdx,
+	)
+	require.NoError(t, err)
+}
+
+// TestMatchingUtxoRefsByAddressWithOrderingSnapshotTieBreak seeds more
+// snapshot-imported exact-address UTxOs sharing one slot, block index, and
+// output index than the internal scan's per-batch size (1024), so the
+// keyset cursor can only resume correctly past the batch boundary by
+// carrying the last row's tx_id. Without it, the next batch's predicate
+// re-matches (duplicating) or excludes (dropping) every tied row instead of
+// resuming after the one already returned.
+func TestMatchingUtxoRefsByAddressWithOrderingSnapshotTieBreak(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	payment := bytes.Repeat([]byte{0x9a}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	const total = 1200
+	const importSlot = 42
+	wantHashes := make(map[string]bool, total)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		for i := range total {
+			txHash := make([]byte, 32)
+			binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+			seedExactAddressImportedUtxo(t, raw, addr, importSlot, 0, txHash)
+			wantHashes[string(txHash)] = true
+			encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount:  1_000_000,
+			})
+			if err != nil {
+				return err
+			}
+			if err := db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
+	refs, err := db.MatchingUtxoRefsByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(
+		t, refs, total,
+		"tied snapshot-imported rows must not be dropped or duplicated "+
+			"across the scan's batch boundary",
+	)
+	got := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		require.False(t, got[string(ref.Hash)], "duplicate ref for tx %x", ref.Hash)
+		got[string(ref.Hash)] = true
+	}
+	assert.Equal(t, wantHashes, got)
+}
+
+// TestMatchingUtxoRefsByAddressWithOrderingExceedsOldCandidateScanLimit
+// seeds more exact-address UTxOs than the page-fill scan's
+// exactAddressCandidateScanLimit (10,000). AddressUTXOs relies on this scan
+// for an exact-address total, which -- unlike a page fetch -- cannot stop
+// once a page is full; applying that same cap here previously turned a
+// valid, merely large, address listing into a hard error instead of
+// completing it.
+func TestMatchingUtxoRefsByAddressWithOrderingExceedsOldCandidateScanLimit(
+	t *testing.T,
+) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	payment := bytes.Repeat([]byte{0x5c}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	const total = 10_050
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		tx, err := raw.Begin()
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback() //nolint:errcheck
+		for i := range total {
+			txHash := make([]byte, 32)
+			binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+			txID := uint(i + 1)
+			slot := uint64(i) + 1
+			amount := slot * 1_000_000
+			if _, err := tx.Exec(`
+INSERT INTO "transaction" (
+    id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
+) VALUES (?, ?, ?, 0, 0, '0', '0', '0', TRUE)`,
+				txID, txHash, slot,
+			); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
+INSERT INTO utxo (
+    transaction_id, tx_id, payment_key, staking_key, credential_tag,
+    added_slot, deleted_slot, amount, output_idx, payment_script
+) VALUES (?, ?, ?, NULL, 0, ?, 0, ?, 0, FALSE)`,
+				txID,
+				txHash,
+				addr.PaymentKeyHash().Bytes(),
+				slot,
+				strconv.FormatUint(amount, 10),
+			); err != nil {
+				return err
+			}
+			encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount:  amount,
+			})
+			if err != nil {
+				return err
+			}
+			if err := db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded); err != nil {
+				return err
+			}
+		}
+		return tx.Commit()
+	}))
+
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
+	refs, err := db.MatchingUtxoRefsByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Len(t, refs, total)
+}
+
 // TestUtxosByAddressLoadsAssets proves GetUtxosByAddress still attaches
 // native assets to its results after candidate selection was split from
 // asset loading (assets are now loaded once on the deduplicated result set

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -56,8 +56,25 @@ func seedExactAddressUtxo(
 	hashByte byte,
 ) models.Utxo {
 	t.Helper()
+	return seedExactAddressUtxoWithHash(
+		t, db, raw, addr, slot, bytes.Repeat([]byte{hashByte}, 32),
+	)
+}
+
+// seedExactAddressUtxoWithHash is seedExactAddressUtxo with an explicit
+// 32-byte transaction hash, for callers seeding more than 256 rows: a
+// single repeated hashByte collides past that count, since it is the
+// transaction table's hash.
+func seedExactAddressUtxoWithHash(
+	t *testing.T,
+	db *Database,
+	raw *sql.DB,
+	addr lcommon.Address,
+	slot uint64,
+	txHash []byte,
+) models.Utxo {
+	t.Helper()
 	txID := uint(slot)
-	txHash := bytes.Repeat([]byte{hashByte}, 32)
 	_, err := raw.Exec(`
 INSERT INTO "transaction" (
     id, hash, slot, block_index, type, fee, collateral_fee, ttl, valid
@@ -310,6 +327,265 @@ func TestUtxoAddressQueriesPreserveExactIdentityAndPagination(t *testing.T) {
 	hasEnterpriseTx, err := db.HasTransactionsByAddress(enterprise, nil)
 	require.NoError(t, err)
 	assert.True(t, hasEnterpriseTx)
+}
+
+// TestCountAndPageUtxosByAddressWithOrderingCoarseMatch seeds a stake
+// credential with a large number of live UTxOs (standing in for a "large
+// address", the scenario dingo/3520 flags for unbounded pagination work) and
+// proves CountUtxosByAddressWithOrdering and Offset/Descending pagination on
+// GetUtxosByAddressWithOrdering return correct, tightly bounded windows
+// without loading the full result set: the shared credential pattern here
+// never needs CBOR-based exact-address filtering, so a cheap SQL COUNT and a
+// LIMIT/OFFSET fetch are the entire answer, matching how NodeAdapter.AccountUTXOs
+// (api/blockfrost) now queries a stake credential's UTxOs.
+func TestCountAndPageUtxosByAddressWithOrderingCoarseMatch(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	const total = 250
+	stake := bytes.Repeat([]byte{0xfe}, lcommon.AddressHashSize)
+	for i := range total {
+		payment := make([]byte, lcommon.AddressHashSize)
+		binary.BigEndian.PutUint32(payment, uint32(i)+1)
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			lcommon.AddressNetworkTestnet,
+			payment,
+			stake,
+		)
+		require.NoError(t, err)
+		slot := uint64(i) + 1
+		seedExactAddressUtxo(t, db, raw, addr, slot, byte(i))
+	}
+
+	query := &models.UtxoWithOrderingQuery{
+		AddressPatterns: []models.UtxoAddressPattern{{DelegationPart: stake}},
+	}
+
+	count, err := db.CountUtxosByAddressWithOrdering(query, nil)
+	require.NoError(t, err)
+	assert.Equal(t, total, count)
+
+	t.Run("ascending page stops at the requested window", func(t *testing.T) {
+		page, err := db.UtxosByAddressWithOrdering(
+			&models.UtxoWithOrderingQuery{
+				AddressPatterns: query.AddressPatterns,
+				Limit:           10,
+				Offset:          20,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, page, 10)
+		// Ascending order by producing slot: offset 20 lands on the 21st
+		// seeded row (slot 21), not the 1st.
+		assert.Equal(t, uint64(21), page[0].TxSlot)
+		assert.Equal(t, uint64(30), page[len(page)-1].TxSlot)
+	})
+
+	t.Run("descending page returns newest first without a full reverse", func(t *testing.T) {
+		page, err := db.UtxosByAddressWithOrdering(
+			&models.UtxoWithOrderingQuery{
+				AddressPatterns: query.AddressPatterns,
+				Limit:           10,
+				Descending:      true,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, page, 10)
+		assert.Equal(t, uint64(total), page[0].TxSlot)
+		assert.Equal(t, uint64(total-9), page[len(page)-1].TxSlot)
+	})
+
+	t.Run("offset past the end returns an empty page", func(t *testing.T) {
+		page, err := db.UtxosByAddressWithOrdering(
+			&models.UtxoWithOrderingQuery{
+				AddressPatterns: query.AddressPatterns,
+				Limit:           10,
+				Offset:          total,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, page)
+	})
+}
+
+// TestCountUtxosByAddressWithOrderingRejectsExactAddress proves
+// CountUtxosByAddressWithOrdering refuses to compute a count for
+// exact-address patterns: the coarse SQL predicate over-matches address
+// forms that share a payment/delegation credential (pointer addresses being
+// the concrete case), so a plain COUNT(*) against it would silently report
+// too many UTxOs instead of failing loudly.
+func TestCountUtxosByAddressWithOrderingRejectsExactAddress(t *testing.T) {
+	db := openTestDB(t)
+
+	payment := bytes.Repeat([]byte{0x11}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
+
+	_, err = db.CountUtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+		},
+		nil,
+	)
+	require.ErrorIs(t, err, models.ErrExactAddressRequiresCbor)
+}
+
+// TestUtxosByAddressWithOrderingRejectsOffsetOnExactAddress proves Offset
+// pagination is refused for exact-address patterns, for the same reason
+// CountUtxosByAddressWithOrdering is: SQL OFFSET would skip coarse
+// candidates, not exact matches, so the skipped count would not equal
+// Offset for an address whose coarse predicate over-matches.
+func TestUtxosByAddressWithOrderingRejectsOffsetOnExactAddress(t *testing.T) {
+	db := openTestDB(t)
+
+	payment := bytes.Repeat([]byte{0x22}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
+
+	_, err = db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+			Limit:           10,
+			Offset:          10,
+		},
+		nil,
+	)
+	require.ErrorIs(t, err, models.ErrOffsetRequiresCoarseMatch)
+}
+
+// TestUtxosByAddressWithOrderingRejectsDescendingKeyset proves Descending
+// cannot be combined with keyset (After) pagination: the After predicate's
+// comparison operators assume ascending order, so silently accepting both
+// would return rows in the wrong direction from the cursor instead of
+// failing loudly.
+func TestUtxosByAddressWithOrderingRejectsDescendingKeyset(t *testing.T) {
+	db := openTestDB(t)
+
+	_, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			MatchAllAddresses: true,
+			Descending:        true,
+			After:             &models.UtxoOrderingCursor{Slot: 1},
+			Limit:             10,
+		},
+		nil,
+	)
+	require.ErrorIs(t, err, models.ErrDescendingKeysetUnsupported)
+}
+
+// TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings proves
+// MatchingUtxoRefsByAddressWithOrdering applies the same CBOR-based exact
+// match as UtxosByAddressWithOrdering: it returns exactly the enterprise
+// address's own UTxOs, in ascending order, excluding pointer-address
+// siblings that share its payment credential.
+func TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	payment := bytes.Repeat([]byte{0xab}, lcommon.AddressHashSize)
+	enterprise, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	pointerOne := exactAddressTestPointer(t, payment, 0x01)
+
+	rows := []struct {
+		addr lcommon.Address
+		slot uint64
+		hash byte
+	}{
+		{pointerOne, 1, 0x01},
+		{enterprise, 2, 0x02},
+		{enterprise, 4, 0x04},
+		{enterprise, 6, 0x06},
+	}
+	seeded := make([]models.Utxo, len(rows))
+	for i := range rows {
+		seeded[i] = seedExactAddressUtxo(
+			t, db, raw, rows[i].addr, rows[i].slot, rows[i].hash,
+		)
+	}
+
+	pattern, err := models.ExactUtxoAddressPattern(enterprise)
+	require.NoError(t, err)
+	refs, err := db.MatchingUtxoRefsByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, refs, 3)
+	assert.Equal(t, seeded[1].TxId, refs[0].Hash)
+	assert.Equal(t, seeded[2].TxId, refs[1].Hash)
+	assert.Equal(t, seeded[3].TxId, refs[2].Hash)
+}
+
+// TestMatchingUtxoRefsByAddressWithOrderingCrossesBatchBoundary seeds more
+// exact-address UTxOs than the internal scan's per-batch size (1024) and
+// proves the keyset-cursor continuation across batches neither drops nor
+// duplicates a match -- the risk a batched scan carries that a single
+// unbounded fetch does not.
+func TestMatchingUtxoRefsByAddressWithOrderingCrossesBatchBoundary(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	payment := bytes.Repeat([]byte{0x71}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+
+	const total = 1100
+	wantHashes := make([][]byte, total)
+	for i := range total {
+		txHash := make([]byte, 32)
+		binary.BigEndian.PutUint32(txHash[28:], uint32(i)+1)
+		row := seedExactAddressUtxoWithHash(
+			t, db, raw, addr, uint64(i)+1, txHash,
+		)
+		wantHashes[i] = row.TxId
+	}
+
+	pattern, err := models.ExactUtxoAddressPattern(addr)
+	require.NoError(t, err)
+	refs, err := db.MatchingUtxoRefsByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, refs, total)
+	gotHashes := make([][]byte, len(refs))
+	for i := range refs {
+		gotHashes[i] = refs[i].Hash
+	}
+	assert.Equal(t, wantHashes, gotHashes)
 }
 
 // TestUtxosByAddressLoadsAssets proves GetUtxosByAddress still attaches

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -383,20 +383,23 @@ func TestCountAndPageUtxosByAddressWithOrderingCoarseMatch(t *testing.T) {
 		assert.Equal(t, uint64(30), page[len(page)-1].TxSlot)
 	})
 
-	t.Run("descending page returns newest first without a full reverse", func(t *testing.T) {
-		page, err := db.UtxosByAddressWithOrdering(
-			&models.UtxoWithOrderingQuery{
-				AddressPatterns: query.AddressPatterns,
-				Limit:           10,
-				Descending:      true,
-			},
-			nil,
-		)
-		require.NoError(t, err)
-		require.Len(t, page, 10)
-		assert.Equal(t, uint64(total), page[0].TxSlot)
-		assert.Equal(t, uint64(total-9), page[len(page)-1].TxSlot)
-	})
+	t.Run(
+		"descending page returns newest first without a full reverse",
+		func(t *testing.T) {
+			page, err := db.UtxosByAddressWithOrdering(
+				&models.UtxoWithOrderingQuery{
+					AddressPatterns: query.AddressPatterns,
+					Limit:           10,
+					Descending:      true,
+				},
+				nil,
+			)
+			require.NoError(t, err)
+			require.Len(t, page, 10)
+			assert.Equal(t, uint64(total), page[0].TxSlot)
+			assert.Equal(t, uint64(total-9), page[len(page)-1].TxSlot)
+		},
+	)
 
 	t.Run("offset past the end returns an empty page", func(t *testing.T) {
 		page, err := db.UtxosByAddressWithOrdering(
@@ -585,7 +588,9 @@ func TestCountAndFetchShareSnapshotWithinOneTxn(t *testing.T) {
 // match as UtxosByAddressWithOrdering: it returns exactly the enterprise
 // address's own UTxOs, in ascending order, excluding pointer-address
 // siblings that share its payment credential.
-func TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings(t *testing.T) {
+func TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings(
+	t *testing.T,
+) {
 	db := openTestDB(t)
 	raw := rawSQLiteMetadataFixture(t, db)
 
@@ -636,7 +641,9 @@ func TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings(t *testing
 // proves the keyset-cursor continuation across batches neither drops nor
 // duplicates a match -- the risk a batched scan carries that a single
 // unbounded fetch does not.
-func TestMatchingUtxoRefsByAddressWithOrderingCrossesBatchBoundary(t *testing.T) {
+func TestMatchingUtxoRefsByAddressWithOrderingCrossesBatchBoundary(
+	t *testing.T,
+) {
 	db := openTestDB(t)
 	raw := rawSQLiteMetadataFixture(t, db)
 
@@ -773,7 +780,12 @@ func TestMatchingUtxoRefsByAddressWithOrderingSnapshotTieBreak(t *testing.T) {
 	)
 	got := make(map[string]bool, len(refs))
 	for _, ref := range refs {
-		require.False(t, got[string(ref.Hash)], "duplicate ref for tx %x", ref.Hash)
+		require.False(
+			t,
+			got[string(ref.Hash)],
+			"duplicate ref for tx %x",
+			ref.Hash,
+		)
 		got[string(ref.Hash)] = true
 	}
 	assert.Equal(t, wantHashes, got)
@@ -859,6 +871,94 @@ INSERT INTO utxo (
 	)
 	require.NoError(t, err)
 	assert.Len(t, refs, total)
+}
+
+// TestUtxosByAddressWithOrderingSnapshotTieBreak seeds enough
+// snapshot-imported candidates sharing one slot, block index, and output
+// index -- 118 pointer-address siblings followed by 12 exact-address
+// matches, all tied and ordered only by tx_id -- that UtxosByAddressWithOrdering's
+// exact-address page-fill scan (batch size 128) splits the 12 matches
+// across its batch boundary: the first batch's last row and the second
+// batch's first candidates all tie on slot/block index/output index. The
+// keyset cursor can only resume past that boundary without revisiting it by
+// carrying the last row's tx_id.
+func TestUtxosByAddressWithOrderingSnapshotTieBreak(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	payment := bytes.Repeat([]byte{0x4d}, lcommon.AddressHashSize)
+	target, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		nil,
+	)
+	require.NoError(t, err)
+	sibling := exactAddressTestPointer(t, payment, 0x01)
+
+	const (
+		importSlot   = 7
+		siblingCount = 118
+		matchCount   = 12
+	)
+	wantHashes := make(map[string]bool, matchCount)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *Txn) error {
+		seedRow := func(addr lcommon.Address, txID uint32) error {
+			txHash := make([]byte, 32)
+			binary.BigEndian.PutUint32(txHash[28:], txID)
+			seedExactAddressImportedUtxo(t, raw, addr, importSlot, 0, txHash)
+			encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount:  1_000_000,
+			})
+			if err != nil {
+				return err
+			}
+			return db.Blob().SetUtxo(txn.Blob(), txHash, 0, encoded)
+		}
+		txID := uint32(1)
+		for range siblingCount {
+			if err := seedRow(sibling, txID); err != nil {
+				return err
+			}
+			txID++
+		}
+		for range matchCount {
+			txHash := make([]byte, 32)
+			binary.BigEndian.PutUint32(txHash[28:], txID)
+			wantHashes[string(txHash)] = true
+			if err := seedRow(target, txID); err != nil {
+				return err
+			}
+			txID++
+		}
+		return nil
+	}))
+
+	pattern, err := models.ExactUtxoAddressPattern(target)
+	require.NoError(t, err)
+	got, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: []models.UtxoAddressPattern{pattern},
+			Limit:           matchCount,
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(
+		t, got, matchCount,
+		"tied snapshot-imported matches must not be dropped across the "+
+			"scan's batch boundary",
+	)
+	seen := make(map[string]bool, len(got))
+	for _, u := range got {
+		require.False(
+			t, seen[string(u.TxId)],
+			"duplicate UTxO for tx %x", u.TxId,
+		)
+		seen[string(u.TxId)] = true
+		require.True(t, wantHashes[string(u.TxId)], "unexpected tx %x", u.TxId)
+	}
 }
 
 // TestUtxosByAddressLoadsAssets proves GetUtxosByAddress still attaches

--- a/database/utxo_exact_address_test.go
+++ b/database/utxo_exact_address_test.go
@@ -491,6 +491,95 @@ func TestUtxosByAddressWithOrderingRejectsDescendingKeyset(t *testing.T) {
 	require.ErrorIs(t, err, models.ErrDescendingKeysetUnsupported)
 }
 
+// TestUtxosByAddressWithOrderingRejectsOffsetKeyset proves Offset cannot be
+// combined with keyset (After) pagination: applying both would filter to
+// rows after the cursor and then additionally skip Offset rows within that
+// filtered set, silently returning a page shifted by both controls instead
+// of the single, well-defined page either one alone describes.
+func TestUtxosByAddressWithOrderingRejectsOffsetKeyset(t *testing.T) {
+	db := openTestDB(t)
+
+	_, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			MatchAllAddresses: true,
+			Offset:            10,
+			After:             &models.UtxoOrderingCursor{Slot: 1},
+			Limit:             10,
+		},
+		nil,
+	)
+	require.ErrorIs(t, err, models.ErrOffsetKeysetUnsupported)
+}
+
+// TestCountAndFetchShareSnapshotWithinOneTxn proves the fix for a review
+// finding on AccountUTXOs/AddressUTXOs: a count and a subsequent page fetch
+// against a nil Txn each open their own transaction, so a commit landing
+// between them could make the reported total and the returned page
+// describe different UTxO sets. Passing one Txn to both calls instead
+// (what the adapter now does) must keep them on the same snapshot even
+// when a conflicting write commits in between.
+func TestCountAndFetchShareSnapshotWithinOneTxn(t *testing.T) {
+	db := openTestDB(t)
+	raw := rawSQLiteMetadataFixture(t, db)
+
+	stakeKey := bytes.Repeat([]byte{0x81}, lcommon.AddressHashSize)
+	payment := bytes.Repeat([]byte{0x82}, lcommon.AddressHashSize)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkTestnet,
+		payment,
+		stakeKey,
+	)
+	require.NoError(t, err)
+	for i := range 5 {
+		seedExactAddressUtxo(t, db, raw, addr, uint64(i)+1, byte(i)+1)
+	}
+
+	query := &models.UtxoWithOrderingQuery{
+		AddressPatterns: []models.UtxoAddressPattern{
+			{DelegationPart: stakeKey},
+		},
+	}
+
+	// Opens its transaction eagerly (sqlstore.Store.transaction calls
+	// BeginTx before returning), fixing its snapshot right here, before
+	// the extra rows below exist.
+	txn := db.Transaction(false)
+	defer txn.Release()
+
+	before, err := db.CountUtxosByAddressWithOrdering(query, txn)
+	require.NoError(t, err)
+	require.Equal(t, 5, before)
+
+	// A conflicting write commits out-of-band, as a live node's chain
+	// processing would between an API request's two calls.
+	for i := range 3 {
+		seedExactAddressUtxo(t, db, raw, addr, uint64(100+i), byte(100+i))
+	}
+
+	// A fresh (nil-txn) read observes the new rows...
+	after, err := db.CountUtxosByAddressWithOrdering(query, nil)
+	require.NoError(t, err)
+	require.Equal(t, 8, after)
+
+	// ...but reusing the original txn still sees only the original
+	// snapshot: the count and the page fetch below cannot disagree about
+	// how many rows exist.
+	stillBefore, err := db.CountUtxosByAddressWithOrdering(query, txn)
+	require.NoError(t, err)
+	require.Equal(t, 5, stillBefore)
+
+	rows, err := db.UtxosByAddressWithOrdering(
+		&models.UtxoWithOrderingQuery{
+			AddressPatterns: query.AddressPatterns,
+			Limit:           100,
+		},
+		txn,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 5)
+}
+
 // TestMatchingUtxoRefsByAddressWithOrderingExcludesPointerSiblings proves
 // MatchingUtxoRefsByAddressWithOrdering applies the same CBOR-based exact
 // match as UtxosByAddressWithOrdering: it returns exactly the enterprise

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8998,23 +8998,6 @@ func (ls *LedgerState) UtxosByAddressWithOrdering(
 	return utxos, nil
 }
 
-// CountUtxosByAddressWithOrdering returns the number of live UTxOs matching
-// q's coarse SQL predicate. See Database.CountUtxosByAddressWithOrdering.
-func (ls *LedgerState) CountUtxosByAddressWithOrdering(
-	q *models.UtxoWithOrderingQuery,
-) (int, error) {
-	return ls.db.CountUtxosByAddressWithOrdering(q, nil)
-}
-
-// MatchingUtxoRefsByAddressWithOrdering returns the references of every
-// live UTxO matching q's address patterns. See
-// Database.MatchingUtxoRefsByAddressWithOrdering.
-func (ls *LedgerState) MatchingUtxoRefsByAddressWithOrdering(
-	q *models.UtxoWithOrderingQuery,
-) ([]models.UtxoId, error) {
-	return ls.db.MatchingUtxoRefsByAddressWithOrdering(q, nil)
-}
-
 // UtxosByAddressAtSlot returns all UTxOs belonging to the
 // specified address that existed at the given slot.
 func (ls *LedgerState) UtxosByAddressAtSlot(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8998,6 +8998,23 @@ func (ls *LedgerState) UtxosByAddressWithOrdering(
 	return utxos, nil
 }
 
+// CountUtxosByAddressWithOrdering returns the number of live UTxOs matching
+// q's coarse SQL predicate. See Database.CountUtxosByAddressWithOrdering.
+func (ls *LedgerState) CountUtxosByAddressWithOrdering(
+	q *models.UtxoWithOrderingQuery,
+) (int, error) {
+	return ls.db.CountUtxosByAddressWithOrdering(q, nil)
+}
+
+// MatchingUtxoRefsByAddressWithOrdering returns the references of every
+// live UTxO matching q's address patterns. See
+// Database.MatchingUtxoRefsByAddressWithOrdering.
+func (ls *LedgerState) MatchingUtxoRefsByAddressWithOrdering(
+	q *models.UtxoWithOrderingQuery,
+) ([]models.UtxoId, error) {
+	return ls.db.MatchingUtxoRefsByAddressWithOrdering(q, nil)
+}
+
 // UtxosByAddressAtSlot returns all UTxOs belonging to the
 // specified address that existed at the given slot.
 func (ls *LedgerState) UtxosByAddressAtSlot(


### PR DESCRIPTION
## Summary

One Blockfrost pagination path accepted an unbounded `page` value, and the
address/account UTxO endpoints always loaded and fully materialized an
address's or account's entire live UTxO set before slicing out one page
(full-reversing it for descending order). This bounds both paths to the
requested page instead.

- `ParsePagination` now clamps `page` the same way it already clamped
  `count`.
- `AccountUTXOs` (stake-credential UTxOs) now uses a cheap SQL `COUNT` plus
  a `LIMIT`/`OFFSET`/`ORDER`-bound fetch — its address pattern only needs a
  coarse SQL match, so this is safe and complete.
- `AddressUTXOs` still needs CBOR-based exact-address matching to compute
  an accurate total (a coarse `COUNT`/`OFFSET` is not safe there), so it
  now does a reference-only scan (no assets, no full rows) for the total
  and ordering, then fetches full data for only the requested page.

## Changes, file by file

- `api/blockfrost/pagination.go` — `ParsePagination` clamps `page` to
  `MaxPaginationPage`; adds `paginationOffset` (overflow-safe page→offset).
- `api/blockfrost/adapter_account_activity.go` — `AccountUTXOs` rewritten
  to use a `COUNT` plus a bounded `Limit`/`Offset`/`Descending` fetch
  instead of loading and reversing the full result set.
- `api/blockfrost/adapter.go` — `AddressUTXOs` rewritten to fetch matching
  UTxO references only (no assets/full rows), then fetch full data for
  just the requested page via the existing `UtxosByRefs` path. Removes the
  now-unused `paginateUtxos` helper.
- `database/models/utxo.go` — adds `Offset`, `Descending`, and
  `SkipAssets` to `UtxoWithOrderingQuery`, plus two new sentinel errors for
  invalid combinations.
- `database/plugin/metadata/sqlstore/utxo.go` — `GetUtxosByAddressWithOrdering`
  honors the new query options; adds `CountUtxosByAddressWithOrdering`
  (plain `COUNT(*)`, rejected for exact-address patterns).
- `database/plugin/metadata/store.go` — declares
  `CountUtxosByAddressWithOrdering` on the store interface.
- `database/utxo.go` — adds `Database.CountUtxosByAddressWithOrdering` and
  `Database.MatchingUtxoRefsByAddressWithOrdering` (the bounded
  reference-only scan for exact-address patterns).
- `ledger/state.go` — thin `LedgerState` wrappers for both new database
  methods.
- `DATABASE.md` — documents the new query options and the
  count-vs-reference-scan split between `AccountUTXOs` and `AddressUTXOs`.

Closes #3520 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dingo/3520 by bounding Blockfrost pagination and the address UTxO endpoints: `page` is now clamped like `count`, and loading a single page no longer materializes an account's or address's entire live UTxO history.

**Bug Fixes**

- `ParsePagination` now clamps `page` to `MaxPaginationPage`; the page-to-offset conversion is overflow-safe.
- Huge `page` values now return an empty page past the end instead of reaching unchecked offset arithmetic.

**Refactors**

- `AccountUTXOs` uses a SQL `COUNT` plus a `LIMIT`/`OFFSET`/`ORDER`-bound fetch instead of loading and reversing the full result set.
- `AddressUTXOs` fetches matching UTxO references only (no assets, no full rows), then loads full data for just the requested page via `UtxosByRefs`.
- Both endpoints pass one shared read transaction to their count/scan and page-fetch calls, so the reported total and returned page describe the same snapshot under concurrent chain updates.
- Both exact-address scans — `MatchingUtxoRefsByAddressWithOrdering` and `UtxosByAddressWithOrdering`'s page-fill loop — now carry the last transaction ID in their keyset cursor, so snapshot-imported rows tied on slot, block index, and output index survive batch boundaries.
- The reference scan no longer applies the page-fill candidate cap that had turned large address listings into errors.
- `GetUtxosByAddressWithOrdering` gains `Offset`, `Descending`, and `SkipAssets` query options, with `Offset` and `Descending` rejected for keyset `After` and `Offset` rejected for exact-address patterns.
- Adds `CountUtxosByAddressWithOrdering` and `MatchingUtxoRefsByAddressWithOrdering` database methods backing the two endpoints.

<sup>Written for commit 03f737b54bb7f499676970f0235a1b550c54726d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable pagination and total counts for address and account UTxO queries.
  - Supports ascending or descending ordering, offsets, page limits, and efficient large-result handling.
  - Preserves native asset details when requested, with options to omit asset data for faster responses.
  - Ensures totals and page results reflect the same database snapshot.

- **Bug Fixes**
  - Prevents invalid combinations of keyset pagination, offsets, and descending ordering.
  - Correctly handles empty results, oversized pages, and pages beyond the available data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->