### PR TITLE
fix(governance): make ratification enactment atomic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7994,7 +7994,36 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    "CIP-0163 activation" above.
 7. Governance enactment (`governance.ProcessEpoch`): treasury withdrawals and
    proposal-deposit returns, which observe the post-POOLREAP treasury. The
-   proposal-independent voting denominators — DRep voting power
+   ENACT pass first checks the locally deterministic failure surfaces used by
+   Dingo's RATIFY path: action decoding, proposal-deposit and withdrawal reward
+   addresses, protocol-parameter and hard-fork updates on cloned parameters,
+   positive committee quorum, withdrawal sum overflow, and the running treasury
+   budget. A legacy/already-ratified proposal that positively fails this
+   preflight has its ratification marker cleared and journaled at the boundary,
+   so it remains pending without blocking later proposals or epoch advance.
+   Once preflight succeeds, any error from the actual `EnactProposal` call is a
+   storage or other operational failure and aborts the whole boundary
+   transaction; it is never converted into proposal-local non-enactability.
+   Proposals already durably marked enacted at this exact boundary are replayed
+   fail-closed instead: skipping one after the stake-reward pot reset would keep
+   its enacted marker while losing its effects.
+
+   The subsequent RATIFY pass carries the post-ENACT treasury as a running
+   budget. Each accepted treasury withdrawal consumes that budget; an
+   over-budget withdrawal or a withdrawal whose `uint64` amount sum overflows
+   remains pending, and evaluation continues with later proposals. This is the
+   treasury-capacity portion of Conway RATIFY's running enactment state, not a
+   claim that this preflight implements every formal ENACT predicate. In
+   particular it does not add committee-term validation; committee membership
+   and term state remain part of the actual enactment path. A parameter update
+   is tested against a clone during preflight and that result is discarded;
+   only a successful actual enactment advances `UpdatedPParams`. RATIFY does
+   not thread a prospective parameter-update result into the parameter view of
+   later candidates in the same pass. This is another reason the behavior
+   described here is specifically the running-treasury subset, not the full
+   formal ENACT-state transition.
+
+   The proposal-independent voting denominators — DRep voting power
    (`LoadDRepVotingState`, the heavy `account`⋈`utxo` aggregation), the pool
    stake snapshot (`LoadSPOVotingState`), and committee state
    (`LoadCommitteeVotingState`) — are computed once per epoch tick and reused

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -168,6 +168,16 @@ key registered in the current `pool` row cannot prove which key was effective
 at an older boundary, so the migration never backfills historical rows from
 live pool state.
 
+Migration `v6` (`governance-ratification-history`, integer version 6) adds
+`governance_proposal_ratification_history`. Each row records the exact
+ratification state after a transition, keyed by proposal and transition slot;
+a clear transition stores NULL marker values. The migration backfills every
+existing paired ratification marker at its recorded `ratified_slot`. Runtime
+rollback first removes transitions after the rollback point, then restores the
+proposal from its latest remaining history row (or to pending when none
+remains). The append-only lifecycle sequence makes repeated clear/re-ratify
+cycles rollback-safe and survives restart on all SQL metadata providers.
+
 The upgrade runner owns a `schema_migrations` row per contiguous integer version with
 `version`, stable `name`, SHA-256 `checksum`, `phase`, opaque `cursor`, `dirty`,
 Unix-millisecond `started_at`/`updated_at`, and nullable `completed_at`.
@@ -871,6 +881,7 @@ again.
 | `deregistration_drep` | `id`, `credential_tag`, `drep_credential`, `certificate_id`, `added_slot`, `deposit_amount` | PK `id`; indexes `(credential_tag, drep_credential)`, `certificate_id`, `added_slot` | DRep deregistration certificate. |
 | `update_drep` | `id`, `credential_tag`, `credential`, `anchor_url`, `anchor_hash`, `certificate_id`, `added_slot` | PK `id`; indexes `(credential_tag, credential)`, `certificate_id`, `added_slot` | DRep update certificate. |
 | `governance_proposal` | `id`, `tx_hash`, `action_index`, `action_type`, `proposed_epoch`, `expires_epoch`, `parent_tx_hash`, `parent_action_idx`, `enacted_epoch`, `enacted_slot`, `ratified_epoch`, `ratified_slot`, `policy_hash`, `anchor_url`, `anchor_hash`, `deposit`, `return_address`, `gov_action_cbor`, `expired_epoch`, `expired_slot`, `added_slot`, `deleted_slot` | PK `id`; unique `(tx_hash, action_index)`; composite `(parent_tx_hash, parent_action_idx)` (`idx_gov_proposal_parent`); indexes action type, epochs, lifecycle slots, `added_slot`, `deleted_slot` | Governance action lifecycle. Votes join by `governance_vote.proposal_id`. `gov_action_cbor` stores the era-specific GovAction CBOR used for enactment and transaction validation; replay may rewrite ratified parameter-change actions at an era boundary, such as Conway to Dijkstra, so old databases should be rebuilt from chain data when this encoding changes. `expires_epoch` is inclusive; validation derives its final slot from the proposal epoch's start and epoch length. The ledger view exposes only rows without `enacted_epoch` or `expired_epoch` as pending actions, while the latest enacted rows for the four CIP-1694 purposes are exposed separately as purpose roots. Same-boundary epoch replay reads proposals whose `enacted_epoch/enacted_slot` or `expired_epoch/expired_slot` already match the boundary to restore treasury/reward side effects after stake reward pot reset. |
+| `governance_proposal_ratification_history` | `id`, `proposal_id`, `transition_slot`, `ratified_epoch`, `ratified_slot` | PK `id`; indexes `transition_slot`, `(proposal_id, transition_slot, id)` | Rollback journal for proposal ratification lifecycle. A paired epoch/slot records ratification; NULL marker values record an explicit return to pending. FK `proposal_id` references `governance_proposal.id` with cascade deletion. Rollback deletes transitions above the target and restores the latest remaining state, with `id` breaking ties between transitions at the same slot. |
 | `governance_vote` | `id`, `proposal_id`, `voter_type`, `voter_credential_tag`, `voter_credential`, `vote`, `anchor_url`, `anchor_hash`, `added_slot`, `vote_updated_slot`, `deleted_slot` | PK `id`; unique `(proposal_id, voter_type, voter_credential_tag, voter_credential)`; indexes proposal/voter/lifecycle slots | Vote on a governance proposal. `voter_type`: 0 committee, 1 DRep, 2 SPO. `voter_credential_tag`: 0 key hash, 1 script hash for committee/DRep voters; 0 for SPO key hashes. `vote`: 0 No, 1 Yes, 2 Abstain. |
 | `constitution` | `id`, `anchor_url`, `anchor_hash`, `policy_hash`, `added_slot`, `deleted_slot` | PK `id`; unique `added_slot`; index `deleted_slot` | Current or historical constitution references. |
 | `committee_member` | `id`, `cold_cred_hash`, `expires_epoch`, `added_slot`, `deleted_slot` | PK `id`; unique `cold_cred_hash`; indexes `added_slot`, `deleted_slot` | Snapshot-imported committee state. |
@@ -2406,6 +2417,23 @@ FROM governance_proposal
 WHERE tx_hash = decode($1, 'hex')
   AND action_index = $2
   AND deleted_slot IS NULL;
