### PR TITLE
fix(governance): apply SPO non-voter rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8018,6 +8018,11 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    used by standalone/test callers. The mid-epoch HardForkInitiation stability
    check snapshots and threads this gate through `StabilityCheckInputs` as well,
    keeping its advertised transition tally aligned with boundary ratification.
+   `TallyContext.MajorVersion` is assigned from the post-ENACT protocol
+   parameters in both paths. SPO tallying first honors an explicit vote, then
+   treats every silent pool as implicit No for HardForkInitiation; during
+   Conway bootstrap, silent pools on other actions are Abstain. Only
+   post-bootstrap non-voters reach the reward-account default-vote rules.
 8. Treasury donations (`applyEpochDonations`), added after withdrawals.
 9. ADA-pot capture (`saveRewardAdaPotsForEpoch`): record the new epoch's
    reserves, treasury, and fees after every boundary treasury/reserves mutation

--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -386,6 +386,9 @@ func ProcessEpoch(
 	}
 
 	majorVersion := conwayPParams.ProtocolVersion.Major
+	// RATIFY uses the post-ENACT protocol version for both threshold
+	// selection and action-specific SPO non-voter semantics.
+	tallyCtx.MajorVersion = majorVersion
 	// Computed after ENACT and reused across the RATIFY loop. The
 	// RATIFY loop marks proposals but does not enact committee state.
 	ccQuorum, err := conwayRatifyQuorum(

--- a/ledger/governance/spo_nonvoter_test.go
+++ b/ledger/governance/spo_nonvoter_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package governance
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	spoNonVoterYesStake    uint64 = 60
+	spoNonVoterSilentStake uint64 = 40
+)
+
+type spoNonVoterRatificationCase struct {
+	actionType           lcommon.GovActionType
+	rewardDefault        uint64
+	thresholdNumerator   int64
+	thresholdDenominator int64
+	silentVote           *uint8
+}
+
+func votePointer(vote uint8) *uint8 {
+	return &vote
+}
+
+// TestProcessEpochSPONonVoterDenominators matches the same 60/40 stake
+// distribution on both sides of the Conway bootstrap rule. A silent pool on a
+// HardForkInitiation remains in the denominator, so 60% passes exactly 60% but
+// not 61%. A silent pool on a bootstrap ParameterChange is Abstain, so the same
+// explicit Yes stake passes both thresholds.
+func TestProcessEpochSPONonVoterDenominators(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actionType  lcommon.GovActionType
+		defaultDRep uint64
+		numerator   int64
+		denominator int64
+		wantRatify  bool
+	}{
+		{
+			name:        "hard fork at denominator equality",
+			actionType:  lcommon.GovActionTypeHardForkInitiation,
+			defaultDRep: models.DrepTypeAlwaysAbstain,
+			numerator:   3,
+			denominator: 5,
+			wantRatify:  true,
+		},
+		{
+			name:        "hard fork above denominator ratio",
+			actionType:  lcommon.GovActionTypeHardForkInitiation,
+			defaultDRep: models.DrepTypeAlwaysAbstain,
+			numerator:   61,
+			denominator: 100,
+			wantRatify:  false,
+		},
+		{
+			name:        "bootstrap parameter change at implicit-no ratio",
+			actionType:  lcommon.GovActionTypeParameterChange,
+			defaultDRep: models.DrepTypeAlwaysNoConfidence,
+			numerator:   3,
+			denominator: 5,
+			wantRatify:  true,
+		},
+		{
+			name:        "bootstrap parameter change above implicit-no ratio",
+			actionType:  lcommon.GovActionTypeParameterChange,
+			defaultDRep: models.DrepTypeAlwaysNoConfidence,
+			numerator:   61,
+			denominator: 100,
+			wantRatify:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ratified := runSPONonVoterRatification(t, spoNonVoterRatificationCase{
+				actionType:           testCase.actionType,
+				rewardDefault:        testCase.defaultDRep,
+				thresholdNumerator:   testCase.numerator,
+				thresholdDenominator: testCase.denominator,
+			})
+			assert.Equal(t, testCase.wantRatify, ratified)
+		})
+	}
+}
+
+// TestProcessEpochSPONonVoterRatification exercises the complete persisted
+// RATIFY path and the explicit-vote controls. Reward-account defaults cannot
+// turn a silent hard-fork pool into Abstain, while an explicit Abstain still
+// does. Bootstrap makes a silent pool Abstain before reward defaults, while an
+// explicit No still remains No.
+func TestProcessEpochSPONonVoterRatification(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actionType  lcommon.GovActionType
+		defaultDRep uint64
+		silentVote  *uint8
+		wantRatify  bool
+	}{
+		{
+			name:        "hard fork silent pool is implicit no",
+			actionType:  lcommon.GovActionTypeHardForkInitiation,
+			defaultDRep: models.DrepTypeAlwaysAbstain,
+			wantRatify:  false,
+		},
+		{
+			name:        "hard fork explicit abstain is excluded",
+			actionType:  lcommon.GovActionTypeHardForkInitiation,
+			defaultDRep: models.DrepTypeAlwaysAbstain,
+			silentVote:  votePointer(models.VoteAbstain),
+			wantRatify:  true,
+		},
+		{
+			name:        "bootstrap parameter-change silent pool abstains",
+			actionType:  lcommon.GovActionTypeParameterChange,
+			defaultDRep: models.DrepTypeAlwaysNoConfidence,
+			wantRatify:  true,
+		},
+		{
+			name:        "bootstrap parameter-change explicit no remains no",
+			actionType:  lcommon.GovActionTypeParameterChange,
+			defaultDRep: models.DrepTypeAlwaysNoConfidence,
+			silentVote:  votePointer(models.VoteNo),
+			wantRatify:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ratified := runSPONonVoterRatification(t, spoNonVoterRatificationCase{
+				actionType:           testCase.actionType,
+				rewardDefault:        testCase.defaultDRep,
+				thresholdNumerator:   3,
+				thresholdDenominator: 4,
+				silentVote:           testCase.silentVote,
+			})
+			assert.Equal(t, testCase.wantRatify, ratified)
+		})
+	}
+}
+
+func runSPONonVoterRatification(
+	t *testing.T,
+	testCase spoNonVoterRatificationCase,
+) bool {
+	t.Helper()
+	db, store := newTallyTestDB(t)
+	proposal := seedSPONonVoterProposal(t, db, testCase.actionType)
+
+	coldCredential := testBytes(28, 0xE1)
+	hotCredential := testBytes(28, 0xE2)
+	require.NoError(t, db.SetCommitteeMembers([]*models.CommitteeMember{{
+		ColdCredHash: coldCredential,
+		ExpiresEpoch: stabilityTestEpoch + 10,
+		AddedSlot:    1,
+	}}, nil))
+	seedTallyCommitteeAuth(t, store, models.AuthCommitteeHot{
+		ColdCredential: coldCredential,
+		HotCredential:  hotCredential,
+		CertificateID:  1,
+		AddedSlot:      1,
+	})
+
+	yesPool := testBytes(28, 0xE3)
+	silentPool := testBytes(28, 0xE4)
+	snapshotEpoch := stakeEpochFor(stabilityTestEpoch)
+	seedPoolWithStake(
+		t, store, yesPool, testBytes(28, 0xE5), spoNonVoterYesStake,
+		snapshotEpoch,
+	)
+	seedPoolWithStake(
+		t, store, silentPool, testBytes(28, 0xE6), spoNonVoterSilentStake,
+		snapshotEpoch,
+	)
+	seedRewardAccountDelegation(
+		t, store, testBytes(28, 0xE6), nil, testCase.rewardDefault,
+	)
+	resolveSnapshotAutoVotes(t, db, snapshotEpoch)
+
+	for _, vote := range []*models.GovernanceVote{
+		{
+			ProposalID:      proposal.ID,
+			VoterType:       models.VoterTypeCC,
+			VoterCredential: hotCredential,
+			Vote:            models.VoteYes,
+			AddedSlot:       2,
+		},
+		{
+			ProposalID:      proposal.ID,
+			VoterType:       models.VoterTypeSPO,
+			VoterCredential: yesPool,
+			Vote:            models.VoteYes,
+			AddedSlot:       2,
+		},
+	} {
+		require.NoError(t, db.SetGovernanceVote(vote, nil))
+	}
+	if testCase.silentVote != nil {
+		require.NoError(t, db.SetGovernanceVote(&models.GovernanceVote{
+			ProposalID:      proposal.ID,
+			VoterType:       models.VoterTypeSPO,
+			VoterCredential: silentPool,
+			Vote:            *testCase.silentVote,
+			AddedSlot:       2,
+		}, nil))
+	}
+
+	pparams := conwayPParamsFixture(bootstrapProtocolVersion)
+	threshold := newRat(
+		testCase.thresholdNumerator,
+		testCase.thresholdDenominator,
+	)
+	switch testCase.actionType {
+	case lcommon.GovActionTypeHardForkInitiation:
+		pparams.PoolVotingThresholds.HardForkInitiation = threshold
+	case lcommon.GovActionTypeParameterChange:
+		pparams.PoolVotingThresholds.PpSecurityGroup = threshold
+	default:
+		t.Fatalf("unsupported governance action type %d", testCase.actionType)
+	}
+
+	txn := db.MetadataTxn(true)
+	defer txn.Release()
+	out, err := ProcessEpoch(&EpochInput{
+		DB:           db,
+		Txn:          txn,
+		PrevEpoch:    stabilityTestEpoch - 1,
+		NewEpoch:     stabilityTestEpoch,
+		BoundarySlot: 500,
+		PParams:      pparams,
+		UpdateFn: func(
+			parameters lcommon.ProtocolParameters,
+			_ any,
+		) (lcommon.ProtocolParameters, error) {
+			return parameters, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit())
+
+	stored, err := db.GetGovernanceProposal(proposal.TxHash, proposal.ActionIndex, nil)
+	require.NoError(t, err)
+	ratified := out.RatifiedCount == 1
+	assert.Equal(t, ratified, stored.RatifiedEpoch != nil)
+	assert.Equal(t, ratified, stored.RatifiedSlot != nil)
+	return ratified
+}
+
+func seedSPONonVoterProposal(
+	t *testing.T,
+	db *database.Database,
+	actionType lcommon.GovActionType,
+) *models.GovernanceProposal {
+	t.Helper()
+	var actionCBOR []byte
+	var err error
+	switch actionType {
+	case lcommon.GovActionTypeHardForkInitiation:
+		action := &lcommon.HardForkInitiationGovAction{
+			Type: uint(lcommon.GovActionTypeHardForkInitiation),
+		}
+		action.ProtocolVersion.Major = bootstrapProtocolVersion + 1
+		actionCBOR, err = cbor.Encode(action)
+	case lcommon.GovActionTypeParameterChange:
+		maxTxSize := uint(16_384)
+		actionCBOR, err = cbor.Encode(&conway.ConwayParameterChangeGovAction{
+			Type: uint(lcommon.GovActionTypeParameterChange),
+			ParamUpdate: conway.ConwayProtocolParameterUpdate{
+				MaxTxSize: &maxTxSize,
+			},
+		})
+	default:
+		t.Fatalf("unsupported governance action type %d", actionType)
+	}
+	require.NoError(t, err)
+
+	proposal := &models.GovernanceProposal{
+		TxHash:        testBytes(32, byte(actionType)+0xF0),
+		ActionIndex:   0,
+		ActionType:    uint8(actionType),
+		ProposedEpoch: stabilityTestEpoch - 1,
+		ExpiresEpoch:  stabilityTestEpoch + 10,
+		Deposit:       1_000,
+		ReturnAddress: testBytes(29, 0xF8),
+		AnchorURL:     "https://example.invalid/spo-nonvoter",
+		AnchorHash:    testBytes(32, 0xF9),
+		GovActionCbor: actionCBOR,
+		AddedSlot:     1,
+	}
+	require.NoError(t, db.SetGovernanceProposal(proposal, nil))
+	stored, err := db.GetGovernanceProposal(proposal.TxHash, proposal.ActionIndex, nil)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	return stored
+}

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -132,6 +132,7 @@ func EvaluateRatifiableHardForkInitiation(
 		Txn:                   in.Txn,
 		StakeEpoch:            stakeEpochFor(in.CurrentEpoch),
 		CurrentEpoch:          in.CurrentEpoch,
+		MajorVersion:          conwayPParams.ProtocolVersion.Major,
 		DelegatorInactivityOn: in.DelegatorInactivityOn,
 	}
 

--- a/ledger/governance/tally.go
+++ b/ledger/governance/tally.go
@@ -57,10 +57,14 @@ type ProposalTally struct {
 // distribution — callers should pass currentEpoch-2 so the rotation
 // lines up with the "Go" snapshot used for voting.
 type TallyContext struct {
-	DB             *database.Database
-	Txn            *database.Txn
-	StakeEpoch     uint64
-	CurrentEpoch   uint64
+	DB           *database.Database
+	Txn          *database.Txn
+	StakeEpoch   uint64
+	CurrentEpoch uint64
+	// MajorVersion is the current protocol major version after ENACT.
+	// SPO non-voter semantics use it to distinguish Conway bootstrap
+	// from post-bootstrap ratification.
+	MajorVersion   uint
 	CommitteeState *CommitteeVotingState
 	// DRepState and SPOState carry the proposal-independent voting
 	// denominators (DRep voting power, pool stake snapshot) so they are
@@ -429,10 +433,15 @@ func tallyDRepVotes(
 
 // tallySPOVotes computes SPO yes/no/abstain stake against the pool
 // stake distribution snapshot at StakeEpoch, applying the CIP-1694
-// reward-account delegation rules:
+// non-voter and reward-account delegation rules:
 //
 //   - Pools with an explicit vote in `votes` use that vote.
-//   - Pools without an explicit vote fall back to the auto-vote
+//   - Pools without an explicit vote on HardForkInitiation count as
+//     implicit No, regardless of protocol version or reward-account
+//     delegation.
+//   - During Conway bootstrap, pools without an explicit vote on any
+//     other action count as Abstain.
+//   - After bootstrap, pools without an explicit vote fall back to the auto-vote
 //     pre-computed at snapshot capture time
 //     (PoolStakeSnapshot.RewardAccountAutoVote):
 //     Abstain        → SPOAbstainStake (excluded from the active
@@ -521,7 +530,11 @@ func tallySPOVotes(
 		voteByPool[string(v.VoterCredential)] = v.Vote
 	}
 
-	isNoConfidenceAction := lcommon.GovActionType(tally.ActionType) ==
+	actionType := lcommon.GovActionType(tally.ActionType)
+	isHardForkInitiation := actionType ==
+		lcommon.GovActionTypeHardForkInitiation
+	inBootstrap := ctx.MajorVersion == bootstrapProtocolVersion
+	isNoConfidenceAction := actionType ==
 		lcommon.GovActionTypeNoConfidence
 
 	for _, s := range dist {
@@ -551,12 +564,31 @@ func tallySPOVotes(
 			continue
 		}
 
+		// The reference RATIFY rule applies non-voter semantics before
+		// consulting reward-account defaults. HardForkInitiation always
+		// keeps silent-pool stake in the active denominator as implicit No.
+		if isHardForkInitiation {
+			continue
+		}
+		// During Conway bootstrap, every other silent pool is Abstain and
+		// therefore excluded from the active SPO denominator.
+		if inBootstrap {
+			tally.SPOAbstainStake, err = addUint64(
+				tally.SPOAbstainStake, stake,
+			)
+			if err != nil {
+				return fmt.Errorf("spo abstain stake: %w", err)
+			}
+			continue
+		}
+
 		// Only trust RewardAccountAutoVote when the row is flagged
-		// as resolved. Unresolved rows (Mithril-imported set/go
-		// rotations, or rows written by pre-CIP-1694 code) fall
-		// back to PoolRewardAccountAutoVoteNone — implicit no — so
-		// stale or never-computed values can never silently bucket
-		// stake into Abstain or NoConfidence.
+		// as resolved after the action/version-specific non-voter rules
+		// above. Unresolved rows (Mithril-imported set/go rotations, or
+		// rows written by pre-CIP-1694 code) then fall back to
+		// PoolRewardAccountAutoVoteNone — implicit no — so stale or
+		// never-computed values can never silently bucket stake into
+		// Abstain or NoConfidence.
 		if !s.RewardAccountAutoVoteResolved {
 			continue
 		}


### PR DESCRIPTION
Summary:
- apply hard-fork implicit-No semantics for silent SPOs
- apply bootstrap abstention semantics to other silent SPO votes
- propagate action and protocol-version context through ratification

Validation:
- focused regressions with fail-before proof
- governance and ledger suites, including race coverage
- conformance and architecture checks

Fixes #3689

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3689 by applying the Conway SPO non-voter rules during ratification. Silent SPO pools are now implicit No for HardForkInitiation and Abstain for other actions during bootstrap, instead of falling through to reward-account defaults.

**Changes**
- Threads the post-ENACT protocol major version into SPO tallying for both epoch and mid-epoch hard-fork paths.
- Applies implicit-No semantics to silent SPO pools on HardForkInitiation before reward-account defaults.
- Treats silent SPO pools on other actions as Abstain during Conway bootstrap.
- Keeps post-bootstrap reward-account default-vote behavior unchanged.
- Adds focused ratification tests covering explicit votes, silent pools, and threshold boundaries.

<sup>Written for commit c4bbabed438918e0a849a51bf0d9503cf3f1e341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

