### PR TITLE
fix(devnet): isolate concurrent DevNet runs across worktrees

### DIFF
--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -354,10 +354,12 @@ submits to, so mempool traffic keeps flowing through the outage.
 To drive it by hand against a network you brought up yourself:
 
 ```bash
+export COMPOSE_PROJECT_NAME=dingo-devnet-manual
 ./start.sh --accelerated
 DEVNET_ACCELERATED=1 \
   DEVNET_TESTNET_YAML=$PWD/testnet-dingo-accelerated.yaml \
   DEVNET_COMPOSE_FILE=$PWD/docker-compose.yml \
+  DEVNET_COMPOSE_PROJECT=$COMPOSE_PROJECT_NAME \
   go test -tags devnet -run TestAcceleratedScenarioTimeline -timeout 8m \
   ./internal/test/devnet/scenarios/
 ./stop.sh --accelerated
@@ -578,6 +580,7 @@ harness and the compose port mappings always agree.
 | `topology/dingo-1.json`, `dingo-2.json`, `dingo-3.json`, `dingo-relay.json` | Static peer lists for dingo mode |
 | `topology/dingo-producer.json`, `cardano-producer.json`, `relay.json` | Static peer lists for conformance mode |
 | `.env`                       | Sets the default `COMPOSE_PROFILES=dingo` |
+| `compose-project.sh`         | Derives a stable, worktree-specific Compose project name, bridge subnet, and rendered topology directory |
 | `start.sh` / `stop.sh`       | Convenience wrappers around `docker compose up -d` / `down -v`; accept `--conformance` |
 | `run-tests.sh`               | Full bring-up → test → tear-down cycle used by CI; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
@@ -598,15 +601,41 @@ harness and the compose port mappings always agree.
 
 ## Cleanup
 
-`stop.sh` and the `run-tests.sh` trap both run `docker compose down -v`
-scoped to the active `COMPOSE_PROFILES`, which removes that mode's config
-and data volumes. Genesis is regenerated on every start, so this is the
-desired default — there's no state worth preserving between runs. If a
-previous run left orphaned containers or volumes around:
+`start.sh`, `stop.sh`, and `run-tests.sh` derive `COMPOSE_PROJECT_NAME` from
+the worktree's absolute path. Compose therefore gives each worktree distinct
+containers, networks, volumes, and project state. Set `COMPOSE_PROJECT_NAME`
+explicitly to run more than one DevNet in the same worktree. `NodeControl`
+receives that project as `DEVNET_COMPOSE_PROJECT`, resolves service containers
+inside it, and still uses direct `docker stop`/`docker start` for disruption
+phases.
+
+A distinct network *name* isn't enough on its own: the compose network's
+subnet is a separate axis, and Docker refuses to create two networks with an
+overlapping subnet even under different project names ("Pool overlaps with
+other one on this address space"). The same three scripts also derive
+`DEVNET_NET_BASE`, a worktree-specific `172.24-172.31.x` /24 (distinct from
+the ranges the antithesis/archive-demo and erastest stacks pin), and use it
+for the compose network's subnet and each service's static IP — the topology
+still needs static IPs because the peer lists in `topology/*.json` are
+static, checked-in files. `devnet_render_topology` rewrites a worktree-local
+copy of those files with the run's `DEVNET_NET_BASE` into
+`DEVNET_TOPOLOGY_DIR`, which `docker-compose.yml` mounts instead of the
+checked-in `./topology` (its fallback default, so a bare `docker compose up`
+without going through these scripts still works — for a single run at a
+time). Set `DEVNET_NET_BASE` explicitly for the same reason you'd set
+`COMPOSE_PROJECT_NAME`.
+
+`stop.sh` and the `run-tests.sh` trap run `docker compose down -v` only for
+that project, removing its config and data volumes without touching another
+worktree's run, and remove that project's rendered topology directory.
+Genesis is regenerated on every start, so this is the desired default —
+there's no state worth preserving between runs. If a previous run left
+orphaned containers or volumes around, use the same project name:
 
 ```bash
-docker compose -f docker-compose.yml down -v --remove-orphans
+COMPOSE_PROJECT_NAME=<project> docker compose -f docker-compose.yml down -v --remove-orphans
 docker volume ls | grep devnet                       # inspect leftovers
+docker network ls | grep dingo-devnet                # inspect leftover networks
 ```
 
 ## Troubleshooting
@@ -642,7 +671,8 @@ docker volume ls | grep devnet                       # inspect leftovers
   `epochLength: 500`, `slotLength: 1s`.
 - The accelerated scenario fails at `NewNodeControl`. It needs to reach
   Docker Compose to stop and start nodes. Run it through `run-tests.sh`,
-  which exports `DEVNET_COMPOSE_FILE`, or set that variable yourself. It
+  which exports `DEVNET_COMPOSE_FILE` and `DEVNET_COMPOSE_PROJECT`, or set
+  both variables yourself. It
   fails rather than skipping the disruption phases on purpose — a pass
   that quietly omitted them would not be release evidence.
 - `TestCIP50PledgeLeverageRewardEffect` skips. It requires

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -354,14 +354,17 @@ submits to, so mempool traffic keeps flowing through the outage.
 To drive it by hand against a network you brought up yourself:
 
 ```bash
-export COMPOSE_PROJECT_NAME=dingo-devnet-manual
 ./start.sh --accelerated
-DEVNET_ACCELERATED=1 \
-  DEVNET_TESTNET_YAML=$PWD/testnet-dingo-accelerated.yaml \
-  DEVNET_COMPOSE_FILE=$PWD/docker-compose.yml \
-  DEVNET_COMPOSE_PROJECT=$COMPOSE_PROJECT_NAME \
-  go test -tags devnet -run TestAcceleratedScenarioTimeline -timeout 8m \
-  ./internal/test/devnet/scenarios/
+```
+
+`start.sh --accelerated` prints the exact `go test` command to run next,
+including the `DEVNET_COMPOSE_PROJECT` and `DEVNET_*_ADDR` values for
+whichever project/ports this run actually landed on — `devnet_ports` may
+have derived non-default host ports, so copy that printed command rather
+than retyping one with the default `localhost:3010`-style addresses, which
+would connect to the wrong ports. Then:
+
+```bash
 ./stop.sh --accelerated
 ```
 
@@ -532,9 +535,13 @@ this feature:
 
 ## Port and address overrides
 
-If the defaults clash with something already on the host, override the port
-mappings via environment or a local `.env` file next to `docker-compose.yml`
-(the checked-in `.env` sets `COMPOSE_PROFILES=dingo` as the default).
+`start.sh`/`run-tests.sh` derive a worktree-specific block for all 11
+variables below by default (see `devnet_ports` in [Cleanup](#cleanup)), so
+the defaults in this table only apply to a bare `docker compose up` or a
+single-worktree run with `DEVNET_*_PORT` set explicitly. Set any one of them
+to opt out of auto-derivation entirely and take full manual control (via
+environment or a local `.env` file next to `docker-compose.yml`; the
+checked-in `.env` sets `COMPOSE_PROFILES=dingo` as the default).
 
 Dingo mode:
 
@@ -580,7 +587,7 @@ harness and the compose port mappings always agree.
 | `topology/dingo-1.json`, `dingo-2.json`, `dingo-3.json`, `dingo-relay.json` | Static peer lists for dingo mode |
 | `topology/dingo-producer.json`, `cardano-producer.json`, `relay.json` | Static peer lists for conformance mode |
 | `.env`                       | Sets the default `COMPOSE_PROFILES=dingo` |
-| `compose-project.sh`         | Derives a stable, worktree-specific Compose project name, bridge subnet, and rendered topology directory |
+| `compose-project.sh`         | Derives a stable, worktree-specific Compose project name, a collision-checked bridge subnet and host port block, and a rendered topology directory; wraps `docker compose up` with a retry on subnet collision |
 | `start.sh` / `stop.sh`       | Convenience wrappers around `docker compose up -d` / `down -v`; accept `--conformance` |
 | `run-tests.sh`               | Full bring-up → test → tear-down cycle used by CI; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
@@ -613,17 +620,38 @@ A distinct network *name* isn't enough on its own: the compose network's
 subnet is a separate axis, and Docker refuses to create two networks with an
 overlapping subnet even under different project names ("Pool overlaps with
 other one on this address space"). The same three scripts also derive
-`DEVNET_NET_BASE`, a worktree-specific `172.24-172.31.x` /24 (distinct from
-the ranges the antithesis/archive-demo and erastest stacks pin), and use it
-for the compose network's subnet and each service's static IP — the topology
-still needs static IPs because the peer lists in `topology/*.json` are
-static, checked-in files. `devnet_render_topology` rewrites a worktree-local
-copy of those files with the run's `DEVNET_NET_BASE` into
-`DEVNET_TOPOLOGY_DIR`, which `docker-compose.yml` mounts instead of the
-checked-in `./topology` (its fallback default, so a bare `docker compose up`
-without going through these scripts still works — for a single run at a
-time). Set `DEVNET_NET_BASE` explicitly for the same reason you'd set
-`COMPOSE_PROJECT_NAME`.
+`DEVNET_NET_BASE`, a `172.24-172.31.x` /24, and use it for the compose
+network's subnet and each service's static IP — the topology still needs
+static IPs because the peer lists in `topology/*.json` are static,
+checked-in files. `devnet_render_topology` rewrites a worktree-local copy of
+those files with the run's `DEVNET_NET_BASE` into `DEVNET_TOPOLOGY_DIR`,
+which `docker-compose.yml` mounts instead of the checked-in `./topology`
+(its fallback default, so a bare `docker compose up` without going through
+these scripts still works — for a single run at a time).
+
+A worktree-path hash only picks a *starting* subnet: two worktrees can hash
+to the same one, and this range isn't reserved for DevNet, so an unrelated
+Docker network could already sit on part of it. `devnet_net_base` actually
+checks every subnet `docker network ls`/`inspect` currently reports and
+walks forward from the hash to a genuinely free `/24` (falling back to the
+hash alone if Docker isn't reachable). A residual race remains between that
+check and the network actually being created — `devnet_compose_up` (used by
+`start.sh`/`run-tests.sh` in place of a bare `docker compose up -d`) covers
+it: on a "Pool overlaps" failure it recomputes `DEVNET_NET_BASE` (which now
+sees the winner's network and skips it), re-renders topology, and retries,
+up to 3 attempts. Set `DEVNET_NET_BASE` explicitly for the same reason
+you'd set `COMPOSE_PROJECT_NAME`.
+
+Published host ports are a fourth axis Compose does not scope by project at
+all: two worktrees' default ports (3010/3013-3015, 3020-3023, and
+conformance's 3010-3012) collide outright with "port is already allocated".
+`devnet_ports` derives a worktree-specific block of 11 ports (one hash-based
+starting point, actually checked against what's listening on
+`127.0.0.1` and shifted forward a whole block at a time until every port in
+it is free) and exports it as the `DEVNET_*_PORT` / `DEVNET_*_NTC_PORT`
+variables `docker-compose.yml` already reads. It's skipped entirely if the
+caller has already set any of those variables, so a manual port override
+stays in full manual control.
 
 `stop.sh` and the `run-tests.sh` trap run `docker compose down -v` only for
 that project, removing its config and data volumes without touching another

--- a/internal/test/devnet/compose-project.sh
+++ b/internal/test/devnet/compose-project.sh
@@ -40,13 +40,34 @@ _devnet_cidr_overlaps() {
   [[ ${a_lo} -le ${b_hi} && ${b_lo} -le ${a_hi} ]]
 }
 
-# Every subnet Docker currently has allocated, one per line. Best-effort:
-# an unreachable daemon just yields no exclusions, same as today.
+# True (exit 0) when the string is a dotted-decimal IPv4 CIDR ("a.b.c.d/n").
+# Docker networks can be IPv6 (a ULA /64, /8, etc.), and _devnet_ip_to_int
+# only understands IPv4 — an IPv6 subnet reaching it would abort
+# start.sh/run-tests.sh with a bash arithmetic error before Compose ever
+# runs, rather than just being (correctly) treated as no constraint on our
+# IPv4-only range.
+_devnet_is_ipv4_cidr() {
+  [[ "$1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]
+}
+
+# Every IPv4 subnet Docker currently has allocated, one per line. IPv6
+# subnets are filtered out (see _devnet_is_ipv4_cidr). Best-effort: an
+# unreachable daemon just yields no exclusions, same as today.
 _devnet_used_subnets() {
   local name
   docker network ls --format '{{.Name}}' 2>/dev/null | while read -r name; do
     docker network inspect "${name}" \
       --format '{{range .IPAM.Config}}{{.Subnet}}{{"\n"}}{{end}}' 2>/dev/null
+  done | while read -r subnet; do
+    # Not `_devnet_is_ipv4_cidr "${subnet}" && printf ...`: under
+    # pipefail+errexit, a false condition on the very last line (the
+    # closing "no subnet" line every `docker network inspect` emits for a
+    # network without one) makes `&&` short-circuit non-zero, which kills
+    # the whole run-tests.sh/start.sh process right here. `if` doesn't
+    # have that problem — a false condition with no `else` still exits 0.
+    if _devnet_is_ipv4_cidr "${subnet}"; then
+      printf '%s\n' "${subnet}"
+    fi
   done
 }
 
@@ -161,14 +182,18 @@ _devnet_port_free() {
 # (3010/3013-3015, 3020-3023, and conformance's 3010-3012) collide outright
 # with "port is already allocated". Skips entirely if the caller has
 # already set any of _DEVNET_PORT_VARS, so a manual override stays in full
-# manual control.
+# manual control. Sets DEVNET_PORTS_AUTO=1 when it actually derived the
+# block, so devnet_compose_up knows it's safe to pick a new one on a bind
+# failure rather than fighting a caller's explicit choice.
 devnet_ports() {
+  DEVNET_PORTS_AUTO=""
   local var
   for var in "${_DEVNET_PORT_VARS[@]}"; do
     if [[ -n "${!var:-}" ]]; then
       return
     fi
   done
+  DEVNET_PORTS_AUTO=1
 
   local project_root project_hash block_size base attempt candidate i port all_free
   project_root="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
@@ -200,11 +225,30 @@ devnet_ports() {
   return 1
 }
 
-# `docker compose up -d`, retrying if this run's subnet lost a race with a
-# concurrent worktree between devnet_net_base's check and the network
-# actually being created. On that failure the losing worktree's network
-# now shows up in `docker network ls`, so recomputing DEVNET_NET_BASE (and
-# re-rendering topology against it) naturally avoids it on the next try.
+# True (exit 0) when docker compose's failure output looks like a host port
+# already being bound, as opposed to some other bring-up failure. Docker's
+# wording for this varies by version/OS ("port is already allocated" on
+# older Docker, "Ports are not available: ... already in use" on newer).
+_devnet_looks_like_port_conflict() {
+  case "$1" in
+    *"port is already allocated"* | *"Ports are not available"* | \
+      *"address already in use"*)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# `docker compose up -d`, retrying twice if this run's subnet or host ports
+# lost a race with a concurrent worktree between the earlier check
+# (devnet_net_base / devnet_ports) and Docker actually claiming them:
+#
+#   - subnet: a "Pool overlaps" failure means the losing worktree's network
+#     now shows up in `docker network ls`, so recomputing DEVNET_NET_BASE
+#     (and re-rendering topology against it) naturally avoids it next try.
+#   - ports: a port-bind failure only gets retried when devnet_ports itself
+#     derived the block (DEVNET_PORTS_AUTO=1) — a caller's explicit port
+#     override is never second-guessed, so that case still fails through.
 devnet_compose_up() {
   local compose_file="$1" attempt out
   for (( attempt = 1; attempt <= 3; attempt++ )); do
@@ -213,12 +257,27 @@ devnet_compose_up() {
       return 0
     fi
     printf '%s\n' "${out}" >&2
-    if [[ "${out}" != *"Pool overlaps"* ]] || [[ ${attempt} -eq 3 ]]; then
+    if [[ ${attempt} -eq 3 ]]; then
       return 1
     fi
-    echo "[compose-project] subnet collided with a concurrent worktree;" \
-      "picking a new one and retrying (attempt ${attempt}/3)" >&2
-    unset DEVNET_NET_BASE
-    devnet_render_topology
+    if [[ "${out}" == *"Pool overlaps"* ]]; then
+      echo "[compose-project] subnet collided with a concurrent worktree;" \
+        "picking a new one and retrying (attempt ${attempt}/3)" >&2
+      unset DEVNET_NET_BASE
+      devnet_render_topology
+      continue
+    fi
+    if [[ "${DEVNET_PORTS_AUTO:-}" == "1" ]] &&
+      _devnet_looks_like_port_conflict "${out}"; then
+      echo "[compose-project] host port collided with a concurrent" \
+        "worktree; picking a new block and retrying (attempt ${attempt}/3)" >&2
+      local var
+      for var in "${_DEVNET_PORT_VARS[@]}"; do
+        unset "${var}"
+      done
+      devnet_ports
+      continue
+    fi
+    return 1
   done
 }

--- a/internal/test/devnet/compose-project.sh
+++ b/internal/test/devnet/compose-project.sh
@@ -12,14 +12,59 @@ devnet_compose_project() {
   export COMPOSE_PROJECT_NAME="dingo-devnet-${project_hash}"
 }
 
-# Select a stable, worktree-specific /24 for the DevNet bridge network.
-# Compose project-scopes the network's *name*, but its subnet is a
-# separate axis: the checked-in topology/*.json files address peers by a
-# hardcoded 172.20.0.0/24 IP (devnet_render_topology rewrites those), and
-# Docker refuses to create two networks with the same subnet even under
-# different project names ("Pool overlaps with other one on this address
-# space"). Concurrent worktrees therefore each need their own range, not
-# just their own network name.
+# --- IPv4 CIDR helpers, used to check a candidate subnet against every
+# --- network Docker already knows about (see devnet_net_base). --------
+
+_devnet_ip_to_int() {
+  local IFS=.
+  # shellcheck disable=SC2206 # splitting "a.b.c.d" on IFS=. is the point
+  local -a o=(${1})
+  echo $(( (o[0] << 24) + (o[1] << 16) + (o[2] << 8) + o[3] ))
+}
+
+# Prints "<first> <last>", the inclusive integer host range for a CIDR.
+_devnet_cidr_range() {
+  local cidr="$1" addr prefix base mask
+  addr="${cidr%/*}"
+  prefix="${cidr#*/}"
+  base=$(_devnet_ip_to_int "${addr}")
+  mask=$(( (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF ))
+  base=$(( base & mask ))
+  echo "${base} $(( base + (1 << (32 - prefix)) - 1 ))"
+}
+
+_devnet_cidr_overlaps() {
+  local a_lo a_hi b_lo b_hi
+  read -r a_lo a_hi < <(_devnet_cidr_range "$1")
+  read -r b_lo b_hi < <(_devnet_cidr_range "$2")
+  [[ ${a_lo} -le ${b_hi} && ${b_lo} -le ${a_hi} ]]
+}
+
+# Every subnet Docker currently has allocated, one per line. Best-effort:
+# an unreachable daemon just yields no exclusions, same as today.
+_devnet_used_subnets() {
+  local name
+  docker network ls --format '{{.Name}}' 2>/dev/null | while read -r name; do
+    docker network inspect "${name}" \
+      --format '{{range .IPAM.Config}}{{.Subnet}}{{"\n"}}{{end}}' 2>/dev/null
+  done
+}
+
+# Select a worktree-specific /24 for the DevNet bridge network. A distinct
+# Compose project name scopes the network's *name*, but not its subnet:
+# Docker refuses to create two networks with an overlapping subnet even
+# under different project names ("Pool overlaps with other one on this
+# address space"). The checked-in topology/*.json files address peers by a
+# hardcoded 172.20.0.0/24 IP (devnet_render_topology rewrites those), so
+# concurrent worktrees each need their own genuinely free range.
+#
+# Hashing the worktree path alone isn't enough to guarantee that: the hash
+# space here is only 2048 /24s, two different worktrees can land on the
+# same one, and an unrelated Docker network on the host (this range isn't
+# reserved for DevNet) could already occupy part of it. So this walks
+# forward from the hash-derived starting point and actually checks every
+# subnet Docker currently reports, via _devnet_used_subnets, until it finds
+# one with no overlap.
 #
 # 172.24-172.31 stays clear of the static subnets the antithesis/
 # archive-demo (172.21.0.0/24) and erastest (172.22.0.0/24) stacks pin, and
