### PR TITLE
fix(leios): tolerate cross-EB double-consume on the closure apply path

### DIFF
--- a/database/plugin/metadata/domain_stores_test.go
+++ b/database/plugin/metadata/domain_stores_test.go
@@ -161,6 +161,7 @@ var transactionStoreMethods = []string{
 	"NewBatchAccumulator",
 	"FlushBatch",
 	"SetTransactionBatched",
+	"SetTransactionLeiosClosure",
 	"SetTransaction",
 	"SetGapBlockTransaction",
 	"RecomputeGapCollateralFee",

--- a/database/plugin/metadata/sqlite/shared_sqlstore_leios_closure_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_leios_closure_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package sqlite
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore"
+	"github.com/blinklabs-io/dingo/database/types"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// consumeTx builds a transaction with the given hash byte that consumes the one
+// producer input and produces a single output, mirroring a Leios endorser-block
+// transaction.
+func consumeTx(hashByte byte, input mockTransactionInput) *mockTransaction {
+	h := lcommon.Blake2b256{}
+	h[0] = hashByte
+	return &mockTransaction{
+		hash:     h,
+		isValid:  true,
+		consumed: []lcommon.TransactionInput{input},
+		produced: []lcommon.Utxo{{
+			Id:     mockTransactionInput{hash: h, index: 0},
+			Output: &mockTransactionOutput{amount: big.NewInt(600)},
+		}},
+	}
+}
+
+// TestSharedSQLStoreLeiosClosureTolerateDoubleConsume covers the cross-EB
+// double-consume that wedged the Musashi ledger pipeline: two certified
+// endorser-block transactions name the same input across blocks. The reference
+// ledger's applyLeiosClosure (ValidateNone) folds the closure without
+// re-validation, so the second consume of an already-spent input is a no-op.
+// SetTransaction (ranking-block path) must still reject it as a double-spend,
+// while SetTransactionLeiosClosure must tolerate it and still write the second
+// transaction's produced output.
+func TestSharedSQLStoreLeiosClosureTolerateDoubleConsume(t *testing.T) {
+	t.Parallel()
+
+	producerHash := lcommon.Blake2b256{}
+	producerHash[0] = 0xa1
+	input := mockTransactionInput{hash: producerHash, index: 0}
+
+	// newStoreWithSpentInput returns a store whose producer input has already
+	// been spent by an earlier certified transaction (txA).
+	newStoreWithSpentInput := func(t *testing.T) (*sqlstore.Store, *mockTransaction) {
+		t.Helper()
+		store, _ := newSharedSQLStore(t)
+		require.NoError(t, store.CreateUtxo(nil, &models.Utxo{
+			TxId: producerHash.Bytes(), OutputIdx: 0, Amount: 700, AddedSlot: 5,
+		}))
+		txA := consumeTx(0xa2, input)
+		pointA := ocommon.Point{Slot: 10, Hash: bytes.Repeat([]byte{0xc1}, 32)}
+		require.NoError(t, store.SetTransaction(txA, pointA, 0, nil, true, nil))
+		return store, txA
+	}
+
+	// Ranking-block path: the second consume of the already-spent input must
+	// fail with ErrUtxoConflict.
+	t.Run("ranking block rejects double consume", func(t *testing.T) {
+		t.Parallel()
+		store, _ := newStoreWithSpentInput(t)
+		txB := consumeTx(0xb2, input)
+		pointB := ocommon.Point{Slot: 20, Hash: bytes.Repeat([]byte{0xc2}, 32)}
+		err := store.SetTransaction(txB, pointB, 0, nil, true, nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, types.ErrUtxoConflict)
+	})
+
+	// Leios closure path: the second consume is a no-op, the call succeeds, the
+	// producer input stays spent by the first transaction, and the second
+	// transaction's produced output is written.
+	t.Run("leios closure tolerates double consume", func(t *testing.T) {
+		t.Parallel()
+		store, txA := newStoreWithSpentInput(t)
+		txB := consumeTx(0xb3, input)
+		pointB := ocommon.Point{Slot: 20, Hash: bytes.Repeat([]byte{0xc3}, 32)}
+		require.NoError(
+			t,
+			store.SetTransactionLeiosClosure(txB, pointB, 0, nil, true, nil),
+		)
+
+		// Producer input remains spent by the first (earlier certified) tx.
+		spent, err := store.GetUtxoIncludingSpent(producerHash.Bytes(), 0, nil)
+		require.NoError(t, err)
+		require.NotNil(t, spent)
+		require.True(
+			t,
+			bytes.Equal(txA.hash.Bytes(), spent.SpentAtTxId[:]),
+			"producer input must remain spent by the first certified tx",
+		)
+
+		// The second transaction and its produced output are recorded.
+		stored, err := store.GetTransactionByHash(txB.hash.Bytes(), nil)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		producedB, err := store.GetUtxo(txB.hash.Bytes(), 0, nil)
+		require.NoError(t, err)
+		require.NotNil(t, producedB)
+		require.Equal(t, uint64(600), uint64(producedB.Amount))
+	})
+}

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -95,7 +95,7 @@ func (s *Store) SetTransactionBatchedHistorical(
 	}
 	return s.setTransaction(
 		transaction, point, index, certDeposits,
-		skipWithdrawalWitness, historicalBackfill, txn,
+		skipWithdrawalWitness, historicalBackfill, false, txn,
 	)
 }
 
