### PR TITLE
fix(forging): enforce protocol KES lifetime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3897,33 +3897,31 @@ The start, expiry, current-period, and remaining-period gauges use that same
 protocol lifetime; the KES key's `2^depth` cryptographic capacity remains a
 separate upper bound rather than an operational lifetime.
 
-Each production forge attempt identifies one complete credential generation at
-the runtime gate. It releases that generation before the pluggable
-`LeaderChecker` callback so a callback that synchronously initiates a reload
-cannot deadlock on the generation lock, then reacquires the generation and
-requires the generation number to be unchanged. A concurrent reload therefore
-abandons the slot rather than mixing election from one generation with
-construction or signing from another. Once revalidated after selection, the
-attempt holds the generation read lease through KES evolution, VRF/KES signing,
-and local block construction. `DefaultBlockBuilder` receives that same
-package-private generation rather than re-reading `PoolCredentials`. The lease
-ends once the block is signed, before pluggable validation, adoption, and
-observability callbacks, because those phases no longer consume credentials
-and may safely initiate a reload themselves. The pool ID and VRF verification
-key are permanently pinned by the first successful load on a
-`PoolCredentials`; later reloads may rotate KES/opcert material for that
-identity but an attempted pool or VRF identity replacement clears the active
-generation and is rejected. This keeps the long-lived leader schedule's
-identity coherent without rebuilding it during a forge attempt.
-Credential reload and KES-policy revalidation take the exclusive side of the
-generation lock, which is separate from the ordinary credential accessor
-lock. They therefore wait for an in-flight attempt without preventing a
-pluggable builder from using read-only credential accessors. Reload and
-revalidation cannot replace the key, opcert, start, maximum, or expiry
-independently. A completed reload or
-revalidation is therefore a linearization boundary: the old generation may
-finish before it, while the next attempt sees the new generation in its gate,
-signing inputs, logs, and gauges together.
+Each production forge attempt takes an independently owned snapshot of one
+complete credential generation at the runtime gate. The snapshot deep-copies
+the VRF secret, KES secret, verification keys, opcert, and validated lifetime;
+it never aliases mutable key material in `PoolCredentials`. No credential lock
+is therefore held across the pluggable leader, Leios, mempool, ledger,
+block-builder, validation, adoption, or observer callbacks. A callback may
+synchronously reload or revalidate credentials without waiting on its own call
+stack. The snapshot's secret copies are best-effort zeroized when the attempt
+finishes.
+
+Generation checks after leader and Leios callbacks and after block construction
+reject callback output when the owner generation changed. This is required for
+custom builders, which cannot consume the package-private snapshot. The
+`DefaultBlockBuilder` receives the exact snapshot and performs the same check
+before returning, so provider-triggered reloads cannot publish a block assembled
+from shared mutable credentials. KES evolution advances the still-current owner
+and its private snapshot before provider callbacks; VRF proof, opcert fields,
+and KES signature are then derived only from that snapshot. A concurrent reload
+that linearizes after a generation check may coexist with the old snapshot, but
+cannot mutate it or mix its cryptographic inputs. The pool ID and VRF
+verification key remain permanently pinned by the first successful load;
+later reloads may rotate KES/opcert material for that identity, while an
+attempted pool or VRF identity replacement clears the active generation and is
+rejected. This keeps the long-lived leader schedule coherent without rebuilding
+it during a forge attempt.
 
 Steps 2, 6, and 7 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 7) already recovered its own panics separately, since observability hooks are expected to be best-effort.
 
@@ -3943,10 +3941,11 @@ reading the key. Operational certificates contain public data and remain
 exempt from the secret-key permission check.
 
 `PoolCredentials.LoadFromFiles` parses replacement files before taking the
-exclusive generation lock, then atomically installs all key material and the
-opcert as a new, unvalidated generation. A failed reload clears the active
-credentials while retaining the first successful load's pool/VRF identity pin,
-so a later retry cannot silently switch the identity used by leader election.
+credential write lock, then atomically installs all key material and the opcert
+as a new, unvalidated generation. Replaced VRF and KES secret material is
+best-effort zeroized. A failed reload clears the active credentials while
+retaining the first successful load's pool/VRF identity pin, so a later retry
+cannot silently switch the identity used by leader election.
 Operational-certificate signature and KES-key validation is generation state:
 every load clears it, `ValidateOpCert` publishes it only for the current
 generation, and `ValidateKESPeriod` repeats the cryptographic check before it

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3854,18 +3854,20 @@ Both halves of sigma come from the same Mark row set for the same snapshot epoch
 `BlockForger` runs a slot-based loop that:
 1. Waits for the next slot boundary using the wall-clock slot timer
 2. Checks leader eligibility via the `Election`
-3. Reads the parent ranking block's `LeiosAnnouncement`, selects only the matching eligible Leios endorser-block certificate, and independently produces and broadcasts a new endorser block for the current slot when eligible
-4. Assembles a block from a neutral pending-transaction provider using `DefaultBlockBuilder`
-5. Optionally self-validates the forged block before adoption (see below)
-6. Submits the forged block directly to the primary chain for synchronous local
+3. Computes the current KES period and declines forging at the operational
+   certificate's protocol expiry
+4. Reads the parent ranking block's `LeiosAnnouncement`, selects only the matching eligible Leios endorser-block certificate, and independently produces and broadcasts a new endorser block for the current slot when eligible
+5. Assembles a block from a neutral pending-transaction provider using `DefaultBlockBuilder`
+6. Optionally self-validates the forged block before adoption (see below)
+7. Submits the forged block directly to the primary chain for synchronous local
    admission, before running observability callbacks. Local admission validates
    the actual chain tip and contiguous block number, but does not compare the
    block with peer-delivered pending headers. Successful adoption clears those
    now-conflicting headers; a genuinely stale parent is still rejected without
    changing the queued headers.
-7. After successful local adoption, synchronously removes the block's confirmed transactions from the mempool
+8. After successful local adoption, synchronously removes the block's confirmed transactions from the mempool
 
-Step 4's transaction selection runs inside `LedgerState.WithTxValidationSession`
+Step 5's transaction selection runs inside `LedgerState.WithTxValidationSession`
 (the same mechanism the mempool backend rebuilds use above): one pinned ledger
 generation, one validation reference slot, and one repeatable-read transaction
 cover every mempool transaction considered for the candidate block, not a
@@ -3878,19 +3880,28 @@ it, by slot, hash, and block number, against the parent point the candidate
 already committed to (`nextBlockNumber`/`prevHash`) before selection started;
 a mismatch — a peer block landing mid-selection — rejects the candidate
 before VRF/KES signing (`selected parent changed during block assembly`)
-rather than relying solely on step 6's `Chain.AddLocalBlock` check, which
+rather than relying solely on step 7's `Chain.AddLocalBlock` check, which
 still runs as the final backstop against any race not closed here.
 
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.
 KES periods are computed from the era-aware absolute slot (`currentSlot / slotsPerKESPeriod`) for both startup opcert validation and forge-time signing, so networks with Byron-era prefixes do not skew the current KES period by converting wall-clock duration directly through the Shelley slot length.
+Successful startup validation captures Shelley genesis `MaxKESEvolutions` on
+the loaded credentials. `NewBlockForger` rejects credentials without that
+validated protocol lifetime and precomputes the expiry with overflow checks.
+At each leader slot, the runtime gate admits the half-open interval
+`[opcertStart, opcertStart + MaxKESEvolutions)` and logs/counts a
+could-not-forge disposition at or after the exclusive end before either Leios
+or ranking-block construction. The expiry and remaining-period gauges use that
+same protocol lifetime; the KES key's `2^depth` cryptographic capacity remains
+a separate upper bound rather than an operational lifetime.
 
-Steps 2, 5, and 6 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 6) already recovered its own panics separately, since observability hooks are expected to be best-effort.
+Steps 2, 6, and 7 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 7) already recovered its own panics separately, since observability hooks are expected to be best-effort.
 
 When Dijkstra/Leios is active, `DefaultBlockBuilder` emits the Musashi prototype's 12-field Dijkstra header body for every forged Dijkstra ranking block: the standard Praos/Babbage fields plus `leios_certified` and `leios_announcement`. A locally forged endorser block is announced in the same-slot ranking block's `leios_announcement` as `[eb_hash, eb_size]`; `eb_size` is rejected before header construction if it exceeds the CDDL `uint .size 4` bound. If the pipeline has a certified, non-equivocated EB inside its inclusion window whose hash matches the parent ranking block's `LeiosAnnouncement`, the forger also populates the prototype `DijkstraLeiosCertificate` body field and sets `leios_certified=true`. Prototype-2026w29 permits that CertRB to carry the new same-slot announcement as well as the certificate for its parent's EB. Before constructing the new EB, the forger reads the certified EB's manifest and filters those transaction hashes from its mempool view, matching the prototype's post-certificate rebase without mutating the live mempool before block adoption; if the certified closure is unavailable, it safely forges the certificate-only RB. The certified EB is marked embedded only after the CertRB is adopted locally.
 
 #### Optional Self-Validation (`DINGO_VALIDATE_FORGED_BLOCK`)
 
-When `validateForgedBlock` is enabled in config, the forger invokes `LedgerState.ValidateForgedBlock` between step 3 and step 5. This runs three checks: (a) VRF proof and KES signature verification of the block header, (b) body-hash non-zero guard, and (c) per-transaction ledger rule validation against the current UTxO state with an intra-block overlay so outputs created by earlier transactions in the same block are visible to later ones. A failing block is logged, counted in `dingo_forge_validation_failed_total`, and dropped without being adopted or diffused. Validation wall-clock time is recorded in the `dingo_forge_validation_duration_seconds` histogram. Disabled by default; intended for block producers who want defence-in-depth against builder bugs at the cost of additional forge-to-diffusion latency.
+When `validateForgedBlock` is enabled in config, the forger invokes `LedgerState.ValidateForgedBlock` between steps 5 and 7. This runs three checks: (a) VRF proof and KES signature verification of the block header, (b) body-hash non-zero guard, and (c) per-transaction ledger rule validation against the current UTxO state with an intra-block overlay so outputs created by earlier transactions in the same block are visible to later ones. A failing block is logged, counted in `dingo_forge_validation_failed_total`, and dropped without being adopted or diffused. Validation wall-clock time is recorded in the `dingo_forge_validation_duration_seconds` histogram. Disabled by default; intended for block producers who want defence-in-depth against builder bugs at the cost of additional forge-to-diffusion latency.
 
 ### Pool Credentials (`ledger/forging/keys.go`, `keystore/`)
 
@@ -3900,6 +3911,12 @@ VRF and KES secret-key loads check permissions on the open file handle and
 reject group/other access on Unix or insecure DACL grants on Windows before
 reading the key. Operational certificates contain public data and remain
 exempt from the secret-key permission check.
+
+`PoolCredentials.ValidateKESPeriod` validates and retains the Shelley genesis
+protocol lifetime only on success. Reloading credentials or any failed
+validation clears it, so production construction fails closed instead of
+falling back to the KES depth capacity. `OpCertExpiryPeriod` and
+`PeriodsRemaining` report zero until that policy has been validated.
 
 ### Leios Voting (`ledger/leios/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3955,12 +3955,17 @@ atomically publishes the opcert
 `{start, MaxKESEvolutions, expiry}` policy only on success; failed validation
 retains the loaded material but clears the policy. Both paths therefore fail
 closed instead of falling back to an older policy or the KES depth capacity.
+Revalidating an unchanged, already-valid operational certificate preserves its
+published protocol lifetime; a failed revalidation still clears that lifetime.
 `OpCertExpiryPeriod` and `PeriodsRemaining` report zero until the current
 generation has both a validated certificate and policy. The exported
 `DefaultBlockBuilder.BuildBlock` and `BuildBlockWithLeios` entrypoints enforce
 that same half-open interval inside the generation-backed builder path before
 they inspect the chain tip, mempool, VRF key, or Leios inputs, so direct callers
-cannot bypass the forger's outer gate.
+cannot bypass the forger's outer gate. `BlockForger.SignBlockHeader` also
+requires the same validated interval; `PoolCredentials.KESSign` remains the
+lower-level cryptographic primitive used by credential tooling and tests that
+may not have Shelley genesis context.
 
 ### Leios Voting (`ledger/leios/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3853,9 +3853,9 @@ Both halves of sigma come from the same Mark row set for the same snapshot epoch
 
 `BlockForger` runs a slot-based loop that:
 1. Waits for the next slot boundary using the wall-clock slot timer
-2. Checks leader eligibility via the `Election`
-3. Computes the current KES period and declines forging at the operational
+2. Computes the current KES period and declines forging at the operational
    certificate's protocol expiry
+3. Checks leader eligibility via the `Election`
 4. Reads the parent ranking block's `LeiosAnnouncement`, selects only the matching eligible Leios endorser-block certificate, and independently produces and broadcasts a new endorser block for the current slot when eligible
 5. Assembles a block from a neutral pending-transaction provider using `DefaultBlockBuilder`
 6. Optionally self-validates the forged block before adoption (see below)
@@ -3917,13 +3917,15 @@ and its private snapshot before provider callbacks; VRF proof, opcert fields,
 and KES signature are then derived only from that snapshot. A concurrent reload
 that linearizes after a generation check may coexist with the old snapshot, but
 cannot mutate it or mix its cryptographic inputs. The pool ID and VRF
-verification key remain permanently pinned by the first successful load;
+verification key derived from the loaded VRF seed remain permanently pinned by
+the first successful load. A 64-byte VRF key envelope's supplied public-key
+suffix must match that derivation, and only the derived identity is installed;
 later reloads may rotate KES/opcert material for that identity, while an
 attempted pool or VRF identity replacement clears the active generation and is
 rejected. This keeps the long-lived leader schedule coherent without rebuilding
 it during a forge attempt.
 
-Steps 2, 6, and 7 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 7) already recovered its own panics separately, since observability hooks are expected to be best-effort.
+Steps 3, 6, and 7 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 7) already recovered its own panics separately, since observability hooks are expected to be best-effort.
 
 When Dijkstra/Leios is active, `DefaultBlockBuilder` emits the Musashi prototype's 12-field Dijkstra header body for every forged Dijkstra ranking block: the standard Praos/Babbage fields plus `leios_certified` and `leios_announcement`. A locally forged endorser block is announced in the same-slot ranking block's `leios_announcement` as `[eb_hash, eb_size]`; `eb_size` is rejected before header construction if it exceeds the CDDL `uint .size 4` bound. If the pipeline has a certified, non-equivocated EB inside its inclusion window whose hash matches the parent ranking block's `LeiosAnnouncement`, the forger also populates the prototype `DijkstraLeiosCertificate` body field and sets `leios_certified=true`. Prototype-2026w29 permits that CertRB to carry the new same-slot announcement as well as the certificate for its parent's EB. Before constructing the new EB, the forger reads the certified EB's manifest and filters those transaction hashes from its mempool view, matching the prototype's post-certificate rebase without mutating the live mempool before block adoption; if the certified closure is unavailable, it safely forges the certificate-only RB. The certified EB is marked embedded only after the CertRB is adopted locally.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3888,21 +3888,33 @@ KES periods are computed from the era-aware absolute slot (`currentSlot / slotsP
 Successful startup validation captures Shelley genesis `MaxKESEvolutions` on
 the loaded credentials together with the opcert start and overflow-checked
 exclusive expiry. `NewBlockForger` rejects credentials without that validated
-protocol lifetime. At each leader slot, the runtime gate admits exactly the
+protocol lifetime. Before leader selection at each candidate slot, the runtime
+gate admits exactly the
 half-open interval `[opcertStart, opcertStart + MaxKESEvolutions)`: periods
 before the start and at or after the exclusive end both log/count a
-could-not-forge disposition before either Leios or ranking-block construction.
+could-not-forge disposition before Praos, Leios, or ranking-block work.
 The start, expiry, current-period, and remaining-period gauges use that same
 protocol lifetime; the KES key's `2^depth` cryptographic capacity remains a
 separate upper bound rather than an operational lifetime.
 
-Each production forge attempt holds a read lease on one complete credential
-generation from the runtime gate through KES evolution, VRF/KES signing, local
-block construction. `DefaultBlockBuilder` receives that same package-private
-generation rather than re-reading `PoolCredentials`. The lease ends once the
-block is signed, before pluggable validation, adoption, and observability
-callbacks, because those phases no longer consume credentials and may safely
-initiate a reload themselves.
+Each production forge attempt identifies one complete credential generation at
+the runtime gate. It releases that generation before the pluggable
+`LeaderChecker` callback so a callback that synchronously initiates a reload
+cannot deadlock on the generation lock, then reacquires the generation and
+requires the generation number to be unchanged. A concurrent reload therefore
+abandons the slot rather than mixing election from one generation with
+construction or signing from another. Once revalidated after selection, the
+attempt holds the generation read lease through KES evolution, VRF/KES signing,
+and local block construction. `DefaultBlockBuilder` receives that same
+package-private generation rather than re-reading `PoolCredentials`. The lease
+ends once the block is signed, before pluggable validation, adoption, and
+observability callbacks, because those phases no longer consume credentials
+and may safely initiate a reload themselves. The pool ID and VRF verification
+key are permanently pinned by the first successful load on a
+`PoolCredentials`; later reloads may rotate KES/opcert material for that
+identity but an attempted pool or VRF identity replacement clears the active
+generation and is rejected. This keeps the long-lived leader schedule's
+identity coherent without rebuilding it during a forge attempt.
 Credential reload and KES-policy revalidation take the exclusive side of the
 generation lock, which is separate from the ordinary credential accessor
 lock. They therefore wait for an in-flight attempt without preventing a
@@ -3933,12 +3945,21 @@ exempt from the secret-key permission check.
 `PoolCredentials.LoadFromFiles` parses replacement files before taking the
 exclusive generation lock, then atomically installs all key material and the
 opcert as a new, unvalidated generation. A failed reload clears the active
-credentials. `ValidateKESPeriod` atomically publishes the opcert
+credentials while retaining the first successful load's pool/VRF identity pin,
+so a later retry cannot silently switch the identity used by leader election.
+Operational-certificate signature and KES-key validation is generation state:
+every load clears it, `ValidateOpCert` publishes it only for the current
+generation, and `ValidateKESPeriod` repeats the cryptographic check before it
+atomically publishes the opcert
 `{start, MaxKESEvolutions, expiry}` policy only on success; failed validation
 retains the loaded material but clears the policy. Both paths therefore fail
 closed instead of falling back to an older policy or the KES depth capacity.
 `OpCertExpiryPeriod` and `PeriodsRemaining` report zero until the current
-generation has a validated policy.
+generation has both a validated certificate and policy. The exported
+`DefaultBlockBuilder.BuildBlock` and `BuildBlockWithLeios` entrypoints enforce
+that same half-open interval inside the generation-backed builder path before
+they inspect the chain tip, mempool, VRF key, or Leios inputs, so direct callers
+cannot bypass the forger's outer gate.
 
 ### Leios Voting (`ledger/leios/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3886,14 +3886,32 @@ still runs as the final backstop against any race not closed here.
 The forger tracks slot battles (competing blocks at the same slot) and skips forging when the node is not sufficiently synced, controlled by `forgeSyncToleranceSlots` and `forgeStaleGapThresholdSlots`.
 KES periods are computed from the era-aware absolute slot (`currentSlot / slotsPerKESPeriod`) for both startup opcert validation and forge-time signing, so networks with Byron-era prefixes do not skew the current KES period by converting wall-clock duration directly through the Shelley slot length.
 Successful startup validation captures Shelley genesis `MaxKESEvolutions` on
-the loaded credentials. `NewBlockForger` rejects credentials without that
-validated protocol lifetime and precomputes the expiry with overflow checks.
-At each leader slot, the runtime gate admits the half-open interval
-`[opcertStart, opcertStart + MaxKESEvolutions)` and logs/counts a
-could-not-forge disposition at or after the exclusive end before either Leios
-or ranking-block construction. The expiry and remaining-period gauges use that
-same protocol lifetime; the KES key's `2^depth` cryptographic capacity remains
-a separate upper bound rather than an operational lifetime.
+the loaded credentials together with the opcert start and overflow-checked
+exclusive expiry. `NewBlockForger` rejects credentials without that validated
+protocol lifetime. At each leader slot, the runtime gate admits exactly the
+half-open interval `[opcertStart, opcertStart + MaxKESEvolutions)`: periods
+before the start and at or after the exclusive end both log/count a
+could-not-forge disposition before either Leios or ranking-block construction.
+The start, expiry, current-period, and remaining-period gauges use that same
+protocol lifetime; the KES key's `2^depth` cryptographic capacity remains a
+separate upper bound rather than an operational lifetime.
+
+Each production forge attempt holds a read lease on one complete credential
+generation from the runtime gate through KES evolution, VRF/KES signing, local
+block construction. `DefaultBlockBuilder` receives that same package-private
+generation rather than re-reading `PoolCredentials`. The lease ends once the
+block is signed, before pluggable validation, adoption, and observability
+callbacks, because those phases no longer consume credentials and may safely
+initiate a reload themselves.
+Credential reload and KES-policy revalidation take the exclusive side of the
+generation lock, which is separate from the ordinary credential accessor
+lock. They therefore wait for an in-flight attempt without preventing a
+pluggable builder from using read-only credential accessors. Reload and
+revalidation cannot replace the key, opcert, start, maximum, or expiry
+independently. A completed reload or
+revalidation is therefore a linearization boundary: the old generation may
+finish before it, while the next attempt sees the new generation in its gate,
+signing inputs, logs, and gauges together.
 
 Steps 2, 6, and 7 each call into a pluggable interface (`LeaderChecker`, `BlockValidator`, `BlockBroadcaster`) that the node wires up at composition time, so a panic inside one of those implementations is contained rather than propagating out of `checkAndForgeProduction` — which would otherwise crash the forger's producer-loop goroutine, and with it the process, since nothing else recovers a goroutine panic in Go. Each callback is invoked through a `*Safe` wrapper (`checkLeaderSafe`, `validateForgedBlockSafe`, `addBlockSafe`) that recovers and converts a panic into the same outcome as that phase's ordinary failure path — "not leader" for selection, a validation failure for validation, an `AddBlock` error for publication — so worker accounting (`forgeNotLeader`/`forgeValidationFailed`/`forgeCouldNot`), `running` state, and shutdown behavior are unaffected, and the next forge cycle proceeds normally. Recovered panics are counted by phase in `dingo_forge_panic_recovered_total` and logged with a stack trace. The `blockForged` observer callback (step 7) already recovered its own panics separately, since observability hooks are expected to be best-effort.
 
@@ -3912,11 +3930,15 @@ reject group/other access on Unix or insecure DACL grants on Windows before
 reading the key. Operational certificates contain public data and remain
 exempt from the secret-key permission check.
 
-`PoolCredentials.ValidateKESPeriod` validates and retains the Shelley genesis
-protocol lifetime only on success. Reloading credentials or any failed
-validation clears it, so production construction fails closed instead of
-falling back to the KES depth capacity. `OpCertExpiryPeriod` and
-`PeriodsRemaining` report zero until that policy has been validated.
+`PoolCredentials.LoadFromFiles` parses replacement files before taking the
+exclusive generation lock, then atomically installs all key material and the
+opcert as a new, unvalidated generation. A failed reload clears the active
+credentials. `ValidateKESPeriod` atomically publishes the opcert
+`{start, MaxKESEvolutions, expiry}` policy only on success; failed validation
+retains the loaded material but clears the policy. Both paths therefore fail
+closed instead of falling back to an older policy or the KES depth capacity.
+`OpCertExpiryPeriod` and `PeriodsRemaining` report zero until the current
+generation has a validated policy.
 
 ### Leios Voting (`ledger/leios/`)
 

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -255,6 +255,13 @@ func (b *DefaultBlockBuilder) buildBlock(
 			err,
 		)
 	}
