### PR TITLE
fix(leios): validate fetched endorser-block txs by full-transaction hash, not body hash

### DIFF
--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1511,7 +1511,7 @@ func buildLeiosEB(
 		// (validateLeiosEndorserBlockTxs) and Haskell reference nodes, so a
 		// peer fetching a locally forged EB validates it instead of rejecting
 		// every tx (blinklabs-io/dingo#3641).
-		if _, ok := validLeiosTransactionHash(tx.Hash); !ok ||
+		if !validLeiosTransactionHash(tx.Hash) ||
 			len(tx.Cbor) == 0 || len(tx.Cbor) > math.MaxUint16 {
 			continue
 		}
@@ -1536,14 +1536,13 @@ func buildLeiosEB(
 	return ebCbor, h.Bytes(), bodies, nil
 }
 
-func validLeiosTransactionHash(hash string) ([]byte, bool) {
+func validLeiosTransactionHash(hash string) bool {
 	raw, err := hex.DecodeString(hash)
-	return raw, err == nil && len(raw) == 32
+	return err == nil && len(raw) == 32
 }
 
 func validLeiosTransactionReference(tx MempoolTransaction) bool {
-	_, hashOK := validLeiosTransactionHash(tx.Hash)
-	return hashOK && len(tx.Cbor) > 0 && len(tx.Cbor) <= math.MaxUint16
+	return validLeiosTransactionHash(tx.Hash) && len(tx.Cbor) > 0 && len(tx.Cbor) <= math.MaxUint16
 }
 
 // modeString returns a string representation of the forging mode.

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1504,15 +1504,22 @@ func buildLeiosEB(
 	// keeping body i aligned with reference i.
 	bodies = make([][]byte, 0, len(txs))
 	for _, tx := range txs {
-		raw, ok := validLeiosTransactionHash(tx.Hash)
-		if !ok || len(tx.Cbor) == 0 || len(tx.Cbor) > math.MaxUint16 {
+		// The manifest reference is content-addressed by (hash, size) over
+		// the FULL serialized transaction: TransactionSize is len(tx.Cbor),
+		// so TransactionHash must be the hash of that same full CBOR, not the
+		// Cardano tx-id / body hash. This matches the fetch-side validator
+		// (validateLeiosEndorserBlockTxs) and Haskell reference nodes, so a
+		// peer fetching a locally forged EB validates it instead of rejecting
+		// every tx (blinklabs-io/dingo#3641).
+		if _, ok := validLeiosTransactionHash(tx.Hash); !ok ||
+			len(tx.Cbor) == 0 || len(tx.Cbor) > math.MaxUint16 {
 			continue
 		}
 		// Bounded above by the MaxUint16 check on len(tx.Cbor) above. Kept
 		// on one line so the directive stays attached to the conversion.
 		size := uint16(len(tx.Cbor)) // #nosec G115
 		refs = append(refs, lcommon.LeiosTransactionReference{
-			TransactionHash: lcommon.NewBlake2b256(raw),
+			TransactionHash: lcommon.Blake2b256Hash(tx.Cbor),
 			TransactionSize: size,
 		})
 		bodies = append(bodies, tx.Cbor)

--- a/ledger/forging/leios_eb_build_test.go
+++ b/ledger/forging/leios_eb_build_test.go
@@ -15,6 +15,7 @@
 package forging
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -225,8 +226,8 @@ func TestBuildLeiosEBReferencesUseFullTransactionHash(t *testing.T) {
 	// Regression guard: the old (buggy) contract hashed the decoded tx.Hash
 	// (tx-id / body hash). That value must NOT equal the reference hash now,
 	// or a fetching peer would reject every locally forged tx again.
-	rawHash, ok := validLeiosTransactionHash(txs[0].Hash)
-	require.True(t, ok)
+	rawHash, err := hex.DecodeString(txs[0].Hash)
+	require.NoError(t, err)
 	require.NotEqual(
 		t,
 		lcommon.NewBlake2b256(rawHash),

--- a/ledger/forging/leios_eb_build_test.go
+++ b/ledger/forging/leios_eb_build_test.go
@@ -192,3 +192,45 @@ func TestSelectValidLeiosTransactionsRejectsUnrepresentableParent(
 	require.NoError(t, err)
 	require.Empty(t, selected)
 }
+
+// TestBuildLeiosEBReferencesUseFullTransactionHash verifies that buildLeiosEB
+// content-addresses each manifest reference by the hash of the FULL transaction
+// CBOR (not the Cardano tx-id / body hash). This is exactly the check the
+// fetch-side validator (ouroboros.validateLeiosEndorserBlockTxs) performs —
+// Blake2b256(txCbor) == ref.TransactionHash — so a peer fetching a locally
+// forged EB validates every tx instead of rejecting it (blinklabs-io/dingo#3641).
+func TestBuildLeiosEBReferencesUseFullTransactionHash(t *testing.T) {
+	txs := []MempoolTransaction{
+		{Hash: strings.Repeat("11", 32), Cbor: []byte{0x01, 0x02, 0x03}},
+		{Hash: strings.Repeat("aa", 32), Cbor: []byte{0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	ebCbor, _, bodies, err := buildLeiosEB(txs)
+	require.NoError(t, err)
+
+	eb, err := lcommon.NewLeiosEndorserBlockFromCbor(ebCbor)
+	require.NoError(t, err)
+	require.Len(t, eb.TransactionReferences, len(bodies))
+	for i, ref := range eb.TransactionReferences {
+		// The same equality validateLeiosEndorserBlockTxs enforces on fetch.
+		require.Equalf(
+			t,
+			lcommon.Blake2b256Hash(bodies[i]),
+			ref.TransactionHash,
+			"reference %d hash must be Blake2b256 of the full tx CBOR",
+			i,
+		)
+	}
+
+	// Regression guard: the old (buggy) contract hashed the decoded tx.Hash
+	// (tx-id / body hash). That value must NOT equal the reference hash now,
+	// or a fetching peer would reject every locally forged tx again.
+	rawHash, ok := validLeiosTransactionHash(txs[0].Hash)
+	require.True(t, ok)
+	require.NotEqual(
+		t,
+		lcommon.NewBlake2b256(rawHash),
+		eb.TransactionReferences[0].TransactionHash,
+		"reference hash must be the full-tx hash, not the tx-id/body hash",
+	)
+}

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -286,10 +286,14 @@ func cloneRawMessages(in []cbor.RawMessage) []cbor.RawMessage {
 }
 
 // validateLeiosEndorserBlockTxs binds fetched transaction wire values to the
-// manifest before the complete set is cached or applied. Leios transaction
-// references use the Cardano transaction ID (the hash of the transaction body)
-// and the complete transaction's encoded size, while leios-fetch carries each
-// transaction either directly or in a CBOR byte-string wrapper.
+// manifest before the complete set is cached or applied. Each Leios manifest
+// reference is content-addressed over the FULL serialized transaction: the
+// TransactionHash is Blake2b256 of the complete transaction CBOR (NOT the
+// Cardano tx-id / body hash) and TransactionSize is that CBOR's length. Both
+// the fetch-side validator here and the forge-side reference builder
+// (buildLeiosEB) use this same full-transaction contract, matching Haskell
+// reference nodes. leios-fetch carries each transaction either directly or in
+// a CBOR byte-string wrapper.
 func validateLeiosEndorserBlockTxs(
 	manifestRaw []byte,
 	txsRaw []cbor.RawMessage,


### PR DESCRIPTION

## Problem
`c9692061` ("fix(leios): bind fetched transactions to manifests", in v0.70.2 and
main) validates each fetched endorser-block transaction against the manifest by
hashing **only the transaction body** (`txElems[0]`) and comparing to
`ref.TransactionHash`:

```go
if bodyHash := lcommon.Blake2b256Hash(txElems[0]); bodyHash != ref.TransactionHash {
    return fmt.Errorf("endorser tx %d body hash mismatch", index)
}
```

But the same manifest reference carries `TransactionSize == len(txCbor)` — the
size of the **full** serialized transaction. The manifest is a content-addressed
(hash+size) reference to the full tx, so `TransactionHash` is the hash of the
full tx, not the Cardano tx-id / body hash. Against a reference (Haskell) node's
endorser blocks, EVERY fetched tx fails this check ("endorser tx 0 body hash
mismatch", 0/N accepted), so no endorser block can be backfilled and a catching-up
node wedges permanently on the first EB-bearing block it needs.

The existing unit test did not catch this because its fixture builds the
reference hash the same (body-only) way the validator checks it —
`TransactionHash: lcommon.Blake2b256Hash(txElems[0])` — so it is self-consistent
with the bug.

## Evidence
A node behind a Haskell reference relay: the relay serves the EB completely
(`MsgLeiosBlockTxsRequest [start]→[done]`, bitmap echoed, all txs), but the Dingo
client logs `tx fetch (0/N): validate fetched transaction: endorser tx 0 body
hash mismatch` for every EB (474, 218, 2098, 115 txs …). Deterministic; the node
logged the wedge 151 times over 75 minutes.

## Fix
Hash the full transaction bytes, consistent with `TransactionSize`:
```go
if txHash := lcommon.Blake2b256Hash(txCbor); txHash != ref.TransactionHash {
    return fmt.Errorf("endorser tx %d hash mismatch", index)
}
```
and update the test fixture to build `TransactionHash` from `txCbor`.

## Verified
Built and deployed to a wedged BP behind a Haskell reference relay: the
`... body hash mismatch` errors went from constant (151/75min) to **zero**, and
the node began applying endorser-block transactions past the previously-stuck EB
(slot 1863115) — confirming the fetched txs are now accepted. (A separate,
downstream ledger issue — "UTxO already spent" applying an EB tx at a later slot —
is NOT addressed here and is filed separately.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes endorser-block transaction hashing so both fetched and locally forged EBs validate against the manifest, and a catching-up node no longer wedges on EB-bearing blocks.

- The fetch-side validator now hashes the full serialized transaction CBOR instead of only the body, matching the manifest's `TransactionHash`/`TransactionSize` contract.
- `buildLeiosEB` now sets `TransactionHash` to the full tx CBOR hash instead of the Cardano tx-id/body hash, so peers can fetch locally forged EBs.
- Adds a regression test asserting forged references hash the full tx CBOR.

<sup>Written for commit c245595362755521ca50665ec2c208ced4480981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of Leios endorser transactions by checking the hash of the complete transaction data.
  - Fixed validation behavior for wrapped transactions, reducing the risk of valid transactions being incorrectly rejected.
  - Updated validation error messaging to clearly indicate when a transaction hash does not match its reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->