### PR TITLE
fix(ledger): bump plutigo so cost model tables match the live networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
 	github.com/blinklabs-io/gouroboros v0.202.2
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
-	github.com/blinklabs-io/plutigo v0.4.0
+	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/blockfrost/blockfrost-go v0.5.0
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/consensys/gnark-crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/blinklabs-io/gouroboros v0.202.2 h1:rb21cE7YJwpbh/fEWxC5IpSig+zdDsuZU
 github.com/blinklabs-io/gouroboros v0.202.2/go.mod h1:y+bzoTL4JC1qu5m2NTERWuFl+fz6JPKBq22lQDIpjWs=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
-github.com/blinklabs-io/plutigo v0.4.0 h1:DVh4LtCq4Hc7Rfc5jSGD2cLK7610y8ai9F7vwW9r620=
-github.com/blinklabs-io/plutigo v0.4.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
+github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=
+github.com/blinklabs-io/plutigo v0.5.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
 github.com/blockfrost/blockfrost-go v0.5.0 h1:I+qEQw5Re9UHolKZGJE0FtuQL3a7L0WqEYkEO4GisIw=
 github.com/blockfrost/blockfrost-go v0.5.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/ledger/eras/cost_models_test.go
+++ b/ledger/eras/cost_models_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCostModelParameterTablesMatchLiveNetworks pins plutigo's cost model
+// parameter tables to the cost model lengths mainnet, preprod and preview all
+// publish at protocol version 11. The three networks carry byte identical
+// models, checked against Koios `epoch_params` for mainnet epoch 652, preprod
+// 310 and preview 1404.
+//
+// The evaluator maps the on-chain cost model onto these tables positionally:
+// cek.costModelFromList walks the parameter names and assigns data[i] to the
+// name at index i, breaking out at i >= len(data). It does not error when the
+// on-chain model is longer than the table, it silently ignores the excess. So
+// a table shorter than what the chain publishes is not a compile failure or a
+// runtime error, it is wrong ExUnits on the mainnet script path
+// (ledger/eras/{alonzo,babbage,conway}.go pass pp.CostModels[...] straight
+// into cek.NewEvalContext).
+//
+// plutigo v0.4.0 had 328/328/346 against these 332/332/350, and the shortfall
+// was not a clean truncation: valueData and unValueData changed shape rather
+// than gaining appended entries, so nine tail values landed on five
+// differently shaped names before the last four were dropped. This test exists
+// so the next upstream parameter addition fails here instead of silently
+// mispricing builtins.
+func TestCostModelParameterTablesMatchLiveNetworks(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version lang.LanguageVersion
+		want    int
+	}{
+		{name: "PlutusV1", version: lang.LanguageVersionV1, want: 332},
+		{name: "PlutusV2", version: lang.LanguageVersionV2, want: 332},
+		{name: "PlutusV3", version: lang.LanguageVersionV3, want: 350},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Len(
+				t,
+				lang.GetParamNamesForVersion(testCase.version),
+				testCase.want,
+			)
+		})
+	}
+}
+
+// TestCostModelParameterTablesPriceValueDataBuiltins checks the specific
+// parameters whose shape changed in plutigo v0.5.0. valueData's cpu and memory
+// costs each split into an intercept and a slope, and unValueData's cpu went
+// from intercept/slope to a three coefficient form while its memory gained a
+// slope. Asserting the names, not just the count, catches a table that is the
+// right length but carries the older single-argument forms.
+func TestCostModelParameterTablesPriceValueDataBuiltins(t *testing.T) {
+	required := []string{
+		"valueData-cpu-arguments-intercept",
+		"valueData-cpu-arguments-slope",
+		"valueData-memory-arguments-intercept",
+		"valueData-memory-arguments-slope",
+		"unValueData-cpu-arguments-c0",
+		"unValueData-cpu-arguments-c1",
+		"unValueData-cpu-arguments-c2",
+		"unValueData-memory-arguments-intercept",
+		"unValueData-memory-arguments-slope",
+	}
+	versions := map[string]lang.LanguageVersion{
+		"PlutusV1": lang.LanguageVersionV1,
+		"PlutusV2": lang.LanguageVersionV2,
+		"PlutusV3": lang.LanguageVersionV3,
+	}
+	for name, version := range versions {
+		t.Run(name, func(t *testing.T) {
+			params := lang.GetParamNamesForVersion(version)
+			present := make(map[string]struct{}, len(params))
+			for _, param := range params {
+				present[param] = struct{}{}
+			}
+			for _, want := range required {
+				require.Contains(t, present, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

plutigo v0.4.0's cost model parameter tables are 328/328/346 for PlutusV1/V2/V3. Mainnet, preprod and preview all publish 332/332/350 at protocol version 11, byte identical across the three (checked against Koios `epoch_params` for mainnet epoch 652, preprod 310, preview 1404).

The shortfall was not a clean truncation. `valueData` and `unValueData` changed shape rather than gaining appended entries:

- `valueData` cpu went from a single `valueData-cpu-arguments` to `-intercept` plus `-slope`, and memory likewise
- `unValueData` cpu went from `-intercept`/`-slope` to `-c0`/`-c1`/`-c2`, and memory gained a `-slope`

That replaces 5 names with 9 at the tail of each table, from index 319 in V1 and V2 and index 337 in V3. `cek.costModelFromList` maps the on-chain model onto the name table positionally and breaks out at `i >= len(data)`, so with a 332 entry model against a 328 entry table it assigned nine tail values to five differently shaped names, then silently dropped the last four. No error either way. Every other parameter is at the same index in both tables and was unaffected.

V1 also renames `blake2b` to `blake2b_256` and `verifySignature` to `verifyEd25519Signature` at index 14 and following. Those are position preserving and cost nothing.

## Reach

`ledger/eras/{alonzo,babbage,conway}.go` pass the on-chain `pp.CostModels[...]` straight into `cek.NewEvalContext` (for example `ledger/eras/conway.go:1081`), so this is the mainnet script evaluation path. A transaction whose scripts call `valueData` or `unValueData` was budgeted against wrong costs, which can disagree with cardano-node in either direction: rejecting a valid transaction, or admitting one the reference node rejects.

Storage and hashing were not affected. The full list is kept in the protocol parameters and the script data hash is computed over that, so only evaluation read the bad mapping.

## Change

`go.mod` moves plutigo v0.4.0 to v0.5.0, whose tables are 332/332/350 and match the published models exactly. `go mod tidy` produced no other module changes.

`ledger/eras/cost_models_test.go` adds two tests. `TestCostModelParameterTablesMatchLiveNetworks` pins the three lengths. `TestCostModelParameterTablesPriceValueDataBuiltins` asserts the nine `valueData`/`unValueData` parameter names are present, because a table of the right length still carrying the older single-argument forms would be the same defect. All six subtests fail against v0.4.0 and pass against v0.5.0.

## Validation

- `go test -tags dingo_extra_plugins ./...`: 82 packages, exit 0
- `internal/test/conformance`: pass
- `ledger/eras`: pass
- `golangci-lint run ./...`: 0 issues
- `make docs-parity`: pass
- `nilaway` and `modernize` each report one finding, both in files this change does not touch (`ledger/leios/manager_test.go:1281`, `ledger/state.go:6279`) and both reproduced on a main based checkout

DevNet was not run. A cost model change alters ExUnits accounting on the block production path, so `run-tests.sh --conformance` is worth running before merge.

`DATABASE.md` and `ARCHITECTURE.md` checked and not affected.

Fixes #3653

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `plutigo` from v0.4.0 to v0.5.0 so cost model tables match live networks. The old tables were 328/328/346 for PlutusV1/V2/V3 versus the published 332/332/350, so scripts using `valueData` or `unValueData` were priced against wrong ExUnits and could disagree with cardano-node.

**Details**
- `cek.costModelFromList` maps on-chain models positionally and silently dropped excess entries, so the shortfall never errored.
- The missing entries weren't appended: five parameter names changed shape into nine at each table tail.
- New tests pin the table lengths and the nine changed names; both fail against v0.4.0.

<sup>Written for commit 6fed80f123f416e250ec824bdd50612cb3ecef89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