+	// Evolve both the selected snapshot and the still-current owner before any
+	// provider callback. The snapshot remains independently usable while a
+	// callback reloads credentials; a changed owner generation is rejected
+	// before the resulting block can escape this method.
+	if err := credentials.updateKESPeriod(kesPeriod); err != nil {
+		return nil, nil, fmt.Errorf("failed to update KES period: %w", err)
+	}
 
 	// Get current chain tip
 	currentTip := b.chainTip.Tip()
@@ -1030,6 +1037,12 @@ func (b *DefaultBlockBuilder) buildBlock(
 		"total_memory", totalExUnits.Memory,
 		"total_steps", totalExUnits.Steps,
 	)
+	if err := credentials.ensureCurrent(); err != nil {
+		return nil, nil, fmt.Errorf(
+			"credentials changed during block assembly: %w",
+			err,
+		)
+	}
 
 	return ledgerBlock, blockCbor, nil
 }

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -186,7 +186,9 @@ func (b *DefaultBlockBuilder) BuildBlock(
 	slot uint64,
 	kesPeriod uint64,
 ) (ledger.Block, []byte, error) {
-	return b.buildBlock(slot, kesPeriod, LeiosBlockData{})
+	generation := b.creds.acquireCredentialGeneration()
+	defer generation.release()
+	return b.buildBlock(slot, kesPeriod, LeiosBlockData{}, generation)
 }
 
 // BlockForger.buildBlock discovers the Leios capability with a runtime type
@@ -194,7 +196,10 @@ func (b *DefaultBlockBuilder) BuildBlock(
 // misses, so drift in BuildBlockWithLeios would break Leios forging at forge
 // time rather than at build time. Unlike the session-provider assertion above
 // this one is loud, but it is the same class of defect the guard prevents.
-var _ LeiosBlockBuilder = (*DefaultBlockBuilder)(nil)
+var (
+	_ LeiosBlockBuilder                = (*DefaultBlockBuilder)(nil)
+	_ credentialGenerationBlockBuilder = (*DefaultBlockBuilder)(nil)
+)
 
 // BuildBlockWithLeios creates a Dijkstra block with Leios prototype
 // announcement or certificate data committed into the block body/header.
@@ -203,7 +208,18 @@ func (b *DefaultBlockBuilder) BuildBlockWithLeios(
 	kesPeriod uint64,
 	leios LeiosBlockData,
 ) (ledger.Block, []byte, error) {
-	return b.buildBlock(slot, kesPeriod, leios)
+	generation := b.creds.acquireCredentialGeneration()
+	defer generation.release()
+	return b.buildBlock(slot, kesPeriod, leios, generation)
+}
+
+func (b *DefaultBlockBuilder) buildBlockWithCredentialGeneration(
+	slot uint64,
+	kesPeriod uint64,
+	leios LeiosBlockData,
+	generation *credentialGeneration,
+) (ledger.Block, []byte, error) {
+	return b.buildBlock(slot, kesPeriod, leios, generation)
 }
 
 // errParentChangedDuringBuild indicates the chain tip moved while
@@ -228,6 +244,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 	slot uint64,
 	kesPeriod uint64,
 	leios LeiosBlockData,
+	credentials *credentialGeneration,
 ) (ledger.Block, []byte, error) {
 	// Get current chain tip
 	currentTip := b.chainTip.Tip()
@@ -705,7 +722,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 	}
 
 	// Get VRF key from credentials
-	vrfVKey := b.creds.GetVRFVKey()
+	vrfVKey := credentials.vrfVKey()
 	if len(vrfVKey) == 0 {
 		return nil, nil, errors.New("VRF verification key not loaded")
 	}
@@ -761,7 +778,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 				err,
 			)
 		}
-		nonceProof, nonceOutput, err := b.creds.VRFProve(nonceInput)
+		nonceProof, nonceOutput, err := credentials.vrfProve(nonceInput)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"failed to generate TPraos nonce VRF proof: %w",
@@ -779,7 +796,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 				err,
 			)
 		}
-		leaderProof, leaderOutput, err := b.creds.VRFProve(leaderInput)
+		leaderProof, leaderOutput, err := credentials.vrfProve(leaderInput)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"failed to generate TPraos leader VRF proof: %w",
@@ -793,7 +810,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create VRF input: %w", err)
 		}
-		vrfProof, vrfOutput, err := b.creds.VRFProve(alpha)
+		vrfProof, vrfOutput, err := credentials.vrfProve(alpha)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to generate VRF proof: %w", err)
 		}
@@ -801,7 +818,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 	}
 
 	// Get OpCert from credentials
-	opCert := b.creds.GetOpCert()
+	opCert := credentials.opCert()
 	if opCert == nil {
 		return nil, nil, errors.New("operational certificate not loaded")
 	}
@@ -930,7 +947,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 		return nil, nil, fmt.Errorf("failed to encode header body: %w", err)
 	}
 
-	signature, err := b.creds.KESSign(kesPeriod, headerBodyCbor)
+	signature, err := credentials.kesSign(kesPeriod, headerBodyCbor)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to sign block header: %w", err)
 	}

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -246,6 +246,16 @@ func (b *DefaultBlockBuilder) buildBlock(
 	leios LeiosBlockData,
 	credentials *credentialGeneration,
 ) (ledger.Block, []byte, error) {
+	// Keep the protocol lifetime guard inside the generation-backed path so
+	// both exported builder entrypoints and BlockForger fail before reading the
+	// mempool, chain state, VRF key, or Leios inputs.
+	if err := credentials.validateKESPeriod(kesPeriod); err != nil {
+		return nil, nil, fmt.Errorf(
+			"cannot build block outside operational certificate lifetime: %w",
+			err,
+		)
+	}
+
 	// Get current chain tip
 	currentTip := b.chainTip.Tip()
 

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -38,9 +39,11 @@ import (
 // mockMempool implements MempoolProvider for testing.
 type mockMempool struct {
 	transactions []MempoolTransaction
+	calls        int
 }
 
 func (m *mockMempool) Transactions() []MempoolTransaction {
+	m.calls++
 	return m.transactions
 }
 
@@ -187,6 +190,138 @@ func TestNewDefaultBlockBuilder(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, builder)
+}
+
+func TestExportedBuildersEnforceProtocolKESLifetime(t *testing.T) {
+	tests := []struct {
+		name        string
+		start       uint64
+		max         uint64
+		period      uint64
+		wantErr     string
+		wantMempool int
+	}{
+		{
+			name:    "pre-start",
+			start:   1,
+			max:     2,
+			period:  0,
+			wantErr: "not valid before",
+		},
+		{
+			name:        "start",
+			start:       0,
+			max:         2,
+			period:      0,
+			wantMempool: 1,
+		},
+		{
+			name:        "last-valid",
+			start:       0,
+			max:         2,
+			period:      1,
+			wantMempool: 1,
+		},
+		{
+			name:    "expiry",
+			start:   0,
+			max:     2,
+			period:  2,
+			wantErr: "operational certificate expired",
+		},
+	}
+	builders := []struct {
+		name string
+		call func(*DefaultBlockBuilder, uint64) (ledger.Block, []byte, error)
+	}{
+		{
+			name: "BuildBlock",
+			call: func(
+				builder *DefaultBlockBuilder,
+				period uint64,
+			) (ledger.Block, []byte, error) {
+				return builder.BuildBlock(1001, period)
+			},
+		},
+		{
+			name: "BuildBlockWithLeios",
+			call: func(
+				builder *DefaultBlockBuilder,
+				period uint64,
+			) (ledger.Block, []byte, error) {
+				return builder.BuildBlockWithLeios(
+					1001,
+					period,
+					LeiosBlockData{},
+				)
+			},
+		},
+	}
+
+	for _, entrypoint := range builders {
+		for _, test := range tests {
+			t.Run(entrypoint.name+"/"+test.name, func(t *testing.T) {
+				creds := setupTestCredentials(t)
+				creds.generationMu.Lock()
+				creds.mu.Lock()
+				creds.generation++
+				creds.opCertStartKES = test.start
+				creds.maxKESEvolutions = test.max
+				creds.opCertExpiryKES = test.start + test.max
+				creds.opCertValidated = true
+				creds.mu.Unlock()
+				creds.generationMu.Unlock()
+
+				mempool := &mockMempool{
+					transactions: []MempoolTransaction{},
+				}
+				builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+					Mempool: mempool,
+					PParamsProvider: &mockPParamsProvider{
+						pparams: &dijkstra.DijkstraProtocolParameters{
+							ConwayProtocolParameters: conway.ConwayProtocolParameters{
+								MaxTxSize:        16384,
+								MaxBlockBodySize: 90112,
+								ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+									Major: 10,
+								},
+							},
+						},
+					},
+					ChainTip: &mockChainTip{
+						tip: ochainsync.Tip{
+							Point: ocommon.Point{
+								Slot: 1000,
+								Hash: make([]byte, 32),
+							},
+							BlockNumber: 100,
+						},
+					},
+					EpochNonce: &mockEpochNonceProvider{
+						epoch: 1,
+						nonce: make([]byte, 32),
+					},
+					Credentials: creds,
+				})
+				require.NoError(t, err)
+				if test.wantErr == "" && test.period > 0 {
+					require.NoError(t, creds.UpdateKESPeriod(test.period))
+				}
+
+				block, blockCbor, err := entrypoint.call(builder, test.period)
+				if test.wantErr != "" {
+					require.ErrorContains(t, err, test.wantErr)
+					require.Nil(t, block)
+					require.Nil(t, blockCbor)
+				} else {
+					require.NoError(t, err)
+					require.NotNil(t, block)
+					require.NotEmpty(t, blockCbor)
+				}
+				require.Equal(t, test.wantMempool, mempool.calls)
+			})
+		}
+	}
 }
 
 func TestBuildBlockEmptyMempool(t *testing.T) {
@@ -450,7 +585,7 @@ func TestBuildBlockMissingVRFKey(t *testing.T) {
 	// Build should fail with missing VRF key
 	_, _, err := builder.BuildBlock(1001, 0)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "VRF verification key not loaded")
+	assert.Contains(t, err.Error(), "credentials not loaded")
 }
 
 func TestBuildBlockInvalidColdVKeySize(t *testing.T) {
@@ -505,7 +640,7 @@ func TestBuildBlockInvalidColdVKeySize(t *testing.T) {
 	// Build should fail with invalid cold vkey size
 	_, _, err := builder.BuildBlock(1001, 0)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid cold verification key size")
+	assert.Contains(t, err.Error(), "credentials not loaded")
 }
 
 func TestBuildBlockInvalidVRFVKeySize(t *testing.T) {
@@ -560,7 +695,7 @@ func TestBuildBlockInvalidVRFVKeySize(t *testing.T) {
 	// Build should fail with invalid VRF vkey size
 	_, _, err := builder.BuildBlock(1001, 0)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid VRF verification key size")
+	assert.Contains(t, err.Error(), "credentials not loaded")
 }
 
 func TestBuildBlockTxExceedsMaxSize(t *testing.T) {

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"math"
 	"testing"
+	"time"
 
 	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -106,6 +107,10 @@ func setupTestCredentials(t *testing.T) *PoolCredentials {
 	vrfPath, kesPath, opCertPath := createTestKeys(t)
 	creds := NewPoolCredentials()
 	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, creds.ValidateKESPeriod(
+		synthGenesis(100, 62, time.Second, time.Unix(0, 0)),
+		0,
+	))
 	return creds
 }
 

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"log/slog"
 	"math"
 	"testing"
 	"time"
@@ -131,6 +130,42 @@ func setupTestCredentials(t *testing.T) *PoolCredentials {
 		0,
 	))
 	return creds
+}
+
+func setupCredentialValidationBuilder(
+	t *testing.T,
+	creds *PoolCredentials,
+) *DefaultBlockBuilder {
+	t.Helper()
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool: &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{
+			pparams: &conway.ConwayProtocolParameters{
+				MaxTxSize:        16384,
+				MaxBlockBodySize: 90112,
+				MaxBlockExUnits: lcommon.ExUnits{
+					Memory: 62000000,
+					Steps:  20000000000,
+				},
+			},
+		},
+		ChainTip: &mockChainTip{
+			tip: ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 1000,
+					Hash: make([]byte, 32),
+				},
+				BlockNumber: 100,
+			},
+		},
+		EpochNonce: &mockEpochNonceProvider{
+			epoch: 1,
+			nonce: make([]byte, 32),
+		},
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+	return builder
 }
 
 func TestNewDefaultBlockBuilder(t *testing.T) {
@@ -618,168 +653,39 @@ func TestBuildBlockUsesDingoProtocolMinor(t *testing.T) {
 }
 
 func TestBuildBlockMissingVRFKey(t *testing.T) {
-	// Create credentials with nil VRF key to test error handling
-	creds := &PoolCredentials{
-		vrfSKey: nil,
-		vrfVKey: nil, // This should cause BuildBlock to fail
-		kesSKey: nil,
-		kesVKey: make([]byte, 32), // Valid size
-		opCert: &OpCert{
-			KESVKey:     make([]byte, 32),
-			IssueNumber: 0,
-			KESPeriod:   0,
-			Signature:   make([]byte, 64),
-			ColdVKey:    make([]byte, 32),
-		},
-	}
+	creds := setupTestCredentials(t)
+	creds.mu.Lock()
+	creds.generation++
+	creds.vrfVKey = nil
+	creds.mu.Unlock()
+	builder := setupCredentialValidationBuilder(t, creds)
 
-	mempool := &mockMempool{transactions: []MempoolTransaction{}}
-
-	pparams := &conway.ConwayProtocolParameters{
-		MaxTxSize:        16384,
-		MaxBlockBodySize: 90112,
-		MaxBlockExUnits: lcommon.ExUnits{
-			Memory: 62000000,
-			Steps:  20000000000,
-		},
-	}
-	pparamsProvider := &mockPParamsProvider{pparams: pparams}
-
-	chainTip := &mockChainTip{
-		tip: ochainsync.Tip{
-			Point: ocommon.Point{
-				Slot: 1000,
-				Hash: make([]byte, 32),
-			},
-			BlockNumber: 100,
-		},
-	}
-
-	epochNonce := &mockEpochNonceProvider{epoch: 1, nonce: make([]byte, 32)}
-
-	builder := &DefaultBlockBuilder{
-		logger:          slog.Default(),
-		mempool:         mempool,
-		pparamsProvider: pparamsProvider,
-		chainTip:        chainTip,
-		epochNonce:      epochNonce,
-		creds:           creds,
-	}
-
-	// Build should fail with missing VRF key
 	_, _, err := builder.BuildBlock(1001, 0)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "credentials not loaded")
+	require.ErrorContains(t, err, "VRF verification key not loaded")
 }
 
 func TestBuildBlockInvalidColdVKeySize(t *testing.T) {
-	// Create credentials with invalid cold vkey size
-	creds := &PoolCredentials{
-		vrfSKey: make([]byte, 32),
-		vrfVKey: make([]byte, 32), // Valid
-		kesSKey: nil,
-		kesVKey: make([]byte, 32), // Valid
-		opCert: &OpCert{
-			KESVKey:     make([]byte, 32),
-			IssueNumber: 0,
-			KESPeriod:   0,
-			Signature:   make([]byte, 64),
-			ColdVKey:    make([]byte, 16), // Invalid size - should be 32
-		},
-	}
+	creds := setupTestCredentials(t)
+	creds.mu.Lock()
+	creds.generation++
+	creds.opCert.ColdVKey = make([]byte, 16)
+	creds.mu.Unlock()
+	builder := setupCredentialValidationBuilder(t, creds)
 
-	mempool := &mockMempool{transactions: []MempoolTransaction{}}
-
-	pparams := &conway.ConwayProtocolParameters{
-		MaxTxSize:        16384,
-		MaxBlockBodySize: 90112,
-		MaxBlockExUnits: lcommon.ExUnits{
-			Memory: 62000000,
-			Steps:  20000000000,
-		},
-	}
-	pparamsProvider := &mockPParamsProvider{pparams: pparams}
-
-	chainTip := &mockChainTip{
-		tip: ochainsync.Tip{
-			Point: ocommon.Point{
-				Slot: 1000,
-				Hash: make([]byte, 32),
-			},
-			BlockNumber: 100,
-		},
-	}
-
-	epochNonce := &mockEpochNonceProvider{epoch: 1, nonce: make([]byte, 32)}
-
-	builder := &DefaultBlockBuilder{
-		logger:          slog.Default(),
-		mempool:         mempool,
-		pparamsProvider: pparamsProvider,
-		chainTip:        chainTip,
-		epochNonce:      epochNonce,
-		creds:           creds,
-	}
-
-	// Build should fail with invalid cold vkey size
 	_, _, err := builder.BuildBlock(1001, 0)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "credentials not loaded")
