### PR TITLE
ci: fail when embedded network configs drift from the shipped image

### DIFF
--- a/.github/workflows/config-parity.yml
+++ b/.github/workflows/config-parity.yml
@@ -1,0 +1,58 @@
+name: config-parity
+
+# The network configs under config/cardano/ exist twice: embedded in the
+# binary here (config/cardano/embed.go), and in
+# blinklabs-io/docker-cardano-configs, which the release image ships as
+# /opt/cardano/config/ (see the cardano-configs stage in the Dockerfile) and
+# which downstream tooling copies out of the image. CARDANO_NETWORK=<net>
+# resolves to one or the other depending on how dingo was deployed, so the
+# same network name means the same chain only while the two stay identical.
+on:
+  pull_request:
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Gates merges. Compares against the cardano-configs image tag the
+  # Dockerfile pins, which is what a built image actually contains, so a
+  # config change is satisfiable inside one pull request here: bump the
+  # pinned tag and update config/cardano/ in the same commit. Comparing
+  # against the configs repository's main branch instead would pass as soon
+  # as that branch moved, while the image this repository builds still
+  # shipped the old config.
+  config-parity:
+    name: config-parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
+      - name: config-parity
+        # Run through the Makefile so this CI check and `make config-parity`
+        # cannot drift apart.
+        run: make config-parity
+
+  # Does not gate merges. The job above pins to a released image, so it stays
+  # green while docker-cardano-configs moves ahead of that pin; this reports
+  # when it has, meaning a tag bump is due. Drift introduced in that
+  # repository produces no event here, hence the schedule.
+  config-upstream:
+    name: config-upstream
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
+      - name: config-parity-against-upstream-main
+        env:
+          CARDANO_CONFIGS_REF: main
+        run: make config-parity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ The default target formats and builds; tests are a separate target.
 ```
 make lint         # import-boundaries, all modules, windows, nilaway, modernize
 make docs-parity
+make config-parity
 make golines
 make sql-check    # only when database/sql queries or sqlc.yaml changed
 make govulncheck  # reachable Go vulnerabilities; needs network

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Go Cardano node (Ouroboros). Derivable info (build targets, flags, package layou
 make lint         # import-boundaries, all modules, windows, nilaway, modernize
 modernize --fix ./...   # optional: auto-apply modernize's findings
 make docs-parity
+make config-parity  # embedded configs vs the pinned cardano-configs image; needs network + docker
 make golines
 make sql-check    # only when database/sql queries or sqlc.yaml changed
 make govulncheck  # reachable Go vulnerabilities; needs network

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ GO_TAG_FLAGS=$(if $(strip $(BUILD_TAGS)),-tags "$(BUILD_TAGS)",)
 # run modernize only against hand-written packages to avoid generator drift.
 MODERNIZE_PACKAGES=$(shell go list $(GO_TAG_FLAGS) -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./... | grep -Ev '/database/plugin/(blob/(aws|gcs)|metadata/(mysql|postgres)|metadata/sqlstore/internal/query/(mysql|postgres|sqlite))$$|/midnight$$')
 
-.PHONY: all build help install uninstall mod-tidy clean format golines lint import-boundaries docs-parity proto sql sql-check govulncheck test test-live-lifecycle bench bench-ci bench-mempool bench-mempool-normal bench-mempool-degenerate bench-mempool-revalidation test-load test-load-log test-load-profile test-devnet
+.PHONY: all build help install uninstall mod-tidy clean format golines lint import-boundaries docs-parity config-parity proto sql sql-check govulncheck test test-live-lifecycle bench bench-ci bench-mempool bench-mempool-normal bench-mempool-degenerate bench-mempool-revalidation test-load test-load-log test-load-profile test-devnet
 
 # Default target
 all: format build ## Format and build (default)
@@ -95,6 +95,9 @@ import-boundaries: ## Check reviewed package import boundaries
 
 docs-parity: ## Check docs against go.mod, the Makefile, and the DevNet compose file
 	go test ./internal/docsparity
+
+config-parity: ## Fail if the embedded network configs drift from docker-cardano-configs
+	./bin/config-parity.sh
 
 proto: $(PROTOC) ## Generate Go code from protobuf definitions
 	go build -o $(TOOLS_BIN)/protoc-gen-go google.golang.org/protobuf/cmd/protoc-gen-go

--- a/bin/config-parity.sh
+++ b/bin/config-parity.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail when the network configs embedded in the dingo binary have drifted
+# from the docker-cardano-configs copy the release image ships.
+#
+# The two copies must stay byte-identical because they are the same config
+# reached by two different runtime paths. `CARDANO_NETWORK=<net>` with no
+# config file serves the copy embedded here via config/cardano/embed.go,
+# while the release image ships the docker-cardano-configs copy as
+# /opt/cardano/config/ and downstream tooling copies it out of there. A
+# change landing in only one of them makes the Docker and binary
+# deployments run different chains under the same network name.
+#
+# The default comparison is against the cardano-configs image tag the
+# Dockerfile pins, not against that repository's main branch, because the
+# pinned tag is what a built image actually contains. That also makes the
+# check satisfiable inside a single dingo pull request: bump the pinned tag
+# and update the embedded copy together and it goes green, with no window
+# where it is red waiting on another repository to merge. Comparing against
+# main instead would go green the moment that branch moved, while the image
+# this repository builds still shipped the old config.
+#
+# Sources, in precedence order:
+#   CARDANO_CONFIGS_DIR  an existing checkout or extracted config tree
+#   CARDANO_CONFIGS_REF  a branch, tag, or commit SHA of the repository
+#   (default)            the image tag pinned in the Dockerfile
+
+set -euo pipefail
+
+configs_repo="https://github.com/blinklabs-io/docker-cardano-configs"
+configs_image="ghcr.io/blinklabs-io/cardano-configs"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+# Files that exist here with no counterpart in docker-cardano-configs, and
+# are expected to. Anything else missing from that repository is drift.
+dingo_only=(
+	"preview/README.md"
+)
+
+# These files are shipped by cardano-configs but are intentionally not embedded
+# by dingo. Keep the allowlist explicit so any new upstream file still fails.
+upstream_only=(
+	"preview/db-sync-config.json"
+	"preview/tracer-config.json"
+	"mainnet/db-sync-config.json"
+	"mainnet/tracer-config.json"
+	"preprod/db-sync-config.json"
+	"preprod/tracer-config.json"
+	"musashi/tracer-config.json"
+)
+
+configs_dir="${CARDANO_CONFIGS_DIR:-}"
+configs_ref="${CARDANO_CONFIGS_REF:-}"
+source_desc=""
+cleanup_dir=""
+if [[ -n "${configs_dir}" ]]; then
+	source_desc="${configs_dir}"
+else
+	cleanup_dir="$(mktemp -d)"
+	# shellcheck disable=SC2064 # expand cleanup_dir now, not at trap time
+	trap "rm -rf '${cleanup_dir}'" EXIT
+	if [[ -n "${configs_ref}" ]]; then
+		source_desc="${configs_repo} at ${configs_ref}"
+		echo "cloning ${source_desc}"
+		git clone --quiet --filter=blob:none "${configs_repo}" \
+			"${cleanup_dir}/configs"
+		git -C "${cleanup_dir}/configs" fetch --quiet origin "${configs_ref}"
+		git -C "${cleanup_dir}/configs" checkout --quiet FETCH_HEAD
+		configs_dir="${cleanup_dir}/configs"
+	else
+		tag="$(sed -n "s|^FROM ${configs_image}:\\([^ ]*\\) .*|\\1|p" Dockerfile | head -1)"
+		if [[ -z "${tag}" ]]; then
+			echo "error: no ${configs_image} tag found in Dockerfile" >&2
+			exit 1
+		fi
+		source_desc="${configs_image}:${tag}"
+		echo "extracting /config from ${source_desc}"
+		container="$(docker create "${source_desc}")"
+		# shellcheck disable=SC2064 # expand both now, not at trap time
+		trap "docker rm --force '${container}' >/dev/null 2>&1 || true; rm -rf '${cleanup_dir}'" EXIT
+		mkdir -p "${cleanup_dir}/configs"
+		docker cp "${container}:/config" "${cleanup_dir}/configs/config"
+		configs_dir="${cleanup_dir}/configs"
+	fi
+fi
+
+# Check exactly the networks config/cardano/embed.go embeds, so adding a
+# network to that directive brings it under this check automatically.
+embed_line="$(grep -m1 '^//go:embed ' config/cardano/embed.go)" || {
+	echo "error: no //go:embed directive found in config/cardano/embed.go" >&2
+	exit 1
+}
+read -r -a networks <<<"${embed_line#//go:embed }"
+if [[ ${#networks[@]} -eq 0 ]]; then
+	echo "error: no networks found in config/cardano/embed.go" >&2
+	exit 1
+fi
+
+if [[ -d "${configs_dir}/config" ]]; then
+	configs_root="${configs_dir}/config"
+else
+	configs_root="${configs_dir}"
+fi
+if [[ ! -d "${configs_root}/${networks[0]}" ]]; then
+	echo "error: ${configs_dir} has no config tree" >&2
+	exit 1
+fi
+
+drift=0
+checked=0
+for network in "${networks[@]}"; do
+	upstream="${configs_root}/${network}"
+	if [[ ! -d "${upstream}" ]]; then
+		echo "DRIFT ${network}: not present in ${source_desc}"
+		drift=$((drift + 1))
+		continue
+	fi
+	while IFS= read -r tracked; do
+		relative="${tracked#config/cardano/}"
+		skip=0
+		for allowed in "${dingo_only[@]}"; do
+			[[ "${relative}" == "${allowed}" ]] && skip=1 && break
+		done
+		[[ ${skip} -eq 1 ]] && continue
+		checked=$((checked + 1))
+		counterpart="${configs_root}/${relative}"
+		if [[ ! -e "${counterpart}" ]]; then
+			echo "DRIFT ${relative}: missing from ${source_desc}"
+			drift=$((drift + 1))
+			continue
+		fi
+		if ! diff -u "${counterpart}" "${tracked}" \
+			--label "cardano-configs/config/${relative}" \
+			--label "dingo/config/cardano/${relative}"; then
+			drift=$((drift + 1))
+		fi
+	done < <(git ls-files "config/cardano/${network}")
+	while IFS= read -r relative; do
+		skip=0
+		for allowed in "${upstream_only[@]}"; do
+			[[ "${network}/${relative}" == "${allowed}" ]] && skip=1 && break
+		done
+		[[ ${skip} -eq 1 ]] && continue
+		if ! git ls-files --error-unmatch "config/cardano/${network}/${relative}" \
+			>/dev/null 2>&1; then
+			echo "DRIFT ${network}/${relative}: missing from dingo"
+			drift=$((drift + 1))
+		fi
+	done < <(
+		cd "${upstream}"
+		find . -type f -print | sed 's|^./||' | sort
+	)
+done
+
+if [[ ${drift} -ne 0 ]]; then
+	cat >&2 <<EOF
+
+${drift} file(s) differ from ${source_desc}.
+
+Both copies must change together. Land the change in
+${configs_repo}, release a
+cardano-configs image containing it, then in this repository bump the
+pinned tag in the Dockerfile and update config/cardano/ in the same commit.
+EOF
+	exit 1
+fi
+
+echo "${checked} file(s) across ${#networks[@]} network(s) match ${source_desc}"


### PR DESCRIPTION
## What

`bin/config-parity.sh` diffs the network configs embedded in the binary against the docker-cardano-configs copy shipped in the release image. `make config-parity` runs it locally, and `.github/workflows/config-parity.yml` runs it in CI.

The embedded and image copies are the same configuration reached through two runtime paths. `CARDANO_NETWORK=<net>` with no config file serves `config/cardano/`; the release image ships the docker-cardano-configs copy as `/opt/cardano/config/`.

## Scope

The script compares every tracked file under the networks named by `config/cardano/embed.go`: 54 files across devnet, mainnet, musashi, preprod, and preview. `preview/README.md` is the only allowlisted file without an upstream counterpart.

## Comparison target

The PR job compares against the cardano-configs image tag pinned in the Dockerfile, currently `20260829-1`. A config update can therefore bump the pin and update `config/cardano/` in the same PR. A separate weekly job compares against upstream `main` and reports when a new image pin is due.

Repository branch protection must require the `config-parity` check context before this becomes a merge gate.

## Sources

`CARDANO_CONFIGS_DIR` uses an already extracted tree, `CARDANO_CONFIGS_REF` clones a git ref, and the default extracts `/config` from the pinned image.

## Verification

- passes for 54 files across 5 networks against `20260829-1`
- reports unified diffs for content drift
- reports missing counterpart paths
- `shellcheck` and `actionlint` pass
- `make docs-parity` passes with the new Makefile target

Split out of #3636 so it can merge independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to verify that embedded network configuration files remain identical to the corresponding release configurations.
  * Pull requests now receive configuration parity validation before merge.
  * Scheduled checks compare configurations with the upstream source weekly, with optional manual runs.
  * Added a pre-commit checklist step to detect configuration drift and report affected files with remediation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->