### PR TITLE
fix(ledger): validate phase two during historical replay

### DIFF
--- a/ledger/block_transaction_validity_test.go
+++ b/ledger/block_transaction_validity_test.go
@@ -287,6 +287,131 @@ func TestLedgerProcessBlockDijkstraValidityOutcomeStateTransitions(
 		})
 	}
 }
+
+// TestLedgerProcessBlockHistoricalValidationRunsPhase2 verifies the
+// configuration decision at the real block-application boundary.  A
+// historical-validation replay must pass a LedgerView with phase-two
+// validation enabled; the trusted-replay control retains the skip shortcut.
+func TestLedgerProcessBlockHistoricalValidationRunsPhase2(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name              string
+		validationEnabled bool
+		wantValidationErr bool
+	}{
+		{
+			name:              "historical validation evaluates phase two",
+			validationEnabled: true,
+			wantValidationErr: true,
+		},
+		{
+			name:              "trusted replay keeps phase two skipped",
+			validationEnabled: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := newTestDB(t)
+			tx := omockledger.NewTransactionBuilder()
+			tx.WithId(bytes.Repeat([]byte{0x52}, 32))
+			tx.WithType(gdijkstra.TxTypeDijkstra)
+			tx.WithValid(true)
+			var txHash [32]byte
+			copy(txHash[:], tx.Hash().Bytes())
+			offsets := &database.BlockIngestionResult{
+				TxOffsets: map[[32]byte]database.CborOffset{
+					txHash: {BlockSlot: 10, ByteLength: 1},
+				},
+			}
+
+			phase2Called := false
+			testEra := eras.DijkstraEraDesc
+			testEra.ValidateTxFunc = func(
+				_ lcommon.Transaction,
+				_ uint64,
+				state lcommon.LedgerState,
+				_ lcommon.ProtocolParameters,
+			) error {
+				phase2Called = true
+				skipper, ok := state.(interface {
+					SkipPhase2Validation() bool
+				})
+				if ok && skipper.SkipPhase2Validation() {
+					return nil
+				}
+				return conway.PlutusScriptFailedError{
+					Err: errors.New("phase-two validation mismatch"),
+				}
+			}
+			pparams := &gdijkstra.DijkstraProtocolParameters{
+				ConwayProtocolParameters: conway.ConwayProtocolParameters{
+					ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+						Major: gdijkstra.MinProtocolVersionDijkstra,
+					},
+					MaxBlockBodySize:   100_000,
+					MaxBlockHeaderSize: 100_000,
+				},
+			}
+			nodeConfig := newTestShelleyGenesisCfg(t)
+			nodeConfig.ShelleyGenesis().NetworkId = "Testnet"
+			ls := &LedgerState{
+				db:         db,
+				activeEras: []eras.EraDesc{testEra},
+				config: LedgerStateConfig{
+					CardanoNodeConfig: nodeConfig,
+					Logger:            testLogger(),
+				},
+				currentEra: testEra,
+			}
+			block := &validityOutcomeTestBlock{
+				header: &gdijkstra.DijkstraBlockHeader{
+					BabbageBlockHeader: babbage.BabbageBlockHeader{
+						Body: babbage.BabbageBlockHeaderBody{
+							BlockNumber: 1,
+							Slot:        10,
+							ProtoVersion: babbage.BabbageProtoVersion{
+								Major: gdijkstra.MinProtocolVersionDijkstra,
+							},
+						},
+					},
+				},
+				txs: []lcommon.Transaction{tx},
+				era: gdijkstra.EraDijkstra,
+			}
+			skipPhase2 := shouldSkipConfiguredPhase2Validation(
+				tt.validationEnabled,
+				true,
+				true,
+			)
+			processErr := db.Transaction(true).Do(func(txn *database.Txn) error {
+				_, err := ls.ledgerProcessBlock(
+					txn,
+					ocommon.NewPoint(10, block.Hash().Bytes()),
+					block,
+					true,
+					false,
+					skipPhase2,
+					nil,
+					envelopeParent{origin: true},
+					offsets,
+					testEra,
+					pparams,
+					nil,
+				)
+				return err
+			})
+			require.True(t, phase2Called)
+			if tt.wantValidationErr {
+				var plutusErr conway.PlutusScriptFailedError
+				require.ErrorAs(t, processErr, &plutusErr)
+			} else {
+				require.NoError(t, processErr)
+			}
+		})
+	}
+}
+
 func (b *validityOutcomeTestBlock) Cbor() []byte { return []byte{0x82, 0x80, 0x80} }
 func (b *validityOutcomeTestBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
 	return nil, nil

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3851,6 +3851,18 @@ func (ls *LedgerState) shouldSkipPhase2ValidationForBlockAtCurrentTip(
 	)
 }
 