+	require.ErrorContains(t, err, "invalid cold verification key size")
 }
 
 func TestBuildBlockInvalidVRFVKeySize(t *testing.T) {
-	// Create credentials with invalid VRF vkey size
-	creds := &PoolCredentials{
-		vrfSKey: make([]byte, 32),
-		vrfVKey: make([]byte, 16), // Invalid size - should be 32
-		kesSKey: nil,
-		kesVKey: make([]byte, 32),
-		opCert: &OpCert{
-			KESVKey:     make([]byte, 32),
-			IssueNumber: 0,
-			KESPeriod:   0,
-			Signature:   make([]byte, 64),
-			ColdVKey:    make([]byte, 32),
-		},
-	}
+	creds := setupTestCredentials(t)
+	creds.mu.Lock()
+	creds.generation++
+	creds.vrfVKey = make([]byte, 16)
+	creds.mu.Unlock()
+	builder := setupCredentialValidationBuilder(t, creds)
 
-	mempool := &mockMempool{transactions: []MempoolTransaction{}}
-
-	pparams := &conway.ConwayProtocolParameters{
-		MaxTxSize:        16384,
-		MaxBlockBodySize: 90112,
-		MaxBlockExUnits: lcommon.ExUnits{
-			Memory: 62000000,
-			Steps:  20000000000,
-		},
-	}
-	pparamsProvider := &mockPParamsProvider{pparams: pparams}
-
-	chainTip := &mockChainTip{
-		tip: ochainsync.Tip{
-			Point: ocommon.Point{
-				Slot: 1000,
-				Hash: make([]byte, 32),
-			},
-			BlockNumber: 100,
-		},
-	}
-
-	epochNonce := &mockEpochNonceProvider{epoch: 1, nonce: make([]byte, 32)}
-
-	builder := &DefaultBlockBuilder{
-		logger:          slog.Default(),
-		mempool:         mempool,
-		pparamsProvider: pparamsProvider,
-		chainTip:        chainTip,
-		epochNonce:      epochNonce,
-		creds:           creds,
-	}
-
-	// Build should fail with invalid VRF vkey size
 	_, _, err := builder.BuildBlock(1001, 0)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "credentials not loaded")
