### PR TITLE
fix(governance): enforce committee term limits

### DIFF
--- a/ledger/governance/epoch.go
+++ b/ledger/governance/epoch.go
@@ -475,39 +475,34 @@ func ProcessEpoch(
 		if err != nil {
 			return nil, fmt.Errorf("tally: %w", err)
 		}
-		// For ParameterChange, decode the action so thresholds can
-		// take the touched parameter groups into account (especially
-		// so SPOs only gate security-group changes, and DReps select
-		// the most restrictive touched group).
+		// Decode the action once for every action-specific ratification
+		// predicate. ParameterChange uses the touched parameter groups for
+		// threshold selection, while UpdateCommittee checks proposed member
+		// expiries against the current epoch and committee term limit.
+		action, decodeErr := decodeGovAction(
+			proposal.GovActionCbor, proposal.ActionType,
+		)
+		if decodeErr != nil {
+			if in.Logger != nil {
+				in.Logger.Error(
+					"skipping proposal: failed to decode governance action",
+					"tx_hash",
+					shortHash(proposal.TxHash),
+					"action_index",
+					proposal.ActionIndex,
+					"action_type",
+					proposal.ActionType,
+					"error",
+					decodeErr,
+					"component",
+					"governance",
+				)
+			}
+			continue
+		}
 		var paramUpdate *conway.ConwayProtocolParameterUpdate
 		if lcommon.GovActionType(proposal.ActionType) ==
 			lcommon.GovActionTypeParameterChange {
-			action, decodeErr := decodeGovAction(
-				proposal.GovActionCbor, proposal.ActionType,
-			)
-			if decodeErr != nil {
-				// A decode failure means we cannot tell which
-				// parameter groups are touched; silently falling
-				// through with paramUpdate==nil would let SPO
-				// checks return nil and allow security-group
-				// changes to ratify without SPO approval. Skip
-				// this proposal and surface the error so it is
-				// investigated.
-				if in.Logger != nil {
-					in.Logger.Error(
-						"skipping proposal: failed to decode parameter change action",
-						"tx_hash",
-						shortHash(proposal.TxHash),
-						"action_index",
-						proposal.ActionIndex,
-						"error",
-						decodeErr,
-						"component",
-						"governance",
-					)
-				}
-				continue
-			}
 			a, ok := action.(*conway.ConwayParameterChangeGovAction)
 			if !ok {
 				if in.Logger != nil {
@@ -530,7 +525,9 @@ func ProcessEpoch(
 		decision := ShouldRatify(RatifyInputs{
 			Tally:                 tally,
 			PParams:               conwayPParams,
+			GovAction:             action,
 			ParamUpdate:           paramUpdate,
+			CurrentEpoch:          in.NewEpoch,
 			ActiveDRepCount:       activeDRepCount,
 			ActiveCCCount:         activeCCCount,
 			CCQuorum:              ccQuorum,

--- a/ledger/governance/epoch_test.go
+++ b/ledger/governance/epoch_test.go
@@ -15,6 +15,7 @@
 package governance
 
 import (
+	"math"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -710,6 +711,155 @@ func TestCommitteeNoConfidenceStateUsesEnactedCommitteeRoot(t *testing.T) {
 	assert.True(t, committeeNoConfidenceState(&models.GovernanceProposal{
 		ActionType: uint8(lcommon.GovActionTypeNoConfidence),
 	}))
+}
+
+func TestProcessEpochCommitteeTermLimit(t *testing.T) {
+	const currentEpoch = uint64(10)
+	uintPtr := func(value uint) *uint { return &value }
+	tests := []struct {
+		name         string
+		termLimit    uint64
+		memberExpiry *uint
+		actionType   lcommon.GovActionType
+		wantRatified bool
+	}{
+		{
+			name:         "within limit",
+			termLimit:    5,
+			memberExpiry: uintPtr(14),
+			actionType:   lcommon.GovActionTypeUpdateCommittee,
+			wantRatified: true,
+		},
+		{
+			name:         "exact boundary",
+			termLimit:    5,
+			memberExpiry: uintPtr(15),
+			actionType:   lcommon.GovActionTypeUpdateCommittee,
+			wantRatified: true,
+		},
+		{
+			name:         "over limit remains pending",
+			termLimit:    5,
+			memberExpiry: uintPtr(16),
+			actionType:   lcommon.GovActionTypeUpdateCommittee,
+			wantRatified: false,
+		},
+		{
+			name:         "overflowing bound",
+			termLimit:    math.MaxUint64,
+			memberExpiry: uintPtr(20),
+			actionType:   lcommon.GovActionTypeUpdateCommittee,
+			wantRatified: true,
+		},
+		{
+			name:         "empty members",
+			termLimit:    0,
+			actionType:   lcommon.GovActionTypeUpdateCommittee,
+			wantRatified: true,
+		},
+		{
+			name:         "non committee action",
+			termLimit:    0,
+			actionType:   lcommon.GovActionTypeNoConfidence,
+			wantRatified: true,
+		},
+	}
+
+	for testIndex, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, _ := newTallyTestDB(t)
+			var action lcommon.GovAction
+			switch test.actionType {
+			case lcommon.GovActionTypeUpdateCommittee:
+				members := make(map[*lcommon.Credential]uint)
+				if test.memberExpiry != nil {
+					credential := &lcommon.Credential{
+						CredType: lcommon.CredentialTypeAddrKeyHash,
+					}
+					copy(credential.Credential[:], testBytes(28, byte(testIndex+1)))
+					members[credential] = *test.memberExpiry
+				}
+				action = &lcommon.UpdateCommitteeGovAction{
+					Type:       uint(test.actionType),
+					CredEpochs: members,
+					Quorum:     newRat(2, 3),
+				}
+			case lcommon.GovActionTypeNoConfidence:
+				action = &lcommon.NoConfidenceGovAction{
+					Type: uint(test.actionType),
+				}
+			default:
+				t.Fatalf("unsupported action type %d", test.actionType)
+			}
+			actionCBOR, err := cbor.Encode(action)
+			require.NoError(t, err)
+
+			txHash := testBytes(32, byte(0x80+testIndex))
+			require.NoError(t, db.SetGovernanceProposal(
+				&models.GovernanceProposal{
+					TxHash:        txHash,
+					ActionIndex:   0,
+					ActionType:    uint8(test.actionType),
+					ProposedEpoch: currentEpoch - 1,
+					ExpiresEpoch:  currentEpoch + 10,
+					AnchorURL:     "https://example.invalid/committee-term",
+					AnchorHash:    testBytes(32, byte(0x90+testIndex)),
+					ReturnAddress: testBytes(29, byte(0xa0+testIndex)),
+					GovActionCbor: actionCBOR,
+					AddedSlot:     100,
+				},
+				nil,
+			))
+
+			pparams := conwayPParamsFixture(10)
+			pparams.CommitteeTermLimit = test.termLimit
+			pparams.DRepVotingThresholds.CommitteeNormal = newRat(0, 1)
+			pparams.PoolVotingThresholds.CommitteeNormal = newRat(0, 1)
+			pparams.DRepVotingThresholds.MotionNoConfidence = newRat(0, 1)
+			pparams.PoolVotingThresholds.MotionNoConfidence = newRat(0, 1)
+
+			txn := db.MetadataTxn(true)
+			defer txn.Release()
+			out, err := ProcessEpoch(&EpochInput{
+				DB:           db,
+				Txn:          txn,
+				PrevEpoch:    currentEpoch - 1,
+				NewEpoch:     currentEpoch,
+				BoundarySlot: 500,
+				PParams:      pparams,
+				UpdateFn: func(
+					pparams lcommon.ProtocolParameters,
+					_ any,
+				) (lcommon.ProtocolParameters, error) {
+					return pparams, nil
+				},
+			})
+			require.NoError(t, err)
+			require.NoError(t, txn.Commit())
+
+			if test.wantRatified {
+				assert.Equal(t, 1, out.RatifiedCount)
+			} else {
+				assert.Equal(t, 0, out.RatifiedCount)
+			}
+			proposal, err := db.GetGovernanceProposal(txHash, 0, nil)
+			require.NoError(t, err)
+			if test.wantRatified {
+				require.NotNil(t, proposal.RatifiedEpoch)
+				assert.Equal(t, currentEpoch, *proposal.RatifiedEpoch)
+			} else {
+				assert.Nil(t, proposal.RatifiedEpoch)
+				assert.Nil(t, proposal.RatifiedSlot)
+				assert.Nil(t, proposal.EnactedEpoch)
+				assert.Nil(t, proposal.ExpiredEpoch)
+				assert.Nil(t, proposal.DeletedSlot)
+				active, err := db.GetActiveGovernanceProposals(currentEpoch, nil)
+				require.NoError(t, err)
+				require.Len(t, active, 1)
+				assert.Equal(t, txHash, active[0].TxHash)
+			}
+		})
+	}
 }
 
 // buildInfoProposal is a test helper that creates a GovernanceProposal with

--- a/ledger/governance/ratify.go
+++ b/ledger/governance/ratify.go
@@ -43,12 +43,14 @@ type RatifyDecision struct {
 }
 
 // RatifyInputs is the decoded-action-aware shape callers pass to
-// ShouldRatify. The paramUpdate pointer is consulted for ParameterChange
-// proposals so DRep and SPO thresholds can be selected precisely.
+// ShouldRatify. GovAction carries the proposal body for action-specific
+// predicates, while ParamUpdate selects precise ParameterChange thresholds.
 type RatifyInputs struct {
 	Tally                 *ProposalTally
 	PParams               *conway.ConwayProtocolParameters
+	GovAction             lcommon.GovAction
 	ParamUpdate           *conway.ConwayProtocolParameterUpdate
+	CurrentEpoch          uint64
 	ActiveDRepCount       int // reserved for future min-DRep-count gate
 	ActiveCCCount         int
 	CCQuorum              *big.Rat
@@ -97,6 +99,22 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 			return decision
 		default:
 			decision.FailureReason = "action is not eligible during bootstrap"
+			return decision
+		}
+	}
+
+	if actionType == lcommon.GovActionTypeUpdateCommittee {
+		updateCommittee, ok := in.GovAction.(*lcommon.UpdateCommitteeGovAction)
+		if !ok || updateCommittee == nil {
+			decision.FailureReason = "missing update committee action"
+			return decision
+		}
+		if !committeeTermsWithinLimit(
+			updateCommittee,
+			in.CurrentEpoch,
+			in.PParams.CommitteeTermLimit,
+		) {
+			decision.FailureReason = "committee member term exceeds limit"
 			return decision
 		}
 	}
@@ -166,6 +184,25 @@ func ShouldRatify(in RatifyInputs) RatifyDecision {
 		decision.FailureReason = "threshold not met"
 	}
 	return decision
+}
+
+// committeeTermsWithinLimit implements Conway RATIFY's
+// validCommitteeTerm predicate. Subtraction after the greater-than check is
+// equivalent to expiry <= currentEpoch + termLimit without overflowing the
+// epoch sum. An empty member map satisfies the universal predicate.
+func committeeTermsWithinLimit(
+	action *lcommon.UpdateCommitteeGovAction,
+	currentEpoch uint64,
+	termLimit uint64,
+) bool {
+	for _, expiry := range action.CredEpochs {
+		expiryEpoch := uint64(expiry)
+		if expiryEpoch > currentEpoch &&
+			expiryEpoch-currentEpoch > termLimit {
+			return false
+		}
+	}
+	return true
 }
 
 // getDRepThreshold returns the DRep yes-ratio threshold for the action

--- a/ledger/governance/ratify_test.go
+++ b/ledger/governance/ratify_test.go
@@ -71,9 +71,18 @@ func ratifyInputs(
 	majorVersion uint,
 	committeeNoConfidence bool,
 ) RatifyInputs {
+	var govAction lcommon.GovAction
+	if tally != nil && lcommon.GovActionType(tally.ActionType) ==
+		lcommon.GovActionTypeUpdateCommittee {
+		govAction = &lcommon.UpdateCommitteeGovAction{
+			Type:       uint(lcommon.GovActionTypeUpdateCommittee),
+			CredEpochs: map[*lcommon.Credential]uint{},
+		}
+	}
 	return RatifyInputs{
 		Tally:                 tally,
 		PParams:               pparams,
+		GovAction:             govAction,
 		ActiveDRepCount:       activeDReps,
 		ActiveCCCount:         activeCC,
 		CCQuorum:              ccQuorum,
@@ -385,9 +394,17 @@ func TestShouldRatify_ActionBodyMatrixAcrossBootstrapBoundary(t *testing.T) {
 				if tc.action == lcommon.GovActionTypeInfo {
 					want = false
 				}
+				var govAction lcommon.GovAction
+				if tc.action == lcommon.GovActionTypeUpdateCommittee {
+					govAction = &lcommon.UpdateCommitteeGovAction{
+						Type:       uint(tc.action),
+						CredEpochs: map[*lcommon.Credential]uint{},
+					}
+				}
 				d := ShouldRatify(RatifyInputs{
 					Tally:         makeTally(tc.action, votes),
 					PParams:       pparams,
+					GovAction:     govAction,
 					ParamUpdate:   tc.param,
 					ActiveCCCount: 3,
 					CCQuorum:      big.NewRat(2, 3),

--- a/ledger/governance/stability.go
+++ b/ledger/governance/stability.go
@@ -177,27 +177,8 @@ func EvaluateRatifiableHardForkInitiation(
 		if !validateParentChain(proposal, hardForkRoot) {
 			continue
 		}
-		tally, err := TallyProposal(tallyCtx, proposal)
-		if err != nil {
-			return nil, fmt.Errorf("tally proposal: %w", err)
-		}
-		decision := ShouldRatify(RatifyInputs{
-			Tally:                 tally,
-			PParams:               conwayPParams,
-			ParamUpdate:           nil, // not used for HardForkInitiation
-			ActiveDRepCount:       activeDRepCount,
-			ActiveCCCount:         committeeState.ActiveMemberCount,
-			CCQuorum:              ccQuorum,
-			MajorVersion:          conwayPParams.ProtocolVersion.Major,
-			CommitteeNoConfidence: committeeNoConfidence,
-		})
-		if !decision.Ratified {
-			continue
-		}
-		// Decode to extract the target protocol version; an active
-		// HardForkInitiation that fails to decode here is a
-		// data-integrity bug, but the conservative behaviour is to
-		// skip it rather than abort the whole check.
+		// Decode before ratification so the same decoded-action-aware input
+		// shape is used by this mid-epoch check and the boundary RATIFY loop.
 		action, err := decodeGovAction(
 			proposal.GovActionCbor, proposal.ActionType,
 		)
@@ -205,6 +186,25 @@ func EvaluateRatifiableHardForkInitiation(
 			if in.OnProposalDecodeFailure != nil {
 				in.OnProposalDecodeFailure(proposal, err)
 			}
+			continue
+		}
+		tally, err := TallyProposal(tallyCtx, proposal)
+		if err != nil {
+			return nil, fmt.Errorf("tally proposal: %w", err)
+		}
+		decision := ShouldRatify(RatifyInputs{
+			Tally:                 tally,
+			PParams:               conwayPParams,
+			GovAction:             action,
+			ParamUpdate:           nil, // not used for HardForkInitiation
+			CurrentEpoch:          in.CurrentEpoch,
+			ActiveDRepCount:       activeDRepCount,
+			ActiveCCCount:         committeeState.ActiveMemberCount,
+			CCQuorum:              ccQuorum,
+			MajorVersion:          conwayPParams.ProtocolVersion.Major,
+			CommitteeNoConfidence: committeeNoConfidence,
+		})
+		if !decision.Ratified {
 			continue
 		}
 		hf, ok := action.(*lcommon.HardForkInitiationGovAction)

--- a/ledger/governance/tally_test.go
+++ b/ledger/governance/tally_test.go
@@ -113,8 +113,12 @@ func TestTallyDRepVotesIncludesAlwaysNoConfidence(t *testing.T) {
 	assert.True(t, noConfidenceDecision.DRepApproved)
 
 	updateCommitteeDecision := ShouldRatify(RatifyInputs{
-		Tally:           updateCommitteeTally,
-		PParams:         pparams,
+		Tally:   updateCommitteeTally,
+		PParams: pparams,
+		GovAction: &lcommon.UpdateCommitteeGovAction{
+			Type:       uint(lcommon.GovActionTypeUpdateCommittee),
+			CredEpochs: map[*lcommon.Credential]uint{},
+		},
 		ActiveDRepCount: 0,
 		MajorVersion:    10,
 	})


### PR DESCRIPTION
Summary:
- enforce committee member term limits during ratification
- propagate the current epoch and decoded action through governance processing
- keep over-limit proposals pending

Validation:
- focused regressions with fail-before proof
- governance and ledger suites, including race coverage
- conformance, formatting, architecture, and import-boundary checks

Fixes #3688

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces committee term limits for `UpdateCommittee` proposals during ratification; proposals whose member expiries exceed `CommitteeTermLimit` now stay pending instead of being ratified. Fixes #3688.

- `ShouldRatify` now receives the decoded governance action and current epoch so it can check proposed member expiries.
- Decodes the action once in both epoch-boundary and mid-epoch ratification paths instead of only for `ParameterChange`.
- Proposals with over-limit member expiries remain active and pending; empty member sets are unaffected.

<sup>Written for commit 9e7070b4b1306d138d4a20d742643bd56ec0d691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

