### PR TITLE
fix(ledger): reject malformed stored epoch nonces

### DIFF
--- a/ledger/candidate_nonce.go
+++ b/ledger/candidate_nonce.go
@@ -245,12 +245,12 @@ func (ls *LedgerState) computeCandidateNonceFast(
 				"get nonce for last epoch block: %w", err,
 			)
 		}
-		if len(nonce) == 0 {
+		if len(nonce) != 32 {
 			// The last block in the blob store has no committed
-			// block_nonce row yet — the metadata pipeline is
-			// behind. Force the slow path so we recompute the
-			// epoch's evolving nonce from CBOR with all blocks
-			// included.
+			// block_nonce row yet, or its row is malformed — the
+			// metadata pipeline is behind or has stale data. Force
+			// the slow path so we recompute the epoch's evolving
+			// nonce from CBOR with all blocks included.
 			return nil, nil, errNoncesMissing
 		}
 		evolvingNonce = nonce
@@ -298,7 +298,7 @@ func (ls *LedgerState) computeCandidateNonceFast(
 					err,
 				)
 			}
-			if len(nonce) == 0 {
+			if len(nonce) != 32 {
 				return nil, nil, errNoncesMissing
 			}
 			candidateNonce = nonce

--- a/ledger/candidate_nonce_as_of_test.go
+++ b/ledger/candidate_nonce_as_of_test.go
@@ -154,3 +154,21 @@ func TestFoldEndSlotForTip(t *testing.T) {
 		"the maximum slot saturates rather than wrapping to zero, which "+
 			"would fold nothing and report the epoch's opening values")
 }
+
+func TestComputeCandidateNonceFastRejectsMalformedNonceRows(t *testing.T) {
+	db := newTestDB(t)
+	hash := bytes.Repeat([]byte{0x71}, 32)
+	require.NoError(t, db.BlockCreate(models.Block{
+		Slot: 100, Hash: hash, PrevHash: bytes.Repeat([]byte{0x72}, 32),
+		Cbor: []byte{0x80}, Number: 1, Type: byron.BlockTypeByronMain,
+	}, nil))
+	require.NoError(t, db.SetBlockNonce(hash, 100, []byte{0x01}, false, nil))
+	ls := &LedgerState{db: db}
+	err := db.Transaction(false).Do(func(txn *database.Txn) error {
+		_, _, err := ls.computeCandidateNonceFast(txn,
+			bytes.Repeat([]byte{0x73}, 32), bytes.Repeat([]byte{0x74}, 32),
+			0, 101, 101)
+		return err
+	})
+	require.ErrorIs(t, err, errNoncesMissing)
+}


### PR DESCRIPTION
## Summary

Reject malformed persisted epoch nonce rows and recompute the nonce instead of using invalid metadata for epoch VRF state. This keeps epoch-boundary verification fail-safe while allowing recovery from corrupted or legacy nonce data.

Fixes #3630

## Validation

- `go test ./ledger -run TestComputeCandidateNonceFastRejectsMalformedNonceRows`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3630 by rejecting malformed persisted epoch nonce rows, so the ledger recomputes the nonce from CBOR instead of using invalid metadata for epoch VRF state. Previously only empty nonce rows were rejected; now any stored nonce that isn't exactly 32 bytes forces the slow recompute path, keeping epoch-boundary verification fail-safe and allowing recovery from corrupted or legacy data.

<sup>Written for commit bb97e8a0964a1059d2873b986afc1042a373e6d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

