### PR TITLE
fix(ci): install bash for Antithesis instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY . .
 RUN make build
 
 FROM build AS antithesis-build
+RUN apk add --no-cache bash
 RUN go get github.com/antithesishq/antithesis-sdk-go@latest
 RUN go install github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-instrumentor@latest
 RUN make mod-tidy


### PR DESCRIPTION
Fixes #3707.

- installs Bash in the Go builder stage used by Antithesis instrumentation
- keeps the runtime image stages unchanged
- restores the `antithesis` Docker target build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs bash in the Antithesis instrumentation builder stage so the `antithesis` Docker target builds again, fixing issue #3707. Runtime image stages are unchanged.

<sup>Written for commit 2a257d09e8397cbf1751828415895c4f0b3e9303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