+// shouldSkipConfiguredPhase2Validation preserves the trusted-replay shortcut
+// only when historical validation is disabled. When ValidateHistorical is
+// enabled, local phase-2 evaluation is the purpose of that setting and must
+// remain active across the stability boundary.
+func shouldSkipConfiguredPhase2Validation(
+	validationEnabled bool,
+	shouldValidateBlock bool,
+	deepHistoricalBlock bool,
+) bool {
+	return !validationEnabled && shouldValidateBlock && deepHistoricalBlock
+}
+
 // StabilityWindow returns the Ouroboros security stability window for the
 // current era in slots. For Byron the window is 2k; for Shelley+ it is 3k/f.
 // It is safe to call from multiple goroutines.
@@ -5614,11 +5626,14 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 							continue
 						}
 						// Process block
-						skipPhase2Validation := shouldValidateBlock &&
+						skipPhase2Validation := shouldSkipConfiguredPhase2Validation(
+							snapshotValidationEnabled,
+							shouldValidateBlock,
 							ls.shouldSkipPhase2ValidationForBlockAtCurrentTip(
 								next.BlockNumber(),
 								snapshotEra.Id,
-							)
+							),
+						)
 						delta, err = ls.ledgerProcessBlock(
 							txn,
 							tmpPoint,

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -286,6 +286,46 @@ func TestShouldSkipPhase2ValidationForBlockRequiresSecurityParam(t *testing.T) {
 	))
 }
 
+func TestShouldSkipConfiguredPhase2ValidationHonorsHistoricalValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		validationEnabled bool
+		shouldValidate    bool
+		deepHistorical    bool
+		wantSkip          bool
+	}{
+		{
+			name:              "historical validation keeps phase two enabled",
+			validationEnabled: true,
+			shouldValidate:    true,
+			deepHistorical:    true,
+		},
+		{
+			name:           "trusted replay skips deep historical phase two",
+			shouldValidate: true,
+			deepHistorical: true,
+			wantSkip:       true,
+		},
+		{
+			name:              "unvalidated block does not skip phase two",
+			validationEnabled: true,
+			deepHistorical:    true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.wantSkip, shouldSkipConfiguredPhase2Validation(
+				test.validationEnabled,
+				test.shouldValidate,
+				test.deepHistorical,
+			))
+		})
+	}
+}
+
 func TestShouldSkipPhase2ValidationForBlockAtCurrentTipRefreshesChainTip(
 	t *testing.T,
 ) {

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -313,6 +313,17 @@ func TestShouldSkipConfiguredPhase2ValidationHonorsHistoricalValidation(t *testi
 			validationEnabled: true,
 			deepHistorical:    true,
 		},
+		{
+			name:           "disabled validation does not skip an unvalidated block",
+			shouldValidate: false,
+			deepHistorical: true,
+		},
+		{
+			name:              "non-historical block does not skip phase two",
+			validationEnabled: true,
+			shouldValidate:    true,
+			deepHistorical:    false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Historical replay currently skips local Plutus phase-2 evaluation for blocks
outside the stability window even when historical validation is enabled.

Keep phase-2 validation enabled for that configured mode while preserving the
trusted-replay shortcut when historical validation is disabled. Add focused
coverage for both behaviors.

Fixes #3503

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes historical replay so local Plutus phase-2 evaluation runs when historical validation is enabled, instead of being skipped for blocks outside the stability window. Fixes #3503.

- Keeps the trusted-replay shortcut, which skips phase 2 only when historical validation is disabled.
- Adds coverage for the skip decision and for phase-2 behavior at the block-application boundary across historical, trusted-replay, and unvalidated scenarios.

<sup>Written for commit d4ad5d3c86ae5258b939f707ecf1d03e5c2cb1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical validation now remains active during deep block processing when configured, improving validation accuracy across stability boundaries.
  * Trusted replay shortcuts no longer bypass phase-two validation when historical validation is enabled.

* **Tests**
  * Added coverage for historical validation, trusted replay, and unvalidated block scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->