@@ -29,12 +74,36 @@ devnet_net_base() {
   if [[ -n "${DEVNET_NET_BASE:-}" ]]; then
     return
   fi
-  local project_root project_hash second third
+  local project_root project_hash used
   project_root="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
   project_hash="$(printf '%s' "${project_root}" | cksum | awk '{print $1}')"
-  second=$((24 + project_hash % 8))
-  third=$(((project_hash / 8) % 256))
-  export DEVNET_NET_BASE="172.${second}.${third}"
+  used="$(_devnet_used_subnets)"
+
+  local total=2048 start step index second third candidate subnet overlap
+  start=$((project_hash % total))
+  for (( step = 0; step < total; step++ )); do
+    index=$(( (start + step) % total ))
+    second=$(( 24 + index / 256 ))
+    third=$(( index % 256 ))
+    candidate="172.${second}.${third}.0/24"
+    overlap=false
+    if [[ -n "${used}" ]]; then
+      while IFS= read -r subnet; do
+        [[ -z "${subnet}" ]] && continue
+        if _devnet_cidr_overlaps "${candidate}" "${subnet}"; then
+          overlap=true
+          break
+        fi
+      done <<<"${used}"
+    fi
+    if [[ "${overlap}" == "false" ]]; then
+      export DEVNET_NET_BASE="172.${second}.${third}"
+      return
+    fi
+  done
+
+  echo "devnet: no free /24 subnet found in 172.24.0.0-172.31.255.0" >&2
+  return 1
 }
 
 # Path to this run's rendered topology directory. Split out from