+	require.ErrorContains(t, err, "invalid VRF verification key size")
 }
 
 func TestBuildBlockTxExceedsMaxSize(t *testing.T) {

--- a/ledger/forging/builder_test.go
+++ b/ledger/forging/builder_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
 	dingoversion "github.com/blinklabs-io/dingo/internal/version"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -68,6 +69,21 @@ type mockChainTip struct {
 }
 
 func (m *mockChainTip) Tip() ochainsync.Tip {
+	return m.tip
+}
+
+type reentrantChainTip struct {
+	tip         ochainsync.Tip
+	callback    func() error
+	callbackErr error
+	called      bool
+}
+
+func (m *reentrantChainTip) Tip() ochainsync.Tip {
+	if !m.called {
+		m.called = true
+		m.callbackErr = m.callback()
+	}
 	return m.tip
 }
 
@@ -262,7 +278,6 @@ func TestExportedBuildersEnforceProtocolKESLifetime(t *testing.T) {
 		for _, test := range tests {
 			t.Run(entrypoint.name+"/"+test.name, func(t *testing.T) {
 				creds := setupTestCredentials(t)
-				creds.generationMu.Lock()
 				creds.mu.Lock()
 				creds.generation++
 				creds.opCertStartKES = test.start
@@ -270,7 +285,6 @@ func TestExportedBuildersEnforceProtocolKESLifetime(t *testing.T) {
 				creds.opCertExpiryKES = test.start + test.max
 				creds.opCertValidated = true
 				creds.mu.Unlock()
-				creds.generationMu.Unlock()
 
 				mempool := &mockMempool{
 					transactions: []MempoolTransaction{},
@@ -322,6 +336,76 @@ func TestExportedBuildersEnforceProtocolKESLifetime(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestDefaultBuilderRejectsReentrantProviderReload(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	creds := NewPoolCredentials()
+	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	genesis := synthGenesis(100, 62, time.Second, time.Unix(0, 0))
+	require.NoError(t, creds.ValidateKESPeriod(genesis, 0))
+
+	chainTip := &reentrantChainTip{
+		tip: ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 1000,
+				Hash: make([]byte, 32),
+			},
+			BlockNumber: 100,
+		},
+		callback: func() error {
+			if err := creds.LoadFromFiles(
+				vrfPath,
+				kesPath,
+				opCertPath,
+			); err != nil {
+				return err
+			}
+			return creds.ValidateKESPeriod(genesis, 0)
+		},
+	}
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool: &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{
+			pparams: &dijkstra.DijkstraProtocolParameters{
+				ConwayProtocolParameters: conway.ConwayProtocolParameters{
+					MaxTxSize:        16384,
+					MaxBlockBodySize: 90112,
+					ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+						Major: 10,
+					},
+				},
+			},
+		},
+		ChainTip: chainTip,
+		EpochNonce: &mockEpochNonceProvider{
+			epoch: 1,
+			nonce: make([]byte, 32),
+		},
+		Credentials: creds,
+	})
+	require.NoError(t, err)
+
+	type buildResult struct {
+		block ledger.Block
+		cbor  []byte
+		err   error
+	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		block, blockCbor, err := builder.BuildBlock(1001, 0)
+		resultCh <- buildResult{block: block, cbor: blockCbor, err: err}
+	}()
+	result := dingotestutil.RequireReceive(
+		t,
+		resultCh,
+		time.Second,
+		"reentrant default-builder provider reload completion",
+	)
+	require.ErrorContains(t, result.err, "credential generation changed")
+	require.Nil(t, result.block)
+	require.Nil(t, result.cbor)
+	require.NoError(t, chainTip.callbackErr)
 }
 
 func TestBuildBlockEmptyMempool(t *testing.T) {

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -824,6 +824,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 
 	// Ensure KES key is at correct period
 	if err := generation.updateKESPeriod(kesPeriod); err != nil {
+		f.incCouldNotForge()
 		return fmt.Errorf("failed to update KES period: %w", err)
 	}
 
@@ -1201,7 +1202,18 @@ func (f *BlockForger) SignBlockHeader(
 		return nil, errors.New("credentials not loaded")
 	}
 
-	return f.creds.KESSign(kesPeriod, headerBytes)
+	generation := f.creds.acquireCredentialGeneration()
+	defer generation.release()
+	if err := generation.validateKESPeriod(kesPeriod); err != nil {
+		return nil, fmt.Errorf(
+			"cannot sign block header outside operational certificate lifetime: %w",
+			err,
+		)
+	}
+	if err := generation.updateKESPeriod(kesPeriod); err != nil {
+		return nil, fmt.Errorf("failed to update KES period: %w", err)
+	}
+	return generation.kesSign(kesPeriod, headerBytes)
 }
 
 // SlotTracker returns the forger's slot tracker, which can be used

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -77,10 +77,6 @@ type BlockForger struct {
 	blockForged      BlockForgedObserver
 	slotClock        SlotClockProvider
 	slotDuration     time.Duration
-	// KES protocol limits are captured from the Shelley genesis validation
-	// performed on creds. They are distinct from the KES key depth capacity.
-	maxKESEvolutions uint64
-	opCertExpiryKES  uint64
 
 	// Slot battle detection
 	slotTracker *SlotTracker
@@ -133,6 +129,19 @@ type LeiosBlockBuilder interface {
 		slot uint64,
 		kesPeriod uint64,
 		leios LeiosBlockData,
+	) (ledger.Block, []byte, error)
+}
+
+// credentialGenerationBlockBuilder lets the production builder consume the
+// exact credential generation pinned by BlockForger. It is intentionally
+// package-private: BlockBuilder and LeiosBlockBuilder remain API-compatible,
+// while DefaultBlockBuilder avoids re-reading mutable shared credentials.
+type credentialGenerationBlockBuilder interface {
+	buildBlockWithCredentialGeneration(
+		slot uint64,
+		kesPeriod uint64,
+		leios LeiosBlockData,
+		generation *credentialGeneration,
 	) (ledger.Block, []byte, error)
 }
 
@@ -362,16 +371,15 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		if cfg.SlotClock == nil {
 			return nil, errors.New("production mode requires slot clock")
 		}
-		maxEvolutions, expiryPeriod, err :=
-			cfg.Credentials.validatedKESProtocolLifetime()
+		generation := cfg.Credentials.acquireCredentialGeneration()
+		_, _, _, err := generation.validatedKESProtocolLifetime()
+		generation.release()
 		if err != nil {
 			return nil, fmt.Errorf(
 				"production mode requires a validated KES protocol lifetime: %w",
 				err,
 			)
 		}
-		f.maxKESEvolutions = maxEvolutions
-		f.opCertExpiryKES = expiryPeriod
 		if cfg.LeiosProduceChecker != nil && cfg.LeiosTxValidator == nil {
 			return nil, errors.New(
 				"production Leios forging requires transaction validator",
@@ -404,15 +412,9 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 	// Dynamic gauges (currentKESPeriod, remainingKESPeriods) are
 	// updated on every slot-win in updateKESMetrics().
 	if f.metrics != nil && f.creds != nil {
-		opCert := f.creds.GetOpCert()
-		if opCert != nil {
-			f.metrics.opCertStartKES.Set(
-				float64(opCert.KESPeriod),
-			)
-			f.metrics.opCertExpiryKES.Set(
-				float64(f.opCertExpiryKES),
-			)
-		}
+		generation := f.creds.acquireCredentialGeneration()
+		f.updateKESPolicyMetrics(generation)
+		generation.release()
 	}
 
 	return f, nil
@@ -444,7 +446,9 @@ func (f *BlockForger) Start(ctx context.Context) error {
 					currentSlot,
 					slotsPerKES,
 				); err == nil {
-					f.updateKESMetrics(kesPeriod)
+					generation := f.creds.acquireCredentialGeneration()
+					f.updateKESMetrics(kesPeriod, generation)
+					generation.release()
 				}
 			}
 		}
@@ -686,15 +690,47 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	if err != nil {
 		return err
 	}
-	f.updateKESMetrics(kesPeriod)
-	if kesPeriod >= f.opCertExpiryKES {
+	generation := f.creds.acquireCredentialGeneration()
+	generationReleased := false
+	defer func() {
+		if !generationReleased {
+			generation.release()
+		}
+	}()
+	f.updateKESMetrics(kesPeriod, generation)
+	opCertStart, maxEvolutions, opCertExpiry, policyErr := generation.validatedKESProtocolLifetime()
+	if policyErr != nil {
+		f.incCouldNotForge()
+		f.logger.Error(
+			"forge skip: KES protocol lifetime is not validated",
+			"slot", currentSlot,
+			"current_kes_period", kesPeriod,
+			"credential_generation", generation.id,
+			"error", policyErr,
+		)
+		return nil
+	}
+	if kesPeriod < opCertStart {
+		f.incCouldNotForge()
+		f.logger.Error(
+			"forge skip: operational certificate is not yet valid",
+			"slot", currentSlot,
+			"current_kes_period", kesPeriod,
+			"opcert_start_period", opCertStart,
+			"opcert_expiry_period", opCertExpiry,
+			"max_kes_evolutions", maxEvolutions,
+		)
+		return nil
+	}
+	if kesPeriod >= opCertExpiry {
 		f.incCouldNotForge()
 		f.logger.Error(
 			"forge skip: operational certificate expired; rotate the operational certificate",
 			"slot", currentSlot,
 			"current_kes_period", kesPeriod,
-			"opcert_expiry_period", f.opCertExpiryKES,
-			"max_kes_evolutions", f.maxKESEvolutions,
+			"opcert_start_period", opCertStart,
+			"opcert_expiry_period", opCertExpiry,
+			"max_kes_evolutions", maxEvolutions,
 		)
 		return nil
 	}
@@ -747,7 +783,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	f.logger.Info("producing block", "slot", currentSlot)
 
 	// Ensure KES key is at correct period
-	if err := f.creds.UpdateKESPeriod(kesPeriod); err != nil {
+	if err := generation.updateKESPeriod(kesPeriod); err != nil {
 		return fmt.Errorf("failed to update KES period: %w", err)
 	}
 
@@ -756,11 +792,17 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		currentSlot,
 		kesPeriod,
 		leiosBlockData,
+		generation,
 	)
 	if err != nil {
 		f.incCouldNotForge()
 		return fmt.Errorf("failed to build block: %w", err)
 	}
+	// Key material is no longer needed after the block is signed. End the
+	// generation lease before invoking pluggable validation, adoption, or
+	// observer callbacks so those callbacks can safely trigger a reload.
+	generation.release()
+	generationReleased = true
 
 	// Optionally self-validate before adoption and diffusion.
 	// Runs here — before success metrics and the blockForged observer — so
@@ -923,7 +965,16 @@ func (f *BlockForger) buildBlock(
 	slot uint64,
 	kesPeriod uint64,
 	leiosData LeiosBlockData,
+	generation *credentialGeneration,
 ) (ledger.Block, []byte, error) {
+	if generationBuilder, ok := f.blockBuilder.(credentialGenerationBlockBuilder); ok {
+		return generationBuilder.buildBlockWithCredentialGeneration(
+			slot,
+			kesPeriod,
+			leiosData,
+			generation,
+		)
+	}
 	if leiosData.empty() {
 		return f.blockBuilder.BuildBlock(slot, kesPeriod)
 	}
@@ -1014,23 +1065,26 @@ func (f *BlockForger) reportForgeCallbackPanic(phase string, r any) {
 // Safe to call when metrics are nil.
 func (f *BlockForger) updateKESMetrics(
 	currentPeriod uint64,
+	generation *credentialGeneration,
 ) {
 	if f.metrics == nil {
 		return
 	}
 	f.metrics.currentKESPeriod.Set(float64(currentPeriod))
 	f.metrics.remainingKESPeriods.Set(
-		float64(f.creds.PeriodsRemaining(currentPeriod)),
+		float64(generation.periodsRemaining(currentPeriod)),
 	)
-	opCert := f.creds.GetOpCert()
-	if opCert != nil {
-		f.metrics.opCertStartKES.Set(
-			float64(opCert.KESPeriod),
-		)
-		f.metrics.opCertExpiryKES.Set(
-			float64(f.opCertExpiryKES),
-		)
+	f.updateKESPolicyMetrics(generation)
+}
+
+func (f *BlockForger) updateKESPolicyMetrics(
+	generation *credentialGeneration,
+) {
+	if f.metrics == nil {
+		return
 	}
+	f.metrics.opCertStartKES.Set(float64(generation.opCertStartKES))
+	f.metrics.opCertExpiryKES.Set(float64(generation.opCertExpiryKES))
 }
 
 // RecordSlotBattle increments the slot battles counter. This is

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -717,16 +717,6 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
-	// Do not hold the generation lease across the pluggable leader callback:
-	// it may synchronously trigger a credential reload. Remember the generation
-	// selected by the policy gate and require that exact generation again after
-	// the callback. Pool and VRF identity changes are rejected by LoadFromFiles,
-	// so the election's startup identity remains valid; a same-identity KES or
-	// opcert reload changes the generation and safely abandons this attempt.
-	attemptGeneration := generation.id
-	generation.release()
-	generationReleased = true
-
 	// Check if we're the leader for this slot only after the KES gate.
 	isLeader := f.checkLeaderSafe(currentSlot)
 	if !isLeader {
@@ -741,15 +731,16 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
-	generation = f.creds.acquireCredentialGeneration()
-	generationReleased = false
-	if generation.id != attemptGeneration {
+	// The credential snapshot owns its secret material, so the callback above
+	// never holds a writer-blocking lease. A reload still invalidates this
+	// attempt before any Leios or block-construction work begins.
+	if err := generation.ensureCurrent(); err != nil {
 		f.incCouldNotForge()
 		f.logger.Warn(
 			"forge skip: credentials changed during leader selection",
 			"slot", currentSlot,
-			"selected_generation", attemptGeneration,
-			"current_generation", generation.id,
+			"selected_generation", generation.id,
+			"error", err,
 		)
 		return nil
 	}
@@ -814,6 +805,20 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			}
 		}
 	}
+	// Leios providers, mempool access, transaction validation, and broadcaster
+	// callbacks are all pluggable. They run without credential locks; if one
+	// reloads or revalidates credentials, abandon the ranking-block attempt
+	// before evolving or consuming the selected snapshot.
+	if err := generation.ensureCurrent(); err != nil {
+		f.incCouldNotForge()
+		f.logger.Warn(
+			"forge skip: credentials changed during Leios processing",
+			"slot", currentSlot,
+			"selected_generation", generation.id,
+			"error", err,
+		)
+		return nil
+	}
 
 	f.logger.Info("producing block", "slot", currentSlot)
 
@@ -833,9 +838,9 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.incCouldNotForge()
 		return fmt.Errorf("failed to build block: %w", err)
 	}
-	// Key material is no longer needed after the block is signed. End the
-	// generation lease before invoking pluggable validation, adoption, or
-	// observer callbacks so those callbacks can safely trigger a reload.
+	// Key material is no longer needed after the block is signed. Zeroize the
+	// independently owned snapshot before invoking pluggable validation,
+	// adoption, or observer callbacks.
 	generation.release()
 	generationReleased = true
 
@@ -1002,24 +1007,43 @@ func (f *BlockForger) buildBlock(
 	leiosData LeiosBlockData,
 	generation *credentialGeneration,
 ) (ledger.Block, []byte, error) {
+	var (
+		block     ledger.Block
+		blockCbor []byte
+		err       error
+	)
 	if generationBuilder, ok := f.blockBuilder.(credentialGenerationBlockBuilder); ok {
-		return generationBuilder.buildBlockWithCredentialGeneration(
+		block, blockCbor, err = generationBuilder.buildBlockWithCredentialGeneration(
 			slot,
 			kesPeriod,
 			leiosData,
 			generation,
 		)
-	}
-	if leiosData.empty() {
-		return f.blockBuilder.BuildBlock(slot, kesPeriod)
-	}
-	leiosBuilder, ok := f.blockBuilder.(LeiosBlockBuilder)
-	if !ok {
-		return nil, nil, errors.New(
-			"leios block data requires a LeiosBlockBuilder",
+	} else if leiosData.empty() {
+		block, blockCbor, err = f.blockBuilder.BuildBlock(slot, kesPeriod)
+	} else {
+		leiosBuilder, ok := f.blockBuilder.(LeiosBlockBuilder)
+		if !ok {
+			return nil, nil, errors.New(
+				"leios block data requires a LeiosBlockBuilder",
+			)
+		}
+		block, blockCbor, err = leiosBuilder.BuildBlockWithLeios(
+			slot,
+			kesPeriod,
+			leiosData,
 		)
 	}
-	return leiosBuilder.BuildBlockWithLeios(slot, kesPeriod, leiosData)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Custom builders cannot consume the package-private immutable snapshot.
+	// Reject their output (and any default-builder output racing a callback
+	// reload) if the selected owner generation changed while the callback ran.
+	if err := generation.ensureCurrent(); err != nil {
+		return nil, nil, err
+	}
+	return block, blockCbor, nil
 }
 
 // incCouldNotForge increments Forge_could_not_forge. Safe to call

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -77,6 +77,10 @@ type BlockForger struct {
 	blockForged      BlockForgedObserver
 	slotClock        SlotClockProvider
 	slotDuration     time.Duration
+	// KES protocol limits are captured from the Shelley genesis validation
+	// performed on creds. They are distinct from the KES key depth capacity.
+	maxKESEvolutions uint64
+	opCertExpiryKES  uint64
 
 	// Slot battle detection
 	slotTracker *SlotTracker
@@ -256,7 +260,8 @@ type ForgerConfig struct {
 	Logger       *slog.Logger
 	SlotDuration time.Duration
 
-	// Production mode configuration
+	// Production mode configuration. Credentials must have passed
+	// ValidateKESPeriod so the forger can enforce the genesis KES lifetime.
 	Credentials      *PoolCredentials
 	LeaderChecker    LeaderChecker
 	BlockBuilder     BlockBuilder
@@ -357,6 +362,16 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		if cfg.SlotClock == nil {
 			return nil, errors.New("production mode requires slot clock")
 		}
+		maxEvolutions, expiryPeriod, err :=
+			cfg.Credentials.validatedKESProtocolLifetime()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"production mode requires a validated KES protocol lifetime: %w",
+				err,
+			)
+		}
+		f.maxKESEvolutions = maxEvolutions
+		f.opCertExpiryKES = expiryPeriod
 		if cfg.LeiosProduceChecker != nil && cfg.LeiosTxValidator == nil {
 			return nil, errors.New(
 				"production Leios forging requires transaction validator",
@@ -395,7 +410,7 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 				float64(opCert.KESPeriod),
 			)
 			f.metrics.opCertExpiryKES.Set(
-				float64(f.creds.OpCertExpiryPeriod()),
+				float64(f.opCertExpiryKES),
 			)
 		}
 	}
@@ -660,6 +675,30 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.metrics.forgeNodeIsLeader.Inc()
 	}
 
+	// Compute and enforce the protocol KES lifetime before any Leios or
+	// ranking-block construction. The expiry was checked for overflow when
+	// the production forger was created, so this comparison cannot wrap.
+	slotsPerKESPeriod := f.slotClock.SlotsPerKESPeriod()
+	if slotsPerKESPeriod == 0 {
+		return errors.New("slots per KES period is zero")
+	}
+	kesPeriod, err := CurrentKESPeriod(currentSlot, slotsPerKESPeriod)
+	if err != nil {
+		return err
+	}
+	f.updateKESMetrics(kesPeriod)
+	if kesPeriod >= f.opCertExpiryKES {
+		f.incCouldNotForge()
+		f.logger.Error(
+			"forge skip: operational certificate expired; rotate the operational certificate",
+			"slot", currentSlot,
+			"current_kes_period", kesPeriod,
+			"opcert_expiry_period", f.opCertExpiryKES,
+			"max_kes_evolutions", f.maxKESEvolutions,
+		)
+		return nil
+	}
+
 	leiosBlockData, embeddedEb := f.leiosBlockDataForSlot(currentSlot)
 	if f.leiosChecker != nil {
 		var excludedTxHashes map[string]struct{}
@@ -707,24 +746,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 
 	f.logger.Info("producing block", "slot", currentSlot)
 
-	// Calculate KES period for this slot
-	// KES period = slot / slots_per_kes_period
-	slotsPerKESPeriod := f.slotClock.SlotsPerKESPeriod()
-	if slotsPerKESPeriod == 0 {
-		return errors.New("slots per KES period is zero")
-	}
-	kesPeriod, err := CurrentKESPeriod(currentSlot, slotsPerKESPeriod)
-	if err != nil {
-		return err
-	}
-
 	// Ensure KES key is at correct period
 	if err := f.creds.UpdateKESPeriod(kesPeriod); err != nil {
 		return fmt.Errorf("failed to update KES period: %w", err)
 	}
-
-	// Update KES metrics after successful evolution
-	f.updateKESMetrics(kesPeriod)
 
 	// Build the block
 	block, blockCbor, err := f.buildBlock(
@@ -985,8 +1010,8 @@ func (f *BlockForger) reportForgeCallbackPanic(phase string, r any) {
 	)
 }
 
-// updateKESMetrics updates KES gauges after a successful KES
-// period update. Safe to call when metrics are nil.
+// updateKESMetrics updates KES protocol-lifetime gauges for the current slot.
+// Safe to call when metrics are nil.
 func (f *BlockForger) updateKESMetrics(
 	currentPeriod uint64,
 ) {
@@ -1003,7 +1028,7 @@ func (f *BlockForger) updateKESMetrics(
 			float64(opCert.KESPeriod),
 		)
 		f.metrics.opCertExpiryKES.Set(
-			float64(f.creds.OpCertExpiryPeriod()),
+			float64(f.opCertExpiryKES),
 		)
 	}
 }

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -660,28 +660,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
-	// Check if we're the leader for this slot
-	isLeader := f.checkLeaderSafe(currentSlot)
-	if !isLeader {
-		f.logger.Debug(
-			"forge check: not leader for slot",
-			"current_slot", currentSlot,
-			"tip_slot", tipSlot,
-		)
-		if f.metrics != nil {
-			f.metrics.forgeNotLeader.Inc()
-		}
-		return nil
-	}
-
-	// We are the slot leader
-	if f.metrics != nil {
-		f.metrics.forgeNodeIsLeader.Inc()
-	}
-
-	// Compute and enforce the protocol KES lifetime before any Leios or
-	// ranking-block construction. The expiry was checked for overflow when
-	// the production forger was created, so this comparison cannot wrap.
+	// Compute and enforce the protocol KES lifetime before Praos leader
+	// selection, Leios work, or ranking-block construction. The expiry was
+	// checked for overflow when the production forger was created, so these
+	// comparisons cannot wrap.
 	slotsPerKESPeriod := f.slotClock.SlotsPerKESPeriod()
 	if slotsPerKESPeriod == 0 {
 		return errors.New("slots per KES period is zero")
@@ -733,6 +715,59 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			"max_kes_evolutions", maxEvolutions,
 		)
 		return nil
+	}
+
+	// Do not hold the generation lease across the pluggable leader callback:
+	// it may synchronously trigger a credential reload. Remember the generation
+	// selected by the policy gate and require that exact generation again after
+	// the callback. Pool and VRF identity changes are rejected by LoadFromFiles,
+	// so the election's startup identity remains valid; a same-identity KES or
+	// opcert reload changes the generation and safely abandons this attempt.
+	attemptGeneration := generation.id
+	generation.release()
+	generationReleased = true
+
+	// Check if we're the leader for this slot only after the KES gate.
+	isLeader := f.checkLeaderSafe(currentSlot)
+	if !isLeader {
+		f.logger.Debug(
+			"forge check: not leader for slot",
+			"current_slot", currentSlot,
+			"tip_slot", tipSlot,
+		)
+		if f.metrics != nil {
+			f.metrics.forgeNotLeader.Inc()
+		}
+		return nil
+	}
+
+	generation = f.creds.acquireCredentialGeneration()
+	generationReleased = false
+	if generation.id != attemptGeneration {
+		f.incCouldNotForge()
+		f.logger.Warn(
+			"forge skip: credentials changed during leader selection",
+			"slot", currentSlot,
+			"selected_generation", attemptGeneration,
+			"current_generation", generation.id,
+		)
+		return nil
+	}
+	if err := generation.validateKESPeriod(kesPeriod); err != nil {
+		f.incCouldNotForge()
+		f.logger.Error(
+			"forge skip: credential generation became invalid during leader selection",
+			"slot", currentSlot,
+			"credential_generation", generation.id,
+			"error", err,
+		)
+		return nil
+	}
+
+	// We are the slot leader with the same credential generation that passed
+	// the pre-selection gate.
+	if f.metrics != nil {
+		f.metrics.forgeNodeIsLeader.Inc()
 	}
 
 	leiosBlockData, embeddedEb := f.leiosBlockDataForSlot(currentSlot)

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -105,6 +105,98 @@ func TestCheckAndForgeProductionWaitsForUnknownActiveUpstreamTarget(t *testing.T
 	assert.Zero(t, broadcaster.calls)
 }
 
+func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
+	creds := setupTestCredentials(t)
+	genesis := synthGenesis(1, 2, time.Second, time.Unix(0, 0))
+	require.NoError(t, creds.ValidateKESPeriod(genesis, 0))
+
+	block := newForgerTestBlock(1, 2)
+	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
+	broadcaster := &forgerTestBroadcaster{}
+	clock := &forgerTestSlotClock{
+		currentSlot:       1,
+		chainTipSlot:      0,
+		slotsPerKESPeriod: 1,
+	}
+	var logs bytes.Buffer
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(&logs, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock:        clock,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	// The final period in [start, start+maxEvolutions) remains valid.
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Equal(t, 1, builder.calls)
+	require.Equal(t, 1, broadcaster.calls)
+	lastValidCurrent := testutil.ToFloat64(forger.metrics.currentKESPeriod)
+	lastValidRemaining := testutil.ToFloat64(
+		forger.metrics.remainingKESPeriods,
+	)
+	lastValidExpiry := testutil.ToFloat64(forger.metrics.opCertExpiryKES)
+
+	// The same loaded producer reaches the first expired period while running.
+	clock.currentSlot = 2
+	clock.chainTipSlot = 1
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Equal(t, 1, builder.calls, "expired period must not build a block")
+	require.Equal(
+		t,
+		1,
+		broadcaster.calls,
+		"expired period must not broadcast a block",
+	)
+	require.Contains(t, logs.String(), "operational certificate expired")
+	require.Equal(t, float64(1), lastValidCurrent)
+	require.Equal(t, float64(1), lastValidRemaining)
+	require.Equal(t, float64(2), lastValidExpiry)
+
+	require.Equal(
+		t,
+		float64(2),
+		testutil.ToFloat64(forger.metrics.currentKESPeriod),
+	)
+	require.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.remainingKESPeriods),
+	)
+	require.Equal(
+		t,
+		float64(2),
+		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+func TestNewBlockForgerRejectsUnvalidatedKESLifetime(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	creds := NewPoolCredentials()
+	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	_, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{},
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock: forgerTestSlotClock{
+			slotsPerKESPeriod: 1,
+		},
+	})
+	require.ErrorContains(t, err, "validated KES protocol lifetime")
+}
+
 type forgerTestBuilder struct {
 	block      ledger.Block
 	cbor       []byte

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -21,9 +21,12 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -170,6 +173,367 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 	require.Equal(
 		t,
 		float64(2),
+		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
+	creds := setupTestCredentials(t)
+	creds.opCert.KESPeriod = 5
+	require.NoError(t, creds.ValidateKESPeriod(
+		synthGenesis(1, 2, time.Second, time.Unix(0, 0)),
+		5,
+	))
+
+	block := newForgerTestBlock(4, 2)
+	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
+	broadcaster := &forgerTestBroadcaster{}
+	leiosChecker := &forgerTestLeiosChecker{reason: "not eligible"}
+	var logs bytes.Buffer
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(&logs, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       4,
+			chainTipSlot:      3,
+			slotsPerKESPeriod: 1,
+		},
+		LeiosProduceChecker: leiosChecker,
+		LeiosEBBroadcaster:  &forgerTestLeiosCaster{},
+		LeiosMempool:        forgerTestMempoolProvider{},
+		LeiosTxValidator:    &mockTxValidator{},
+		PromRegistry:        prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		forger.checkAndForgeProduction(context.Background()),
+		"pre-start policy gate must decline before KES evolution",
+	)
+	require.Zero(t, leiosChecker.calls, "pre-start period must not run Leios")
+	require.Zero(t, builder.calls, "pre-start period must not build a block")
+	require.Zero(
+		t,
+		broadcaster.calls,
+		"pre-start period must not broadcast a block",
+	)
+	require.Contains(
+		t,
+		logs.String(),
+		"operational certificate is not yet valid",
+	)
+	require.Equal(
+		t,
+		float64(4),
+		testutil.ToFloat64(forger.metrics.currentKESPeriod),
+	)
+	require.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.remainingKESPeriods),
+	)
+	require.Equal(
+		t,
+		float64(5),
+		testutil.ToFloat64(forger.metrics.opCertStartKES),
+	)
+	require.Equal(
+		t,
+		float64(7),
+		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+type forgerCredentialGenerationBuilder struct {
+	creds       *PoolCredentials
+	block       ledger.Block
+	cbor        []byte
+	entered     chan struct{}
+	read        chan struct{}
+	readDone    chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	readOnce    sync.Once
+
+	mu             sync.Mutex
+	calls          int
+	signed         bool
+	opCertStart    uint64
+	opCertExpiry   uint64
+	signingPeriod  uint64
+	signingErrText string
+}
+
+func (b *forgerCredentialGenerationBuilder) BuildBlock(
+	_ uint64,
+	kesPeriod uint64,
+) (ledger.Block, []byte, error) {
+	b.enteredOnce.Do(func() { close(b.entered) })
+	<-b.read
+
+	opCert := b.creds.GetOpCert()
+	message := []byte("credential generation race")
+	signature, err := b.creds.KESSign(kesPeriod, message)
+
+	b.mu.Lock()
+	b.calls++
+	b.signingPeriod = kesPeriod
+	b.opCertExpiry = b.creds.OpCertExpiryPeriod()
+	if opCert != nil {
+		b.opCertStart = opCert.KESPeriod
+		if err == nil {
+			b.signed = kes.VerifySignedKES(
+				b.creds.GetKESVKey(),
+				kesPeriod-opCert.KESPeriod,
+				message,
+				signature,
+			)
+		}
+	}
+	if err != nil {
+		b.signingErrText = err.Error()
+	}
+	b.mu.Unlock()
+
+	b.readOnce.Do(func() { close(b.readDone) })
+	<-b.release
+	if err != nil {
+		return nil, nil, err
+	}
+	return b.block, b.cbor, nil
+}
+
+func (b *forgerCredentialGenerationBuilder) snapshot() (
+	calls int,
+	signed bool,
+	start uint64,
+	expiry uint64,
+	period uint64,
+	signingErr string,
+) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls,
+		b.signed,
+		b.opCertStart,
+		b.opCertExpiry,
+		b.signingPeriod,
+		b.signingErrText
+}
+
+func TestCheckAndForgeProductionSerializesCredentialReload(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	creds := NewPoolCredentials()
+	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, creds.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+
+	block := newForgerTestBlock(1, 2)
+	builder := &forgerCredentialGenerationBuilder{
+		creds:    creds,
+		block:    block,
+		cbor:     block.cbor,
+		entered:  make(chan struct{}),
+		read:     make(chan struct{}),
+		readDone: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	broadcaster := &forgerTestBroadcaster{}
+	clock := &forgerTestSlotClock{
+		currentSlot:       1,
+		chainTipSlot:      0,
+		slotsPerKESPeriod: 1,
+	}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock:        clock,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	forgeDone := make(chan error, 1)
+	go func() {
+		forgeDone <- forger.checkAndForgeProduction(context.Background())
+	}()
+	dingotestutil.RequireReceive(
+		t,
+		builder.entered,
+		time.Second,
+		"builder entered",
+	)
+
+	reloadStarted := make(chan struct{})
+	reloadDone := make(chan error, 1)
+	go func() {
+		close(reloadStarted)
+		if err := creds.LoadFromFiles(vrfPath, kesPath, opCertPath); err != nil {
+			reloadDone <- err
+			return
+		}
+		reloadDone <- creds.ValidateKESPeriod(
+			synthGenesis(1, 1, time.Second, time.Unix(0, 0)),
+			0,
+		)
+	}()
+	dingotestutil.RequireReceive(
+		t,
+		reloadStarted,
+		time.Second,
+		"reload started",
+	)
+
+	var releaseOnce sync.Once
+	releaseBuilder := func() {
+		releaseOnce.Do(func() { close(builder.release) })
+	}
+	defer releaseBuilder()
+	dingotestutil.RequireNoReceive(
+		t,
+		reloadDone,
+		100*time.Millisecond,
+		"credential reload must wait for the active forge generation",
+	)
+	close(builder.read)
+	dingotestutil.RequireReceive(
+		t,
+		builder.readDone,
+		time.Second,
+		"builder credential reads must not deadlock behind queued reload",
+	)
+	dingotestutil.RequireNoReceive(
+		t,
+		reloadDone,
+		100*time.Millisecond,
+		"credential reload must wait through generation-backed signing",
+	)
+	releaseBuilder()
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(
+			t,
+			forgeDone,
+			time.Second,
+			"forge completion",
+		),
+	)
+	require.NoError(
+		t,
+		dingotestutil.RequireReceive(
+			t,
+			reloadDone,
+			time.Second,
+			"reload completion",
+		),
+	)
+
+	calls, signed, start, expiry, period, signingErr := builder.snapshot()
+	require.Equal(t, 1, calls)
+	require.True(t, signed)
+	require.Empty(t, signingErr)
+	require.Equal(t, uint64(0), start)
+	require.Equal(t, uint64(3), expiry)
+	require.Equal(t, uint64(1), period)
+	require.Equal(t, 1, broadcaster.calls)
+
+	// The successful shorter-lifetime reload is visible as one complete
+	// generation on the next cycle: gate and telemetry switch together.
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	calls, _, _, _, _, _ = builder.snapshot()
+	require.Equal(t, 1, calls, "reloaded expired generation must not build")
+	require.Equal(t, 1, broadcaster.calls)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.currentKESPeriod),
+	)
+	require.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.remainingKESPeriods),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+func TestCheckAndForgeProductionFailsClosedAfterKESRevalidation(t *testing.T) {
+	creds := setupTestCredentials(t)
+	require.NoError(t, creds.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+
+	block := newForgerTestBlock(1, 2)
+	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
+	broadcaster := &forgerTestBroadcaster{}
+	var logs bytes.Buffer
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(&logs, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       1,
+			chainTipSlot:      0,
+			slotsPerKESPeriod: 1,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	revalidationErr := creds.ValidateKESPeriod(
+		synthGenesis(1, 1, time.Second, time.Unix(0, 0)),
+		1,
+	)
+	require.ErrorContains(t, revalidationErr, "operational certificate expired")
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Zero(t, builder.calls, "failed revalidation must disable building")
+	require.Zero(
+		t,
+		broadcaster.calls,
+		"failed revalidation must disable broadcasting",
+	)
+	require.Contains(t, logs.String(), "KES protocol lifetime is not validated")
+	require.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.remainingKESPeriods),
+	)
+	require.Equal(
+		t,
+		float64(0),
 		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
 	)
 	require.Equal(

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -48,6 +48,60 @@ func (forgerTestLeader) NextLeaderSlot(
 	return fromSlot, true
 }
 
+type forgerBlockingLeader struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (l *forgerBlockingLeader) ShouldProduceBlock(uint64) bool {
+	l.mu.Lock()
+	l.calls++
+	l.mu.Unlock()
+	l.enteredOnce.Do(func() { close(l.entered) })
+	<-l.release
+	return true
+}
+
+func (l *forgerBlockingLeader) NextLeaderSlot(
+	fromSlot uint64,
+) (uint64, bool) {
+	return fromSlot, true
+}
+
+func (l *forgerBlockingLeader) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+type forgerCountingLeader struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (l *forgerCountingLeader) ShouldProduceBlock(uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls++
+	return true
+}
+
+func (l *forgerCountingLeader) NextLeaderSlot(
+	fromSlot uint64,
+) (uint64, bool) {
+	return fromSlot, true
+}
+
+func (l *forgerCountingLeader) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
 type forgerTestSlotClock struct {
 	currentSlot       uint64
 	chainTipSlot      uint64
@@ -121,12 +175,13 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 		chainTipSlot:      0,
 		slotsPerKESPeriod: 1,
 	}
+	leader := &forgerCountingLeader{}
 	var logs bytes.Buffer
 	forger, err := NewBlockForger(ForgerConfig{
 		Mode:             ModeProduction,
 		Logger:           slog.New(slog.NewJSONHandler(&logs, nil)),
 		Credentials:      creds,
-		LeaderChecker:    forgerTestLeader{},
+		LeaderChecker:    leader,
 		BlockBuilder:     builder,
 		BlockBroadcaster: broadcaster,
 		SlotClock:        clock,
@@ -136,6 +191,7 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 
 	// The final period in [start, start+maxEvolutions) remains valid.
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Equal(t, 1, leader.callCount())
 	require.Equal(t, 1, builder.calls)
 	require.Equal(t, 1, broadcaster.calls)
 	lastValidCurrent := testutil.ToFloat64(forger.metrics.currentKESPeriod)
@@ -148,6 +204,12 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 	clock.currentSlot = 2
 	clock.chainTipSlot = 1
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"expired period must not run leader selection",
+	)
 	require.Equal(t, 1, builder.calls, "expired period must not build a block")
 	require.Equal(
 		t,
@@ -184,22 +246,28 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 
 func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 	creds := setupTestCredentials(t)
+	creds.generationMu.Lock()
+	creds.mu.Lock()
+	creds.generation++
 	creds.opCert.KESPeriod = 5
-	require.NoError(t, creds.ValidateKESPeriod(
-		synthGenesis(1, 2, time.Second, time.Unix(0, 0)),
-		5,
-	))
+	creds.opCertStartKES = 5
+	creds.maxKESEvolutions = 2
+	creds.opCertExpiryKES = 7
+	creds.opCertValidated = true
+	creds.mu.Unlock()
+	creds.generationMu.Unlock()
 
 	block := newForgerTestBlock(4, 2)
 	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
 	broadcaster := &forgerTestBroadcaster{}
 	leiosChecker := &forgerTestLeiosChecker{reason: "not eligible"}
+	leader := &forgerCountingLeader{}
 	var logs bytes.Buffer
 	forger, err := NewBlockForger(ForgerConfig{
 		Mode:             ModeProduction,
 		Logger:           slog.New(slog.NewJSONHandler(&logs, nil)),
 		Credentials:      creds,
-		LeaderChecker:    forgerTestLeader{},
+		LeaderChecker:    leader,
 		BlockBuilder:     builder,
 		BlockBroadcaster: broadcaster,
 		SlotClock: forgerTestSlotClock{
@@ -219,6 +287,11 @@ func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 		t,
 		forger.checkAndForgeProduction(context.Background()),
 		"pre-start policy gate must decline before KES evolution",
+	)
+	require.Zero(
+		t,
+		leader.callCount(),
+		"pre-start period must not run leader selection",
 	)
 	require.Zero(t, leiosChecker.calls, "pre-start period must not run Leios")
 	require.Zero(t, builder.calls, "pre-start period must not build a block")
@@ -257,6 +330,74 @@ func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 		float64(1),
 		testutil.ToFloat64(forger.metrics.forgeCouldNot),
 	)
+}
+
+func TestCheckAndForgeProductionRejectsIdentityReloadDuringSelection(
+	t *testing.T,
+) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	creds := NewPoolCredentials()
+	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, creds.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+
+	leader := &forgerBlockingLeader{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(1, 2),
+	}
+	broadcaster := &forgerTestBroadcaster{}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       1,
+			chainTipSlot:      0,
+			slotsPerKESPeriod: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	forgeDone := make(chan error, 1)
+	go func() {
+		forgeDone <- forger.checkAndForgeProduction(context.Background())
+	}()
+	dingotestutil.RequireReceive(t, leader.entered, time.Second, "leader entered")
+
+	alternateVRFPath := createAlternateTestVRFKey(t)
+	reloadDone := make(chan error, 1)
+	go func() {
+		reloadDone <- creds.LoadFromFiles(
+			alternateVRFPath,
+			kesPath,
+			opCertPath,
+		)
+	}()
+	reloadErr := dingotestutil.RequireReceive(
+		t,
+		reloadDone,
+		time.Second,
+		"identity-changing reload completion",
+	)
+	require.ErrorContains(t, reloadErr, "cannot change pool or VRF identity")
+	close(leader.release)
+	require.NoError(t, dingotestutil.RequireReceive(
+		t,
+		forgeDone,
+		time.Second,
+		"forge completion",
+	))
+	require.Equal(t, 1, leader.callCount())
+	require.Zero(t, builder.calls)
+	require.Zero(t, broadcaster.calls)
 }
 
 type forgerCredentialGenerationBuilder struct {
@@ -559,6 +700,38 @@ func TestNewBlockForgerRejectsUnvalidatedKESLifetime(t *testing.T) {
 		},
 	})
 	require.ErrorContains(t, err, "validated KES protocol lifetime")
+}
+
+func TestNewBlockForgerRejectsInvalidOpCertGeneration(t *testing.T) {
+	vrfPath, kesPath, _ := createTestKeys(t)
+	corrupted := strings.Replace(testOpCertJSON, "89fc9e9f", "88fc9e9f", 1)
+	require.NotEqual(t, testOpCertJSON, corrupted)
+	creds := NewPoolCredentials()
+	require.NoError(t, creds.LoadFromFiles(
+		vrfPath,
+		kesPath,
+		writeTestOpCert(t, corrupted),
+	))
+	require.ErrorContains(
+		t,
+		creds.ValidateKESPeriod(
+			synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+			0,
+		),
+		"signature verification failed",
+	)
+
+	_, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{},
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock: forgerTestSlotClock{
+			slotsPerKESPeriod: 1,
+		},
+	})
+	require.ErrorContains(t, err, "operational certificate is not validated")
 }
 
 type forgerTestBuilder struct {

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -329,6 +329,68 @@ func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 	)
 }
 