+```
+
+`ClearGovernanceProposalRatification` is the explicit lifecycle transition
+used when a legacy ratified proposal positively fails deterministic ENACT
+preflight. It clears only the ratification marker and appends the pending state
+to `governance_proposal_ratification_history` in the same transaction, without
+changing the general `SetGovernanceProposal` upsert contract (whose nil
+lifecycle fields mean "preserve the stored value"):
+
+```sql
+UPDATE governance_proposal
+SET ratified_epoch = NULL, ratified_slot = NULL
+WHERE tx_hash = $1 AND action_index = $2;
+
+INSERT INTO governance_proposal_ratification_history
+  (proposal_id, transition_slot, ratified_epoch, ratified_slot)
+VALUES ($proposal_id, $boundary_slot, NULL, NULL);
 ```
 
 Votes for a proposal:

--- a/database/governance.go
+++ b/database/governance.go
@@ -280,6 +280,43 @@ func (d *Database) SetGovernanceProposal(
 	return nil
 }
 
+// ClearGovernanceProposalRatification moves a proposal back to the active,
+// pending state at transitionSlot. Governance epoch processing uses it when a
+// legacy ratified row fails a deterministic enactment precondition.
+func (d *Database) ClearGovernanceProposalRatification(
+	txHash []byte,
+	actionIndex uint32,
+	transitionSlot uint64,
+	txn *Txn,
+) error {
+	owned := false
+	if txn == nil {
+		txn = d.MetadataTxn(true)
+		owned = true
+		defer txn.Release()
+	}
+	if err := d.governanceStore().ClearGovernanceProposalRatification(
+		txHash,
+		actionIndex,
+		transitionSlot,
+		txn.Metadata(),
+	); err != nil {
+		return fmt.Errorf(
+			"failed to clear governance proposal ratification: %w",
+			err,
+		)
+	}
+	if owned {
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf(
+				"failed to commit proposal ratification clear: %w",
+				err,
+			)
+		}
+	}
+	return nil
+}
+
 // GetChildGovernanceProposals returns all active proposals whose parent is
 // the given proposal (parentTxHash + parentActionIdx). Only proposals not
 // yet enacted, expired, or soft-deleted are returned. Used during epoch

--- a/database/plugin/metadata/domain_stores_test.go
+++ b/database/plugin/metadata/domain_stores_test.go
@@ -54,6 +54,7 @@ var governanceStoreMethods = []string{
 	"GetExpiredGovernanceProposalsAt",
 	"GetLastEnactedGovernanceProposal",
 	"SetGovernanceProposal",
+	"ClearGovernanceProposalRatification",
 	"GetChildGovernanceProposals",
 	"GetGovernanceVotes",
 	"SetGovernanceVote",

--- a/database/plugin/metadata/sqlite/ratification_history_test.go
+++ b/database/plugin/metadata/sqlite/ratification_history_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRatificationHistorySurvivesRestart(t *testing.T) {
+	dataDir := t.TempDir()
+	first, err := NewSQLStore(
+		Config{DataDir: dataDir},
+		metadata.ProviderDependencies{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+	require.NoError(t, first.Start(t.Context()))
+
+	ratifiedEpoch := uint64(5)
+	ratifiedSlot := uint64(550)
+	proposal := &models.GovernanceProposal{
+		TxHash:        []byte("restart-ratification-history"),
+		ActionIndex:   0,
+		ActionType:    6,
+		ProposedEpoch: 1,
+		ExpiresEpoch:  100,
+		RatifiedEpoch: &ratifiedEpoch,
+		RatifiedSlot:  &ratifiedSlot,
+		AnchorURL:     "https://example.invalid/governance",
+		AnchorHash:    []byte("restart-governance-anchor"),
+		ReturnAddress: []byte("restart-return-address"),
+		GovActionCbor: []byte{0x80},
+		AddedSlot:     500,
+	}
+	write := first.Transaction(t.Context())
+	require.NoError(t, first.SetGovernanceProposal(proposal, write))
+	require.NoError(t, first.ClearGovernanceProposalRatification(
+		proposal.TxHash,
+		proposal.ActionIndex,
+		600,
+		write,
+	))
+	require.NoError(t, write.Commit())
+	require.NoError(t, first.Close())
+
+	second, err := NewSQLStore(
+		Config{DataDir: dataDir},
+		metadata.ProviderDependencies{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	require.NoError(t, second.Start(t.Context()))
+
+	read := second.ReadTransaction(t.Context())
+	got, err := second.GetGovernanceProposal(
+		proposal.TxHash,
+		proposal.ActionIndex,
+		read,
+	)
+	require.NoError(t, err)
+	require.NoError(t, read.Rollback())
+	require.NotNil(t, got)
+	require.Nil(t, got.RatifiedEpoch)
+	require.Nil(t, got.RatifiedSlot)
+
+	rollback := second.Transaction(t.Context())
+	require.NoError(t, second.DeleteGovernanceProposalsAfterSlot(599, rollback))
+	require.NoError(t, rollback.Commit())
+
+	read = second.ReadTransaction(t.Context())
+	got, err = second.GetGovernanceProposal(
+		proposal.TxHash,
+		proposal.ActionIndex,
+		read,
+	)
+	require.NoError(t, err)
+	require.NoError(t, read.Rollback())
+	require.NotNil(t, got)
+	require.NotNil(t, got.RatifiedEpoch)
+	require.NotNil(t, got.RatifiedSlot)
+	require.Equal(t, uint64(5), *got.RatifiedEpoch)
+	require.Equal(t, uint64(550), *got.RatifiedSlot)
+}

--- a/database/plugin/metadata/sqlstore/governance.go
+++ b/database/plugin/metadata/sqlstore/governance.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
@@ -183,9 +184,26 @@ func (s *Store) SetGovernanceProposal(
 	if proposal == nil {
 		return errors.New("set governance proposal: nil proposal")
 	}
+	if (proposal.RatifiedEpoch == nil) != (proposal.RatifiedSlot == nil) {
+		return errors.New(
+			"set governance proposal: ratified epoch and slot must both be set or both be nil",
+		)
+	}
 	return s.withWriteTransaction(
 		txn,
 		func(db queryer, ctx context.Context) error {
+			var previousEpoch, previousSlot sql.NullInt64
+			previousErr := db.QueryRowContext(ctx, `
+SELECT ratified_epoch, ratified_slot
+FROM governance_proposal
+WHERE tx_hash = ? AND action_index = ?`,
+				proposal.TxHash,
+				proposal.ActionIndex,
+			).Scan(&previousEpoch, &previousSlot)
+			if previousErr != nil && !errors.Is(previousErr, sql.ErrNoRows) {
+				return previousErr
+			}
+
 			var id uint
 			err := db.QueryRowContext(ctx, `
 INSERT INTO governance_proposal (
@@ -249,9 +267,91 @@ RETURNING id`,
 				proposal.AddedSlot,
 				proposal.DeletedSlot,
 			).Scan(&id)
-			if err == nil {
-				proposal.ID = id
+			if err != nil {
+				return err
 			}
+			proposal.ID = id
+
+			if proposal.RatifiedEpoch == nil {
+				return nil
+			}
+			if previousErr == nil && previousEpoch.Valid && previousSlot.Valid &&
+				previousEpoch.Int64 >= 0 && previousSlot.Int64 >= 0 &&
+				uint64(previousEpoch.Int64) == *proposal.RatifiedEpoch &&
+				uint64(previousSlot.Int64) == *proposal.RatifiedSlot {
+				return nil
+			}
+			_, err = db.ExecContext(ctx, `
+INSERT INTO governance_proposal_ratification_history (
+    proposal_id, transition_slot, ratified_epoch, ratified_slot
+) VALUES (?, ?, ?, ?)`,
+				id,
+				*proposal.RatifiedSlot,
+				*proposal.RatifiedEpoch,
+				*proposal.RatifiedSlot,
+			)
+			return err
+		},
+	)
+}
+
+func (s *Store) ClearGovernanceProposalRatification(
+	txHash []byte,
+	actionIndex uint32,
+	transitionSlot uint64,
+	txn types.Txn,
+) error {
+	return s.withWriteTransaction(
+		txn,
+		func(db queryer, ctx context.Context) error {
+			var (
+				id            uint
+				ratifiedEpoch sql.NullInt64
+				ratifiedSlot  sql.NullInt64
+			)
+			if err := db.QueryRowContext(ctx, `
+SELECT id, ratified_epoch, ratified_slot
+FROM governance_proposal
+WHERE tx_hash = ? AND action_index = ?`,
+				txHash,
+				actionIndex,
+			).Scan(&id, &ratifiedEpoch, &ratifiedSlot); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return errors.New(
+						"clear proposal ratification: expected 1 row, found 0",
+					)
+				}
+				return err
+			}
+			if !ratifiedEpoch.Valid && !ratifiedSlot.Valid {
+				return nil
+			}
+			if ratifiedEpoch.Valid != ratifiedSlot.Valid {
+				return errors.New(
+					"clear proposal ratification: inconsistent ratification marker",
+				)
+			}
+			result, err := db.ExecContext(ctx, `
+UPDATE governance_proposal
+SET ratified_epoch = NULL, ratified_slot = NULL
+WHERE id = ?`, id)
+			if err != nil {
+				return err
+			}
+			rows, err := result.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if rows != 1 {
+				return fmt.Errorf(
+					"clear proposal ratification: expected 1 row, updated %d",
+					rows,
+				)
+			}
+			_, err = db.ExecContext(ctx, `
+INSERT INTO governance_proposal_ratification_history (
+    proposal_id, transition_slot, ratified_epoch, ratified_slot
+) VALUES (?, ?, NULL, NULL)`, id, transitionSlot)
 			return err
 		},
 	)
@@ -339,25 +439,58 @@ func (s *Store) DeleteGovernanceProposalsAfterSlot(
 	return s.withWriteTransaction(
 		txn,
 		func(db queryer, ctx context.Context) error {
-			queries := []string{
-				"DELETE FROM governance_proposal WHERE added_slot > ?",
-				`UPDATE governance_proposal SET deleted_slot = NULL
+			queries := []struct {
+				query string
+				args  []any
+			}{
+				{
+					query: "DELETE FROM governance_proposal WHERE added_slot > ?",
+					args:  []any{slot},
+				},
+				{
+					query: `UPDATE governance_proposal SET deleted_slot = NULL
 				 WHERE deleted_slot > ?`,
-				`UPDATE governance_proposal
-				 SET ratified_epoch = NULL, ratified_slot = NULL
-				 WHERE ratified_slot > ?`,
-				`UPDATE governance_proposal
+					args: []any{slot},
+				},
+				{
+					query: `DELETE FROM governance_proposal_ratification_history
+				 WHERE transition_slot > ?`,
+					args: []any{slot},
+				},
+				{
+					query: `UPDATE governance_proposal
+				 SET ratified_epoch = (
+				     SELECT history.ratified_epoch
+				     FROM governance_proposal_ratification_history AS history
+				     WHERE history.proposal_id = governance_proposal.id
+				     ORDER BY history.transition_slot DESC, history.id DESC
+				     LIMIT 1
+				 ), ratified_slot = (
+				     SELECT history.ratified_slot
+				     FROM governance_proposal_ratification_history AS history
+				     WHERE history.proposal_id = governance_proposal.id
+				     ORDER BY history.transition_slot DESC, history.id DESC
+				     LIMIT 1
+				 )`,
+				},
+				{
+					query: `UPDATE governance_proposal
 				 SET enacted_epoch = NULL, enacted_slot = NULL
 				 WHERE enacted_slot > ?`,
-				`UPDATE governance_proposal
+					args: []any{slot},
+				},
+				{
+					query: `UPDATE governance_proposal
 				 SET expired_epoch = NULL, expired_slot = NULL
 				 WHERE expired_slot > ?`,
+					args: []any{slot},
+				},
 			}
 			for _, query := range queries {
 				if _, err := db.ExecContext(
 					ctx,
-					query,
-					slot,
+					query.query,
+					query.args...,
 				); err != nil {
 					return err
 				}

--- a/database/plugin/metadata/sqlstore/migrations/registry.go
+++ b/database/plugin/metadata/sqlstore/migrations/registry.go
@@ -29,11 +29,12 @@ import (
 var migrationSQL embed.FS
 
 const (
-	initialSchemaRelease          = "v1alpha1"
-	leiosKeySchemaRelease         = "leios-key-registration"
-	tokenRegistrySchemaRelease    = "token-registry-metadata"
-	accountBaselineSchemaRelease  = "account-import-baseline"
-	leiosSnapshotKeySchemaRelease = "leios-snapshot-keys"
+	initialSchemaRelease                       = "v1alpha1"
+	leiosKeySchemaRelease                      = "leios-key-registration"
+	tokenRegistrySchemaRelease                 = "token-registry-metadata"
+	accountBaselineSchemaRelease               = "account-import-baseline"
+	leiosSnapshotKeySchemaRelease              = "leios-snapshot-keys"
+	governanceRatificationHistorySchemaRelease = "governance-ratification-history"
 )
 
 // schemaVersions names every migration in ascending version order.
@@ -47,6 +48,11 @@ var schemaVersions = []struct {
 	{Version: 3, Name: tokenRegistrySchemaRelease, Dir: "v3"},
 	{Version: 4, Name: accountBaselineSchemaRelease, Dir: "v4"},
 	{Version: 5, Name: leiosSnapshotKeySchemaRelease, Dir: "v5"},
+	{
+		Version: 6,
+		Name:    governanceRatificationHistorySchemaRelease,
+		Dir:     "v6",
+	},
 }
 
 // SQLiteRegistry returns the checked-in SQLite migration registry.

--- a/database/plugin/metadata/sqlstore/migrations/registry_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/registry_test.go
@@ -27,7 +27,7 @@ func TestSQLiteRegistry(t *testing.T) {
 	registry, err := SQLiteRegistry()
 	require.NoError(t, err)
 	require.NoError(t, validateRegistry(registry, "sqlite"))
-	require.Len(t, registry, 5)
+	require.Len(t, registry, 6)
 	require.Equal(t, 1, registry[0].Version)
 	require.Equal(t, "v1alpha1", registry[0].Name)
 	require.GreaterOrEqual(t, len(registry[0].SQL["sqlite"].Expand), 303)
@@ -70,6 +70,22 @@ func TestSQLiteRegistry(t *testing.T) {
 		"ALTER TABLE `pool_stake_snapshot` ADD COLUMN `leios_key_public` blob",
 		"ALTER TABLE `pool_stake_snapshot` ADD COLUMN `leios_key_possession_proof` blob",
 	}, registry[4].SQL["sqlite"].Expand)
+	require.Equal(t, 6, registry[5].Version)
+	require.Equal(
+		t,
+		"governance-ratification-history",
+		registry[5].Name,
+	)
+	require.Contains(
+		t,
+		registry[5].SQL["sqlite"].Expand[0],
+		"CREATE TABLE IF NOT EXISTS `governance_proposal_ratification_history`",
+	)
+	require.Contains(
+		t,
+		registry[5].SQL["sqlite"].Expand[3],
+		"INSERT INTO `governance_proposal_ratification_history`",
+	)
 }
 
 // TestMySQLRegistryPrefixesAccountBaselinePrimaryKey guards the v4 migration's
@@ -133,12 +149,34 @@ func TestMySQLRegistryPrefixesPoolOpCertSequenceIndex(t *testing.T) {
 	registry, err := MySQLRegistry()
 	require.NoError(t, err)
 	require.NoError(t, validateRegistry(registry, "mysql"))
-	require.Len(t, registry, 5)
+	require.Len(t, registry, 6)
 	require.Contains(
 		t,
 		registry[0].SQL["mysql"].Expand,
 		"CREATE INDEX `idx_pool_opcert_sequence_pool_sequence` ON `pool_opcert_sequence`(`pool_key_hash`(255),`sequence`)",
 	)
+}
+
+func TestRatificationHistoryMigrationTranslatesForProviders(t *testing.T) {
+	t.Parallel()
+
+	postgres, err := PostgresRegistry()
+	require.NoError(t, err)
+	postgresSQL := strings.Join(postgres[5].SQL["postgres"].Expand, "\n")
+	require.Contains(t, postgresSQL, `"id" BIGSERIAL PRIMARY KEY`)
+	require.Contains(t, postgresSQL, `"proposal_id" BIGINT NOT NULL`)
+	require.NotContains(t, postgresSQL, "`")
+
+	mysql, err := MySQLRegistry()
+	require.NoError(t, err)
+	mysqlSQL := strings.Join(mysql[5].SQL["mysql"].Expand, "\n")
+	require.Contains(t, mysqlSQL, "`id` BIGINT AUTO_INCREMENT PRIMARY KEY")
+	require.Contains(
+		t,
+		mysqlSQL,
+		"FOREIGN KEY (`proposal_id`) REFERENCES `governance_proposal`(`id`)",
+	)
+	require.NotContains(t, mysqlSQL, "CREATE INDEX IF NOT EXISTS")
 }
 
 func TestMySQLSchemaTranslationPrefixesBlobIndexes(t *testing.T) {

--- a/database/plugin/metadata/sqlstore/migrations/runner_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/runner_test.go
@@ -171,6 +171,61 @@ func TestRunnerFreshDatabaseAndIdempotentRerun(t *testing.T) {
 	require.True(t, completed.Valid)
 }
 
+func TestRatificationHistoryMigrationBackfillsExistingMarker(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	registry, err := SQLiteRegistry()
+	require.NoError(t, err)
+	runner := &Runner{
+		DB:       db,
+		Dialect:  "sqlite",
+		Registry: registry[:5],
+		Locker:   NewProcessLocker(),
+	}
+	require.NoError(t, runner.Run(context.Background()))
+	_, err = db.Exec(`
+INSERT INTO governance_proposal (
+    tx_hash, action_index, action_type, proposed_epoch, expires_epoch,
+    ratified_epoch, ratified_slot, anchor_url, anchor_hash, deposit,
+    return_address, added_slot
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[]byte("pre-history-proposal"),
+		0,
+		6,
+		1,
+		100,
+		5,
+		550,
+		"https://example.invalid/governance",
+		[]byte("pre-history-anchor"),
+		0,
+		[]byte("pre-history-return-address"),
+		500,
+	)
+	require.NoError(t, err)
+
+	runner.Registry = registry
+	require.NoError(t, runner.Run(context.Background()))
+	var transitionSlot, ratifiedEpoch, ratifiedSlot uint64
+	require.NoError(t, db.QueryRow(`
+SELECT transition_slot, ratified_epoch, ratified_slot
+FROM governance_proposal_ratification_history`).Scan(
+		&transitionSlot,
+		&ratifiedEpoch,
+		&ratifiedSlot,
+	))
+	require.Equal(t, uint64(550), transitionSlot)
+	require.Equal(t, uint64(5), ratifiedEpoch)
+	require.Equal(t, uint64(550), ratifiedSlot)
+	_, err = db.Exec(registry[5].SQL["sqlite"].Expand[3])
+	require.NoError(t, err)
+	var count int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM governance_proposal_ratification_history",
+	).Scan(&count))
+	require.Equal(t, 1, count, "migration backfill must be re-runnable")
+}
+
 func TestRunnerResumesBackfillCursor(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/database/plugin/metadata/sqlstore/migrations/v6/sqlite/expand.sql
+++ b/database/plugin/metadata/sqlstore/migrations/v6/sqlite/expand.sql
@@ -1,0 +1,31 @@
+-- Preserve every ratification-state transition so chain rollback can restore
+-- the exact marker that was current at the target slot, including across
+-- repeated clear and re-ratify cycles.
+CREATE TABLE IF NOT EXISTS `governance_proposal_ratification_history` (
+    `id` integer PRIMARY KEY AUTOINCREMENT,
+    `proposal_id` integer NOT NULL,
+    `transition_slot` integer NOT NULL,
+    `ratified_epoch` integer,
+    `ratified_slot` integer,
+    CONSTRAINT `fk_governance_proposal_ratification_history_proposal`
+        FOREIGN KEY (`proposal_id`) REFERENCES `governance_proposal`(`id`)
+        ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS `idx_governance_proposal_ratification_history_transition`
+    ON `governance_proposal_ratification_history`(`transition_slot`);
+CREATE INDEX IF NOT EXISTS `idx_governance_proposal_ratification_history_proposal_transition`
+    ON `governance_proposal_ratification_history`(`proposal_id`,`transition_slot`,`id`);
+INSERT INTO `governance_proposal_ratification_history` (
+    `proposal_id`, `transition_slot`, `ratified_epoch`, `ratified_slot`
+)
+SELECT `proposal`.`id`, `proposal`.`ratified_slot`,
+    `proposal`.`ratified_epoch`, `proposal`.`ratified_slot`
+FROM `governance_proposal` AS `proposal`
+LEFT JOIN `governance_proposal_ratification_history` AS `history`
+    ON `history`.`proposal_id` = `proposal`.`id`
+    AND `history`.`transition_slot` = `proposal`.`ratified_slot`
+    AND `history`.`ratified_epoch` = `proposal`.`ratified_epoch`
+    AND `history`.`ratified_slot` = `proposal`.`ratified_slot`
+WHERE `proposal`.`ratified_epoch` IS NOT NULL
+    AND `proposal`.`ratified_slot` IS NOT NULL
+    AND `history`.`id` IS NULL;

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -234,6 +234,16 @@ type GovernanceStore interface {
 		types.Txn,
 	) error
 
+	// ClearGovernanceProposalRatification moves a proposal back to the active,
+	// pending state at transitionSlot after a deterministic enactment
+	// precondition failure.
+	ClearGovernanceProposalRatification(
+		txHash []byte,
+		actionIndex uint32,
+		transitionSlot uint64,
+		txn types.Txn,
+	) error
+
 	// GetChildGovernanceProposals returns all active proposals whose parent
 	// is the given proposal (matched by txHash + actionIndex). Only returns
 	// proposals not yet enacted, expired, or soft-deleted. Used during

--- a/internal/test/storagetest/metadata.go
+++ b/internal/test/storagetest/metadata.go
@@ -252,6 +252,97 @@ func RunMetadataStoreConformance(
 		require.Empty(t, dreps)
 	})
 
+	t.Run("GovernanceRatificationHistoryRestoresRepeatedCycles", func(t *testing.T) {
+		proposal := &models.GovernanceProposal{
+			TxHash:        []byte(conformanceGateName(t, "proposal")),
+			ActionIndex:   0,
+			ActionType:    6,
+			ProposedEpoch: 1,
+			ExpiresEpoch:  100,
+			AnchorURL:     "https://example.invalid/governance",
+			AnchorHash:    []byte("conformance-governance-anchor"),
+			ReturnAddress: []byte("conformance-return-address"),
+			AddedSlot:     500,
+		}
+		setRatification := func(epoch, slot uint64) {
+			proposal.RatifiedEpoch = &epoch
+			proposal.RatifiedSlot = &slot
+			write := store.Transaction(t.Context())
+			defer func() { require.NoError(t, write.Rollback()) }()
+			require.NoError(
+				t,
+				governanceStore.SetGovernanceProposal(proposal, write),
+			)
+			require.NoError(t, write.Commit())
+		}
+		clearRatification := func(slot uint64) {
+			write := store.Transaction(t.Context())
+			defer func() { require.NoError(t, write.Rollback()) }()
+			require.NoError(t, governanceStore.ClearGovernanceProposalRatification(
+				proposal.TxHash,
+				proposal.ActionIndex,
+				slot,
+				write,
+			))
+			require.NoError(t, write.Commit())
+			proposal.RatifiedEpoch = nil
+			proposal.RatifiedSlot = nil
+		}
+		rollback := func(slot uint64) {
+			write := store.Transaction(t.Context())
+			defer func() { require.NoError(t, write.Rollback()) }()
+			require.NoError(
+				t,
+				governanceStore.DeleteGovernanceProposalsAfterSlot(slot, write),
+			)
+			require.NoError(t, write.Commit())
+		}
+		readMarker := func() (*uint64, *uint64) {
+			read := store.ReadTransaction(t.Context())
+			defer func() { require.NoError(t, read.Rollback()) }()
+			got, err := governanceStore.GetGovernanceProposal(
+				proposal.TxHash,
+				proposal.ActionIndex,
+				read,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			return got.RatifiedEpoch, got.RatifiedSlot
+		}
+
+		setRatification(5, 550)
+		clearRatification(600)
+		setRatification(7, 700)
+		clearRatification(800)
+		epoch, slot := readMarker()
+		require.Nil(t, epoch)
+		require.Nil(t, slot)
+
+		rollback(700)
+		epoch, slot = readMarker()
+		require.NotNil(t, epoch)
+		require.NotNil(t, slot)
+		require.Equal(t, uint64(7), *epoch)
+		require.Equal(t, uint64(700), *slot)
+
+		rollback(600)
+		epoch, slot = readMarker()
+		require.Nil(t, epoch)
+		require.Nil(t, slot)
+
+		rollback(599)
+		epoch, slot = readMarker()
+		require.NotNil(t, epoch)
+		require.NotNil(t, slot)
+		require.Equal(t, uint64(5), *epoch)
+		require.Equal(t, uint64(550), *slot)
+
+		rollback(549)
+		epoch, slot = readMarker()
+		require.Nil(t, epoch)
+		require.Nil(t, slot)
+	})
+
 	t.Run("ConstitutionRoundTripThroughNarrowStore", func(t *testing.T) {
 		// A write as well as a read: a domain interface that can only be
 		// read from would still compile at every call site the split

--- a/ledger/governance/enact.go
+++ b/ledger/governance/enact.go
@@ -239,12 +239,9 @@ func applyTreasuryWithdrawal(
 		treasury = uint64(state.Treasury)
 		reserves = uint64(state.Reserves)
 	}
-	var total uint64
-	for _, amount := range a.Withdrawals {
-		if total > ^uint64(0)-amount {
-			return errors.New("treasury withdrawal amount overflow")
-		}
-		total += amount
+	total, err := treasuryWithdrawalTotal(a)
+	if err != nil {
+		return err
 	}
 	if !ctx.TreasuryWithdrawalRemainingSet {
 		ctx.TreasuryWithdrawalRemaining = treasury
@@ -304,6 +301,25 @@ func applyTreasuryWithdrawal(
 		ctx.Slot,
 		metaTxn,
 	)
+}
+
+// treasuryWithdrawalTotal returns the amount an ENACT transition would remove
+// from its running treasury budget. Dingo stores lovelace in uint64, so an
+// action whose mathematical sum is outside that range is not enactable.
+func treasuryWithdrawalTotal(
+	a *lcommon.TreasuryWithdrawalGovAction,
+) (uint64, error) {
+	if a == nil {
+		return 0, errors.New("nil treasury withdrawal action")
+	}
+	var total uint64
+	for _, amount := range a.Withdrawals {
+		if total > ^uint64(0)-amount {
+			return 0, errors.New("treasury withdrawal amount overflow")
+		}
+		total += amount
+	}
+	return total, nil
 }
 
 // CreditRegisteredRewardAccountAfterSnapshot credits a reward account for an

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
@@ -149,22 +150,11 @@ func ProcessEpoch(
 	if err != nil {
 		return nil, fmt.Errorf("get ratified proposals: %w", err)
 	}
-	enactProposal := func(proposal *models.GovernanceProposal, replay bool) error {
-		enactCtx.PParams = out.UpdatedPParams
-		res, err := EnactProposal(enactCtx, proposal)
-		if err != nil {
-			// Abort the tick: enactment may have partially applied
-			// side effects (committee changes, treasury debit), and
-			// continuing would leave the proposal unmarked-enacted,
-			// so the next tick would re-apply it. Returning the
-			// error lets the surrounding DB transaction roll back.
-			return fmt.Errorf(
-				"enact proposal %s#%d: %w",
-				shortHash(proposal.TxHash),
-				proposal.ActionIndex,
-				err,
-			)
-		}
+	applyEnactmentResult := func(
+		proposal *models.GovernanceProposal,
+		res *EnactmentResult,
+		replay bool,
+	) {
 		if !replay {
 			out.EnactedCount++
 		}
@@ -176,16 +166,104 @@ func ProcessEpoch(
 				out.HardForkInitiated = true
 			}
 		}
-		return nil
 	}
+	enactProposal := func(
+		proposal *models.GovernanceProposal,
+		replay bool,
+	) (bool, error) {
+		// Legacy databases can contain proposals ratified before the current
+		// deterministic enactability checks existed. Classify those known
+		// semantic failures before EnactProposal performs any writes. Once this
+		// preflight succeeds, every EnactProposal error is operational and must
+		// abort the enclosing epoch transaction.
+		if !replay {
+			if _, err := ratificationEnactmentPrecondition(
+				out.UpdatedPParams,
+				in.UpdateFn,
+				proposal,
+				enactCtx.TreasuryWithdrawalRemaining,
+			); err != nil {
+				if err := in.DB.ClearGovernanceProposalRatification(
+					proposal.TxHash,
+					proposal.ActionIndex,
+					in.BoundarySlot,
+					in.Txn,
+				); err != nil {
+					return false, fmt.Errorf(
+						"return deterministically non-enactable proposal %s#%d to pending: %w",
+						shortHash(proposal.TxHash),
+						proposal.ActionIndex,
+						err,
+					)
+				}
+				proposal.RatifiedEpoch = nil
+				proposal.RatifiedSlot = nil
+				if in.Logger != nil {
+					in.Logger.Warn(
+						"governance proposal failed deterministic enactment preflight; returned it to pending",
+						"component", "governance",
+						"tx_hash", shortHash(proposal.TxHash),
+						"action_index", proposal.ActionIndex,
+						"error", err,
+						"epoch", in.NewEpoch,
+					)
+				}
+				return false, nil
+			}
+		}
+
+		candidatePParams, err := cloneGovernanceProtocolParameters(
+			out.UpdatedPParams,
+		)
+		if err != nil {
+			return false, fmt.Errorf("clone enactment pparams: %w", err)
+		}
+		enactCtx.PParams = candidatePParams
+
+		res, err := EnactProposal(enactCtx, proposal)
+		if err != nil {
+			operation := "enact proposal"
+			if replay {
+				// A replay restores the side effects of a proposal already durably
+				// marked enacted at this boundary. It is fatal for the same reason
+				// as an operational error after successful preflight: continuing
+				// would commit an enacted marker without its effects.
+				operation = "replay enacted proposal"
+			}
+			return false, fmt.Errorf(
+				"%s %s#%d: %w",
+				operation,
+				shortHash(proposal.TxHash),
+				proposal.ActionIndex,
+				err,
+			)
+		}
+		applyEnactmentResult(proposal, res, replay)
+		return true, nil
+	}
+	successfullyEnacted := append(
+		make(
+			[]*models.GovernanceProposal,
+			0,
+			len(replayedEnacted)+len(ratified),
+		),
+		replayedEnacted...,
+	)
 	for _, proposal := range replayedEnacted {
-		if err := enactProposal(proposal, true); err != nil {
+		if _, err := enactProposal(proposal, true); err != nil {
 			return nil, err
 		}
 	}
 	for _, proposal := range ratified {
-		if err := enactProposal(proposal, false); err != nil {
+		enacted, err := enactProposal(
+			proposal,
+			false,
+		)
+		if err != nil {
 			return nil, err
+		}
+		if enacted {
+			successfullyEnacted = append(successfullyEnacted, proposal)
 		}
 	}
 
@@ -261,11 +339,10 @@ func ProcessEpoch(
 	orphanSeeds := make(
 		[]*models.GovernanceProposal,
 		0,
-		len(replayedEnacted)+len(ratified)+
+		len(successfullyEnacted)+
 			len(replayedExpired)+len(expired),
 	)
-	orphanSeeds = append(orphanSeeds, replayedEnacted...)
-	orphanSeeds = append(orphanSeeds, ratified...)
+	orphanSeeds = append(orphanSeeds, successfullyEnacted...)
 	orphanSeeds = append(orphanSeeds, replayedExpired...)
 	orphanSeeds = append(orphanSeeds, expired...)
 	orphanCount, err := removeOrphanedProposals(
@@ -399,6 +476,11 @@ func ProcessEpoch(
 	// NoConfidence and UpdateCommittee in the same tick don't both
 	// fire — the spec allows at most one ratification per purpose.
 	ratifiedThisTickByPurpose := make(map[govActionPurpose]bool)
+	// RATIFY carries the post-ENACT treasury in its enactment state. Accepted
+	// withdrawals consume this budget immediately, even though they are not
+	// enacted until a later boundary and even when an unregistered destination
+	// would leave the corresponding lovelace in Dingo's physical treasury pot.
+	ratificationTreasuryRemaining := enactCtx.TreasuryWithdrawalRemaining
 
 	sort.SliceStable(stillActive, func(i, j int) bool {
 		return govActionPriority(stillActive[i]) <
@@ -540,6 +622,26 @@ func ProcessEpoch(
 		if !decision.Ratified {
 			continue
 		}
+		nextTreasuryRemaining, enactabilityErr := ratificationEnactmentPrecondition(
+			out.UpdatedPParams,
+			in.UpdateFn,
+			proposal,
+			ratificationTreasuryRemaining,
+		)
+		if enactabilityErr != nil {
+			if in.Logger != nil {
+				in.Logger.Warn(
+					"skipping proposal: enactment precondition failed",
+					"component", "governance",
+					"tx_hash", shortHash(proposal.TxHash),
+					"action_index", proposal.ActionIndex,
+					"action_type", proposal.ActionType,
+					"error", enactabilityErr,
+					"epoch", in.NewEpoch,
+				)
+			}
+			continue
+		}
 		// Per CIP-1694, the deposit is returned at enactment (or
 		// expiry), not at ratification. EnactProposal handles the
 		// refund on the next epoch tick.
@@ -555,6 +657,7 @@ func ProcessEpoch(
 		if purpose != purposeNone {
 			ratifiedThisTickByPurpose[purpose] = true
 		}
+		ratificationTreasuryRemaining = nextTreasuryRemaining
 		out.RatifiedCount++
 		if isDelayingActionPurpose(purpose) {
 			break
@@ -584,6 +687,141 @@ func ProcessEpoch(
 	}
 
 	return out, nil
+}
+
+func cloneGovernanceProtocolParameters(
+	pparams lcommon.ProtocolParameters,
+) (lcommon.ProtocolParameters, error) {
+	if pparams == nil {
+		return nil, errors.New("nil governance pparams")
+	}
+	if _, ok := pparams.(*conway.ConwayProtocolParameters); !ok {
+		return nil, fmt.Errorf(
+			"unsupported governance pparams type %T",
+			pparams,
+		)
+	}
+	data, err := cbor.Encode(pparams)
+	if err != nil {
+		return nil, fmt.Errorf("encode governance pparams: %w", err)
+	}
+	var cloned conway.ConwayProtocolParameters
+	if _, err := cbor.Decode(data, &cloned); err != nil {
+		return nil, fmt.Errorf("decode governance pparams: %w", err)
+	}
+	return &cloned, nil
+}
+
+// ratificationEnactmentPrecondition checks the deterministic failure surfaces
+// required before RATIFY may accept a proposal. It also returns the running
+// treasury budget after accepting a treasury withdrawal. Database writes are
+// deliberately not attempted here. Once this preflight succeeds, an error from
+// the later ENACT pass is treated as operational and aborts the epoch.
+func ratificationEnactmentPrecondition(
+	pparams lcommon.ProtocolParameters,
+	updateFn func(lcommon.ProtocolParameters, any) (lcommon.ProtocolParameters, error),
+	proposal *models.GovernanceProposal,
+	treasuryRemaining uint64,
+) (uint64, error) {
+	if proposal == nil {
+		return treasuryRemaining, errors.New("nil proposal")
+	}
+	if proposal.Deposit > 0 {
+		if _, _, err := rewardAccountStakeCredential(
+			proposal.ReturnAddress,
+		); err != nil {
+			return treasuryRemaining, fmt.Errorf(
+				"proposal deposit return: %w",
+				err,
+			)
+		}
+	}
+	action, err := decodeGovActionForPParams(
+		proposal.GovActionCbor,
+		proposal.ActionType,
+		pparams,
+	)
+	if err != nil {
+		return treasuryRemaining, fmt.Errorf("decode gov action: %w", err)
+	}
+
+	switch a := action.(type) {
+	case *conway.ConwayParameterChangeGovAction:
+		candidate, err := cloneGovernanceProtocolParameters(pparams)
+		if err != nil {
+			return treasuryRemaining, err
+		}
+		if _, err := updateFn(candidate, a.ParamUpdate); err != nil {
+			return treasuryRemaining, fmt.Errorf("apply param update: %w", err)
+		}
+	case *lcommon.HardForkInitiationGovAction:
+		candidate, err := cloneGovernanceProtocolParameters(pparams)
+		if err != nil {
+			return treasuryRemaining, err
+		}
+		if _, err := setProtocolVersion(
+			candidate,
+			a.ProtocolVersion.Major,
+			a.ProtocolVersion.Minor,
+		); err != nil {
+			return treasuryRemaining, fmt.Errorf("schedule hard fork: %w", err)
+		}
+	case *lcommon.TreasuryWithdrawalGovAction:
+		total, err := treasuryWithdrawalTotal(a)
+		if err != nil {
+			return treasuryRemaining, err
+		}
+		if total > treasuryRemaining {
+			return treasuryRemaining, fmt.Errorf(
+				"treasury withdrawal of %d exceeds running ratification budget %d",
+				total,
+				treasuryRemaining,
+			)
+		}
+		for rewardAddr := range a.Withdrawals {
+			if rewardAddr == nil {
+				return treasuryRemaining, errors.New(
+					"nil treasury withdrawal reward address",
+				)
+			}
+			rewardAddrBytes, err := rewardAddr.Bytes()
+			if err != nil {
+				return treasuryRemaining, fmt.Errorf(
+					"encode treasury withdrawal reward address: %w",
+					err,
+				)
+			}
+			if _, _, err := rewardAccountStakeCredential(
+				rewardAddrBytes,
+			); err != nil {
+				return treasuryRemaining, fmt.Errorf(
+					"treasury withdrawal reward account: %w",
+					err,
+				)
+			}
+		}
+		return treasuryRemaining - total, nil
+	case *lcommon.UpdateCommitteeGovAction:
+		if a.Quorum.Rat == nil || a.Quorum.Sign() <= 0 {
+			return treasuryRemaining, errors.New(
+				"committee quorum must be positive",
+			)
+		}
+	case *lcommon.InfoGovAction:
+		// RATIFY rejects Info actions before calling this preflight. A legacy
+		// row can nevertheless already carry a ratification marker, and the
+		// existing ENACT path finalizes that row without action-specific side
+		// effects. It is therefore not a deterministic EnactProposal failure.
+	case *lcommon.NoConfidenceGovAction,
+		*lcommon.NewConstitutionGovAction:
+		// These actions have no additional deterministic local precondition.
+	default:
+		return treasuryRemaining, fmt.Errorf(
+			"unsupported gov action type %T",
+			action,
+		)
+	}
+	return treasuryRemaining, nil
 }
 
 // stakeEpochFor returns the epoch whose "mark" snapshot should be used

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -575,7 +575,7 @@ func TestProcessEpochUnclaimedDepositDoesNotIncreaseWithdrawalCapacity(
 
 	txn := db.MetadataTxn(true)
 	defer txn.Release()
-	_, err = ProcessEpoch(&EpochInput{
+	out, err := ProcessEpoch(&EpochInput{
 		DB:           db,
 		Txn:          txn,
 		PrevEpoch:    4,
@@ -589,12 +589,26 @@ func TestProcessEpochUnclaimedDepositDoesNotIncreaseWithdrawalCapacity(
 			return pparams, nil
 		},
 	})
-	require.Error(t, err)
-	assert.Contains(
-		t,
-		err.Error(),
-		"exceeds tracked treasury withdrawal capacity 100",
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+	assert.Equal(t, 1, out.EnactedCount)
+	constitution, err := db.GetGovernanceProposal(testBytes(32, 8), 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, constitution.EnactedEpoch)
+	withdrawal, err := db.GetGovernanceProposal(testBytes(32, 10), 0, nil)
+	require.NoError(t, err)
+	assert.Nil(t, withdrawal.EnactedEpoch)
+	assert.Nil(t, withdrawal.RatifiedEpoch)
+	state, err := store.GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(150), uint64(state.Treasury))
+	account, err := store.GetAccountByCredential(
+		0, withdrawStakeCred, false, nil,
 	)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Zero(t, uint64(account.Reward))
 }
 
 func TestRefundProposalDepositReturnsInactiveRewardAccountToTreasury(

--- a/ledger/governance_ratification_rollback_test.go
+++ b/ledger/governance_ratification_rollback_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailedEnactmentClearRestoresRatificationOnRollback(t *testing.T) {
+	f := newTreasuryRolloverFixture(t, 100)
+	withdrawAddress, _, _ := f.rewardAddress(t, 0x91)
+	proposal := f.addProposal(
+		t,
+		0x92,
+		501,
+		map[*lcommon.Address]uint64{withdrawAddress: 40},
+		[]byte{0xff},
+		1,
+		true,
+	)
+	before := f.proposal(t, proposal)
+	require.NotNil(t, before.RatifiedSlot)
+	originalRatifiedSlot := *before.RatifiedSlot
+
+	result := f.rollover(t, f.currentEpoch, f.currentPParams)
+	cleared := f.proposal(t, proposal)
+	require.Nil(t, cleared.RatifiedSlot)
+
+	rollbackPoint := result.NewCurrentEpoch.StartSlot - 1
+	require.GreaterOrEqual(t, rollbackPoint, originalRatifiedSlot)
+	require.NoError(t, f.db.DeleteGovernanceProposalsAfterSlot(rollbackPoint, nil))
+
+	restored := f.proposal(t, proposal)
+	require.NotNil(
+		t,
+		restored.RatifiedSlot,
+		"rollback must restore the earlier ratification marker",
+	)
+	require.Equal(t, originalRatifiedSlot, *restored.RatifiedSlot)
+}
+
+func TestNodeLocalEnactmentWriteErrorAbortsBoundary(t *testing.T) {
+	f := newTreasuryRolloverFixture(t, 100)
+	withdrawAddress, returnAddress, stakeCredential := f.rewardAddress(t, 0xa1)
+	proposal := f.addProposal(
+		t,
+		0xa2,
+		501,
+		map[*lcommon.Address]uint64{withdrawAddress: 40},
+		returnAddress,
+		0,
+		true,
+	)
+	before := f.proposal(t, proposal)
+	require.NotNil(t, before.RatifiedSlot)
+	originalRatifiedSlot := *before.RatifiedSlot
+
+	raw, err := dbtest.RawSQLiteMetadata(t, f.db)
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+CREATE TRIGGER fail_governance_enact
+BEFORE UPDATE OF enacted_slot ON governance_proposal
+WHEN NEW.enacted_slot IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'injected enactment write failure');
+END`)
+	require.NoError(t, err)
+
+	txn := f.db.Transaction(true)
+	err = txn.Do(func(txn *database.Txn) error {
+		_, rolloverErr := f.ls.processEpochRollover(
+			txn,
+			f.currentEpoch,
+			eras.ConwayEraDesc,
+			f.currentPParams,
+			false,
+		)
+		return rolloverErr
+	})
+	assert.Error(t, err, "a storage error must abort the boundary transaction")
+
+	after := f.proposal(t, proposal)
+	require.NotNil(t, after.RatifiedSlot)
+	assert.Equal(
+		t,
+		originalRatifiedSlot,
+		*after.RatifiedSlot,
+		"an aborted boundary must preserve the earlier ratification marker",
+	)
+	assert.Nil(t, after.EnactedSlot)
+	assert.Zero(t, f.accountReward(t, stakeCredential))
+	treasury, _, _ := networkState(t, f.db)
+	assert.Equal(t, uint64(100), treasury)
+	advancedEpoch, epochErr := f.db.Metadata().GetEpoch(
+		f.currentEpoch.EpochId+1,
+		nil,
+	)
+	require.NoError(t, epochErr)
+	assert.Nil(t, advancedEpoch)
+}
+
+func TestEnactmentWriteHealthyControlCommitsBoundary(t *testing.T) {
+	f := newTreasuryRolloverFixture(t, 100)
+	withdrawAddress, returnAddress, stakeCredential := f.rewardAddress(t, 0xb1)
+	proposal := f.addProposal(
+		t,
+		0xb2,
+		501,
+		map[*lcommon.Address]uint64{withdrawAddress: 40},
+		returnAddress,
+		0,
+		true,
+	)
+
+	result := f.rollover(t, f.currentEpoch, f.currentPParams)
+	after := f.proposal(t, proposal)
+	require.NotNil(t, after.EnactedSlot)
+	require.Equal(t, result.NewCurrentEpoch.StartSlot, *after.EnactedSlot)
+	require.Equal(t, uint64(40), f.accountReward(t, stakeCredential))
+	treasury, _, _ := networkState(t, f.db)
+	require.Equal(t, uint64(60), treasury)
+	advancedEpoch, err := f.db.Metadata().GetEpoch(
+		f.currentEpoch.EpochId+1,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, advancedEpoch)
+}

--- a/ledger/governance_treasury_rollover_test.go
+++ b/ledger/governance_treasury_rollover_test.go
@@ -1,0 +1,422 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const treasuryRolloverGenesisHash = "0101010101010101010101010101010101010101010101010101010101010101"
+
+type treasuryRolloverFixture struct {
+	ls             *LedgerState
+	db             *database.Database
+	currentEpoch   models.Epoch
+	currentPParams *conway.ConwayProtocolParameters
+	hotCredential  []byte
+}
+
+func newTreasuryRolloverFixture(
+	t *testing.T,
+	treasury uint64,
+) *treasuryRolloverFixture {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbtest.CloseDatabase(db))
+	})
+
+	cfg := newTestEraHistoryCfg(t)
+	cfg.ShelleyGenesisHash = treasuryRolloverGenesisHash
+	currentEpoch := newTestEpoch(5, 500, 100, eras.ConwayEraDesc.Id)
+	require.NoError(t, db.SetEpoch(
+		currentEpoch.StartSlot,
+		currentEpoch.EpochId,
+		currentEpoch.Nonce,
+		currentEpoch.EvolvingNonce,
+		currentEpoch.CandidateNonce,
+		currentEpoch.LastEpochBlockNonce,
+		currentEpoch.EraId,
+		currentEpoch.SlotLength,
+		currentEpoch.LengthInSlots,
+		nil,
+	))
+	require.NoError(t, db.Metadata().SetNetworkState(treasury, 1_000, 499, nil))
+
+	pparams := donationTestConwayPParams(10)
+	pparams.MinCommitteeSize = 1
+	pparams.DRepVotingThresholds.TreasuryWithdrawal = cbor.Rat{
+		Rat: big.NewRat(0, 1),
+	}
+
+	coldCredential := repeatByte(28, 0xc1)
+	hotCredential := repeatByte(28, 0xc2)
+	require.NoError(t, db.SetCommitteeMembers([]*models.CommitteeMember{{
+		ColdCredHash: coldCredential,
+		ExpiresEpoch: currentEpoch.EpochId + 20,
+		AddedSlot:    1,
+	}}, nil))
+	require.NoError(t, db.SetCommitteeQuorum(big.NewRat(1, 1), 1, nil))
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+INSERT INTO auth_committee_hot (
+    cold_credential, host_credential, certificate_id, added_slot
+) VALUES (?, ?, ?, ?)`, coldCredential, hotCredential, 1, 1)
+	require.NoError(t, err)
+
+	ls := &LedgerState{
+		db:             db,
+		currentEra:     eras.ConwayEraDesc,
+		currentEpoch:   currentEpoch,
+		currentPParams: pparams,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger: slog.New(slog.NewJSONHandler(
+				io.Discard,
+				nil,
+			)),
+		},
+	}
+	return &treasuryRolloverFixture{
+		ls:             ls,
+		db:             db,
+		currentEpoch:   currentEpoch,
+		currentPParams: pparams,
+		hotCredential:  hotCredential,
+	}
+}
+
+func (f *treasuryRolloverFixture) rewardAddress(
+	t *testing.T,
+	marker byte,
+) (*lcommon.Address, []byte, []byte) {
+	t.Helper()
+	stakeCredential := repeatByte(28, marker)
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		stakeCredential,
+	)
+	require.NoError(t, err)
+	addressBytes, err := address.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, f.db.CreateAccount(nil, &models.Account{
+		StakingKey: stakeCredential,
+		Reward:     types.Uint64(0),
+		Active:     true,
+	}))
+	return &address, addressBytes, stakeCredential
+}
+
+func (f *treasuryRolloverFixture) addProposal(
+	t *testing.T,
+	marker byte,
+	addedSlot uint64,
+	withdrawals map[*lcommon.Address]uint64,
+	returnAddress []byte,
+	deposit uint64,
+	ratified bool,
+) *models.GovernanceProposal {
+	t.Helper()
+	actionCbor, err := cbor.Encode(&lcommon.TreasuryWithdrawalGovAction{
+		Type:        2,
+		Withdrawals: withdrawals,
+	})
+	require.NoError(t, err)
+	proposal := &models.GovernanceProposal{
+		TxHash:        repeatByte(32, marker),
+		ActionIndex:   0,
+		ActionType:    uint8(lcommon.GovActionTypeTreasuryWithdrawal),
+		ProposedEpoch: f.currentEpoch.EpochId,
+		ExpiresEpoch:  f.currentEpoch.EpochId + 20,
+		AnchorURL:     "https://example.invalid/treasury-withdrawal",
+		AnchorHash:    repeatByte(32, marker+1),
+		Deposit:       deposit,
+		ReturnAddress: returnAddress,
+		GovActionCbor: actionCbor,
+		AddedSlot:     addedSlot,
+	}
+	if ratified {
+		ratifiedEpoch := f.currentEpoch.EpochId
+		ratifiedSlot := f.currentEpoch.StartSlot + 50
+		proposal.RatifiedEpoch = &ratifiedEpoch
+		proposal.RatifiedSlot = &ratifiedSlot
+	}
+	require.NoError(t, f.db.SetGovernanceProposal(proposal, nil))
+	require.NoError(t, f.db.SetGovernanceVote(&models.GovernanceVote{
+		ProposalID:      proposal.ID,
+		VoterType:       models.VoterTypeCC,
+		VoterCredential: f.hotCredential,
+		Vote:            models.VoteYes,
+		AddedSlot:       addedSlot + 1,
+	}, nil))
+	return proposal
+}
+
+func (f *treasuryRolloverFixture) rollover(
+	t *testing.T,
+	currentEpoch models.Epoch,
+	currentPParams lcommon.ProtocolParameters,
+) *EpochRolloverResult {
+	t.Helper()
+	var result *EpochRolloverResult
+	txn := f.db.Transaction(true)
+	err := txn.Do(func(txn *database.Txn) error {
+		var rolloverErr error
+		result, rolloverErr = f.ls.processEpochRollover(
+			txn,
+			currentEpoch,
+			eras.ConwayEraDesc,
+			currentPParams,
+			false,
+		)
+		return rolloverErr
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func (f *treasuryRolloverFixture) proposal(
+	t *testing.T,
+	proposal *models.GovernanceProposal,
+) *models.GovernanceProposal {
+	t.Helper()
+	loaded, err := f.db.GetGovernanceProposal(
+		proposal.TxHash,
+		proposal.ActionIndex,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	return loaded
+}
+
+func (f *treasuryRolloverFixture) accountReward(
+	t *testing.T,
+	stakeCredential []byte,
+) uint64 {
+	t.Helper()
+	account, err := f.db.GetAccountByCredential(
+		0,
+		stakeCredential,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	return uint64(account.Reward)
+}
+
+func TestProcessEpochRolloverTreasuryRatificationUsesRunningBudget(
+	t *testing.T,
+) {
+	f := newTreasuryRolloverFixture(t, 100)
+	firstAddress, firstReturn, firstCredential := f.rewardAddress(t, 0x11)
+	secondAddress, secondReturn, secondCredential := f.rewardAddress(t, 0x21)
+	thirdAddress, thirdReturn, _ := f.rewardAddress(t, 0x31)
+	fourthAddress, fourthReturn, fourthCredential := f.rewardAddress(t, 0x41)
+	fifthAddress, _, _ := f.rewardAddress(t, 0x51)
+
+	first := f.addProposal(
+		t, 0x61, 501,
+		map[*lcommon.Address]uint64{firstAddress: 70},
+		firstReturn, 0, false,
+	)
+	second := f.addProposal(
+		t, 0x62, 503,
+		map[*lcommon.Address]uint64{secondAddress: 40},
+		secondReturn, 0, false,
+	)
+	overflow := f.addProposal(
+		t, 0x63, 505,
+		map[*lcommon.Address]uint64{
+			thirdAddress: ^uint64(0),
+			fifthAddress: 1,
+		},
+		thirdReturn, 0, false,
+	)
+	fourth := f.addProposal(
+		t, 0x64, 507,
+		map[*lcommon.Address]uint64{fourthAddress: 30},
+		fourthReturn, 0, false,
+	)
+
+	firstRollover := f.rollover(t, f.currentEpoch, f.currentPParams)
+	assert.Equal(
+		t,
+		f.currentEpoch.EpochId+1,
+		firstRollover.NewCurrentEpoch.EpochId,
+	)
+	assert.NotNil(t, f.proposal(t, first).RatifiedEpoch)
+	assert.Nil(t, f.proposal(t, second).RatifiedEpoch)
+	assert.Nil(t, f.proposal(t, overflow).RatifiedEpoch)
+	assert.NotNil(t, f.proposal(t, fourth).RatifiedEpoch)
+
+	secondRollover := f.rollover(
+		t,
+		firstRollover.NewCurrentEpoch,
+		firstRollover.NewCurrentPParams,
+	)
+	assert.Equal(
+		t,
+		f.currentEpoch.EpochId+2,
+		secondRollover.NewCurrentEpoch.EpochId,
+	)
+	assert.NotNil(t, f.proposal(t, first).EnactedEpoch)
+	assert.Nil(t, f.proposal(t, second).RatifiedEpoch)
+	assert.Nil(t, f.proposal(t, overflow).RatifiedEpoch)
+	assert.NotNil(t, f.proposal(t, fourth).EnactedEpoch)
+	assert.Equal(t, uint64(70), f.accountReward(t, firstCredential))
+	assert.Equal(t, uint64(0), f.accountReward(t, secondCredential))
+	assert.Equal(t, uint64(30), f.accountReward(t, fourthCredential))
+	treasury, _, _ := networkState(t, f.db)
+	assert.Zero(t, treasury)
+}
+
+func TestProcessEpochRolloverEnactmentFailureRollsBackAndRetries(
+	t *testing.T,
+) {
+	f := newTreasuryRolloverFixture(t, 100)
+	failingAddress, failingReturn, failingCredential := f.rewardAddress(t, 0x71)
+	succeedingAddress, succeedingReturn, succeedingCredential := f.rewardAddress(
+		t,
+		0x72,
+	)
+	failing := f.addProposal(
+		t, 0x73, 501,
+		map[*lcommon.Address]uint64{failingAddress: 60},
+		[]byte{0xff}, 1, true,
+	)
+	succeeding := f.addProposal(
+		t, 0x74, 503,
+		map[*lcommon.Address]uint64{succeedingAddress: 50},
+		succeedingReturn, 0, true,
+	)
+	firstRollover := f.rollover(t, f.currentEpoch, f.currentPParams)
+	assert.Equal(
+		t,
+		f.currentEpoch.EpochId+1,
+		firstRollover.NewCurrentEpoch.EpochId,
+	)
+	failedAfterRollover := f.proposal(t, failing)
+	assert.Nil(t, failedAfterRollover.EnactedEpoch)
+	assert.Nil(t, failedAfterRollover.RatifiedEpoch)
+	assert.Nil(t, failedAfterRollover.ExpiredEpoch)
+	assert.Nil(t, failedAfterRollover.DeletedSlot)
+	assert.NotNil(t, f.proposal(t, succeeding).EnactedEpoch)
+	assert.Zero(t, f.accountReward(t, failingCredential))
+	assert.Equal(t, uint64(50), f.accountReward(t, succeedingCredential))
+	treasury, reserves, _ := networkState(t, f.db)
+	assert.Equal(t, uint64(50), treasury)
+
+	retry := f.proposal(t, failing)
+	retry.ReturnAddress = failingReturn
+	require.NoError(t, f.db.SetGovernanceProposal(retry, nil))
+	require.NoError(t, f.db.Metadata().SetNetworkState(
+		70,
+		reserves,
+		firstRollover.NewCurrentEpoch.StartSlot+50,
+		nil,
+	))
+
+	secondRollover := f.rollover(
+		t,
+		firstRollover.NewCurrentEpoch,
+		firstRollover.NewCurrentPParams,
+	)
+	assert.Equal(
+		t,
+		f.currentEpoch.EpochId+2,
+		secondRollover.NewCurrentEpoch.EpochId,
+	)
+	assert.Nil(t, f.proposal(t, failing).EnactedEpoch)
+	assert.NotNil(t, f.proposal(t, failing).RatifiedEpoch)
+	assert.Zero(t, f.accountReward(t, failingCredential))
+	assert.Equal(t, uint64(50), f.accountReward(t, succeedingCredential))
+	treasury, _, _ = networkState(t, f.db)
+	assert.Equal(t, uint64(70), treasury)
+
+	thirdRollover := f.rollover(
+		t,
+		secondRollover.NewCurrentEpoch,
+		secondRollover.NewCurrentPParams,
+	)
+	assert.Equal(
+		t,
+		f.currentEpoch.EpochId+3,
+		thirdRollover.NewCurrentEpoch.EpochId,
+	)
+	assert.NotNil(t, f.proposal(t, failing).EnactedEpoch)
+	assert.Equal(t, uint64(60), f.accountReward(t, failingCredential))
+	assert.Equal(t, uint64(50), f.accountReward(t, succeedingCredential))
+	treasury, _, _ = networkState(t, f.db)
+	assert.Equal(t, uint64(10), treasury)
+}
+
+func TestProcessEpochRolloverReplayEnactmentFailureRemainsFatal(
+	t *testing.T,
+) {
+	f := newTreasuryRolloverFixture(t, 100)
+	withdrawAddress, _, stakeCredential := f.rewardAddress(t, 0x81)
+	proposal := f.addProposal(
+		t, 0x82, 501,
+		map[*lcommon.Address]uint64{withdrawAddress: 40},
+		[]byte{0xff}, 1, true,
+	)
+	enactedEpoch := f.currentEpoch.EpochId + 1
+	enactedSlot := f.currentEpoch.StartSlot +
+		uint64(f.currentEpoch.LengthInSlots)
+	proposal.EnactedEpoch = &enactedEpoch
+	proposal.EnactedSlot = &enactedSlot
+	require.NoError(t, f.db.SetGovernanceProposal(proposal, nil))
+
+	txn := f.db.Transaction(true)
+	err := txn.Do(func(txn *database.Txn) error {
+		_, rolloverErr := f.ls.processEpochRollover(
+			txn,
+			f.currentEpoch,
+			eras.ConwayEraDesc,
+			f.currentPParams,
+			false,
+		)
+		return rolloverErr
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replay enacted proposal")
+	assert.Zero(t, f.accountReward(t, stakeCredential))
+	treasury, _, _ := networkState(t, f.db)
+	assert.Equal(t, uint64(100), treasury)
+	newEpoch, err := f.db.Metadata().GetEpoch(enactedEpoch, nil)
+	require.NoError(t, err)
+	assert.Nil(t, newEpoch)
+}


### PR DESCRIPTION
## Summary

- preflight deterministic enactment failures before ratification
- enforce the running treasury-withdrawal budget
- persist ratification history for rollback and restart recovery
- abort epoch processing on enactment storage failures

## Validation

- focused ledger tests under the race detector
- SQLite, MySQL, and PostgreSQL metadata tests under the race detector
- 315/315 conformance vectors on each metadata backend
- architecture and documentation parity tests

Closes #3652


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes governance enactment atomic so a deterministically un-enactable ratified proposal no longer blocks the epoch boundary. Previously a known failure (bad return address, over-budget withdrawal) aborted the entire tick; now the proposal is returned to pending and later proposals still ratify and enact. Operational storage errors during enactment still abort the boundary transaction and roll back everything.

**Migration**

- Adds `governance_proposal_ratification_history` (migration `v6`) to journal every ratification transition so rollback restores the exact prior marker, including repeated clear/re-ratify cycles.
- Existing ratified proposals are backfilled from their current marker; no manual action needed.

**Behavior**

- RATIFY now enforces a running treasury withdrawal budget, carrying the post-ENACT treasury and skipping over-budget or overflowing withdrawals while continuing with later proposals.
- Preflight covers action decoding, deposit-return and withdrawal addresses, parameter/hard-fork updates on cloned parameters, and positive committee quorum; it does not add committee-term validation.
- Replayed proposals already marked enacted at the boundary fail closed on error instead of being skipped.
- Fixes #3652.

<sup>Written for commit 60c84f13f33adfdb34145f3fdb66d010119c6434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Governance proposals with predictable enactment issues now remain pending instead of blocking epoch rollover.
  - Treasury withdrawals are evaluated against a running budget, allowing later valid proposals to proceed.
  - Governance ratification history is preserved across rollbacks, restarts, and repeated state changes.
  - Unexpected enactment failures still safely abort the boundary operation.

- **Documentation**
  - Updated architecture and database documentation to explain governance rollover and ratification history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->