### PR TITLE
fix(ledger): require withdrawal script redeemers

### DIFF
--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -698,7 +698,8 @@ func validateConwayRequiredPlutusRedeemers(
 	}
 	withdrawalAddrs := sortedConwayWithdrawalAddresses(tx.Withdrawals())
 	for idx, addr := range withdrawalAddrs {
-		if (addr.Type() & lcommon.AddressTypeScriptBit) == 0 {
+		stakeCredential, ok := addr.StakeCredential()
+		if !ok || stakeCredential.CredType != lcommon.CredentialTypeScriptHash {
 			continue
 		}
 		key := lcommon.RedeemerKey{
@@ -708,10 +709,7 @@ func validateConwayRequiredPlutusRedeemers(
 		if err := checkRequired(
 			key,
 			script.ScriptPurposeRewarding{
-				StakeCredential: lcommon.Credential{
-					CredType:   lcommon.CredentialTypeScriptHash,
-					Credential: addr.StakeKeyHash(),
-				},
+				StakeCredential: stakeCredential,
 			},
 		); err != nil {
 			return err

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -726,6 +726,135 @@ func TestValidateTxPlutusConwayMissingScriptWitnessWithoutRedeemerFails(
 	}
 }
 
+func TestValidateTxPlutusConwayWithdrawalRedeemerUsesStakeCredential(
+	t *testing.T,
+) {
+	plutusScript := lcommon.PlutusV2Script([]byte{0x01, 0x02})
+	scriptHash := plutusScript.Hash()
+	keyHash := make([]byte, lcommon.AddressHashSize)
+	keyHash[0] = 0xaa
+
+	newAddress := func(
+		t *testing.T,
+		addrType uint8,
+		paymentAddr []byte,
+		stakingAddr []byte,
+	) *lcommon.Address {
+		t.Helper()
+		addr, err := lcommon.NewAddressFromParts(
+			addrType,
+			lcommon.AddressNetworkTestnet,
+			paymentAddr,
+			stakingAddr,
+		)
+		require.NoError(t, err)
+		return &addr
+	}
+
+	rewardScript := newAddress(
+		t,
+		lcommon.AddressTypeNoneScript,
+		nil,
+		scriptHash.Bytes(),
+	)
+	baseKeyScript := newAddress(
+		t,
+		lcommon.AddressTypeKeyScript,
+		keyHash,
+		scriptHash.Bytes(),
+	)
+	baseScriptKey := newAddress(
+		t,
+		lcommon.AddressTypeScriptKey,
+		scriptHash.Bytes(),
+		keyHash,
+	)
+	enterprise := newAddress(
+		t,
+		lcommon.AddressTypeKeyNone,
+		keyHash,
+		nil,
+	)
+	keyBase := newAddress(
+		t,
+		lcommon.AddressTypeKeyKey,
+		keyHash,
+		keyHash,
+	)
+	malformed := &lcommon.Address{}
+
+	validate := func(
+		t *testing.T,
+		withdrawals map[*lcommon.Address]*big.Int,
+	) error {
+		t.Helper()
+		tx := &mockConwayFeeTx{
+			mockFeeTx: mockFeeTx{
+				txType: txTypeAlonzo,
+				witnesses: &mockWitnessSet{
+					plutusV2Scripts: []lcommon.PlutusV2Script{plutusScript},
+				},
+			},
+			withdrawals: withdrawals,
+		}
+		return ValidateTxPlutusConway(
+			tx,
+			0,
+			newMockLedgerState(),
+			&conway.ConwayProtocolParameters{},
+		)
+	}
+
+	t.Run("script stake credentials require a reward redeemer", func(t *testing.T) {
+		tests := []struct {
+			name string
+			addr *lcommon.Address
+		}{
+			{name: "reward address", addr: rewardScript},
+			{name: "base address", addr: baseKeyScript},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := validate(t, map[*lcommon.Address]*big.Int{
+					tt.addr: big.NewInt(1),
+				})
+				var missing conway.MissingRedeemerForScriptError
+				require.ErrorAs(t, err, &missing)
+				assert.Equal(t, scriptHash, missing.ScriptHash)
+				assert.Equal(t, lcommon.RedeemerTagReward, missing.Tag)
+				assert.Equal(t, uint32(0), missing.Index)
+			})
+		}
+	})
+
+	t.Run("key and absent stake credentials do not require a redeemer", func(t *testing.T) {
+		for name, addr := range map[string]*lcommon.Address{
+			"script payment and key stake": baseScriptKey,
+			"enterprise address":           enterprise,
+			"malformed address":            malformed,
+		} {
+			t.Run(name, func(t *testing.T) {
+				require.NoError(t, validate(t, map[*lcommon.Address]*big.Int{
+					addr: big.NewInt(1),
+				}))
+			})
+		}
+	})
+
+	t.Run("redeemer indexes retain withdrawal ordering", func(t *testing.T) {
+		err := validate(t, map[*lcommon.Address]*big.Int{
+			keyBase:       big.NewInt(1),
+			baseKeyScript: big.NewInt(1),
+			rewardScript:  big.NewInt(1),
+		})
+		var missing conway.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missing)
+		assert.Equal(t, scriptHash, missing.ScriptHash)
+		assert.Equal(t, lcommon.RedeemerTagReward, missing.Tag)
+		assert.Equal(t, uint32(1), missing.Index)
+	})
+}
+
 func TestValidateTxPlutusConwayNativeScriptWitnessWithoutRedeemerPasses(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Use the withdrawal address staking credential to determine whether a Conway reward-purpose Plutus redeemer is required. Add coverage for reward and base script-stake addresses, key-stake and malformed forms, and stable redeemer indexes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Conway withdrawal redeemer detection to use the address's stake credential instead of the address type, so script-stake withdrawals correctly require a reward redeemer.

- The old address-type bit check missed script stake credentials on base addresses.
- Adds tests for reward and base script-stake addresses, key-stake and malformed forms, and stable redeemer indexes.

<sup>Written for commit e5e5ef4d606a65c182b23648f1778e5dbab14e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of withdrawal transactions involving script-based stake credentials.
  * Correctly requires reward redeemers only when applicable.
  * Preserves accurate redeemer indexing across multiple withdrawals.

* **Tests**
  * Added coverage for script, key-based, and missing stake credentials in Conway withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->