+func TestCheckAndForgeProductionCountsKESUpdateFailure(t *testing.T) {
+	creds := setupTestCredentials(t)
+	require.NoError(t, creds.UpdateKESPeriod(1))
+
+	builder := &forgerTestBuilder{block: newForgerTestBlock(1, 2)}
+	broadcaster := &forgerTestBroadcaster{}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       1,
+			chainTipSlot:      0,
+			slotsPerKESPeriod: 100,
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	err = forger.checkAndForgeProduction(context.Background())
+	require.ErrorContains(t, err, "failed to update KES period")
+	require.Zero(t, builder.calls)
+	require.Zero(t, broadcaster.calls)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+func TestSignBlockHeaderEnforcesProtocolKESLifetime(t *testing.T) {
+	creds := setupTestCredentials(t)
+	creds.mu.Lock()
+	creds.generation++
+	creds.opCertStartKES = 0
+	creds.maxKESEvolutions = 2
+	creds.opCertExpiryKES = 2
+	creds.opCertValidated = true
+	creds.mu.Unlock()
+	require.NoError(t, creds.UpdateKESPeriod(2))
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{},
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock: forgerTestSlotClock{
+			slotsPerKESPeriod: 1,
+		},
+	})
+	require.NoError(t, err)
+
+	signature, err := forger.SignBlockHeader(2, []byte("expired header"))
+	require.ErrorIs(t, err, errOpCertExpired)
+	require.Nil(t, signature)
+}
+
 func TestCheckAndForgeProductionRejectsIdentityReloadDuringSelection(
 	t *testing.T,
 ) {

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	dingotestutil "github.com/blinklabs-io/dingo/internal/test/testutil"
-	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -246,7 +245,6 @@ func TestCheckAndForgeProductionStopsAtProtocolKESExpiry(t *testing.T) {
 
 func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 	creds := setupTestCredentials(t)
-	creds.generationMu.Lock()
 	creds.mu.Lock()
 	creds.generation++
 	creds.opCert.KESPeriod = 5
@@ -255,7 +253,6 @@ func TestCheckAndForgeProductionStopsBeforeOpCertStart(t *testing.T) {
 	creds.opCertExpiryKES = 7
 	creds.opCertValidated = true
 	creds.mu.Unlock()
-	creds.generationMu.Unlock()
 
 	block := newForgerTestBlock(4, 2)
 	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
@@ -400,84 +397,29 @@ func TestCheckAndForgeProductionRejectsIdentityReloadDuringSelection(
 	require.Zero(t, broadcaster.calls)
 }
 
-type forgerCredentialGenerationBuilder struct {
-	creds       *PoolCredentials
+type forgerReentrantBuilder struct {
+	callback    func() error
+	callbackErr error
 	block       ledger.Block
 	cbor        []byte
-	entered     chan struct{}
-	read        chan struct{}
-	readDone    chan struct{}
-	release     chan struct{}
-	enteredOnce sync.Once
-	readOnce    sync.Once
-
-	mu             sync.Mutex
-	calls          int
-	signed         bool
-	opCertStart    uint64
-	opCertExpiry   uint64
-	signingPeriod  uint64
-	signingErrText string
+	calls       int
 }
 
-func (b *forgerCredentialGenerationBuilder) BuildBlock(
+func (b *forgerReentrantBuilder) BuildBlock(
 	_ uint64,
-	kesPeriod uint64,
+	_ uint64,
 ) (ledger.Block, []byte, error) {
-	b.enteredOnce.Do(func() { close(b.entered) })
-	<-b.read
-
-	opCert := b.creds.GetOpCert()
-	message := []byte("credential generation race")
-	signature, err := b.creds.KESSign(kesPeriod, message)
-
-	b.mu.Lock()
 	b.calls++
-	b.signingPeriod = kesPeriod
-	b.opCertExpiry = b.creds.OpCertExpiryPeriod()
-	if opCert != nil {
-		b.opCertStart = opCert.KESPeriod
-		if err == nil {
-			b.signed = kes.VerifySignedKES(
-				b.creds.GetKESVKey(),
-				kesPeriod-opCert.KESPeriod,
-				message,
-				signature,
-			)
-		}
+	if b.callback != nil {
+		b.callbackErr = b.callback()
 	}
-	if err != nil {
-		b.signingErrText = err.Error()
-	}
-	b.mu.Unlock()
-
-	b.readOnce.Do(func() { close(b.readDone) })
-	<-b.release
-	if err != nil {
-		return nil, nil, err
+	if b.callbackErr != nil {
+		return nil, nil, b.callbackErr
 	}
 	return b.block, b.cbor, nil
 }
 
-func (b *forgerCredentialGenerationBuilder) snapshot() (
-	calls int,
-	signed bool,
-	start uint64,
-	expiry uint64,
-	period uint64,
-	signingErr string,
-) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.calls,
-		b.signed,
-		b.opCertStart,
-		b.opCertExpiry,
-		b.signingPeriod,
-		b.signingErrText
-}
-
-func TestCheckAndForgeProductionSerializesCredentialReload(t *testing.T) {
+func TestCheckAndForgeProductionRejectsReentrantBuilderReload(t *testing.T) {
 	vrfPath, kesPath, opCertPath := createTestKeys(t)
 	creds := NewPoolCredentials()
 	require.NoError(t, creds.LoadFromFiles(vrfPath, kesPath, opCertPath))
@@ -487,14 +429,22 @@ func TestCheckAndForgeProductionSerializesCredentialReload(t *testing.T) {
 	))
 
 	block := newForgerTestBlock(1, 2)
-	builder := &forgerCredentialGenerationBuilder{
-		creds:    creds,
-		block:    block,
-		cbor:     block.cbor,
-		entered:  make(chan struct{}),
-		read:     make(chan struct{}),
-		readDone: make(chan struct{}),
-		release:  make(chan struct{}),
+	builder := &forgerReentrantBuilder{
+		block: block,
+		cbor:  block.cbor,
+		callback: func() error {
+			if err := creds.LoadFromFiles(
+				vrfPath,
+				kesPath,
+				opCertPath,
+			); err != nil {
+				return err
+			}
+			return creds.ValidateKESPeriod(
+				synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+				0,
+			)
+		},
 	}
 	broadcaster := &forgerTestBroadcaster{}
 	clock := &forgerTestSlotClock{
@@ -518,112 +468,68 @@ func TestCheckAndForgeProductionSerializesCredentialReload(t *testing.T) {
 	go func() {
 		forgeDone <- forger.checkAndForgeProduction(context.Background())
 	}()
-	dingotestutil.RequireReceive(
+	forgeErr := dingotestutil.RequireReceive(
 		t,
-		builder.entered,
+		forgeDone,
 		time.Second,
-		"builder entered",
+		"reentrant builder reload completion",
 	)
+	require.ErrorContains(t, forgeErr, "credential generation changed")
+	require.NoError(t, builder.callbackErr)
+	require.Equal(t, 1, builder.calls)
+	require.Zero(t, broadcaster.calls, "stale builder output must not be adopted")
+}
 
-	reloadStarted := make(chan struct{})
-	reloadDone := make(chan error, 1)
-	go func() {
-		close(reloadStarted)
-		if err := creds.LoadFromFiles(vrfPath, kesPath, opCertPath); err != nil {
-			reloadDone <- err
-			return
-		}
-		reloadDone <- creds.ValidateKESPeriod(
-			synthGenesis(1, 1, time.Second, time.Unix(0, 0)),
-			0,
-		)
-	}()
-	dingotestutil.RequireReceive(
-		t,
-		reloadStarted,
-		time.Second,
-		"reload started",
-	)
+func TestCheckAndForgeProductionRejectsReentrantLeiosRevalidation(
+	t *testing.T,
+) {
+	creds := setupTestCredentials(t)
+	genesis := synthGenesis(1, 3, time.Second, time.Unix(0, 0))
+	require.NoError(t, creds.ValidateKESPeriod(genesis, 0))
 
-	var releaseOnce sync.Once
-	releaseBuilder := func() {
-		releaseOnce.Do(func() { close(builder.release) })
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(1, 2),
 	}
-	defer releaseBuilder()
-	dingotestutil.RequireNoReceive(
+	broadcaster := &forgerTestBroadcaster{}
+	leiosChecker := &forgerTestLeiosChecker{
+		reason: "revalidated",
+		callback: func() error {
+			return creds.ValidateKESPeriod(genesis, 0)
+		},
+	}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       1,
+			chainTipSlot:      0,
+			slotsPerKESPeriod: 1,
+		},
+		LeiosProduceChecker: leiosChecker,
+		LeiosEBBroadcaster:  &forgerTestLeiosCaster{},
+		LeiosMempool:        forgerTestMempoolProvider{},
+		LeiosTxValidator:    &mockTxValidator{},
+	})
+	require.NoError(t, err)
+
+	forgeDone := make(chan error, 1)
+	go func() {
+		forgeDone <- forger.checkAndForgeProduction(context.Background())
+	}()
+	require.NoError(t, dingotestutil.RequireReceive(
 		t,
-		reloadDone,
-		100*time.Millisecond,
-		"credential reload must wait for the active forge generation",
-	)
-	close(builder.read)
-	dingotestutil.RequireReceive(
-		t,
-		builder.readDone,
+		forgeDone,
 		time.Second,
-		"builder credential reads must not deadlock behind queued reload",
-	)
-	dingotestutil.RequireNoReceive(
-		t,
-		reloadDone,
-		100*time.Millisecond,
-		"credential reload must wait through generation-backed signing",
-	)
-	releaseBuilder()
-	require.NoError(
-		t,
-		dingotestutil.RequireReceive(
-			t,
-			forgeDone,
-			time.Second,
-			"forge completion",
-		),
-	)
-	require.NoError(
-		t,
-		dingotestutil.RequireReceive(
-			t,
-			reloadDone,
-			time.Second,
-			"reload completion",
-		),
-	)
-
-	calls, signed, start, expiry, period, signingErr := builder.snapshot()
-	require.Equal(t, 1, calls)
-	require.True(t, signed)
-	require.Empty(t, signingErr)
-	require.Equal(t, uint64(0), start)
-	require.Equal(t, uint64(3), expiry)
-	require.Equal(t, uint64(1), period)
-	require.Equal(t, 1, broadcaster.calls)
-
-	// The successful shorter-lifetime reload is visible as one complete
-	// generation on the next cycle: gate and telemetry switch together.
-	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
-	calls, _, _, _, _, _ = builder.snapshot()
-	require.Equal(t, 1, calls, "reloaded expired generation must not build")
-	require.Equal(t, 1, broadcaster.calls)
-	require.Equal(
-		t,
-		float64(1),
-		testutil.ToFloat64(forger.metrics.currentKESPeriod),
-	)
-	require.Equal(
-		t,
-		float64(0),
-		testutil.ToFloat64(forger.metrics.remainingKESPeriods),
-	)
-	require.Equal(
-		t,
-		float64(1),
-		testutil.ToFloat64(forger.metrics.opCertExpiryKES),
-	)
-	require.Equal(
-		t,
-		float64(1),
-		testutil.ToFloat64(forger.metrics.forgeCouldNot),
-	)
+		"reentrant Leios revalidation completion",
+	))
+	require.NoError(t, leiosChecker.callbackErr)
+	require.Equal(t, 1, leiosChecker.calls)
+	require.Zero(t, builder.calls, "stale Leios attempt must not build")
+	require.Zero(t, broadcaster.calls, "stale Leios attempt must not be adopted")
 }
 
 func TestCheckAndForgeProductionFailsClosedAfterKESRevalidation(t *testing.T) {
@@ -842,10 +748,12 @@ func (b *forgerTestBlock) Cbor() []byte     { return b.cbor }
 func (b *forgerTestBlock) BlockBodyHash() lcommon.Blake2b256 { return lcommon.Blake2b256{} }
 
 type forgerTestLeiosChecker struct {
-	calls   int
-	allowed bool
-	reason  string
-	err     error
+	calls       int
+	allowed     bool
+	reason      string
+	err         error
+	callback    func() error
+	callbackErr error
 }
 
 type forgerTestConfirmedTxRemover struct {
@@ -980,6 +888,12 @@ func (c *forgerTestLeiosChecker) MayProduceEndorserBlock(
 	uint64,
 ) (bool, string, error) {
 	c.calls++
+	if c.callback != nil {
+		c.callbackErr = c.callback()
+		if c.callbackErr != nil {
+			return false, "", c.callbackErr
+		}
+	}
 	return c.allowed, c.reason, c.err
 }
 

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -153,6 +153,10 @@ func (loaded *loadedPoolCredentials) zeroize() {
 		loaded.kesSKey.Zeroize()
 		loaded.kesSKey = nil
 	}
+	loaded.vrfVKey = nil
+	loaded.kesVKey = nil
+	loaded.opCert = nil
+	loaded.poolID = lcommon.PoolId{}
 }
 
 // OpCert represents an operational certificate that binds a KES key to a pool.
@@ -213,12 +217,20 @@ func loadPoolCredentialsFromFiles(
 	vrfSKeyPath string,
 	kesSKeyPath string,
 	opCertPath string,
-) (*loadedPoolCredentials, error) {
+) (_ *loadedPoolCredentials, retErr error) {
+	loaded := &loadedPoolCredentials{}
+	defer func() {
+		if retErr != nil {
+			loaded.zeroize()
+		}
+	}()
+
 	// Load VRF signing key
 	vrfKey, err := loadSecretKeyFromFile(vrfSKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load VRF signing key: %w", err)
 	}
+	loaded.vrfSKey = vrfKey.SKey
 	if len(vrfKey.SKey) != vrf.SeedSize {
 		return nil, fmt.Errorf(
 			"invalid VRF key size: expected %d, got %d",
@@ -226,11 +238,33 @@ func loadPoolCredentialsFromFiles(
 			len(vrfKey.SKey),
 		)
 	}
+	derivedVRFVKey, derivedSeed, err := vrf.KeyGen(vrfKey.SKey)
+	if len(derivedSeed) > 0 {
+		wipeCredentialBytes(derivedSeed)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive VRF verification key: %w", err)
+	}
+	if len(vrfKey.VKey) > 0 &&
+		(len(vrfKey.VKey) != vrf.PublicKeySize ||
+			!bytes.Equal(vrfKey.VKey, derivedVRFVKey)) {
+		return nil, errors.New(
+			"VRF verification key mismatch: supplied key does not match signing seed",
+		)
+	}
+	// Use only the identity derived from the signing seed. Bursa's parsed
+	// verification key is an untrusted suffix in 64-byte cardano-cli files.
+	loaded.vrfVKey = derivedVRFVKey
 
 	// Load KES signing key
 	kesKey, err := loadSecretKeyFromFile(kesSKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KES signing key: %w", err)
+	}
+	loaded.kesSKey = &kes.SecretKey{
+		Depth:  kes.CardanoKesDepth,
+		Period: 0, // Will be updated during block production
+		Data:   kesKey.SKey,
 	}
 	if len(kesKey.SKey) != kes.CardanoKesSecretKeySize {
 		return nil, fmt.Errorf(
@@ -239,11 +273,7 @@ func loadPoolCredentialsFromFiles(
 			len(kesKey.SKey),
 		)
 	}
-	kesSKey := &kes.SecretKey{
-		Depth:  kes.CardanoKesDepth,
-		Period: 0, // Will be updated during block production
-		Data:   kesKey.SKey,
-	}
+	loaded.kesVKey = kesKey.VKey
 
 	// Load operational certificate
 	opCertKey, err := bursa.LoadKeyFromFile(opCertPath)
@@ -253,7 +283,7 @@ func loadPoolCredentialsFromFiles(
 			err,
 		)
 	}
-	opCert := &OpCert{
+	loaded.opCert = &OpCert{
 		KESVKey:     opCertKey.VKey,
 		IssueNumber: opCertKey.OpCertIssueNumber,
 		KESPeriod:   opCertKey.OpCertKesPeriod,
@@ -262,23 +292,18 @@ func loadPoolCredentialsFromFiles(
 	}
 
 	// Derive pool ID from cold verification key (Blake2b-224 hash)
-	poolID := lcommon.PoolId(lcommon.Blake2b224Hash(opCert.ColdVKey))
+	loaded.poolID = lcommon.PoolId(
+		lcommon.Blake2b224Hash(loaded.opCert.ColdVKey),
+	)
 
 	// Validate that OpCert KES vkey matches the loaded KES key
-	if !bytes.Equal(kesKey.VKey, opCert.KESVKey) {
+	if !bytes.Equal(loaded.kesVKey, loaded.opCert.KESVKey) {
 		return nil, errors.New(
 			"KES verification key mismatch: loaded key does not match OpCert KES vkey",
 		)
 	}
 
-	return &loadedPoolCredentials{
-		poolID:  poolID,
-		vrfSKey: vrfKey.SKey,
-		vrfVKey: vrfKey.VKey,
-		kesSKey: kesSKey,
-		kesVKey: kesKey.VKey,
-		opCert:  opCert,
-	}, nil
+	return loaded, nil
 }
 
 func (pc *PoolCredentials) clearUnsafe() {

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -62,8 +62,39 @@ type PoolCredentials struct {
 	// operational certificate. This is distinct from the KES key's 2^depth
 	// cryptographic capacity.
 	maxKESEvolutions uint64
+	opCertStartKES   uint64
+	opCertExpiryKES  uint64
+	generation       uint64
 
-	mu sync.RWMutex
+	// generationMu prevents credential or policy replacement while a forge
+	// attempt is using one generation. Keep it separate from mu so code called
+	// during that attempt can still use the public read-only accessors without
+	// recursively acquiring an RWMutex that has a writer queued behind it.
+	generationMu sync.RWMutex
+	mu           sync.RWMutex
+	kesMu        sync.RWMutex
+}
+
+// credentialGeneration pins one complete credential and protocol-policy
+// generation while a production forge attempt is in flight. The owner read
+// lock remains held until release, so reload and revalidation cannot replace
+// any key, opcert, or lifetime field partway through the attempt.
+type credentialGeneration struct {
+	owner            *PoolCredentials
+	id               uint64
+	loaded           bool
+	maxKESEvolutions uint64
+	opCertStartKES   uint64
+	opCertExpiryKES  uint64
+}
+
+type loadedPoolCredentials struct {
+	poolID  lcommon.PoolId
+	vrfSKey []byte
+	vrfVKey []byte
+	kesSKey *kes.SecretKey
+	kesVKey []byte
+	opCert  *OpCert
 }
 
 // OpCert represents an operational certificate that binds a KES key to a pool.
@@ -120,57 +151,51 @@ func loadSecretKeyFromFile(path string) (*bursa.LoadedKey, error) {
 	return key, nil
 }
 
-// LoadFromFiles loads all pool credentials from the specified file paths.
-// Uses Bursa to parse cardano-cli format key files.
-func (pc *PoolCredentials) LoadFromFiles(
+func loadPoolCredentialsFromFiles(
 	vrfSKeyPath string,
 	kesSKeyPath string,
 	opCertPath string,
-) error {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-	pc.maxKESEvolutions = 0
-
+) (*loadedPoolCredentials, error) {
 	// Load VRF signing key
 	vrfKey, err := loadSecretKeyFromFile(vrfSKeyPath)
 	if err != nil {
-		return fmt.Errorf("failed to load VRF signing key: %w", err)
+		return nil, fmt.Errorf("failed to load VRF signing key: %w", err)
 	}
 	if len(vrfKey.SKey) != vrf.SeedSize {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"invalid VRF key size: expected %d, got %d",
 			vrf.SeedSize,
 			len(vrfKey.SKey),
 		)
 	}
-	pc.vrfSKey = vrfKey.SKey
-	pc.vrfVKey = vrfKey.VKey
 
 	// Load KES signing key
 	kesKey, err := loadSecretKeyFromFile(kesSKeyPath)
 	if err != nil {
-		return fmt.Errorf("failed to load KES signing key: %w", err)
+		return nil, fmt.Errorf("failed to load KES signing key: %w", err)
 	}
 	if len(kesKey.SKey) != kes.CardanoKesSecretKeySize {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"invalid KES key size: expected %d, got %d",
 			kes.CardanoKesSecretKeySize,
 			len(kesKey.SKey),
 		)
 	}
-	pc.kesSKey = &kes.SecretKey{
+	kesSKey := &kes.SecretKey{
 		Depth:  kes.CardanoKesDepth,
 		Period: 0, // Will be updated during block production
 		Data:   kesKey.SKey,
 	}
-	pc.kesVKey = kesKey.VKey
 
 	// Load operational certificate
 	opCertKey, err := bursa.LoadKeyFromFile(opCertPath)
 	if err != nil {
-		return fmt.Errorf("failed to load operational certificate: %w", err)
+		return nil, fmt.Errorf(
+			"failed to load operational certificate: %w",
+			err,
+		)
 	}
-	pc.opCert = &OpCert{
+	opCert := &OpCert{
 		KESVKey:     opCertKey.VKey,
 		IssueNumber: opCertKey.OpCertIssueNumber,
 		KESPeriod:   opCertKey.OpCertKesPeriod,
@@ -179,15 +204,70 @@ func (pc *PoolCredentials) LoadFromFiles(
 	}
 
 	// Derive pool ID from cold verification key (Blake2b-224 hash)
-	pc.poolID = lcommon.PoolId(lcommon.Blake2b224Hash(pc.opCert.ColdVKey))
+	poolID := lcommon.PoolId(lcommon.Blake2b224Hash(opCert.ColdVKey))
 
 	// Validate that OpCert KES vkey matches the loaded KES key
-	if !bytes.Equal(pc.kesVKey, pc.opCert.KESVKey) {
-		return errors.New(
+	if !bytes.Equal(kesKey.VKey, opCert.KESVKey) {
+		return nil, errors.New(
 			"KES verification key mismatch: loaded key does not match OpCert KES vkey",
 		)
 	}
 
+	return &loadedPoolCredentials{
+		poolID:  poolID,
+		vrfSKey: vrfKey.SKey,
+		vrfVKey: vrfKey.VKey,
+		kesSKey: kesSKey,
+		kesVKey: kesKey.VKey,
+		opCert:  opCert,
+	}, nil
+}
+
+func (pc *PoolCredentials) clearUnsafe() {
+	pc.poolID = lcommon.PoolId{}
+	pc.vrfSKey = nil
+	pc.vrfVKey = nil
+	pc.kesSKey = nil
+	pc.kesVKey = nil
+	pc.opCert = nil
+	pc.maxKESEvolutions = 0
+	pc.opCertStartKES = 0
+	pc.opCertExpiryKES = 0
+}
+
+// LoadFromFiles loads all pool credentials from the specified file paths.
+// Uses Bursa to parse cardano-cli format key files. The full loaded material
+// replaces the prior generation atomically. A failed reload invalidates the
+// prior generation so an active forger cannot continue with stale policy.
+func (pc *PoolCredentials) LoadFromFiles(
+	vrfSKeyPath string,
+	kesSKeyPath string,
+	opCertPath string,
+) error {
+	loaded, err := loadPoolCredentialsFromFiles(
+		vrfSKeyPath,
+		kesSKeyPath,
+		opCertPath,
+	)
+
+	pc.generationMu.Lock()
+	defer pc.generationMu.Unlock()
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.generation++
+	if err != nil {
+		pc.clearUnsafe()
+		return err
+	}
+	pc.poolID = loaded.poolID
+	pc.vrfSKey = loaded.vrfSKey
+	pc.vrfVKey = loaded.vrfVKey
+	pc.kesSKey = loaded.kesSKey
+	pc.kesVKey = loaded.kesVKey
+	pc.opCert = loaded.opCert
+	pc.maxKESEvolutions = 0
+	pc.opCertStartKES = loaded.opCert.KESPeriod
+	pc.opCertExpiryKES = 0
 	return nil
 }
 
@@ -212,8 +292,14 @@ func (pc *PoolCredentials) relativeKESPeriodUnsafe(
 // so we translate chain KES periods by subtracting the opcert start period
 // when an opcert is loaded.
 func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	return pc.updateKESPeriodUnsafe(period)
+}
+
+func (pc *PoolCredentials) updateKESPeriodUnsafe(period uint64) error {
+	pc.kesMu.Lock()
+	defer pc.kesMu.Unlock()
 
 	if pc.kesSKey == nil {
 		return errors.New("KES key not loaded")
@@ -261,7 +347,12 @@ func (pc *PoolCredentials) UpdateKESPeriod(period uint64) error {
 func (pc *PoolCredentials) VRFProve(alpha []byte) ([]byte, []byte, error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
+	return pc.vrfProveUnsafe(alpha)
+}
 
+func (pc *PoolCredentials) vrfProveUnsafe(
+	alpha []byte,
+) ([]byte, []byte, error) {
 	if pc.vrfSKey == nil {
 		return nil, nil, errors.New("VRF key not loaded")
 	}
@@ -285,6 +376,15 @@ func (pc *PoolCredentials) KESSign(
 ) ([]byte, error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
+	return pc.kesSignUnsafe(period, message)
+}
+
+func (pc *PoolCredentials) kesSignUnsafe(
+	period uint64,
+	message []byte,
+) ([]byte, error) {
+	pc.kesMu.RLock()
+	defer pc.kesMu.RUnlock()
 
 	if pc.kesSKey == nil {
 		return nil, errors.New("KES key not loaded")
@@ -353,7 +453,10 @@ func (pc *PoolCredentials) GetPoolID() lcommon.PoolId {
 func (pc *PoolCredentials) GetOpCert() *OpCert {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
+	return pc.getOpCertUnsafe()
+}
 
+func (pc *PoolCredentials) getOpCertUnsafe() *OpCert {
 	if pc.opCert == nil {
 		return nil
 	}
@@ -373,6 +476,8 @@ func (pc *PoolCredentials) GetOpCert() *OpCert {
 func (pc *PoolCredentials) GetKESPeriod() uint64 {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
+	pc.kesMu.RLock()
+	defer pc.kesMu.RUnlock()
 	if pc.kesSKey == nil {
 		return 0
 	}
@@ -383,7 +488,89 @@ func (pc *PoolCredentials) GetKESPeriod() uint64 {
 func (pc *PoolCredentials) IsLoaded() bool {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
+	pc.kesMu.RLock()
+	defer pc.kesMu.RUnlock()
+	return pc.isLoadedUnsafe()
+}
+
+func (pc *PoolCredentials) isLoadedUnsafe() bool {
 	return pc.vrfSKey != nil && pc.kesSKey != nil && pc.opCert != nil
+}
+
+func (pc *PoolCredentials) acquireCredentialGeneration() *credentialGeneration {
+	pc.generationMu.RLock()
+	pc.mu.RLock()
+	pc.kesMu.RLock()
+	generation := &credentialGeneration{
+		owner:            pc,
+		id:               pc.generation,
+		loaded:           pc.isLoadedUnsafe(),
+		maxKESEvolutions: pc.maxKESEvolutions,
+		opCertStartKES:   pc.opCertStartKES,
+		opCertExpiryKES:  pc.opCertExpiryKES,
+	}
+	pc.kesMu.RUnlock()
+	pc.mu.RUnlock()
+	return generation
+}
+
+func (g *credentialGeneration) release() {
+	g.owner.generationMu.RUnlock()
+}
+
+func (g *credentialGeneration) validatedKESProtocolLifetime() (
+	uint64,
+	uint64,
+	uint64,
+	error,
+) {
+	if !g.loaded {
+		return 0, 0, 0, errors.New("credentials not loaded")
+	}
+	if g.maxKESEvolutions == 0 || g.opCertExpiryKES == 0 {
+		return 0, 0, 0, errors.New("KES protocol lifetime is not validated")
+	}
+	return g.opCertStartKES,
+		g.maxKESEvolutions,
+		g.opCertExpiryKES,
+		nil
+}
+
+func (g *credentialGeneration) periodsRemaining(currentPeriod uint64) uint64 {
+	if currentPeriod < g.opCertStartKES ||
+		currentPeriod >= g.opCertExpiryKES ||
+		g.maxKESEvolutions == 0 {
+		return 0
+	}
+	return g.opCertExpiryKES - currentPeriod
+}
+
+func (g *credentialGeneration) updateKESPeriod(period uint64) error {
+	return g.owner.updateKESPeriodUnsafe(period)
+}
+
+func (g *credentialGeneration) vrfVKey() []byte {
+	if g.owner.vrfVKey == nil {
+		return nil
+	}
+	return append([]byte(nil), g.owner.vrfVKey...)
+}
+
+func (g *credentialGeneration) vrfProve(
+	alpha []byte,
+) ([]byte, []byte, error) {
+	return g.owner.vrfProveUnsafe(alpha)
+}
+
+func (g *credentialGeneration) opCert() *OpCert {
+	return g.owner.getOpCertUnsafe()
+}
+
+func (g *credentialGeneration) kesSign(
+	period uint64,
+	message []byte,
+) ([]byte, error) {
+	return g.owner.kesSignUnsafe(period, message)
 }
 
 // ValidateOpCert validates that the operational certificate matches the KES key
@@ -465,24 +652,10 @@ func (pc *PoolCredentials) opCertExpiryPeriodUnsafe() (uint64, error) {
 	if pc.opCert == nil {
 		return 0, errors.New("operational certificate not loaded")
 	}
-	return opCertExpiryPeriod(
-		pc.opCert.KESPeriod,
-		pc.maxKESEvolutions,
-	)
-}
-
-func (pc *PoolCredentials) validatedKESProtocolLifetime() (
-	uint64,
-	uint64,
-	error,
-) {
-	pc.mu.RLock()
-	defer pc.mu.RUnlock()
-	expiryPeriod, err := pc.opCertExpiryPeriodUnsafe()
-	if err != nil {
-		return 0, 0, err
+	if pc.maxKESEvolutions == 0 || pc.opCertExpiryKES == 0 {
+		return 0, errors.New("KES protocol lifetime is not validated")
 	}
-	return pc.maxKESEvolutions, expiryPeriod, nil
+	return pc.opCertExpiryKES, nil
 }
 
 // OpCertExpiryPeriod returns the protocol KES period at which the OpCert
@@ -505,7 +678,7 @@ func (pc *PoolCredentials) PeriodsRemaining(currentPeriod uint64) uint64 {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 	expiryPeriod, err := pc.opCertExpiryPeriodUnsafe()
-	if err != nil || currentPeriod < pc.opCert.KESPeriod {
+	if err != nil || currentPeriod < pc.opCertStartKES {
 		return 0
 	}
 	if currentPeriod >= expiryPeriod {
@@ -528,15 +701,21 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	genesis *shelley.ShelleyGenesis,
 	currentSlot uint64,
 ) error {
+	pc.generationMu.Lock()
+	defer pc.generationMu.Unlock()
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
+	pc.generation++
 	// Any failed validation leaves the credentials unusable for production
 	// forging rather than retaining a policy from an earlier genesis.
 	pc.maxKESEvolutions = 0
+	pc.opCertExpiryKES = 0
 
 	if pc.opCert == nil {
+		pc.opCertStartKES = 0
 		return errors.New("operational certificate not loaded")
 	}
+	pc.opCertStartKES = pc.opCert.KESPeriod
 	if genesis == nil {
 		return errors.New("shelley genesis is required")
 	}
@@ -576,6 +755,7 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 		)
 	}
 	pc.maxKESEvolutions = maxEvolutions
+	pc.opCertExpiryKES = expiryPeriod
 	return nil
 }
 

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -64,7 +64,11 @@ type PoolCredentials struct {
 	maxKESEvolutions uint64
 	opCertStartKES   uint64
 	opCertExpiryKES  uint64
+	opCertValidated  bool
 	generation       uint64
+	identitySet      bool
+	identityPoolID   lcommon.PoolId
+	identityVRFVKey  []byte
 
 	// generationMu prevents credential or policy replacement while a forge
 	// attempt is using one generation. Keep it separate from mu so code called
@@ -86,6 +90,7 @@ type credentialGeneration struct {
 	maxKESEvolutions uint64
 	opCertStartKES   uint64
 	opCertExpiryKES  uint64
+	opCertValidated  bool
 }
 
 type loadedPoolCredentials struct {
@@ -233,6 +238,7 @@ func (pc *PoolCredentials) clearUnsafe() {
 	pc.maxKESEvolutions = 0
 	pc.opCertStartKES = 0
 	pc.opCertExpiryKES = 0
+	pc.opCertValidated = false
 }
 
 // LoadFromFiles loads all pool credentials from the specified file paths.
@@ -259,6 +265,19 @@ func (pc *PoolCredentials) LoadFromFiles(
 		pc.clearUnsafe()
 		return err
 	}
+	if pc.identitySet &&
+		(pc.identityPoolID != loaded.poolID ||
+			!bytes.Equal(pc.identityVRFVKey, loaded.vrfVKey)) {
+		pc.clearUnsafe()
+		return errors.New(
+			"runtime credential reload cannot change pool or VRF identity",
+		)
+	}
+	if !pc.identitySet {
+		pc.identitySet = true
+		pc.identityPoolID = loaded.poolID
+		pc.identityVRFVKey = append([]byte(nil), loaded.vrfVKey...)
+	}
 	pc.poolID = loaded.poolID
 	pc.vrfSKey = loaded.vrfSKey
 	pc.vrfVKey = loaded.vrfVKey
@@ -268,6 +287,7 @@ func (pc *PoolCredentials) LoadFromFiles(
 	pc.maxKESEvolutions = 0
 	pc.opCertStartKES = loaded.opCert.KESPeriod
 	pc.opCertExpiryKES = 0
+	pc.opCertValidated = false
 	return nil
 }
 
@@ -508,6 +528,7 @@ func (pc *PoolCredentials) acquireCredentialGeneration() *credentialGeneration {
 		maxKESEvolutions: pc.maxKESEvolutions,
 		opCertStartKES:   pc.opCertStartKES,
 		opCertExpiryKES:  pc.opCertExpiryKES,
+		opCertValidated:  pc.opCertValidated,
 	}
 	pc.kesMu.RUnlock()
 	pc.mu.RUnlock()
@@ -527,6 +548,11 @@ func (g *credentialGeneration) validatedKESProtocolLifetime() (
 	if !g.loaded {
 		return 0, 0, 0, errors.New("credentials not loaded")
 	}
+	if !g.opCertValidated {
+		return 0, 0, 0, errors.New(
+			"operational certificate is not validated",
+		)
+	}
 	if g.maxKESEvolutions == 0 || g.opCertExpiryKES == 0 {
 		return 0, 0, 0, errors.New("KES protocol lifetime is not validated")
 	}
@@ -534,6 +560,30 @@ func (g *credentialGeneration) validatedKESProtocolLifetime() (
 		g.maxKESEvolutions,
 		g.opCertExpiryKES,
 		nil
+}
+
+func (g *credentialGeneration) validateKESPeriod(period uint64) error {
+	start, maxEvolutions, expiry, err := g.validatedKESProtocolLifetime()
+	if err != nil {
+		return err
+	}
+	if period < start {
+		return fmt.Errorf(
+			"operational certificate is not valid before KES period %d (current %d)",
+			start,
+			period,
+		)
+	}
+	if period >= expiry {
+		return fmt.Errorf(
+			"%w: operational certificate expired at KES period %d (current %d, max evolutions %d)",
+			errOpCertExpired,
+			expiry,
+			period,
+			maxEvolutions,
+		)
+	}
+	return nil
 }
 
 func (g *credentialGeneration) periodsRemaining(currentPeriod uint64) uint64 {
@@ -576,9 +626,23 @@ func (g *credentialGeneration) kesSign(
 // ValidateOpCert validates that the operational certificate matches the KES key
 // and that the cold key signature over the certificate body is valid.
 func (pc *PoolCredentials) ValidateOpCert() error {
-	pc.mu.RLock()
-	defer pc.mu.RUnlock()
+	pc.generationMu.Lock()
+	defer pc.generationMu.Unlock()
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.generation++
+	pc.opCertValidated = false
+	pc.maxKESEvolutions = 0
+	pc.opCertExpiryKES = 0
 
+	if err := pc.validateOpCertUnsafe(); err != nil {
+		return err
+	}
+	pc.opCertValidated = true
+	return nil
+}
+
+func (pc *PoolCredentials) validateOpCertUnsafe() error {
 	if pc.opCert == nil {
 		return errors.New("operational certificate not loaded")
 	}
@@ -652,7 +716,9 @@ func (pc *PoolCredentials) opCertExpiryPeriodUnsafe() (uint64, error) {
 	if pc.opCert == nil {
 		return 0, errors.New("operational certificate not loaded")
 	}
-	if pc.maxKESEvolutions == 0 || pc.opCertExpiryKES == 0 {
+	if !pc.opCertValidated ||
+		pc.maxKESEvolutions == 0 ||
+		pc.opCertExpiryKES == 0 {
 		return 0, errors.New("KES protocol lifetime is not validated")
 	}
 	return pc.opCertExpiryKES, nil
@@ -706,16 +772,28 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.generation++
+	previousOpCertValidation := pc.opCertValidated
 	// Any failed validation leaves the credentials unusable for production
 	// forging rather than retaining a policy from an earlier genesis.
 	pc.maxKESEvolutions = 0
 	pc.opCertExpiryKES = 0
+	pc.opCertValidated = false
 
 	if pc.opCert == nil {
 		pc.opCertStartKES = 0
 		return errors.New("operational certificate not loaded")
 	}
 	pc.opCertStartKES = pc.opCert.KESPeriod
+	if pc.isLoadedUnsafe() {
+		if err := pc.validateOpCertUnsafe(); err != nil {
+			return fmt.Errorf("validate operational certificate: %w", err)
+		}
+		pc.opCertValidated = true
+	} else {
+		// Preserve an explicit ValidateOpCert result for focused callers that
+		// validate certificate metadata without loading signing material.
+		pc.opCertValidated = previousOpCertValidation
+	}
 	if genesis == nil {
 		return errors.New("shelley genesis is required")
 	}

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -818,6 +818,11 @@ func (pc *PoolCredentials) ValidateOpCert() error {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.generation++
+	previousStart := pc.opCertStartKES
+	previousMaxEvolutions := pc.maxKESEvolutions
+	previousExpiry := pc.opCertExpiryKES
+	hadValidatedLifetime := pc.opCertValidated &&
+		previousMaxEvolutions > 0 && previousExpiry > previousStart
 	pc.opCertValidated = false
 	pc.maxKESEvolutions = 0
 	pc.opCertExpiryKES = 0
@@ -826,6 +831,10 @@ func (pc *PoolCredentials) ValidateOpCert() error {
 		return err
 	}
 	pc.opCertValidated = true
+	if hadValidatedLifetime && pc.opCert.KESPeriod == previousStart {
+		pc.maxKESEvolutions = previousMaxEvolutions
+		pc.opCertExpiryKES = previousExpiry
+	}
 	return nil
 }
 

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	"github.com/blinklabs-io/bursa"
@@ -35,8 +36,11 @@ import (
 )
 
 var (
-	ErrVRFKeyHashMismatch = errors.New("VRF key hash mismatch")
-	errOpCertExpired      = errors.New("operational certificate expired")
+	ErrVRFKeyHashMismatch          = errors.New("VRF key hash mismatch")
+	errOpCertExpired               = errors.New("operational certificate expired")
+	errCredentialGenerationChanged = errors.New(
+		"credential generation changed during block production",
+	)
 )
 
 const maxSecretKeyFileSize = 1 << 20
@@ -70,27 +74,28 @@ type PoolCredentials struct {
 	identityPoolID   lcommon.PoolId
 	identityVRFVKey  []byte
 
-	// generationMu prevents credential or policy replacement while a forge
-	// attempt is using one generation. Keep it separate from mu so code called
-	// during that attempt can still use the public read-only accessors without
-	// recursively acquiring an RWMutex that has a writer queued behind it.
-	generationMu sync.RWMutex
-	mu           sync.RWMutex
-	kesMu        sync.RWMutex
+	mu    sync.RWMutex
+	kesMu sync.RWMutex
 }
 
-// credentialGeneration pins one complete credential and protocol-policy
-// generation while a production forge attempt is in flight. The owner read
-// lock remains held until release, so reload and revalidation cannot replace
-// any key, opcert, or lifetime field partway through the attempt.
+// credentialGeneration is an independently owned snapshot of one complete
+// credential and protocol-policy generation. It never aliases mutable secret
+// material in PoolCredentials, so callbacks may reload or revalidate the owner
+// without blocking an in-flight attempt or mixing key generations.
 type credentialGeneration struct {
 	owner            *PoolCredentials
 	id               uint64
 	loaded           bool
+	vrfSKey          []byte
+	vrfVerification  []byte
+	kesSKey          *kes.SecretKey
+	kesVerification  []byte
+	operationalCert  *OpCert
 	maxKESEvolutions uint64
 	opCertStartKES   uint64
 	opCertExpiryKES  uint64
 	opCertValidated  bool
+	releaseOnce      sync.Once
 }
 
 type loadedPoolCredentials struct {
@@ -100,6 +105,54 @@ type loadedPoolCredentials struct {
 	kesSKey *kes.SecretKey
 	kesVKey []byte
 	opCert  *OpCert
+}
+
+// wipeCredentialBytes performs best-effort zeroization of independently owned
+// VRF secret snapshots. runtime.KeepAlive prevents the compiler from proving
+// the stores dead before the wipe completes.
+//
+//go:noinline
+func wipeCredentialBytes(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
+	runtime.KeepAlive(data)
+}
+
+func cloneOpCert(opCert *OpCert) *OpCert {
+	if opCert == nil {
+		return nil
+	}
+	return &OpCert{
+		KESVKey:     append([]byte(nil), opCert.KESVKey...),
+		IssueNumber: opCert.IssueNumber,
+		KESPeriod:   opCert.KESPeriod,
+		Signature:   append([]byte(nil), opCert.Signature...),
+		ColdVKey:    append([]byte(nil), opCert.ColdVKey...),
+	}
+}
+
+func cloneKESSecretKey(key *kes.SecretKey) *kes.SecretKey {
+	if key == nil {
+		return nil
+	}
+	return &kes.SecretKey{
+		Depth:  key.Depth,
+		Period: key.Period,
+		Data:   append([]byte(nil), key.Data...),
+	}
+}
+
+func (loaded *loadedPoolCredentials) zeroize() {
+	if loaded == nil {
+		return
+	}
+	wipeCredentialBytes(loaded.vrfSKey)
+	loaded.vrfSKey = nil
+	if loaded.kesSKey != nil {
+		loaded.kesSKey.Zeroize()
+		loaded.kesSKey = nil
+	}
 }
 
 // OpCert represents an operational certificate that binds a KES key to a pool.
@@ -229,6 +282,10 @@ func loadPoolCredentialsFromFiles(
 }
 
 func (pc *PoolCredentials) clearUnsafe() {
+	wipeCredentialBytes(pc.vrfSKey)
+	if pc.kesSKey != nil {
+		pc.kesSKey.Zeroize()
+	}
 	pc.poolID = lcommon.PoolId{}
 	pc.vrfSKey = nil
 	pc.vrfVKey = nil
@@ -256,8 +313,6 @@ func (pc *PoolCredentials) LoadFromFiles(
 		opCertPath,
 	)
 
-	pc.generationMu.Lock()
-	defer pc.generationMu.Unlock()
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.generation++
@@ -269,6 +324,7 @@ func (pc *PoolCredentials) LoadFromFiles(
 		(pc.identityPoolID != loaded.poolID ||
 			!bytes.Equal(pc.identityVRFVKey, loaded.vrfVKey)) {
 		pc.clearUnsafe()
+		loaded.zeroize()
 		return errors.New(
 			"runtime credential reload cannot change pool or VRF identity",
 		)
@@ -278,6 +334,7 @@ func (pc *PoolCredentials) LoadFromFiles(
 		pc.identityPoolID = loaded.poolID
 		pc.identityVRFVKey = append([]byte(nil), loaded.vrfVKey...)
 	}
+	pc.clearUnsafe()
 	pc.poolID = loaded.poolID
 	pc.vrfSKey = loaded.vrfSKey
 	pc.vrfVKey = loaded.vrfVKey
@@ -518,13 +575,17 @@ func (pc *PoolCredentials) isLoadedUnsafe() bool {
 }
 
 func (pc *PoolCredentials) acquireCredentialGeneration() *credentialGeneration {
-	pc.generationMu.RLock()
 	pc.mu.RLock()
 	pc.kesMu.RLock()
 	generation := &credentialGeneration{
 		owner:            pc,
 		id:               pc.generation,
 		loaded:           pc.isLoadedUnsafe(),
+		vrfSKey:          append([]byte(nil), pc.vrfSKey...),
+		vrfVerification:  append([]byte(nil), pc.vrfVKey...),
+		kesSKey:          cloneKESSecretKey(pc.kesSKey),
+		kesVerification:  append([]byte(nil), pc.kesVKey...),
+		operationalCert:  cloneOpCert(pc.opCert),
 		maxKESEvolutions: pc.maxKESEvolutions,
 		opCertStartKES:   pc.opCertStartKES,
 		opCertExpiryKES:  pc.opCertExpiryKES,
@@ -536,7 +597,31 @@ func (pc *PoolCredentials) acquireCredentialGeneration() *credentialGeneration {
 }
 
 func (g *credentialGeneration) release() {
-	g.owner.generationMu.RUnlock()
+	if g == nil {
+		return
+	}
+	g.releaseOnce.Do(func() {
+		wipeCredentialBytes(g.vrfSKey)
+		g.vrfSKey = nil
+		if g.kesSKey != nil {
+			g.kesSKey.Zeroize()
+			g.kesSKey = nil
+		}
+	})
+}
+
+func (g *credentialGeneration) ensureCurrent() error {
+	g.owner.mu.RLock()
+	defer g.owner.mu.RUnlock()
+	if g.owner.generation != g.id {
+		return fmt.Errorf(
+			"%w: selected %d, current %d",
+			errCredentialGenerationChanged,
+			g.id,
+			g.owner.generation,
+		)
+	}
+	return nil
 }
 
 func (g *credentialGeneration) validatedKESProtocolLifetime() (
@@ -596,38 +681,115 @@ func (g *credentialGeneration) periodsRemaining(currentPeriod uint64) uint64 {
 }
 
 func (g *credentialGeneration) updateKESPeriod(period uint64) error {
-	return g.owner.updateKESPeriodUnsafe(period)
+	if err := g.owner.updateKESPeriodForGeneration(g.id, period); err != nil {
+		return err
+	}
+	if g.kesSKey == nil {
+		return errors.New("KES key not loaded")
+	}
+	if period < g.opCertStartKES {
+		return fmt.Errorf(
+			"current KES period %d is before opcert start period %d",
+			period,
+			g.opCertStartKES,
+		)
+	}
+	targetPeriod := period - g.opCertStartKES
+	if targetPeriod < g.kesSKey.Period {
+		return fmt.Errorf(
+			"cannot evolve KES snapshot backward: current period %d, requested %d (absolute %d)",
+			g.kesSKey.Period,
+			targetPeriod,
+			period,
+		)
+	}
+	for g.kesSKey.Period < targetPeriod {
+		newKey, err := kes.Update(g.kesSKey)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to update KES snapshot to period %d (absolute %d): %w",
+				targetPeriod,
+				period,
+				err,
+			)
+		}
+		g.kesSKey = newKey
+	}
+	return nil
+}
+
+func (pc *PoolCredentials) updateKESPeriodForGeneration(
+	generation uint64,
+	period uint64,
+) error {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	if pc.generation != generation {
+		return fmt.Errorf(
+			"%w: selected %d, current %d",
+			errCredentialGenerationChanged,
+			generation,
+			pc.generation,
+		)
+	}
+	return pc.updateKESPeriodUnsafe(period)
 }
 
 func (g *credentialGeneration) vrfVKey() []byte {
-	if g.owner.vrfVKey == nil {
+	if g.vrfVerification == nil {
 		return nil
 	}
-	return append([]byte(nil), g.owner.vrfVKey...)
+	return append([]byte(nil), g.vrfVerification...)
 }
 
 func (g *credentialGeneration) vrfProve(
 	alpha []byte,
 ) ([]byte, []byte, error) {
-	return g.owner.vrfProveUnsafe(alpha)
+	if g.vrfSKey == nil {
+		return nil, nil, errors.New("VRF key not loaded")
+	}
+	proof, output, err := vrf.Prove(g.vrfSKey, alpha)
+	if err != nil {
+		return nil, nil, fmt.Errorf("VRFProve: %w", err)
+	}
+	return proof, output, nil
 }
 
 func (g *credentialGeneration) opCert() *OpCert {
-	return g.owner.getOpCertUnsafe()
+	return cloneOpCert(g.operationalCert)
 }
 
 func (g *credentialGeneration) kesSign(
 	period uint64,
 	message []byte,
 ) ([]byte, error) {
-	return g.owner.kesSignUnsafe(period, message)
+	if g.kesSKey == nil {
+		return nil, errors.New("KES key not loaded")
+	}
+	if period < g.opCertStartKES {
+		return nil, fmt.Errorf(
+			"failed to compute signing KES period for absolute period %d: current KES period %d is before opcert start period %d",
+			period,
+			period,
+			g.opCertStartKES,
+		)
+	}
+	relativePeriod := period - g.opCertStartKES
+	sig, err := kes.Sign(g.kesSKey, relativePeriod, message)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"KESSign relative period %d (absolute %d): %w",
+			relativePeriod,
+			period,
+			err,
+		)
+	}
+	return sig, nil
 }
 
 // ValidateOpCert validates that the operational certificate matches the KES key
 // and that the cold key signature over the certificate body is valid.
 func (pc *PoolCredentials) ValidateOpCert() error {
-	pc.generationMu.Lock()
-	defer pc.generationMu.Unlock()
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.generation++
@@ -767,8 +929,6 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	genesis *shelley.ShelleyGenesis,
 	currentSlot uint64,
 ) error {
-	pc.generationMu.Lock()
-	defer pc.generationMu.Unlock()
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.generation++

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"sync"
 
@@ -33,7 +34,10 @@ import (
 	"github.com/blinklabs-io/gouroboros/vrf"
 )
 
-var ErrVRFKeyHashMismatch = errors.New("VRF key hash mismatch")
+var (
+	ErrVRFKeyHashMismatch = errors.New("VRF key hash mismatch")
+	errOpCertExpired      = errors.New("operational certificate expired")
+)
 
 const maxSecretKeyFileSize = 1 << 20
 
@@ -54,6 +58,10 @@ type PoolCredentials struct {
 
 	// Operational certificate linking KES to pool cold key
 	opCert *OpCert
+	// Protocol lifetime loaded from the Shelley genesis that validated the
+	// operational certificate. This is distinct from the KES key's 2^depth
+	// cryptographic capacity.
+	maxKESEvolutions uint64
 
 	mu sync.RWMutex
 }
@@ -121,6 +129,7 @@ func (pc *PoolCredentials) LoadFromFiles(
 ) error {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
+	pc.maxKESEvolutions = 0
 
 	// Load VRF signing key
 	vrfKey, err := loadSecretKeyFromFile(vrfSKeyPath)
@@ -420,27 +429,85 @@ func (pc *PoolCredentials) ValidateOpCert() error {
 	return nil
 }
 
-// OpCertExpiryPeriod returns the KES period at which the OpCert expires.
-// For depth 6, max periods = 2^6 = 64, so expiry = startPeriod + 64.
+func validateMaxKESEvolutions(maxEvolutions uint64) error {
+	if maxEvolutions == 0 {
+		return errors.New("max KES evolutions must be positive")
+	}
+	capacity := kes.MaxPeriod(kes.CardanoKesDepth)
+	if maxEvolutions > capacity {
+		return fmt.Errorf(
+			"max KES evolutions %d exceeds KES key capacity %d",
+			maxEvolutions,
+			capacity,
+		)
+	}
+	return nil
+}
+
+func opCertExpiryPeriod(
+	startPeriod uint64,
+	maxEvolutions uint64,
+) (uint64, error) {
+	if err := validateMaxKESEvolutions(maxEvolutions); err != nil {
+		return 0, err
+	}
+	if startPeriod > math.MaxUint64-maxEvolutions {
+		return 0, fmt.Errorf(
+			"opcert expiry overflows uint64: start period %d, max evolutions %d",
+			startPeriod,
+			maxEvolutions,
+		)
+	}
+	return startPeriod + maxEvolutions, nil
+}
+
+func (pc *PoolCredentials) opCertExpiryPeriodUnsafe() (uint64, error) {
+	if pc.opCert == nil {
+		return 0, errors.New("operational certificate not loaded")
+	}
+	return opCertExpiryPeriod(
+		pc.opCert.KESPeriod,
+		pc.maxKESEvolutions,
+	)
+}
+
+func (pc *PoolCredentials) validatedKESProtocolLifetime() (
+	uint64,
+	uint64,
+	error,
+) {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	expiryPeriod, err := pc.opCertExpiryPeriodUnsafe()
+	if err != nil {
+		return 0, 0, err
+	}
+	return pc.maxKESEvolutions, expiryPeriod, nil
+}
+
+// OpCertExpiryPeriod returns the protocol KES period at which the OpCert
+// expires. ValidateKESPeriod must first load MaxKESEvolutions from Shelley
+// genesis. It returns zero when no validated protocol lifetime is available.
 func (pc *PoolCredentials) OpCertExpiryPeriod() uint64 {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
-
-	if pc.opCert == nil {
+	expiryPeriod, err := pc.opCertExpiryPeriodUnsafe()
+	if err != nil {
 		return 0
 	}
-	return pc.opCert.KESPeriod + kes.MaxPeriod(kes.CardanoKesDepth)
+	return expiryPeriod
 }
 
-// PeriodsRemaining returns how many KES periods remain before expiry.
+// PeriodsRemaining returns how many protocol KES periods remain before
+// expiry. It returns zero before the OpCert start, at or after expiry, or when
+// no validated protocol lifetime is available.
 func (pc *PoolCredentials) PeriodsRemaining(currentPeriod uint64) uint64 {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
-
-	if pc.opCert == nil {
+	expiryPeriod, err := pc.opCertExpiryPeriodUnsafe()
+	if err != nil || currentPeriod < pc.opCert.KESPeriod {
 		return 0
 	}
-	expiryPeriod := pc.opCert.KESPeriod + kes.MaxPeriod(kes.CardanoKesDepth)
 	if currentPeriod >= expiryPeriod {
 		return 0
 	}
@@ -455,13 +522,17 @@ func (pc *PoolCredentials) PeriodsRemaining(currentPeriod uint64) uint64 {
 //
 // The protocol-level expiry uses MaxKESEvolutions from genesis rather
 // than the raw 2^depth ceiling, so this matches the chain's view of when
-// an opcert stops being valid.
+// an opcert stops being valid. A successful result retains that protocol
+// lifetime for runtime forging checks and operational metrics.
 func (pc *PoolCredentials) ValidateKESPeriod(
 	genesis *shelley.ShelleyGenesis,
 	currentSlot uint64,
 ) error {
-	pc.mu.RLock()
-	defer pc.mu.RUnlock()
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	// Any failed validation leaves the credentials unusable for production
+	// forging rather than retaining a policy from an earlier genesis.
+	pc.maxKESEvolutions = 0
 
 	if pc.opCert == nil {
 		return errors.New("operational certificate not loaded")
@@ -473,22 +544,38 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	if err != nil {
 		return err
 	}
+	if genesis.MaxKESEvolutions <= 0 {
+		return fmt.Errorf(
+			"genesis maxKESEvolutions must be positive, got %d",
+			genesis.MaxKESEvolutions,
+		)
+	}
+	// #nosec G115 -- guarded positive above; int fits within uint64.
+	maxEvolutions := uint64(genesis.MaxKESEvolutions)
+	expiryPeriod, err := opCertExpiryPeriod(
+		pc.opCert.KESPeriod,
+		maxEvolutions,
+	)
+	if err != nil {
+		return err
+	}
 	if pc.opCert.KESPeriod > current {
 		return fmt.Errorf(
 			"opcert KES period %d is in the future (current %d)",
 			pc.opCert.KESPeriod, current,
 		)
 	}
-	maxEvolutions := uint64(genesis.MaxKESEvolutions) // #nosec G115
-	if maxEvolutions > 0 &&
-		current >= pc.opCert.KESPeriod+maxEvolutions {
+	if current >= expiryPeriod {
 		return fmt.Errorf(
-			"opcert KES period %d has expired (current %d, max evolutions %d); rotate the operational certificate",
+			"%w: opcert KES period %d expired at period %d (current %d, max evolutions %d); rotate the operational certificate",
+			errOpCertExpired,
 			pc.opCert.KESPeriod,
+			expiryPeriod,
 			current,
 			maxEvolutions,
 		)
 	}
+	pc.maxKESEvolutions = maxEvolutions
 	return nil
 }
 

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"math"
 	"os"
@@ -28,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/keystore"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -78,6 +80,31 @@ func createTestKeys(t *testing.T) (string, string, string) {
 	return vrfPath, kesPath, opCertPath
 }
 
+func createAlternateTestVRFKey(t *testing.T) string {
+	t.Helper()
+	seed := make([]byte, vrf.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	_, secretKey, err := vrf.KeyGen(seed)
+	require.NoError(t, err)
+	keyFile, err := bursa.GetVRFSKey(secretKey)
+	require.NoError(t, err)
+	data, err := json.Marshal(keyFile)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "alternate-vrf.skey")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
+	return path
+}
+
+func writeTestOpCert(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "opcert.cert")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
 func TestPoolCredentialsLoadFromFiles(t *testing.T) {
 	vrfPath, kesPath, opCertPath := createTestKeys(t)
 	loadedVRF, err := loadSecretKeyFromFile(vrfPath)
@@ -119,6 +146,89 @@ func TestPoolCredentialsLoadFromFiles(t *testing.T) {
 
 	// Verify IsLoaded
 	assert.True(t, pc.IsLoaded())
+}
+
+func TestPoolCredentialsRejectsRuntimeVRFIdentityChange(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, pc.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+
+	err := pc.LoadFromFiles(
+		createAlternateTestVRFKey(t),
+		kesPath,
+		opCertPath,
+	)
+	require.ErrorContains(t, err, "cannot change pool or VRF identity")
+	require.False(t, pc.IsLoaded())
+	require.Zero(t, pc.OpCertExpiryPeriod())
+	require.ErrorContains(
+		t,
+		pc.LoadFromFiles(
+			createAlternateTestVRFKey(t),
+			kesPath,
+			opCertPath,
+		),
+		"cannot change pool or VRF identity",
+	)
+}
+
+func TestPoolCredentialsInvalidOpCertCannotPublishKESPolicy(t *testing.T) {
+	vrfPath, kesPath, _ := createTestKeys(t)
+	corrupted := strings.Replace(testOpCertJSON, "89fc9e9f", "88fc9e9f", 1)
+	require.NotEqual(t, testOpCertJSON, corrupted)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(
+		vrfPath,
+		kesPath,
+		writeTestOpCert(t, corrupted),
+	))
+
+	require.ErrorContains(t, pc.ValidateOpCert(), "signature verification failed")
+	require.ErrorContains(
+		t,
+		pc.ValidateKESPeriod(
+			synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+			0,
+		),
+		"signature verification failed",
+	)
+	generation := pc.acquireCredentialGeneration()
+	defer generation.release()
+	require.ErrorContains(
+		t,
+		generation.validateKESPeriod(0),
+		"operational certificate is not validated",
+	)
+}
+
+func TestPoolCredentialsMismatchedKESReloadFailsClosed(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, pc.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+
+	mismatched := strings.Replace(
+		testOpCertJSON,
+		"4cd49bb0",
+		"5cd49bb0",
+		1,
+	)
+	require.NotEqual(t, testOpCertJSON, mismatched)
+	err := pc.LoadFromFiles(
+		vrfPath,
+		kesPath,
+		writeTestOpCert(t, mismatched),
+	)
+	require.ErrorContains(t, err, "KES verification key mismatch")
+	require.False(t, pc.IsLoaded())
+	require.Zero(t, pc.OpCertExpiryPeriod())
 }
 
 func TestPoolCredentialsRejectsPermissiveSecretKeyModes(t *testing.T) {

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -415,20 +416,23 @@ func TestOpCertValidation(t *testing.T) {
 	// Validate OpCert - should pass since keys match and signature is valid
 	err = pc.ValidateOpCert()
 	require.NoError(t, err)
+	require.NoError(t, pc.ValidateKESPeriod(
+		synthGenesis(100, 62, time.Second, time.Unix(0, 0)),
+		0,
+	))
 
 	// Check expiry period
 	expiryPeriod := pc.OpCertExpiryPeriod()
-	// For depth 6, max periods = 64, starting at period 0
-	assert.Equal(t, uint64(64), expiryPeriod)
+	assert.Equal(t, uint64(62), expiryPeriod)
 
 	// Check periods remaining
 	remaining := pc.PeriodsRemaining(0)
-	assert.Equal(t, uint64(64), remaining)
+	assert.Equal(t, uint64(62), remaining)
 
 	remaining = pc.PeriodsRemaining(32)
-	assert.Equal(t, uint64(32), remaining)
+	assert.Equal(t, uint64(30), remaining)
 
-	remaining = pc.PeriodsRemaining(64)
+	remaining = pc.PeriodsRemaining(62)
 	assert.Equal(t, uint64(0), remaining)
 
 	remaining = pc.PeriodsRemaining(100)
@@ -791,6 +795,44 @@ func TestValidateKESPeriod_NilGenesis(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil genesis")
 	}
+}
+
+func TestValidateKESPeriod_InvalidMaxKESEvolutions(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		max  int
+		want string
+	}{
+		{name: "zero", max: 0, want: "must be positive"},
+		{name: "negative", max: -1, want: "must be positive"},
+		{
+			name: "exceeds key capacity",
+			max:  int(kes.MaxPeriod(kes.CardanoKesDepth)) + 1,
+			want: "exceeds KES key capacity",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			g := synthGenesis(100, test.max, time.Second, time.Unix(0, 0))
+			pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 0}}
+
+			err := pc.ValidateKESPeriod(g, 0)
+			require.ErrorContains(t, err, test.want)
+			require.Zero(t, pc.OpCertExpiryPeriod())
+			require.Zero(t, pc.PeriodsRemaining(0))
+		})
+	}
+}
+
+func TestValidateKESPeriod_ExpiryOverflowFailsClosed(t *testing.T) {
+	g := synthGenesis(1, 3, time.Second, time.Unix(0, 0))
+	pc := &PoolCredentials{
+		opCert: &OpCert{KESPeriod: math.MaxUint64 - 1},
+	}
+
+	err := pc.ValidateKESPeriod(g, math.MaxUint64)
+	require.ErrorContains(t, err, "expiry overflows uint64")
+	require.Zero(t, pc.OpCertExpiryPeriod())
+	require.Zero(t, pc.PeriodsRemaining(math.MaxUint64))
 }
 
 // fakeLedgerView is a test stub for the LedgerView interface.

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -98,6 +98,59 @@ func createAlternateTestVRFKey(t *testing.T) string {
 	return path
 }
 
+func createMismatchedTestVRFEnvelope(
+	t *testing.T,
+	validVRFPath string,
+) string {
+	t.Helper()
+	validKey, err := loadSecretKeyFromFile(validVRFPath)
+	require.NoError(t, err)
+	defer wipeCredentialBytes(validKey.SKey)
+
+	alternateSeed := make([]byte, vrf.SeedSize)
+	for i := range alternateSeed {
+		alternateSeed[i] = byte(i + 1)
+	}
+	derivedVKey, derivedSeed, err := vrf.KeyGen(alternateSeed)
+	require.NoError(t, err)
+	wipeCredentialBytes(derivedSeed)
+	require.NotEqual(t, validKey.VKey, derivedVKey)
+
+	// Cardano CLI's 64-byte envelope is seed || public key. Keep the
+	// original public-key suffix while replacing only its seed.
+	envelope := append(append([]byte(nil), alternateSeed...), validKey.VKey...)
+	keyFile, err := bursa.GetVRFSKey(envelope)
+	require.NoError(t, err)
+	data, err := json.Marshal(keyFile)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "mismatched-vrf.skey")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	testutil.RestrictFileToCurrentUser(t, path)
+	return path
+}
+
+func requireVRFKeyPairCoherent(
+	t *testing.T,
+	credentials *PoolCredentials,
+) {
+	t.Helper()
+	seed := credentials.GetVRFSKey()
+	require.Len(t, seed, vrf.SeedSize)
+	defer wipeCredentialBytes(seed)
+
+	derivedVKey, derivedSeed, err := vrf.KeyGen(seed)
+	require.NoError(t, err)
+	wipeCredentialBytes(derivedSeed)
+	require.Equal(t, derivedVKey, credentials.GetVRFVKey())
+
+	alpha := []byte("credential identity coherence")
+	proof, output, err := credentials.VRFProve(alpha)
+	require.NoError(t, err)
+	verified, err := vrf.Verify(derivedVKey, proof, output, alpha)
+	require.NoError(t, err)
+	require.True(t, verified)
+}
+
 func writeTestOpCert(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "opcert.cert")
@@ -146,6 +199,55 @@ func TestPoolCredentialsLoadFromFiles(t *testing.T) {
 
 	// Verify IsLoaded
 	assert.True(t, pc.IsLoaded())
+	requireVRFKeyPairCoherent(t, pc)
+}
+
+func TestPoolCredentialsRejectsMismatchedVRFEnvelopeAtStartup(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	pc := NewPoolCredentials()
+
+	err := pc.LoadFromFiles(
+		createMismatchedTestVRFEnvelope(t, vrfPath),
+		kesPath,
+		opCertPath,
+	)
+	require.ErrorContains(t, err, "VRF verification key mismatch")
+	require.False(t, pc.IsLoaded())
+	require.Empty(t, pc.GetVRFSKey())
+	require.Empty(t, pc.GetVRFVKey())
+	require.False(t, pc.identitySet)
+}
+
+func TestPoolCredentialsRejectsMismatchedVRFEnvelopeOnReload(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, pc.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+	requireVRFKeyPairCoherent(t, pc)
+	pinnedVKey := append([]byte(nil), pc.identityVRFVKey...)
+
+	err := pc.LoadFromFiles(
+		createMismatchedTestVRFEnvelope(t, vrfPath),
+		kesPath,
+		opCertPath,
+	)
+	require.ErrorContains(t, err, "VRF verification key mismatch")
+	require.False(t, pc.IsLoaded())
+	require.Zero(t, pc.OpCertExpiryPeriod())
+	require.True(t, pc.identitySet)
+	require.Equal(t, pinnedVKey, pc.identityVRFVKey)
+
+	// A failed replacement must not poison the pinned identity. Reloading the
+	// original generation restores coherent leader-election and proof keys.
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+	require.NoError(t, pc.ValidateKESPeriod(
+		synthGenesis(1, 3, time.Second, time.Unix(0, 0)),
+		0,
+	))
+	requireVRFKeyPairCoherent(t, pc)
 }
 
 func TestPoolCredentialsRejectsRuntimeVRFIdentityChange(t *testing.T) {

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -928,6 +928,34 @@ func TestValidateKESPeriod_HappyPath(t *testing.T) {
 	}
 }
 
+func TestValidateOpCertPreservesValidatedKESLifetime(t *testing.T) {
+	pc := setupTestCredentials(t)
+	wantExpiry := pc.OpCertExpiryPeriod()
+	require.NotZero(t, wantExpiry)
+
+	require.NoError(t, pc.ValidateOpCert())
+	require.Equal(t, wantExpiry, pc.OpCertExpiryPeriod())
+
+	generation := pc.acquireCredentialGeneration()
+	start, maxEvolutions, expiry, err := generation.validatedKESProtocolLifetime()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), start)
+	require.Equal(t, uint64(62), maxEvolutions)
+	require.Equal(t, wantExpiry, expiry)
+	generation.release()
+
+	pc.mu.Lock()
+	pc.opCert.Signature[0] ^= 0xff
+	pc.mu.Unlock()
+	require.ErrorContains(t, pc.ValidateOpCert(), "signature verification failed")
+	require.Zero(t, pc.OpCertExpiryPeriod())
+
+	invalidGeneration := pc.acquireCredentialGeneration()
+	defer invalidGeneration.release()
+	_, _, _, err = invalidGeneration.validatedKESProtocolLifetime()
+	require.ErrorContains(t, err, "not validated")
+}
+
 func TestValidateKESPeriod_AtStart(t *testing.T) {
 	// Edge case: opcert KESPeriod equals current period (just rotated
 	// into use). Should pass.


### PR DESCRIPTION
## Summary

- Enforce the protocol KES lifetime before leader selection and block construction.
- Bind election, credentials, operational-certificate validation, and VRF identity to coherent reload generations.
- Prevent callback reload deadlocks and gate exported block builders at KES boundaries.
- Align metrics and architecture documentation with runtime behavior.

## Migration

Production callers of `NewBlockForger` must call `PoolCredentials.ValidateKESPeriod` with Shelley genesis and the current slot before constructing the forger.

## Validation

- Forging tests, normal and race
- Full tagged ledger and conformance tests
- `go vet`, golangci-lint, NilAway, modernize, and formatting checks

Fixes #3696