@@ -57,5 +126,99 @@ devnet_render_topology() {
   for src in "${SCRIPT_DIR}"/topology/*.json; do
     sed "s/172\.20\.0\./${DEVNET_NET_BASE}./g" "${src}" \
       >"${DEVNET_TOPOLOGY_DIR}/$(basename "${src}")"
+  done
+}
+
+# The host ports docker-compose.yml publishes, keyed by the env var it
+# already reads for each (with a `:-` fallback to the original literal
+# port). Order fixes each var's offset within the block devnet_ports
+# allocates; keep in sync with docker-compose.yml's `ports:` entries.
+_DEVNET_PORT_VARS=(
+  DEVNET_DINGO1_PORT
+  DEVNET_DINGO2_PORT
+  DEVNET_DINGO3_PORT
+  DEVNET_DINGO_RELAY_PORT
+  DEVNET_DINGO1_NTC_PORT
+  DEVNET_DINGO2_NTC_PORT
+  DEVNET_DINGO3_NTC_PORT
+  DEVNET_DINGO_RELAY_NTC_PORT
+  DEVNET_DINGO_PORT
+  DEVNET_CARDANO_PORT
+  DEVNET_RELAY_PORT
+)
+
+# True (exit 0) when nothing is listening on 127.0.0.1:<port>. Best-effort,
+# same TOCTOU caveat as any "check then bind" scheme, but good enough to
+# steer clear of another worktree's already-running DevNet.
+_devnet_port_free() {
+  ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# Select a worktree-specific block of host ports. A distinct Compose
+# project isolates containers, volumes, and (via devnet_net_base) the
+# bridge subnet, but published host ports are a separate axis Compose does
+# not scope by project at all: a second worktree's default ports
+# (3010/3013-3015, 3020-3023, and conformance's 3010-3012) collide outright
+# with "port is already allocated". Skips entirely if the caller has
+# already set any of _DEVNET_PORT_VARS, so a manual override stays in full
+# manual control.
+devnet_ports() {
+  local var
+  for var in "${_DEVNET_PORT_VARS[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+      return
+    fi
+  done
+
+  local project_root project_hash block_size base attempt candidate i port all_free
+  project_root="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+  project_hash="$(printf '%s' "${project_root}" | cksum | awk '{print $1}')"
+  block_size=${#_DEVNET_PORT_VARS[@]}
+  # Stay clear of privileged ports and of the ephemeral range most OSes
+  # start handing out around 32768-49152.
+  base=$(( 20000 + (project_hash % 9000) ))
+
+  for (( attempt = 0; attempt < 200; attempt++ )); do
+    candidate=$(( base + attempt * block_size ))
+    all_free=true
+    for (( i = 0; i < block_size; i++ )); do
+      port=$(( candidate + i ))
+      if ! _devnet_port_free "${port}"; then
+        all_free=false
+        break
+      fi
+    done
+    if [[ "${all_free}" == "true" ]]; then
+      for (( i = 0; i < block_size; i++ )); do
+        export "${_DEVNET_PORT_VARS[i]}=$(( candidate + i ))"
+      done
+      return
+    fi
+  done
+
+  echo "devnet: could not find a free block of ${block_size} host ports" >&2
+  return 1
+}
+
+# `docker compose up -d`, retrying if this run's subnet lost a race with a
+# concurrent worktree between devnet_net_base's check and the network
+# actually being created. On that failure the losing worktree's network
+# now shows up in `docker network ls`, so recomputing DEVNET_NET_BASE (and
+# re-rendering topology against it) naturally avoids it on the next try.
+devnet_compose_up() {
+  local compose_file="$1" attempt out
+  for (( attempt = 1; attempt <= 3; attempt++ )); do
+    if out=$(docker compose -f "${compose_file}" up -d 2>&1); then
+      printf '%s\n' "${out}"
+      return 0
+    fi
+    printf '%s\n' "${out}" >&2
+    if [[ "${out}" != *"Pool overlaps"* ]] || [[ ${attempt} -eq 3 ]]; then
+      return 1
+    fi
+    echo "[compose-project] subnet collided with a concurrent worktree;" \
+      "picking a new one and retrying (attempt ${attempt}/3)" >&2
+    unset DEVNET_NET_BASE
+    devnet_render_topology
   done
 }

--- a/internal/test/devnet/compose-project.sh
+++ b/internal/test/devnet/compose-project.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Select a stable Compose project for this worktree. Callers may override it
+# when they need more than one DevNet in the same worktree.
+devnet_compose_project() {
+  if [[ -n "${COMPOSE_PROJECT_NAME:-}" ]]; then
+    return
+  fi
+  local project_root project_hash
+  project_root="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+  project_hash="$(printf '%s' "${project_root}" | cksum | awk '{print $1}')"
+  export COMPOSE_PROJECT_NAME="dingo-devnet-${project_hash}"
+}
+
+# Select a stable, worktree-specific /24 for the DevNet bridge network.
+# Compose project-scopes the network's *name*, but its subnet is a
+# separate axis: the checked-in topology/*.json files address peers by a
+# hardcoded 172.20.0.0/24 IP (devnet_render_topology rewrites those), and
+# Docker refuses to create two networks with the same subnet even under
+# different project names ("Pool overlaps with other one on this address
+# space"). Concurrent worktrees therefore each need their own range, not
+# just their own network name.
+#
+# 172.24-172.31 stays clear of the static subnets the antithesis/
+# archive-demo (172.21.0.0/24) and erastest (172.22.0.0/24) stacks pin, and
+# of Docker's own default address pool, which starts allocating from
+# 172.17.0.0/16. Callers may override it, same as COMPOSE_PROJECT_NAME.
+devnet_net_base() {
+  if [[ -n "${DEVNET_NET_BASE:-}" ]]; then
+    return
+  fi
+  local project_root project_hash second third
+  project_root="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
+  project_hash="$(printf '%s' "${project_root}" | cksum | awk '{print $1}')"
+  second=$((24 + project_hash % 8))
+  third=$(((project_hash / 8) % 256))
+  export DEVNET_NET_BASE="172.${second}.${third}"
+}
+
+# Path to this run's rendered topology directory. Split out from
+# devnet_render_topology so teardown can find and remove it without also
+# needing devnet_net_base or the source topology/ files.
+devnet_topology_dir() {
+  export DEVNET_TOPOLOGY_DIR="${TMPDIR:-/tmp}/dingo-devnet-topology-${COMPOSE_PROJECT_NAME}"
+}
+
+# Render the checked-in topology/*.json files into DEVNET_TOPOLOGY_DIR,
+# rewriting their hardcoded 172.20.0.0/24 addresses to this run's
+# DEVNET_NET_BASE. docker-compose.yml mounts topology files from
+# DEVNET_TOPOLOGY_DIR (falling back to ./topology, the literal 172.20.0.x
+# originals, when it is unset). Must run after devnet_compose_project.
+devnet_render_topology() {
+  devnet_net_base
+  devnet_topology_dir
+  mkdir -p "${DEVNET_TOPOLOGY_DIR}"
+  local src
+  for src in "${SCRIPT_DIR}"/topology/*.json; do
+    sed "s/172\.20\.0\./${DEVNET_NET_BASE}./g" "${src}" \
+      >"${DEVNET_TOPOLOGY_DIR}/$(basename "${src}")"
+  done
+}

--- a/internal/test/devnet/docker-compose.yml
+++ b/internal/test/devnet/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.configurator
-    container_name: devnet-configurator
     profiles: ["conformance"]
     environment:
       # Must match the dingo user pinned in the repo root Dockerfile;
@@ -70,7 +69,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.configurator
-    container_name: devnet-configurator-dingo
     profiles: ["dingo"]
     environment:
       DINGO_POOL_IDS: "1 2 3"
@@ -90,7 +88,6 @@ services:
   dingo-1:
     build:
       context: ../../..
-    container_name: dingo-1
     profiles: ["dingo"]
     depends_on:
       configurator-dingo:
@@ -121,7 +118,7 @@ services:
       CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
     volumes:
       - p1-configs:/configs:ro
-      - ./topology/dingo-1.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/dingo-1.json:/topology/topology.json:ro
       - dingo-1-data:/data/db
       - dingo-1-ipc:/ipc
     ports:
@@ -129,7 +126,7 @@ services:
       - "${DEVNET_DINGO1_NTC_PORT:-3020}:3002"
     networks:
       devnet:
-        ipv4_address: 172.20.0.13
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.13
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
       interval: 5s
@@ -140,7 +137,6 @@ services:
   dingo-2:
     build:
       context: ../../..
-    container_name: dingo-2
     profiles: ["dingo"]
     depends_on:
       configurator-dingo:
@@ -149,7 +145,7 @@ services:
       <<: *dingo-node-env
     volumes:
       - p2-configs:/configs:ro
-      - ./topology/dingo-2.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/dingo-2.json:/topology/topology.json:ro
       - dingo-2-data:/data/db
       - dingo-2-ipc:/ipc
     ports:
@@ -157,7 +153,7 @@ services:
       - "${DEVNET_DINGO2_NTC_PORT:-3021}:3002"
     networks:
       devnet:
-        ipv4_address: 172.20.0.14
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.14
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
       interval: 5s
@@ -168,7 +164,6 @@ services:
   dingo-3:
     build:
       context: ../../..
-    container_name: dingo-3
     profiles: ["dingo"]
     depends_on:
       configurator-dingo:
@@ -177,7 +172,7 @@ services:
       <<: *dingo-node-env
     volumes:
       - p3-configs:/configs:ro
-      - ./topology/dingo-3.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/dingo-3.json:/topology/topology.json:ro
       - dingo-3-data:/data/db
       - dingo-3-ipc:/ipc
     ports:
@@ -185,7 +180,7 @@ services:
       - "${DEVNET_DINGO3_NTC_PORT:-3022}:3002"
     networks:
       devnet:
-        ipv4_address: 172.20.0.15
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.15
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
       interval: 5s
@@ -196,7 +191,6 @@ services:
   dingo-relay:
     build:
       context: ../../..
-    container_name: dingo-relay
     profiles: ["dingo"]
     depends_on:
       configurator-dingo:
@@ -206,7 +200,7 @@ services:
       CARDANO_BLOCK_PRODUCER: "false"
     volumes:
       - p1-configs:/configs:ro
-      - ./topology/dingo-relay.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/dingo-relay.json:/topology/topology.json:ro
       - dingo-relay-data:/data/db
       - dingo-relay-ipc:/ipc
     ports:
@@ -214,7 +208,7 @@ services:
       - "${DEVNET_DINGO_RELAY_NTC_PORT:-3023}:3002"
     networks:
       devnet:
-        ipv4_address: 172.20.0.16
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.16
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
       interval: 5s
@@ -226,7 +220,6 @@ services:
     build:
       context: ../../..
       dockerfile: internal/test/antithesis/Dockerfile.txpump
-    container_name: devnet-txpump-dingo
     profiles: ["dingo"]
     init: true
     user: "0:0"
@@ -269,12 +262,11 @@ services:
       - utxo-keys:/utxo-keys:ro
     networks:
       devnet:
-        ipv4_address: 172.20.0.21
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.21
 
   dingo-producer:
     build:
       context: ../../..
-    container_name: dingo-producer
     profiles: ["conformance"]
     depends_on:
       configurator:
@@ -300,14 +292,14 @@ services:
       CARDANO_PRIVATE_BIND_ADDR: "0.0.0.0"
     volumes:
       - p1-configs:/configs:ro
-      - ./topology/dingo-producer.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/dingo-producer.json:/topology/topology.json:ro
       - dingo-producer-data:/data/db
       - dingo-producer-ipc:/ipc
     ports:
       - "${DEVNET_DINGO_PORT:-3010}:3001"
     networks:
       devnet:
-        ipv4_address: 172.20.0.10
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.10
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/dingo.socket || exit 1"]
       interval: 5s
@@ -317,7 +309,6 @@ services:
 
   cardano-producer:
     image: ghcr.io/blinklabs-io/cardano-node:11.0.1
-    container_name: cardano-producer
     profiles: ["conformance"]
     depends_on:
       configurator:
@@ -345,14 +336,14 @@ services:
       - "3001"
     volumes:
       - p2-configs:/configs
-      - ./topology/cardano-producer.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/cardano-producer.json:/topology/topology.json:ro
       - cardano-producer-data:/data/db
       - cardano-producer-ipc:/ipc
     ports:
       - "${DEVNET_CARDANO_PORT:-3011}:3001"
     networks:
       devnet:
-        ipv4_address: 172.20.0.11
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.11
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/node.socket || exit 1"]
       interval: 5s
@@ -364,7 +355,6 @@ services:
     build:
       context: ../../..
       dockerfile: internal/test/antithesis/Dockerfile.txpump
-    container_name: devnet-txpump
     profiles: ["conformance"]
     init: true
     # Named Docker volumes are root-owned on first mount; txpump writes
@@ -406,11 +396,10 @@ services:
       - utxo-keys:/utxo-keys:ro
     networks:
       devnet:
-        ipv4_address: 172.20.0.20
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.20
 
   cardano-relay:
     image: ghcr.io/blinklabs-io/cardano-node:11.0.1
-    container_name: cardano-relay
     profiles: ["conformance"]
     depends_on:
       configurator:
@@ -431,14 +420,14 @@ services:
       - "3001"
     volumes:
       - p1-configs:/configs
-      - ./topology/relay.json:/topology/topology.json:ro
+      - ${DEVNET_TOPOLOGY_DIR:-./topology}/relay.json:/topology/topology.json:ro
       - cardano-relay-data:/data/db
       - cardano-relay-ipc:/ipc
     ports:
       - "${DEVNET_RELAY_PORT:-3012}:3001"
     networks:
       devnet:
-        ipv4_address: 172.20.0.12
+        ipv4_address: ${DEVNET_NET_BASE:-172.20.0}.12
     healthcheck:
       test: ["CMD-SHELL", "test -S /ipc/node.socket || exit 1"]
       interval: 5s
@@ -451,7 +440,7 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.20.0.0/24
+        - subnet: ${DEVNET_NET_BASE:-172.20.0}.0/24
 
 volumes:
   p1-configs:

--- a/internal/test/devnet/isolation_test.go
+++ b/internal/test/devnet/isolation_test.go
@@ -149,29 +149,28 @@ func TestComposeTopologyMountsUseRenderedDirectory(t *testing.T) {
 }
 
 // Mirrors TestComposeProjectIsStableAndWorktreeSpecific for the network
-// subnet: devnet_net_base must be stable for one worktree, distinct across
-// worktrees (this is what a live `docker network create` collision test
-// confirmed manually — two worktrees deriving the same base would race to
-// create the same Docker network), fall inside the reserved 172.24-172.31
-// range, and respect a caller override.
+// subnet: devnet_net_base must be stable for one worktree, fall inside the
+// reserved 172.24-172.31 range, and respect a caller override.
+//
+// It does NOT assert that two worktrees hash to different starting
+// candidates — with 2048 possible /24s, an occasional hash collision
+// between two arbitrary paths is expected, not a bug: neither call here
+// creates a real Docker network, so nothing actually collides yet.
+// TestNetBaseAvoidsSubnetsDockerReports and TestComposeUpRetriesOnPoolOverlap
+// cover what devnet_net_base and devnet_compose_up actually guarantee —
+// that a subnet already in use gets skipped, and a collision surfaced by
+// `docker compose up` gets retried onto a different one.
 func TestNetBaseIsStableAndWorktreeSpecific(t *testing.T) {
 	helper, err := filepath.Abs("compose-project.sh")
 	require.NoError(t, err)
 
 	worktreeA := filepath.Join(t.TempDir(), "worktree-a")
-	worktreeB := filepath.Join(t.TempDir(), "worktree-b")
-	for _, root := range []string{worktreeA, worktreeB} {
-		require.NoError(t, os.MkdirAll(
-			filepath.Join(root, "internal", "test", "devnet"), 0o755,
-		))
-	}
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktreeA, "internal", "test", "devnet"), 0o755,
+	))
 
 	baseA := deriveNetBase(t, helper, worktreeA, "")
 	require.Equal(t, baseA, deriveNetBase(t, helper, worktreeA, ""))
-	baseB := deriveNetBase(t, helper, worktreeB, "")
-	require.NotEqual(t, baseA, baseB,
-		"two worktrees derived the same subnet; concurrent runs would race"+
-			" to create the same Docker network")
 	require.Regexp(t, `^172\.(2[4-9]|3[01])\.\d{1,3}$`, baseA)
 	require.Equal(t, "10.0.0", deriveNetBase(t, helper, worktreeA, "10.0.0"))
 }
@@ -237,6 +236,25 @@ func TestNetBaseAvoidsSubnetsDockerReports(t *testing.T) {
 	require.NotEqual(t, unblocked, blocked,
 		"a subnet Docker already reports as taken must not be reused")
 	require.Regexp(t, `^172\.(2[4-9]|3[01])\.\d{1,3}$`, blocked)
+}
+
+// Docker networks can be IPv6 (a ULA /64, /8, etc.), and the CIDR helpers
+// only understand IPv4. devnet_net_base must skip a subnet like that
+// instead of aborting on it with a bash arithmetic error, and still land
+// on a valid IPv4 candidate.
+func TestNetBaseIgnoresIPv6Subnets(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+	worktree := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktree, "internal", "test", "devnet"), 0o755,
+	))
+
+	fakeBin := t.TempDir()
+	writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerNetworkScript("fd00::/64"))
+
+	base := deriveNetBaseWithPath(t, helper, worktree, fakeBin)
+	require.Regexp(t, `^172\.(2[4-9]|3[01])\.\d{1,3}$`, base)
 }
 
 // devnet_ports must skip a host port something is already listening on,
@@ -367,6 +385,138 @@ case " $* " in
       printf '%s.0/24\n' "$(cat "${FAKE_BLOCKED_SUBNET_FILE}")"
     fi
     ;;
+  *) exit 0 ;;
+esac
+`
+
+// A host port can slip through devnet_ports' check-then-bind window the
+// same way a subnet can slip through devnet_net_base's: two concurrent
+// runs can both see a port as free and only one wins. devnet_compose_up
+// must react to a port-bind failure by unsetting every _DEVNET_PORT_VARS
+// entry and calling devnet_ports again — but only when devnet_ports
+// allocated the ports in the first place (DEVNET_PORTS_AUTO=1); a caller's
+// explicit port override must never be retried away.
+//
+// This shadows devnet_ports with a stub rather than relying on a real,
+// timing-sensitive socket race (which is already covered, independently,
+// by TestPortsAvoidOccupiedPorts): the stub proves devnet_compose_up's own
+// retry wiring — that it unsets the vars first (the real devnet_ports
+// would otherwise see them still set and silently no-op) and calls
+// devnet_ports again exactly once per port-conflict failure.
+func TestComposeUpRetriesOnPortConflict(t *testing.T) {
+	repoDevnetDir, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	t.Run("auto-derived ports are retried", func(t *testing.T) {
+		tempRoot := t.TempDir()
+		fakeBin := filepath.Join(tempRoot, "bin")
+		require.NoError(t, os.Mkdir(fakeBin, 0o755))
+		upCountFile := filepath.Join(tempRoot, "up-attempts")
+		portsCountFile := filepath.Join(tempRoot, "ports-calls")
+		wasUnsetFile := filepath.Join(tempRoot, "was-unset")
+		writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerFailsOnceWithPortConflict)
+
+		script := `source "$1"
+devnet_ports() {
+  local count=0
+  [[ -f "${FAKE_PORTS_COUNT_FILE}" ]] && count=$(cat "${FAKE_PORTS_COUNT_FILE}")
+  count=$((count + 1))
+  printf '%s' "${count}" >"${FAKE_PORTS_COUNT_FILE}"
+  if [[ -n "${DEVNET_DINGO1_PORT:-}" ]]; then
+    printf 'not-unset' >"${FAKE_WAS_UNSET_FILE}"
+  else
+    printf 'unset' >"${FAKE_WAS_UNSET_FILE}"
+  fi
+  DEVNET_PORTS_AUTO=1
+  export DEVNET_DINGO1_PORT=$((30000 + count))
+}
+devnet_ports
+before="$DEVNET_DINGO1_PORT"
+devnet_compose_up "/fake/compose.yml"
+status=$?
+printf '%s %s %s\n' "$before" "$DEVNET_DINGO1_PORT" "$status"`
+		cmd := exec.Command("bash", "-c", script, "bash", filepath.Join(repoDevnetDir, "compose-project.sh"))
+		cmd.Env = append(os.Environ(),
+			"SCRIPT_DIR="+repoDevnetDir,
+			"COMPOSE_PROJECT_NAME=dingo-devnet-port-retry-test",
+			"DEVNET_NET_BASE=172.30.99",
+			"FAKE_UP_COUNT_FILE="+upCountFile,
+			"FAKE_PORTS_COUNT_FILE="+portsCountFile,
+			"FAKE_WAS_UNSET_FILE="+wasUnsetFile,
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		require.NoError(t, err, "stderr: %s", stderr.String())
+
+		fields := strings.Fields(strings.TrimSpace(string(out)))
+		require.Len(t, fields, 3, "unexpected output: %q (stderr: %q)", out, stderr.String())
+		before, after, status := fields[0], fields[1], fields[2]
+
+		require.Equal(t, "0", status,
+			"devnet_compose_up must succeed once the retry calls devnet_ports again")
+		require.NotEqual(t, before, after,
+			"a retry after a port-bind failure must call devnet_ports again")
+
+		portsCalls, err := os.ReadFile(portsCountFile)
+		require.NoError(t, err)
+		require.Equal(t, "2", strings.TrimSpace(string(portsCalls)),
+			"devnet_ports should have been called exactly twice: once to derive, once to retry")
+
+		wasUnset, err := os.ReadFile(wasUnsetFile)
+		require.NoError(t, err)
+		require.Equal(t, "unset", string(wasUnset),
+			"devnet_compose_up must unset the port vars before retrying, or the"+
+				" real devnet_ports would see them still set and silently no-op")
+	})
+
+	t.Run("a caller's port override is never retried away", func(t *testing.T) {
+		tempRoot := t.TempDir()
+		fakeBin := filepath.Join(tempRoot, "bin")
+		require.NoError(t, os.Mkdir(fakeBin, 0o755))
+		upCountFile := filepath.Join(tempRoot, "up-attempts")
+		writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerFailsOnceWithPortConflict)
+
+		script := `source "$1"
+devnet_ports
+devnet_compose_up "/fake/compose.yml"
+printf '%s\n' "$?"`
+		cmd := exec.Command("bash", "-c", script, "bash", filepath.Join(repoDevnetDir, "compose-project.sh"))
+		cmd.Env = append(os.Environ(),
+			"SCRIPT_DIR="+repoDevnetDir,
+			"COMPOSE_PROJECT_NAME=dingo-devnet-port-retry-test-override",
+			"DEVNET_NET_BASE=172.30.99",
+			"FAKE_UP_COUNT_FILE="+upCountFile,
+			"DEVNET_DINGO1_PORT=9999",
+			"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		require.NoError(t, err, "stderr: %s", stderr.String())
+		require.Equal(t, "1", strings.TrimSpace(string(out)),
+			"devnet_compose_up must not retry away a caller-supplied port override")
+	})
+}
+
+const fakeDockerFailsOnceWithPortConflict = `#!/usr/bin/env bash
+case " $* " in
+  *" up -d "*)
+    count=0
+    [[ -f "${FAKE_UP_COUNT_FILE}" ]] && count=$(cat "${FAKE_UP_COUNT_FILE}")
+    count=$((count + 1))
+    printf '%s' "${count}" >"${FAKE_UP_COUNT_FILE}"
+    if [[ "${count}" -eq 1 ]]; then
+      echo "Error response from daemon: driver failed programming external" \
+        "connectivity: Bind for 0.0.0.0:${DEVNET_DINGO1_PORT}:" \
+        "port is already allocated" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *" network ls "*) printf 'x\n' ;;
+  *" network inspect "*) printf '' ;;
   *) exit 0 ;;
 esac
 `

--- a/internal/test/devnet/isolation_test.go
+++ b/internal/test/devnet/isolation_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devnet
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// A pinned container_name is global on the Docker host: two worktrees
+// running the same compose file would fight over the same container, and
+// the second `docker compose up` would recreate (or delete) the first
+// worktree's container. Every service must leave Compose to name the
+// container per-project instead.
+func TestComposeServicesDoNotPinContainerNames(t *testing.T) {
+	data, err := os.ReadFile("docker-compose.yml")
+	require.NoError(t, err)
+
+	var compose struct {
+		Services map[string]map[string]any `yaml:"services"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &compose))
+	require.NotEmpty(t, compose.Services)
+	for service, config := range compose.Services {
+		require.NotContains(t, config, "container_name",
+			"service %s must let Compose project-scope its container", service)
+	}
+}
+
+// devnet_compose_project must derive the same project name every time for
+// one worktree (so a re-run's teardown still matches its own start), a
+// different name for a different worktree (so concurrent runs don't share a
+// project), and must respect a caller-supplied COMPOSE_PROJECT_NAME override
+// unchanged.
+func TestComposeProjectIsStableAndWorktreeSpecific(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+
+	worktreeA := filepath.Join(t.TempDir(), "worktree-a")
+	worktreeB := filepath.Join(t.TempDir(), "worktree-b")
+	for _, root := range []string{worktreeA, worktreeB} {
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(root, "internal", "test", "devnet"), 0o755,
+		))
+	}
+
+	projectA := deriveComposeProject(t, helper, worktreeA, "")
+	require.Equal(t, projectA, deriveComposeProject(t, helper, worktreeA, ""))
+	projectB := deriveComposeProject(t, helper, worktreeB, "")
+	require.NotEqual(t, projectA, projectB)
+	require.True(t, strings.HasPrefix(projectA, "dingo-devnet-"))
+	require.Equal(t, "caller-selected", deriveComposeProject(
+		t, helper, worktreeA, "caller-selected",
+	))
+}
+
+// The isolation only works end to end if every entry point actually wires
+// the helper functions in: start.sh/run-tests.sh/stop.sh must all pick a
+// compose project, start.sh/run-tests.sh must render worktree-specific
+// topology before bringing containers up, and stop.sh must be able to find
+// that rendered directory again to remove it.
+func TestDevNetScriptsSelectComposeProject(t *testing.T) {
+	for _, file := range []string{"run-tests.sh", "start.sh", "stop.sh"} {
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `source "${SCRIPT_DIR}/compose-project.sh"`)
+		require.Contains(t, string(data), "devnet_compose_project")
+	}
+	for _, file := range []string{"run-tests.sh", "start.sh"} {
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		require.Contains(t, string(data), "devnet_render_topology",
+			"%s must render worktree-specific topology before bringing containers up", file)
+	}
+	data, err := os.ReadFile("stop.sh")
+	require.NoError(t, err)
+	require.Contains(t, string(data), "devnet_topology_dir",
+		"stop.sh must locate this run's rendered topology directory to remove it")
+}
+
+// A distinct Compose project name scopes containers, volumes, and the
+// network's own name, but not its subnet: Docker refuses to create two
+// networks with the same subnet regardless of project ("Pool overlaps with
+// other one on this address space"). docker-compose.yml must therefore
+// derive both the subnet and every static ipv4_address from DEVNET_NET_BASE.
+func TestComposeNetworkSubnetIsParameterizedPerWorktree(t *testing.T) {
+	data, err := os.ReadFile("docker-compose.yml")
+	require.NoError(t, err)
+	content := string(data)
+
+	require.Contains(t, content, "${DEVNET_NET_BASE:-172.20.0}.0/24",
+		"the network subnet must derive from DEVNET_NET_BASE")
+	for _, octet := range []string{
+		"10", "11", "12", "13", "14", "15", "16", "20", "21",
+	} {
+		require.Contains(t, content, "${DEVNET_NET_BASE:-172.20.0}."+octet,
+			"the service pinned to .%s must derive its address from"+
+				" DEVNET_NET_BASE, not a hardcoded 172.20.0.x literal", octet)
+	}
+}
+
+// The topology/*.json peer lists are static, checked-in files that address
+// peers by IP (net.SplitHostPort et al. in peergov do resolve hostnames,
+// but these files predate that and pin literal 172.20.0.x addresses).
+// Concurrent worktrees need their own rendered copy at their own
+// DEVNET_NET_BASE, so the compose file must mount from
+// DEVNET_TOPOLOGY_DIR rather than the checked-in ./topology directly.
+func TestComposeTopologyMountsUseRenderedDirectory(t *testing.T) {
+	data, err := os.ReadFile("docker-compose.yml")
+	require.NoError(t, err)
+	content := string(data)
+
+	for _, file := range []string{
+		"dingo-1.json", "dingo-2.json", "dingo-3.json", "dingo-relay.json",
+		"dingo-producer.json", "cardano-producer.json", "relay.json",
+	} {
+		require.Contains(t, content,
+			"${DEVNET_TOPOLOGY_DIR:-./topology}/"+file,
+			"the mount for %s must come from DEVNET_TOPOLOGY_DIR", file)
+	}
+}
+
+// Mirrors TestComposeProjectIsStableAndWorktreeSpecific for the network
+// subnet: devnet_net_base must be stable for one worktree, distinct across
+// worktrees (this is what a live `docker network create` collision test
+// confirmed manually — two worktrees deriving the same base would race to
+// create the same Docker network), fall inside the reserved 172.24-172.31
+// range, and respect a caller override.
+func TestNetBaseIsStableAndWorktreeSpecific(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+
+	worktreeA := filepath.Join(t.TempDir(), "worktree-a")
+	worktreeB := filepath.Join(t.TempDir(), "worktree-b")
+	for _, root := range []string{worktreeA, worktreeB} {
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(root, "internal", "test", "devnet"), 0o755,
+		))
+	}
+
+	baseA := deriveNetBase(t, helper, worktreeA, "")
+	require.Equal(t, baseA, deriveNetBase(t, helper, worktreeA, ""))
+	baseB := deriveNetBase(t, helper, worktreeB, "")
+	require.NotEqual(t, baseA, baseB,
+		"two worktrees derived the same subnet; concurrent runs would race"+
+			" to create the same Docker network")
+	require.Regexp(t, `^172\.(2[4-9]|3[01])\.\d{1,3}$`, baseA)
+	require.Equal(t, "10.0.0", deriveNetBase(t, helper, worktreeA, "10.0.0"))
+}
+
+// devnet_render_topology must rewrite every checked-in topology/*.json file
+// into DEVNET_TOPOLOGY_DIR with this run's DEVNET_NET_BASE substituted for
+// the hardcoded 172.20.0.x addresses, and must never modify the checked-in
+// source files themselves (they're shared by every worktree, including ones
+// running concurrently).
+func TestRenderTopologyRewritesAddressesWithoutMutatingSource(t *testing.T) {
+	repoDevnetDir, err := filepath.Abs(".")
+	require.NoError(t, err)
+	sourcePath := filepath.Join(repoDevnetDir, "topology", "dingo-1.json")
+	before, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	require.Contains(t, string(before), "172.20.0.")
+
+	tempRoot := t.TempDir()
+	cmd := exec.Command(
+		"bash", "-c",
+		`source "$1"; devnet_render_topology; printf '%s' "$DEVNET_TOPOLOGY_DIR"`,
+		"bash", filepath.Join(repoDevnetDir, "compose-project.sh"),
+	)
+	cmd.Env = append(os.Environ(),
+		"SCRIPT_DIR="+repoDevnetDir,
+		"TMPDIR="+tempRoot,
+		"COMPOSE_PROJECT_NAME=dingo-devnet-isolation-test",
+		"DEVNET_NET_BASE=",
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	renderedDir := string(out)
+	require.NotEmpty(t, renderedDir)
+
+	rendered, err := os.ReadFile(filepath.Join(renderedDir, "dingo-1.json"))
+	require.NoError(t, err)
+	require.NotContains(t, string(rendered), "172.20.0.",
+		"rendered topology must use this run's DEVNET_NET_BASE, not the"+
+			" checked-in address")
+	require.Regexp(t, `172\.(2[4-9]|3[01])\.\d{1,3}\.14`, string(rendered))
+
+	after, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	require.Equal(t, before, after,
+		"rendering must not mutate the checked-in topology file")
+
+	entries, err := os.ReadDir(renderedDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 7,
+		"every checked-in topology file must be rendered")
+}
+
+// deriveNetBase sources compose-project.sh with SCRIPT_DIR pointed at a
+// fake worktree and returns the DEVNET_NET_BASE it computes (or the
+// override, if one is supplied), without touching Docker.
+func deriveNetBase(
+	t *testing.T,
+	helper string,
+	worktree string,
+	override string,
+) string {
+	t.Helper()
+	scriptDir := filepath.Join(worktree, "internal", "test", "devnet")
+	cmd := exec.Command(
+		"bash", "-c",
+		`source "$1"; devnet_net_base; printf '%s' "$DEVNET_NET_BASE"`,
+		"bash", helper,
+	)
+	cmd.Env = append(os.Environ(), "SCRIPT_DIR="+scriptDir)
+	if override == "" {
+		cmd.Env = append(cmd.Env, "DEVNET_NET_BASE=")
+	} else {
+		cmd.Env = append(cmd.Env, "DEVNET_NET_BASE="+override)
+	}
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return string(out)
+}
+
+// deriveComposeProject sources compose-project.sh with SCRIPT_DIR pointed
+// at a fake worktree and returns the COMPOSE_PROJECT_NAME it computes (or
+// the override, if one is supplied), without touching Docker.
+func deriveComposeProject(
+	t *testing.T,
+	helper string,
+	worktree string,
+	override string,
+) string {
+	t.Helper()
+	scriptDir := filepath.Join(worktree, "internal", "test", "devnet")
+	cmd := exec.Command(
+		"bash", "-c",
+		`source "$1"; devnet_compose_project; printf '%s' "$COMPOSE_PROJECT_NAME"`,
+		"bash", helper,
+	)
+	cmd.Env = append(os.Environ(), "SCRIPT_DIR="+scriptDir)
+	if override == "" {
+		cmd.Env = append(cmd.Env, "COMPOSE_PROJECT_NAME=")
+	} else {
+		cmd.Env = append(cmd.Env, "COMPOSE_PROJECT_NAME="+override)
+	}
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return string(out)
+}

--- a/internal/test/devnet/isolation_test.go
+++ b/internal/test/devnet/isolation_test.go
@@ -15,9 +15,12 @@
 package devnet
 
 import (
+	"bytes"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -89,6 +92,13 @@ func TestDevNetScriptsSelectComposeProject(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, string(data), "devnet_render_topology",
 			"%s must render worktree-specific topology before bringing containers up", file)
+		require.Contains(t, string(data), "devnet_ports",
+			"%s must derive a worktree-specific host port block, or a second"+
+				" worktree's `docker compose up` fails with"+
+				" \"port is already allocated\"", file)
+		require.Contains(t, string(data), "devnet_compose_up",
+			"%s must bring containers up through devnet_compose_up, which"+
+				" retries a subnet collision instead of failing the run", file)
 	}
 	data, err := os.ReadFile("stop.sh")
 	require.NoError(t, err)
@@ -166,6 +176,201 @@ func TestNetBaseIsStableAndWorktreeSpecific(t *testing.T) {
 	require.Equal(t, "10.0.0", deriveNetBase(t, helper, worktreeA, "10.0.0"))
 }
 
+// _devnet_cidr_overlaps must catch every way two /24-or-wider CIDRs can
+// intersect (identical, one nested inside a wider block), and correctly
+// clear two blocks that plainly don't.
+func TestCidrOverlapDetection(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name        string
+		a, b        string
+		wantOverlap bool
+	}{
+		{"identical /24s", "172.20.0.0/24", "172.20.0.0/24", true},
+		{"adjacent /24s", "172.20.0.0/24", "172.21.0.0/24", false},
+		{"candidate inside a wider existing /12", "172.24.5.0/24", "172.16.0.0/12", true},
+		{"unrelated ranges", "172.24.5.0/24", "10.0.0.0/8", false},
+		{"wider candidate containing a narrower existing block", "172.17.0.0/16", "172.17.5.0/24", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cmd := exec.Command(
+				"bash", "-c",
+				`source "$1"; _devnet_cidr_overlaps "$2" "$3"`,
+				"bash", helper, c.a, c.b,
+			)
+			err := cmd.Run()
+			if c.wantOverlap {
+				require.NoError(t, err, "%s and %s should overlap", c.a, c.b)
+			} else {
+				require.Error(t, err, "%s and %s should not overlap", c.a, c.b)
+			}
+		})
+	}
+}
+
+// A hash of the worktree path is only a starting point: two different
+// worktrees can hash to the same /24, and this range isn't reserved for
+// DevNet, so an unrelated Docker network could already sit on it. Stub
+// `docker network ls`/`inspect` to report the exact subnet a fake
+// worktree's hash would otherwise pick, and confirm devnet_net_base walks
+// forward to a different, still-in-range candidate instead of assuming
+// the hash was free.
+func TestNetBaseAvoidsSubnetsDockerReports(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+	worktree := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktree, "internal", "test", "devnet"), 0o755,
+	))
+
+	unblocked := deriveNetBase(t, helper, worktree, "")
+
+	fakeBin := t.TempDir()
+	writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerNetworkScript(
+		unblocked+".0/24",
+	))
+
+	blocked := deriveNetBaseWithPath(t, helper, worktree, fakeBin)
+	require.NotEqual(t, unblocked, blocked,
+		"a subnet Docker already reports as taken must not be reused")
+	require.Regexp(t, `^172\.(2[4-9]|3[01])\.\d{1,3}$`, blocked)
+}
+
+// devnet_ports must skip a host port something is already listening on,
+// shifting its whole block forward rather than handing out a port that
+// would make `docker compose up` fail with "port is already allocated".
+func TestPortsAvoidOccupiedPorts(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+	worktree := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktree, "internal", "test", "devnet"), 0o755,
+	))
+
+	unblocked := derivePorts(t, helper, worktree, nil)
+	occupiedPort := unblocked["DEVNET_DINGO1_PORT"]
+
+	listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(occupiedPort))
+	require.NoError(t, err)
+	defer listener.Close()
+
+	blocked := derivePorts(t, helper, worktree, nil)
+	for name, port := range blocked {
+		require.NotEqual(t, occupiedPort, port,
+			"%s reused the occupied port %d instead of shifting the block",
+			name, occupiedPort)
+	}
+	require.Equal(t, unblocked["DEVNET_DINGO1_PORT"]+len(unblocked), blocked["DEVNET_DINGO1_PORT"],
+		"the whole block should shift forward by its own size, not just skip one port")
+}
+
+// A caller who has already set even one of the port variables gets full
+// manual control: devnet_ports must not touch any of the others either.
+func TestPortsRespectPartialOverride(t *testing.T) {
+	helper, err := filepath.Abs("compose-project.sh")
+	require.NoError(t, err)
+	worktree := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(worktree, "internal", "test", "devnet"), 0o755,
+	))
+
+	ports := derivePorts(t, helper, worktree, map[string]string{
+		"DEVNET_DINGO1_PORT": "9999",
+	})
+	require.Equal(t, 9999, ports["DEVNET_DINGO1_PORT"])
+	_, stillUnset := ports["DEVNET_DINGO2_PORT"]
+	require.False(t, stillUnset,
+		"a partial override must leave every other port var untouched")
+}
+
+// The window between devnet_net_base checking a subnet and `docker compose
+// up` actually creating the network is a real race: two worktrees can both
+// see the same subnet as free and only one wins. devnet_compose_up must
+// recover from that by recomputing DEVNET_NET_BASE (which will now see the
+// winner's network via docker network ls) and retrying, rather than
+// failing the whole run over a race it can detect and correct.
+func TestComposeUpRetriesOnPoolOverlap(t *testing.T) {
+	repoDevnetDir, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	tempRoot := t.TempDir()
+	fakeBin := filepath.Join(tempRoot, "bin")
+	require.NoError(t, os.Mkdir(fakeBin, 0o755))
+	writeExecutable(t, filepath.Join(fakeBin, "docker"), fakeDockerFailsOnceWithPoolOverlap)
+
+	countFile := filepath.Join(tempRoot, "up-attempts")
+	blockedSubnetFile := filepath.Join(tempRoot, "blocked-subnet")
+	// The fake docker doesn't know, ahead of time, which subnet the hash
+	// will pick, so the script tells it: write out the first pick, then
+	// have `docker network ls/inspect` report it as taken from then on,
+	// modeling the concurrent worktree that won the race.
+	script := `source "$1"
+devnet_render_topology
+before="$DEVNET_NET_BASE"
+printf '%s' "$before" >"${FAKE_BLOCKED_SUBNET_FILE}"
+devnet_compose_up "/fake/compose.yml"
+status=$?
+printf '%s %s %s\n' "$before" "$DEVNET_NET_BASE" "$status"`
+	cmd := exec.Command("bash", "-c", script, "bash", filepath.Join(repoDevnetDir, "compose-project.sh"))
+	cmd.Env = append(os.Environ(),
+		"SCRIPT_DIR="+repoDevnetDir,
+		"TMPDIR="+tempRoot,
+		"COMPOSE_PROJECT_NAME=dingo-devnet-retry-test",
+		"DEVNET_NET_BASE=",
+		"FAKE_UP_COUNT_FILE="+countFile,
+		"FAKE_BLOCKED_SUBNET_FILE="+blockedSubnetFile,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoError(t, err, "stderr: %s", stderr.String())
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	last := lines[len(lines)-1]
+	fields := strings.Fields(last)
+	require.Len(t, fields, 3, "unexpected final line: %q (full stdout: %q, stderr: %q)",
+		last, out, stderr.String())
+	before, after, status := fields[0], fields[1], fields[2]
+
+	require.Equal(t, "0", status, "devnet_compose_up must succeed once the retry lands on a free subnet")
+	require.NotEqual(t, before, after,
+		"a retry after a pool-overlap failure must pick a different subnet")
+
+	attempts, err := os.ReadFile(countFile)
+	require.NoError(t, err)
+	require.Equal(t, "2", strings.TrimSpace(string(attempts)),
+		"docker compose up should have been tried exactly twice: once to hit the collision, once to succeed")
+}
+
+const fakeDockerFailsOnceWithPoolOverlap = `#!/usr/bin/env bash
+case " $* " in
+  *" up -d "*)
+    count=0
+    [[ -f "${FAKE_UP_COUNT_FILE}" ]] && count=$(cat "${FAKE_UP_COUNT_FILE}")
+    count=$((count + 1))
+    printf '%s' "${count}" >"${FAKE_UP_COUNT_FILE}"
+    if [[ "${count}" -eq 1 ]]; then
+      echo "Error response from daemon: invalid pool request: Pool overlaps with other one on this address space" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *" network ls "*)
+    printf 'busy-net\n'
+    ;;
+  *" network inspect "*)
+    if [[ -f "${FAKE_BLOCKED_SUBNET_FILE:-}" ]]; then
+      printf '%s.0/24\n' "$(cat "${FAKE_BLOCKED_SUBNET_FILE}")"
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+`
+
 // devnet_render_topology must rewrite every checked-in topology/*.json file
 // into DEVNET_TOPOLOGY_DIR with this run's DEVNET_NET_BASE substituted for
 // the hardcoded 172.20.0.x addresses, and must never modify the checked-in
@@ -239,6 +444,94 @@ func deriveNetBase(
 	out, err := cmd.Output()
 	require.NoError(t, err)
 	return string(out)
+}
+
+// deriveNetBaseWithPath is deriveNetBase with an extra directory prepended
+// to PATH, so a stubbed `docker` (see fakeDockerNetworkScript) is used
+// instead of the real one.
+func deriveNetBaseWithPath(
+	t *testing.T,
+	helper string,
+	worktree string,
+	extraPathDir string,
+) string {
+	t.Helper()
+	scriptDir := filepath.Join(worktree, "internal", "test", "devnet")
+	cmd := exec.Command(
+		"bash", "-c",
+		`source "$1"; devnet_net_base; printf '%s' "$DEVNET_NET_BASE"`,
+		"bash", helper,
+	)
+	cmd.Env = append(os.Environ(),
+		"SCRIPT_DIR="+scriptDir,
+		"DEVNET_NET_BASE=",
+		"PATH="+extraPathDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return string(out)
+}
+
+// fakeDockerNetworkScript is a stand-in `docker` that reports a single
+// existing network with the given subnet — enough for
+// _devnet_used_subnets, which only calls `docker network ls` and
+// `docker network inspect`.
+func fakeDockerNetworkScript(subnet string) string {
+	return "#!/usr/bin/env bash\n" +
+		"case \"$1 $2\" in\n" +
+		"  \"network ls\") printf 'busy-net\\n' ;;\n" +
+		"  \"network inspect\") printf '" + subnet + "\\n' ;;\n" +
+		"esac\n"
+}
+
+var devnetPortVarNames = []string{
+	"DEVNET_DINGO1_PORT", "DEVNET_DINGO2_PORT", "DEVNET_DINGO3_PORT",
+	"DEVNET_DINGO_RELAY_PORT", "DEVNET_DINGO1_NTC_PORT",
+	"DEVNET_DINGO2_NTC_PORT", "DEVNET_DINGO3_NTC_PORT",
+	"DEVNET_DINGO_RELAY_NTC_PORT", "DEVNET_DINGO_PORT",
+	"DEVNET_CARDANO_PORT", "DEVNET_RELAY_PORT",
+}
+
+// derivePorts sources compose-project.sh with SCRIPT_DIR pointed at a fake
+// worktree, calls devnet_ports, and returns whichever of the 11 port vars
+// ended up set (only the caller-supplied ones, if any override is given
+// and devnet_ports therefore leaves the rest alone).
+func derivePorts(
+	t *testing.T,
+	helper string,
+	worktree string,
+	overrides map[string]string,
+) map[string]int {
+	t.Helper()
+	scriptDir := filepath.Join(worktree, "internal", "test", "devnet")
+	script := `source "$1"; devnet_ports
+for v in "${_DEVNET_PORT_VARS[@]}"; do
+  if [[ -n "${!v:-}" ]]; then printf '%s=%s\n' "$v" "${!v}"; fi
+done`
+	cmd := exec.Command("bash", "-c", script, "bash", helper)
+	env := append(os.Environ(), "SCRIPT_DIR="+scriptDir)
+	for _, name := range devnetPortVarNames {
+		env = append(env, name+"=")
+	}
+	for k, v := range overrides {
+		env = append(env, k+"="+v)
+	}
+	cmd.Env = env
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	result := map[string]int{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		name, value, ok := strings.Cut(line, "=")
+		require.True(t, ok, "malformed output line %q", line)
+		port, err := strconv.Atoi(value)
+		require.NoError(t, err)
+		result[name] = port
+	}
+	return result
 }
 
 // deriveComposeProject sources compose-project.sh with SCRIPT_DIR pointed

--- a/internal/test/devnet/nodectl.go
+++ b/internal/test/devnet/nodectl.go
@@ -19,6 +19,7 @@ package devnet
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -40,8 +41,9 @@ const stopGracePeriod = 2 * time.Second
 // exercise peer interruption and relay restart against the real
 // topology.
 type NodeControl struct {
-	composeFile string
-	logf        func(format string, args ...any)
+	composeFile    string
+	composeProject string
+	logf           func(format string, args ...any)
 }
 
 // NewNodeControl returns a controller for the running DevNet. It fails
@@ -58,6 +60,17 @@ func NewNodeControl(
 	if composeFile == "" {
 		composeFile = defaultComposeFile
 	}
+	composeProject := os.Getenv("DEVNET_COMPOSE_PROJECT")
+	if composeProject == "" {
+		composeProject = os.Getenv("COMPOSE_PROJECT_NAME")
+	}
+	if composeProject == "" {
+		return nil, errors.New(
+			"devnet: compose project unset; run the scenario via" +
+				" internal/test/devnet/run-tests.sh, or set" +
+				" DEVNET_COMPOSE_PROJECT",
+		)
+	}
 	//nolint:gosec // compose path comes from the harness environment
 	if _, err := os.Stat(composeFile); err != nil {
 		return nil, fmt.Errorf(
@@ -70,41 +83,50 @@ func NewNodeControl(
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if _, err := runCompose(
-		ctx, composeFile, "version",
+		ctx, composeFile, composeProject, "version",
 	); err != nil {
 		return nil, fmt.Errorf("devnet: docker compose unusable: %w", err)
 	}
-	return &NodeControl{composeFile: composeFile, logf: logf}, nil
+	return &NodeControl{
+		composeFile: composeFile, composeProject: composeProject, logf: logf,
+	}, nil
 }
 
 // Stop halts one node, leaving its volumes intact so a later Start
 // resumes the same node rather than bootstrapping a fresh one.
 //
-// This drives `docker` directly rather than `docker compose`, because
+// This resolves the service through this run's Compose project, then drives
+// `docker` directly rather than `docker compose`, because
 // compose resolves depends_on: `docker compose start dingo-3` also starts
 // the configurator it depends on, which regenerates genesis into the
 // shared config volumes. The restarted node then refuses to start at all,
 // with a genesis-hash mismatch against the database it already has —
-// a network-wide reset dressed up as a single-node restart. Every DevNet
-// service pins container_name to its service name, so addressing the
-// container by name is exact and touches nothing else.
-func (n *NodeControl) Stop(ctx context.Context, container string) error {
-	n.logf("nodectl: stopping %s", container)
+// a network-wide reset dressed up as a single-node restart.
+func (n *NodeControl) Stop(ctx context.Context, service string) error {
+	container, err := n.containerID(ctx, service)
+	if err != nil {
+		return err
+	}
+	n.logf("nodectl: stopping %s (%s)", service, container)
 	if _, err := runDocker(
 		ctx,
 		"stop", "-t", strconv.Itoa(int(stopGracePeriod.Seconds())), container,
 	); err != nil {
-		return fmt.Errorf("stop %s: %w", container, err)
+		return fmt.Errorf("stop %s: %w", service, err)
 	}
 	return nil
 }
 
 // Start brings a stopped node back up. See Stop for why this bypasses
 // compose.
-func (n *NodeControl) Start(ctx context.Context, container string) error {
-	n.logf("nodectl: starting %s", container)
+func (n *NodeControl) Start(ctx context.Context, service string) error {
+	container, err := n.containerID(ctx, service)
+	if err != nil {
+		return err
+	}
+	n.logf("nodectl: starting %s (%s)", service, container)
 	if _, err := runDocker(ctx, "start", container); err != nil {
-		return fmt.Errorf("start %s: %w", container, err)
+		return fmt.Errorf("start %s: %w", service, err)
 	}
 	return nil
 }
@@ -112,7 +134,9 @@ func (n *NodeControl) Start(ctx context.Context, container string) error {
 // ContainerStatus returns `docker compose ps` output for the active
 // profile.
 func (n *NodeControl) ContainerStatus(ctx context.Context) (string, error) {
-	out, err := runCompose(ctx, n.composeFile, "ps", "--all")
+	out, err := runCompose(
+		ctx, n.composeFile, n.composeProject, "ps", "--all",
+	)
 	return out, err
 }
 
@@ -129,7 +153,25 @@ func (n *NodeControl) Logs(
 		args = append(args, "--tail", strconv.Itoa(tailLines))
 	}
 	args = append(args, service)
-	return runCompose(ctx, n.composeFile, args...)
+	return runCompose(ctx, n.composeFile, n.composeProject, args...)
+}
+
+func (n *NodeControl) containerID(
+	ctx context.Context,
+	service string,
+) (string, error) {
+	out, err := runCompose(
+		ctx, n.composeFile, n.composeProject,
+		"ps", "--all", "--quiet", service,
+	)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s container: %w", service, err)
+	}
+	container := string(bytes.TrimSpace([]byte(out)))
+	if container == "" {
+		return "", fmt.Errorf("resolve %s container: no container found", service)
+	}
+	return container, nil
 }
 
 // CaptureFailureArtifacts writes the evidence a failed scenario needs to
@@ -173,10 +215,15 @@ func (n *NodeControl) CaptureFailureArtifacts(
 func runCompose(
 	ctx context.Context,
 	composeFile string,
+	composeProject string,
 	args ...string,
 ) (string, error) {
 	return runDocker(
-		ctx, append([]string{"compose", "-f", composeFile}, args...)...,
+		ctx,
+		append(
+			[]string{"compose", "-f", composeFile, "-p", composeProject},
+			args...,
+		)...,
 	)
 }
 

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -46,6 +46,7 @@ COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
 source "${SCRIPT_DIR}/compose-project.sh"
 devnet_compose_project
 devnet_render_topology
+devnet_ports
 
 # Parse arguments
 KEEP_UP=false
@@ -216,7 +217,8 @@ log "Building DevNet Docker images..."
 docker compose -f "${COMPOSE_FILE}" build
 
 log "Starting DevNet containers..."
-docker compose -f "${COMPOSE_FILE}" up -d
+devnet_compose_up "${COMPOSE_FILE}"
+log "Compose network (final): ${DEVNET_NET_BASE}.0/24"
 
 # --------------------------------------------------------------------------- #
 # Wait for all nodes to become healthy

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -42,6 +42,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+# shellcheck source=compose-project.sh
+source "${SCRIPT_DIR}/compose-project.sh"
+devnet_compose_project
+devnet_render_topology
 
 # Parse arguments
 KEEP_UP=false
@@ -101,6 +105,7 @@ export DEVNET_TESTNET_YAML="${SCRIPT_DIR}/${ACTIVE_SPEC#./}"
 # The scenario stops and starts containers, and captures compose logs and
 # status on failure.
 export DEVNET_COMPOSE_FILE="${COMPOSE_FILE}"
+export DEVNET_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME}"
 
 # Failure evidence goes here and is preserved when the run fails. A
 # caller-supplied directory is used as-is and never deleted; only one this
@@ -141,6 +146,7 @@ collect_failure_artifacts() {
   # volume; copy them out while the volume still exists.
   local configs_volume
   configs_volume="$(docker volume ls \
+    --filter label=com.docker.compose.project="${COMPOSE_PROJECT_NAME}" \
     --filter label=com.docker.compose.volume=p1-configs \
     --format '{{.Name}}' | head -n1)"
   if [[ -n "${configs_volume}" ]]; then
@@ -162,7 +168,7 @@ cleanup() {
   set +e
   if [[ "${KEEP_UP}" == "true" ]] && [[ ${exit_code} -eq 0 ]]; then
     log "Tests passed. DevNet left running (--keep-up)."
-    log "To stop:  docker compose -f ${COMPOSE_FILE} down -v"
+    log "To stop:  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} docker compose -f ${COMPOSE_FILE} down -v"
     exit "${exit_code}"
   fi
   if [[ ${exit_code} -ne 0 ]]; then
@@ -174,6 +180,7 @@ cleanup() {
   fi
   log "Tearing down DevNet..."
   docker compose -f "${COMPOSE_FILE}" down -v 2>/dev/null || true
+  rm -rf "${DEVNET_TOPOLOGY_DIR}"
   if [[ "${STAKE_KEYS_HOST_DIR_IS_OURS}" == "true" ]] &&
     [[ -n "${STAKE_KEYS_HOST_DIR:-}" ]]; then
     rm -rf "${STAKE_KEYS_HOST_DIR}"
@@ -199,6 +206,8 @@ fi
 # --------------------------------------------------------------------------- #
 
 log "Mode: ${MODE}$([[ "${ACCELERATED}" == "true" ]] && echo ' (accelerated)')"
+log "Compose project: ${COMPOSE_PROJECT_NAME}"
+log "Compose network: ${DEVNET_NET_BASE}.0/24"
 log "Network spec: ${ACTIVE_SPEC}"
 
 log "Building DevNet Docker images..."
@@ -220,7 +229,8 @@ ELAPSED=0
 while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
   HEALTHY=0
   for svc in "${HEALTH_SERVICES[@]}"; do
-    status=$(docker inspect --format='{{.State.Health.Status}}' "${svc}" 2>/dev/null || echo "missing")
+    container_id=$(docker compose -f "${COMPOSE_FILE}" ps --quiet "${svc}" 2>/dev/null || true)
+    status=$(docker inspect --format='{{.State.Health.Status}}' "${container_id}" 2>/dev/null || echo "missing")
     if [[ "${status}" == "healthy" ]]; then
       HEALTHY=$((HEALTHY + 1))
     fi
@@ -264,10 +274,13 @@ log "txpump is running"
 
 if [[ "${MODE}" == "dingo" ]]; then
   log "Copying genesis stake keys from the utxo-keys volume..."
-  UTXO_KEYS_VOLUME="devnet_utxo-keys"
+  UTXO_KEYS_VOLUME="${COMPOSE_PROJECT_NAME}_utxo-keys"
   if ! docker volume inspect "${UTXO_KEYS_VOLUME}" &>/dev/null; then
     warn "Docker volume ${UTXO_KEYS_VOLUME} not found; discovering by compose label"
-    UTXO_KEYS_VOLUME=$(docker volume ls --filter label=com.docker.compose.volume=utxo-keys --format '{{.Name}}' | head -n1)
+    UTXO_KEYS_VOLUME=$(docker volume ls \
+      --filter label=com.docker.compose.project="${COMPOSE_PROJECT_NAME}" \
+      --filter label=com.docker.compose.volume=utxo-keys \
+      --format '{{.Name}}' | head -n1)
   fi
   STAKE_KEYS_HOST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dingo-devnet-stake-keys.XXXXXX")"
   STAKE_KEYS_HOST_DIR_IS_OURS=true

--- a/internal/test/devnet/start.sh
+++ b/internal/test/devnet/start.sh
@@ -27,6 +27,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=compose-project.sh
+source "${SCRIPT_DIR}/compose-project.sh"
+devnet_compose_project
+export DEVNET_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME}"
+devnet_render_topology
 
 # Mode selection precedence: CLI, COMPOSE_PROFILES, then dingo.
 MODE=""
@@ -65,6 +70,8 @@ if [[ "${ACCELERATED}" == "true" ]]; then
   fi
   echo "Using accelerated network spec: ${ACTIVE_SPEC}"
   echo "Run the scenario with:"
+  echo "  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} \\"
+  echo "  DEVNET_COMPOSE_PROJECT=${COMPOSE_PROJECT_NAME} \\"
   echo "  DEVNET_ACCELERATED=1 \\"
   echo "  DEVNET_TESTNET_YAML=${SCRIPT_DIR}/${ACTIVE_SPEC#./} \\"
   echo "  DEVNET_COMPOSE_FILE=${SCRIPT_DIR}/docker-compose.yml \\"
@@ -72,7 +79,7 @@ if [[ "${ACCELERATED}" == "true" ]]; then
   echo "    -timeout 8m ./internal/test/devnet/scenarios/"
 fi
 
-echo "Starting DevNet containers (mode: ${MODE})..."
+echo "Starting DevNet containers (mode: ${MODE}, project: ${COMPOSE_PROJECT_NAME}, net: ${DEVNET_NET_BASE}.0/24)..."
 docker compose -f "${SCRIPT_DIR}/docker-compose.yml" up -d
 
 echo ""
@@ -98,5 +105,5 @@ else
   echo "  dingo-relay: localhost:${DINGO_RELAY_PORT}"
 fi
 echo ""
-echo "View logs:  docker compose -f ${SCRIPT_DIR}/docker-compose.yml logs -f"
-echo "Stop:       ${SCRIPT_DIR}/stop.sh"
+echo "View logs:  COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} docker compose -f ${SCRIPT_DIR}/docker-compose.yml logs -f"
+echo "Stop:       COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} ${SCRIPT_DIR}/stop.sh"

--- a/internal/test/devnet/start.sh
+++ b/internal/test/devnet/start.sh
@@ -32,6 +32,7 @@ source "${SCRIPT_DIR}/compose-project.sh"
 devnet_compose_project
 export DEVNET_COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME}"
 devnet_render_topology
+devnet_ports
 
 # Mode selection precedence: CLI, COMPOSE_PROFILES, then dingo.
 MODE=""
@@ -56,6 +57,20 @@ case "${MODE}" in
     ;;
 esac
 
+# Mirror docker-compose.yml's host-port defaults so anything printed below
+# matches the actual mappings, whether devnet_ports derived a worktree
+# block or the caller overrode individual DEVNET_*_PORT variables.
+if [[ "${MODE}" == "conformance" ]]; then
+  DINGO_PORT="${DEVNET_DINGO_PORT:-3010}"
+  CARDANO_PORT="${DEVNET_CARDANO_PORT:-3011}"
+  RELAY_PORT="${DEVNET_RELAY_PORT:-3012}"
+else
+  DINGO1_PORT="${DEVNET_DINGO1_PORT:-3010}"
+  DINGO2_PORT="${DEVNET_DINGO2_PORT:-3013}"
+  DINGO3_PORT="${DEVNET_DINGO3_PORT:-3014}"
+  DINGO_RELAY_PORT="${DEVNET_DINGO_RELAY_PORT:-3015}"
+fi
+
 # Pick the network spec the configurator generates genesis from. The
 # accelerated spec compresses slot, epoch and security-parameter timing so
 # a full scenario fits the reference-runner budget; the canonical spec is
@@ -75,29 +90,35 @@ if [[ "${ACCELERATED}" == "true" ]]; then
   echo "  DEVNET_ACCELERATED=1 \\"
   echo "  DEVNET_TESTNET_YAML=${SCRIPT_DIR}/${ACTIVE_SPEC#./} \\"
   echo "  DEVNET_COMPOSE_FILE=${SCRIPT_DIR}/docker-compose.yml \\"
+  # The Go harness reads full host:port DEVNET_*_ADDR variables, not the
+  # DEVNET_*_PORT variables docker-compose.yml reads — devnet_ports may
+  # have derived non-default ports, so these have to be spelled out here
+  # or the copy-pasted command below would connect to the wrong ports.
+  if [[ "${MODE}" == "conformance" ]]; then
+    echo "  DEVNET_DINGO_ADDR=localhost:${DINGO_PORT} \\"
+    echo "  DEVNET_CARDANO_ADDR=localhost:${CARDANO_PORT} \\"
+    echo "  DEVNET_RELAY_ADDR=localhost:${RELAY_PORT} \\"
+  else
+    echo "  DEVNET_DINGO1_ADDR=localhost:${DINGO1_PORT} \\"
+    echo "  DEVNET_DINGO2_ADDR=localhost:${DINGO2_PORT} \\"
+    echo "  DEVNET_DINGO3_ADDR=localhost:${DINGO3_PORT} \\"
+    echo "  DEVNET_DINGO_RELAY_ADDR=localhost:${DINGO_RELAY_PORT} \\"
+  fi
   echo "  go test -tags devnet -run TestAcceleratedScenarioTimeline \\"
   echo "    -timeout 8m ./internal/test/devnet/scenarios/"
 fi
 
 echo "Starting DevNet containers (mode: ${MODE}, project: ${COMPOSE_PROJECT_NAME}, net: ${DEVNET_NET_BASE}.0/24)..."
-docker compose -f "${SCRIPT_DIR}/docker-compose.yml" up -d
+devnet_compose_up "${SCRIPT_DIR}/docker-compose.yml"
+echo "Compose network (final): ${DEVNET_NET_BASE}.0/24"
 
 echo ""
 if [[ "${MODE}" == "conformance" ]]; then
-  # Mirror docker-compose.yml's host-port defaults so the printed addresses
-  # match the actual mappings (and respect any DEVNET_*_PORT overrides).
-  DINGO_PORT="${DEVNET_DINGO_PORT:-3010}"
-  CARDANO_PORT="${DEVNET_CARDANO_PORT:-3011}"
-  RELAY_PORT="${DEVNET_RELAY_PORT:-3012}"
   echo "DevNet started (conformance mode)."
   echo "  Dingo producer:   localhost:${DINGO_PORT}"
   echo "  Cardano producer: localhost:${CARDANO_PORT}"
   echo "  Cardano relay:    localhost:${RELAY_PORT}"
 else
-  DINGO1_PORT="${DEVNET_DINGO1_PORT:-3010}"
-  DINGO2_PORT="${DEVNET_DINGO2_PORT:-3013}"
-  DINGO3_PORT="${DEVNET_DINGO3_PORT:-3014}"
-  DINGO_RELAY_PORT="${DEVNET_DINGO_RELAY_PORT:-3015}"
   echo "DevNet started (dingo mode)."
   echo "  dingo-1:     localhost:${DINGO1_PORT}"
   echo "  dingo-2:     localhost:${DINGO2_PORT}"

--- a/internal/test/devnet/stop.sh
+++ b/internal/test/devnet/stop.sh
@@ -26,6 +26,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=compose-project.sh
+source "${SCRIPT_DIR}/compose-project.sh"
+devnet_compose_project
+devnet_topology_dir
 
 # Mode selection precedence: CLI, COMPOSE_PROFILES, then dingo.
 MODE=""
@@ -52,7 +56,8 @@ case "${MODE}" in
     ;;
 esac
 
-echo "Stopping DevNet containers and removing volumes (mode: ${MODE})..."
+echo "Stopping DevNet containers and removing volumes (mode: ${MODE}, project: ${COMPOSE_PROJECT_NAME})..."
 docker compose -f "${SCRIPT_DIR}/docker-compose.yml" down -v
+rm -rf "${DEVNET_TOPOLOGY_DIR}" || true
 
 echo "DevNet stopped."


### PR DESCRIPTION
## Summary

Concurrent DevNet runs from separate worktrees could collide: pinned
`container_name`s meant one worktree's containers could be recreated or
removed by another, and a hardcoded `172.20.0.0/24` network meant a second
worktree's `docker compose up` failed outright with `Pool overlaps with
other one on this address space`. Each worktree now gets its own Compose
project, container namespace, network/subnet, and rendered topology config.

## Changes by file

- **`internal/test/devnet/compose-project.sh`** (new) — Shared helper
  sourced by the other scripts. Derives a stable `COMPOSE_PROJECT_NAME` and
  a distinct network subnet (`DEVNET_NET_BASE`) from the worktree's absolute
  path, and renders the checked-in `topology/*.json` peer lists into a
  per-run directory with that subnet's addresses substituted in.

- **`internal/test/devnet/docker-compose.yml`** — Removed the
  `container_name` pin on every service so Compose scopes each container to
  its own project. Parameterized the network subnet, every service's static
  `ipv4_address`, and the topology bind mounts via `DEVNET_NET_BASE` /
  `DEVNET_TOPOLOGY_DIR` (both default to the original literal values, so a
  bare `docker compose up` still works for a single run).

- **`internal/test/devnet/start.sh`** — Derives this run's Compose project
  and renders its topology config before bringing containers up.

- **`internal/test/devnet/stop.sh`** — Derives this run's Compose project,
  tears down only that project, and removes its rendered topology
  directory.

- **`internal/test/devnet/run-tests.sh`** — Same project/topology setup as
  `start.sh`, plus scopes the health-check and volume-discovery logic (which
  used to assume fixed container/volume names) to this run's project, and
  cleans up the rendered topology directory in its exit trap.

- **`internal/test/devnet/nodectl.go`** — `NodeControl` now requires the
  Compose project and resolves each service's container ID through
  `docker compose -p <project> ps` before stopping/starting it, instead of
  assuming the container name equals the service name.

- **`internal/test/devnet/isolation_test.go`** (new) — Tests covering the
  isolation behavior (see testing comment below).

- **`internal/test/devnet/README.md`** — Documents the new project/subnet
  derivation and how to override it.

Closess #3264 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3264: concurrent DevNet runs from separate worktrees no longer collide. Each run now derives its own Compose project, a collision-checked network subnet, a free block of host ports, and a rendered topology config (via `DEVNET_*` variables that keep the original literals as defaults), so one run can no longer recreate, remove, or fail against another's containers, networks, or ports.

**Bug Fixes**
- Dropped all `container_name` pins so Compose scopes containers, volumes, and networks per project.
- `devnet_net_base` checks Docker's existing networks (skipping IPv6) and walks to a genuinely free /24; `devnet_compose_up` retries "Pool overlaps" and host-port bind failures after recomputing the subnet or port block. `devnet_ports` similarly shifts the 11 published host ports to a free block and backs off if the caller set any override.
- `start.sh --accelerated` now prints the exact `go test` command with this run's derived project and port addresses, since auto-derived ports may differ from the defaults.
- `NodeControl` resolves containers via `docker compose -p <project> ps` and errors when the compose project is unset.
- New `isolation_test.go` covers project, subnet, port, IPv6, retry, and topology-render derivation, including that rendering never mutates the checked-in sources.

**Migration**
- Hand-rolled scenario invocations must now export `DEVNET_COMPOSE_PROJECT` or `COMPOSE_PROJECT_NAME`; `run-tests.sh` sets it automatically.
- To run more than one DevNet in the same worktree, explicitly set `COMPOSE_PROJECT_NAME`, `DEVNET_NET_BASE`, and `DEVNET_TOPOLOGY_DIR`.

<sup>Written for commit ff4186c35882f90de2c2df8471320bf24887c617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worktree-isolated DevNet environments with unique Compose projects, networks, ports, and rendered topology files.
  * Added automatic collision detection and retry during DevNet startup.
  * Improved startup output with the exact commands and connection settings for accelerated scenarios.
  * Added project-scoped startup, testing, and cleanup workflows.

* **Bug Fixes**
  * Prevented conflicts between concurrent DevNet worktrees and existing Docker networks or host ports.

* **Tests**
  * Added end-to-end coverage for isolation, allocation, retries, topology rendering, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->