### PR TITLE
fix(ledger): stop repeated reward withdrawal replay wedges

### DIFF
--- a/database/models/account.go
+++ b/database/models/account.go
@@ -23,7 +23,14 @@ import (
 	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
-var ErrAccountNotFound = errors.New("account not found")
+var (
+	ErrAccountNotFound = errors.New("account not found")
+	// ErrRewardWithdrawalExceedsBalance identifies a transaction whose
+	// withdrawal cannot be satisfied by the node's persisted reward account.
+	ErrRewardWithdrawalExceedsBalance = errors.New(
+		"reward withdrawal exceeds account balance",
+	)
+)
 
 // AccountCreatedSlotUnset is the sentinel the account create helpers stamp on a
 // freshly built (not-yet-persisted) account so the save helpers can resolve

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -828,9 +828,10 @@ SELECT EXISTS (
 		}
 		if amount.Uint64() > previous {
 			return fmt.Errorf(
-				"reward withdrawal amount %s exceeds account balance %d",
+				"reward withdrawal amount %s exceeds account balance %d: %w",
 				amount.String(),
 				previous,
+				models.ErrRewardWithdrawalExceedsBalance,
 			)
 		}
 		if amount.Sign() == 0 {

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -394,6 +394,9 @@ func isDeterministicTxValidationError(err error) bool {
 	if _, ok := errors.AsType[conway.PlutusScriptFailedError](err); ok {
 		return true
 	}
+	if errors.Is(err, models.ErrRewardWithdrawalExceedsBalance) {
+		return true
+	}
 	_, ok := errors.AsType[eras.DuplicateInputByronError](err)
 	return ok
 }
@@ -468,8 +471,9 @@ func (ls *LedgerState) markDeterministicTxRecoveryResync(
 // separate from unresolved-input recovery: the latter is state-dependent and
 // still needs producer resolution and the security-parameter fallback.
 //
-// The rejection is never terminal. Rejecting the chain that contains a block
-// this node believes is invalid, and continuing to reject it, is the response
+// Structural rejection is normally not terminal. Rejecting the chain that
+// contains a block this node believes is invalid, and continuing to reject it,
+// is the response
 // tryRecoverFromHeaderValidationError already gives a block whose deferred
 // header checks fail (see header_validation_recovery.go): a local
 // false-positive verdict must leave the node able to follow a chain a peer
@@ -482,7 +486,9 @@ func (ls *LedgerState) markDeterministicTxRecoveryResync(
 // no-progress accounting (trackPipelineProgress / ledgerPipelineBackoff)
 // escalates and exports as dingo_ledger_pipeline_stuck. Whether a validation
 // failure should ever become terminal, and what terminal must report, is
-// issue #3261 rather than this path.
+// issue #3261 rather than this path. A repeated reward withdrawal mismatch is
+// the exception: it proves the persisted reward state cannot satisfy the
+// chain's transaction, so retrying the same state would wedge the pipeline.
 func (ls *LedgerState) recoverFromDeterministicTxValidationError(
 	validationErr *txValidationError,
 ) (bool, error) {
@@ -497,6 +503,24 @@ func (ls *LedgerState) recoverFromDeterministicTxValidationError(
 		validationErr,
 	)
 	ls.RUnlock()
+	if resyncSpent && errors.Is(
+		validationErr.Cause,
+		models.ErrRewardWithdrawalExceedsBalance,
+	) {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Error(
+				"replay recovery found a repeated reward withdrawal mismatch; halting instead of retrying indefinitely",
+				"component", "ledger",
+				"failing_block_slot", validationErr.BlockPoint.Slot,
+				"error", validationErr.Cause,
+				"hint", "local reward-account state disagrees with the chain; repair or resync the node before restarting",
+			)
+		}
+		return false, fmt.Errorf(
+			"repeated reward withdrawal mismatch: %w",
+			errHaltLedgerPipeline,
+		)
+	}
 	rewindPoint := ledgerTip.Point
 	if rewindPoint.Slot >= validationErr.BlockPoint.Slot {
 		if ls.config.Logger != nil {

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -1806,6 +1806,31 @@ func TestReplayRecoveryRejectsDeterministicDuplicateInput(t *testing.T) {
 	)
 }
 
+func TestReplayRecoveryHaltsRepeatedRewardWithdrawalMismatch(t *testing.T) {
+	ls := newReplayRecoveryAuditLedger(t, true)
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
+	ls.config.EventBus = bus
+	validation := func() *txValidationError {
+		return &txValidationError{
+			BlockPoint: ocommon.NewPoint(160, testHashBytes("audit-failing")),
+			TxHash:     testHashBytes("reward-withdrawal-mismatch-tx"),
+			Cause: fmt.Errorf(
+				"amount 78446537 exceeds account balance 78446536: %w",
+				models.ErrRewardWithdrawalExceedsBalance,
+			),
+		}
+	}
+
+	recovered, err := ls.tryRecoverFromTxValidationError(validation())
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	recovered, err = ls.tryRecoverFromTxValidationError(validation())
+	require.ErrorIs(t, err, errHaltLedgerPipeline)
+	require.False(t, recovered)
+}
+
 func TestReplayRecoveryRejectsDeterministicPlutusFailure(t *testing.T) {
 	ls := newReplayRecoveryAuditLedger(t, true)
 	bus := event.NewEventBus(nil, nil)


### PR DESCRIPTION
## Summary
- classify over-balance reward withdrawals as deterministic validation failures
- give the first failure a fresh-chain opportunity
- halt repeated identical mismatches with an actionable recovery diagnostic

## Validation
- go test ./database/plugin/metadata/sqlite ./ledger -run 'Test(SharedSQLStoreTransactionWriteParity|ReplayRecovery|LedgerProcessBlocks)' -count=1
- git diff --check

Fixes #3629

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repeated reward withdrawal replay mismatches wedging the ledger pipeline by halting after the first retry instead of retrying indefinitely.

- Classifies reward withdrawal over-balance as a deterministic transaction validation error.
- Allows the first mismatch a fresh-chain resync attempt; a repeated identical mismatch now halts the pipeline with a recovery diagnostic.
- Nodes with reward state that disagrees with the chain will halt and require repair or resync before restarting.

**Testing**
- Adds a test covering the halt-on-repeat behavior.

Fixes #3629.

<sup>Written for commit 569a4d4c937466fda38925bb1ba6925103f93b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reward withdrawals that exceed an account’s balance.
  * Repeated balance mismatches during ledger recovery now halt processing instead of retrying indefinitely.
  * Other structural validation failures remain recoverable through the existing retry flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->