@@ -109,7 +109,30 @@ func (s *Store) SetTransaction(
 ) error {
 	return s.setTransaction(
 		transaction, point, index, certDeposits,
-		skipWithdrawalWitness, false, txn,
+		skipWithdrawalWitness, false, false, txn,
+	)
+}
+
+// SetTransactionLeiosClosure records a transaction on the Leios endorser-block
+// closure path (the Musashi/Haskell-conformant ValidateNone apply). It behaves
+// like SetTransaction except that a consumed input already spent by a
+// *different* transaction is treated as a no-op instead of ErrUtxoConflict,
+// matching the reference ledger's applyLeiosClosure: two certified endorser
+// blocks may legitimately name the same input across blocks, and the canonical
+// chain folds the closure without re-validation rather than rejecting it. Do
+// not use this for ranking-block application, where a real double-spend must
+// still fail.
+func (s *Store) SetTransactionLeiosClosure(
+	transaction lcommon.Transaction,
+	point ocommon.Point,
+	index uint32,
+	certDeposits map[int]uint64,
+	skipWithdrawalWitness bool,
+	txn types.Txn,
+) error {
+	return s.setTransaction(
+		transaction, point, index, certDeposits,
+		skipWithdrawalWitness, false, true, txn,
 	)
 }
 
@@ -120,6 +143,18 @@ func (s *Store) setTransaction(
 	certDeposits map[int]uint64,
 	skipWithdrawalWitness bool,
 	historicalBackfill bool,
+	// tolerateConsumedInputConflict makes a consumed input that is already
+	// spent by a *different* transaction a no-op instead of ErrUtxoConflict.
+	// Set only on the Leios endorser-block closure path (ValidateNone), where
+	// the reference ledger's applyLeiosClosure folds the certified closure onto
+	// the UTxO set without re-validation: re-consuming an input an earlier
+	// certified endorser-block transaction already spent is Map.delete on a
+	// missing key (a no-op), not a fault. Two certified endorser blocks can name
+	// the same input across blocks (a legitimate cross-EB double-consume the
+	// canonical chain tolerates); Dingo previously wedged the ledger pipeline on
+	// it. Normal ranking-block application leaves this false so a real
+	// double-spend still fails.
+	tolerateConsumedInputConflict bool,
 	txn types.Txn,
 ) error {
 	if transaction == nil {
@@ -348,11 +383,21 @@ FROM utxo WHERE tx_id = ? AND output_idx = ?`,
 						input.Index(),
 					)
 				}
+				// Leios closure path: the input is already spent by an earlier
+				// certified endorser-block transaction. The reference ledger
+				// treats this re-consume as a no-op (applyLeiosClosure folds the
+				// closure without re-validation), so skip this input instead of
+				// wedging the pipeline. The produced outputs and the remaining
+				// consumed inputs of this transaction are still applied.
+				if tolerateConsumedInputConflict {
+					continue
+				}
 				return fmt.Errorf(
-					"%w: %x:%d",
+					"%w: %x:%d (already spent_by=%x deleted_slot=%d, this_tx=%x)",
 					types.ErrUtxoConflict,
 					input.Id().Bytes(),
 					input.Index(),
+					spentBy, deletedSlot, hash,
 				)
 			}
 			stakeRefs, err := queryUtxoStakeRefs(ctx, db, refs, false)

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -895,6 +895,21 @@ type TransactionStore interface {
 		types.Txn,
 	) error
 
+	// SetTransactionLeiosClosure stores a transaction on the Leios
+	// endorser-block closure path. Identical to SetTransaction except a
+	// consumed input already spent by a different transaction is a no-op
+	// instead of ErrUtxoConflict, matching the reference ledger's
+	// applyLeiosClosure (ValidateNone) on a legitimate cross-EB double-consume
+	// (see BatchedTxIngestOpts.SkipConsumedInputRecovery).
+	SetTransactionLeiosClosure(
+		lcommon.Transaction,
+		ocommon.Point,
+		uint32, // idx
+		map[int]uint64, // certDeposits
+		bool, // skipWithdrawalWitness
+		types.Txn,
+	) error
+
 	// NewBatchAccumulator creates a metadata-plugin-specific accumulator
 	// for batched transaction ingestion.
 	NewBatchAccumulator() types.MetadataBatchAccumulator

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -280,14 +280,30 @@ func (d *Database) SetTransactionWithOpts(
 	if err := d.ensureTransactionConsumedUtxos(tx, point, txn, nil, opts); err != nil {
 		return err
 	}
-	if err := d.transactionStore().SetTransaction(
-		tx, point, idx, certDeposits,
-		opts.SkipWithdrawalWitnessWrite,
-		txn.Metadata(),
-	); err != nil {
+	// On the Leios endorser-block closure path (SkipConsumedInputRecovery), a
+	// consumed input already spent by a different certified endorser-block
+	// transaction is a no-op, matching the reference ledger's applyLeiosClosure
+	// (ValidateNone), rather than wedging the pipeline with ErrUtxoConflict on a
+	// legitimate cross-EB double-consume. Ranking-block application keeps the
+	// hard conflict check.
+	setTxErr := error(nil)
+	if opts.SkipConsumedInputRecovery {
+		setTxErr = d.transactionStore().SetTransactionLeiosClosure(
+			tx, point, idx, certDeposits,
+			opts.SkipWithdrawalWitnessWrite,
+			txn.Metadata(),
+		)
+	} else {
+		setTxErr = d.transactionStore().SetTransaction(
+			tx, point, idx, certDeposits,
+			opts.SkipWithdrawalWitnessWrite,
+			txn.Metadata(),
+		)
+	}
+	if setTxErr != nil {
 		return fmt.Errorf(
 			"set transaction metadata for tx %s (block idx %d, slot %d): %w",
-			tx.Hash(), idx, point.Slot, err,
+			tx.Hash(), idx, point.Slot, setTxErr,
 		)
 	}
 

--- a/database/tx_context_error_wrap_test.go
+++ b/database/tx_context_error_wrap_test.go
@@ -54,6 +54,17 @@ func (e *erroringMetadata) SetTransaction(
 	return e.injectErr
 }
 
+func (e *erroringMetadata) SetTransactionLeiosClosure(
+	tx lcommon.Transaction,
+	point ocommon.Point,
+	idx uint32,
+	certDeposits map[int]uint64,
+	skipWithdrawalWitness bool,
+	txn types.Txn,
+) error {
+	return e.injectErr
+}
+
 func (e *erroringMetadata) SetTransactionBatched(
 	tx lcommon.Transaction,
 	point ocommon.Point,

--- a/ouroboros/leios_merged.go
+++ b/ouroboros/leios_merged.go
@@ -356,8 +356,8 @@ func validateLeiosEndorserBlockTx(
 			ref.TransactionSize,
 		)
 	}
-	if bodyHash := lcommon.Blake2b256Hash(txElems[0]); bodyHash != ref.TransactionHash {
-		return fmt.Errorf("endorser tx %d body hash mismatch", index)
+	if txHash := lcommon.Blake2b256Hash(txCbor); txHash != ref.TransactionHash {
+		return fmt.Errorf("endorser tx %d hash mismatch", index)
 	}
 	return nil
 }

--- a/ouroboros/leios_merged_test.go
+++ b/ouroboros/leios_merged_test.go
@@ -858,7 +858,7 @@ func testLeiosManifestTx(
 	wrapped, err := cbor.Encode([]byte(txCbor))
 	require.NoError(t, err)
 	return cbor.RawMessage(wrapped), lcommon.LeiosTransactionReference{
-		TransactionHash: lcommon.Blake2b256Hash(txElems[0]),
+		TransactionHash: lcommon.Blake2b256Hash(txCbor),
 		TransactionSize: uint16(len(txCbor)), //nolint:gosec // test fixture is small
 	}
 }
@@ -882,7 +882,7 @@ func TestValidateLeiosEndorserBlockTxsBindsManifestOrder(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			err := validateLeiosEndorserBlockTxs(manifestRaw, txs)
-			require.ErrorContains(t, err, "endorser tx 0 body hash mismatch")
+			require.ErrorContains(t, err, "endorser tx 0 hash mismatch")
 		})
 	}
 }
@@ -1034,7 +1034,7 @@ func TestValidatedLeiosFetchRejectsMismatchBeforePartialRetention(t *testing.T) 
 		2,
 		manifestRaw,
 	)
-	require.ErrorContains(t, err, "endorser tx 0 body hash mismatch")
+	require.ErrorContains(t, err, "endorser tx 0 hash mismatch")
 	cached, ok := o.lookupLeiosEndorserBlock(point.Hash)
 	require.True(t, ok)
 	require.False(t, cached.completeTxCache())


### PR DESCRIPTION
> Stacked on #3641 (EB tx full-hash validation). Until that merges this PR shows two commits; the first is #3641's. Both are needed for a catching-up node to cross an EB-bearing region on the Musashi/Haskell-conformant path.

## Problem
On the Musashi/Haskell-conformant Leios path, a catching-up node wedges its
ledger pipeline deterministically:

```
failed to apply Leios endorser block after storage mutation
  slot=1864040 eb_slot=1864012
  error="apply endorser block transactions: record transaction:
         set transaction metadata for tx 6cf9bcfc…449ffc6 (block idx 691, slot 1864040):
         UTxO already spent: 3fe3ab01…b53e01:0"
block processing failed, restarting pipeline
```

The referenced issue frames this as a ranking block re-applying the *same*
endorser-resident transaction. It is subtler than that: the conflict is raised
because UTxO `3fe3ab01…:0` was already consumed by a **different** certified
endorser-block transaction in an earlier block, and the certified endorser
transaction at `eb_slot=1864012` consumes it again — a legitimate **cross-EB
double-consume**. (If it were the same tx re-applied, the idempotent
`bytes.Equal(spentBy, hash)` guard in `transaction_write.go` would already
`continue`; it does not, because the prior spender is a different tx.)

The closure apply path documents that it is meant to mirror the reference
ledger's `applyLeiosClosure` with `ruleApplyTxValidation ValidateNone`
(`ledger/leios_apply.go:225-238`): the certified closure is folded onto the UTxO
set **without re-validation**, and "a consumed input that is not present is left
as a no-op." In the reference ledger, consuming an already-spent input is
`Map.delete` on a missing key — a no-op, not a fault. Dingo instead reaches
`transaction_write.go` and raises `ErrUtxoConflict`, wedging the pipeline. The
node then sits ~5,400 blocks behind a reference (Haskell) node that applies the
identical chain without any double-spend error.

## Root cause
`setTransaction` in the SQLite metadata store implements the documented no-op
only for the "row absent" case (`sql.ErrNoRows → continue`). For "row present
but already spent by a different tx" it returns `ErrUtxoConflict` unconditionally
— even on the trusted closure apply path where the reference ledger no-ops.

## Fix
Add `SetTransactionLeiosClosure`, used only on the closure apply path
(`SkipConsumedInputRecovery`), which treats an already-spent-by-another-tx
consume as a no-op (skip that input) while still writing the transaction's
produced outputs and remaining consumed inputs. Ranking-block application keeps
the hard `ErrUtxoConflict` check, so a real double-spend still fails. The
resulting UTxO set matches the reference ledger (both transactions' outputs
present, the shared input consumed once).

Files: `database/plugin/metadata/store.go` (+interface method),
`database/plugin/metadata/sqlstore/transaction_write.go` (impl + no-op),
`database/transaction.go` (route closure path to the new method),
plus a unit test in `database/plugin/metadata/sqlite/`.

## Evidence / verification
- New unit test `TestSharedSQLStoreLeiosClosureTolerateDoubleConsume`: ranking
  path rejects the double-consume with `ErrUtxoConflict`; closure path tolerates
  it, keeps the input spent by the first tx, and writes the second tx's output.
- Deployed to two catching-up Musashi block producers wedged at `slot=1864040`.
  Both immediately logged `applied Leios endorser block transactions slot=1864040
  eb_slot=1864012 eb_txs=833` and resumed applying the network's chain toward tip,
  tracking the same ranking-block chain a Haskell reference node is at tip on.
- `go build ./...`, `go vet`, and the `database` + `sqlite` package tests pass.

## Notes
- Stacked on #3641 (EB tx full-hash validation); both are needed for a node to
  cross this region — #3641 to fetch/validate the EB, this to apply its closure.
- The last two releases tightened Leios validation (security-audit changes); this
  restores reference-conformant closure application without loosening
  ranking-block validation.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Leios closure apply path so a catching-up node no longer wedges its ledger pipeline on a legitimate cross-EB double-consume. The metadata store previously raised `ErrUtxoConflict` when a certified endorser-block transaction consumed an input already spent by a different certified transaction, but the reference ledger's `applyLeiosClosure` treats this as a no-op; now the closure path routes through a new `SetTransactionLeiosClosure` that skips already-spent inputs while still writing produced outputs, and ranking-block application keeps the hard conflict check. Also fixes endorser-block transaction validation to hash the full serialized transaction instead of only the body, since the manifest reference is content-addressed to the full transaction and body-hash validation rejects every valid tx served by a reference node.

## Bug Fixes
- Adds `SetTransactionLeiosClosure` to the `TransactionStore` interface; existing implementations must add it.
- Validates the full CBOR transaction against the manifest hash rather than the transaction body.
- Adds unit tests covering the new method, including the store surface and the double-consume behavior.
- Enriches the `ErrUtxoConflict` error with the prior spender and deletion slot for easier diagnosis.

<sup>Written for commit 0c01125ac9990e521e85765f2a781c01572ff510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Leios closure processing now tolerates legitimate cross-transaction double-consumption without incorrectly rejecting the closure.
  * Conflicting inputs continue to be rejected during standard transaction processing, with clearer conflict details.
  * Endorser transaction validation now verifies the complete transaction hash for improved correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
