### PR TITLE
test(dblifecycle): stabilize cloud pruning validation

### DIFF
--- a/internal/dblifecycle/manager_test.go
+++ b/internal/dblifecycle/manager_test.go
@@ -407,7 +407,9 @@ func TestManagerPrunesOldSnapshotsBeyondRetention(t *testing.T) {
 // used by the manager's cloud-destination test doubles. Specialized doubles
 // embed it and override only the operation whose failure they inject.
 type directoryBackedCloudDestination struct {
-	dir string
+	dir      string
+	uploaded chan<- string
+	deleted  chan<- string
 }
 
 func (d *directoryBackedCloudDestination) UploadDir(
@@ -433,6 +435,9 @@ func (d *directoryBackedCloudDestination) UploadDir(
 			return err
 		}
 	}
+	if d.uploaded != nil {
+		d.uploaded <- d.dir
+	}
 	return nil
 }
 
@@ -444,7 +449,13 @@ func (d *directoryBackedCloudDestination) DownloadDir(
 }
 
 func (d *directoryBackedCloudDestination) Delete(context.Context) error {
-	return os.RemoveAll(d.dir)
+	if err := os.RemoveAll(d.dir); err != nil {
+		return err
+	}
+	if d.deleted != nil {
+		d.deleted <- d.dir
+	}
+	return nil
 }
 
 var (
@@ -491,12 +502,23 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 
 	snapshotDir := t.TempDir()
 	cloudBackingDir := t.TempDir()
-	setManagerFakeCloudBackingDir(t, cloudBackingDir)
-	const cloudDest = "managerfaketest://bucket/prefix"
-	// managerFakeCloudDestination resolves a URI's path directly onto the
-	// backing dir (see its registration func above), and cloudDest's own
-	// path component is "/prefix" -- so every snapshot this uploads lands
-	// under cloudBackingDir/prefix/<snapshotID>, not cloudBackingDir/<snapshotID>.
+	uploaded := make(chan string, 3)
+	deleted := make(chan string, 1)
+	registry := lifecycle.NewDestinationRegistry()
+	registry.Register(
+		"managerprunetest",
+		func(uri *url.URL) (lifecycle.CloudDestination, error) {
+			return &directoryBackedCloudDestination{
+				dir: filepath.Join(
+					cloudBackingDir,
+					strings.TrimPrefix(uri.Path, "/"),
+				),
+				uploaded: uploaded,
+				deleted:  deleted,
+			}, nil
+		},
+	)
+	const cloudDest = "managerprunetest://bucket/prefix"
 	cloudPrefixDir := filepath.Join(cloudBackingDir, "prefix")
 
 	m := dblifecycle.NewManager(db, eb, config.DatabaseLifecycleConfig{
@@ -505,32 +527,41 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 		SnapshotEveryNEpochs:     1,
 		SnapshotRetention:        2,
 		SnapshotCloudDestination: cloudDest,
-	}, testManagerBlobPlugin, "sqlite", testDestinationRegistry, nil)
+	}, testManagerBlobPlugin, "sqlite", registry, nil)
 	require.NoError(t, m.Start(context.Background()))
 	defer m.Stop()
 
 	for epoch := uint64(1); epoch <= 3; epoch++ {
 		publishEpochTransition(eb, epoch)
-		require.Eventually(t, func() bool {
-			_, err := os.Stat(filepath.Join(
-				cloudPrefixDir,
-				"epoch-"+strconv.FormatUint(epoch, 10),
-				"manifest.json",
-			))
-			return err == nil
-		}, 5*time.Second, 10*time.Millisecond)
+		epochDir := filepath.Join(
+			cloudPrefixDir,
+			"epoch-"+strconv.FormatUint(epoch, 10),
+		)
+		require.Equal(t, epochDir, testutil.RequireReceive(
+			t,
+			uploaded,
+			30*time.Second,
+			"automatic snapshot cloud upload did not complete",
+		))
+		require.FileExists(t, filepath.Join(epochDir, "manifest.json"))
 	}
 
 	// epoch-1 is beyond retention (2): both its local directory and its
 	// cloud mirror must be gone.
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(filepath.Join(snapshotDir, "epoch-1"))
-		return os.IsNotExist(err)
-	}, 5*time.Second, 10*time.Millisecond)
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(filepath.Join(cloudPrefixDir, "epoch-1"))
-		return os.IsNotExist(err)
-	}, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, filepath.Join(cloudPrefixDir, "epoch-1"),
+		testutil.RequireReceive(
+			t,
+			deleted,
+			30*time.Second,
+			"automatic snapshot cloud prune did not complete",
+		),
+	)
+	// Delete reports the cloud operation itself. Stop is the manager's
+	// documented drain barrier and proves the same handler has completed
+	// the following local prune before inspecting either retained set.
+	require.NoError(t, m.Stop())
+	require.NoDirExists(t, filepath.Join(snapshotDir, "epoch-1"))
+	require.NoDirExists(t, filepath.Join(cloudPrefixDir, "epoch-1"))
 	require.DirExists(t, filepath.Join(cloudPrefixDir, "epoch-2"))
 	require.DirExists(t, filepath.Join(cloudPrefixDir, "epoch-3"))
 }

--- a/internal/dblifecycle/manager_test.go
+++ b/internal/dblifecycle/manager_test.go
@@ -409,11 +409,10 @@ func TestManagerPrunesOldSnapshotsBeyondRetention(t *testing.T) {
 type directoryBackedCloudDestination struct {
 	dir      string
 	uploaded chan<- string
-	deleted  chan<- string
 }
 
 func (d *directoryBackedCloudDestination) UploadDir(
-	_ context.Context,
+	ctx context.Context,
 	localDir string,
 ) error {
 	if err := os.MkdirAll(d.dir, 0o755); err != nil {
@@ -436,7 +435,11 @@ func (d *directoryBackedCloudDestination) UploadDir(
 		}
 	}
 	if d.uploaded != nil {
-		d.uploaded <- d.dir
+		select {
+		case d.uploaded <- d.dir:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	return nil
 }
@@ -449,13 +452,7 @@ func (d *directoryBackedCloudDestination) DownloadDir(
 }
 
 func (d *directoryBackedCloudDestination) Delete(context.Context) error {
-	if err := os.RemoveAll(d.dir); err != nil {
-		return err
-	}
-	if d.deleted != nil {
-		d.deleted <- d.dir
-	}
-	return nil
+	return os.RemoveAll(d.dir)
 }
 
 var (
@@ -502,8 +499,7 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 
 	snapshotDir := t.TempDir()
 	cloudBackingDir := t.TempDir()
-	uploaded := make(chan string, 3)
-	deleted := make(chan string, 1)
+	uploaded := make(chan string)
 	registry := lifecycle.NewDestinationRegistry()
 	registry.Register(
 		"managerprunetest",
@@ -511,15 +507,25 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 			return &directoryBackedCloudDestination{
 				dir: filepath.Join(
 					cloudBackingDir,
-					strings.TrimPrefix(uri.Path, "/"),
+					filepath.FromSlash(strings.TrimPrefix(uri.Path, "/")),
 				),
 				uploaded: uploaded,
-				deleted:  deleted,
 			}, nil
 		},
 	)
 	const cloudDest = "managerprunetest://bucket/prefix"
 	cloudPrefixDir := filepath.Join(cloudBackingDir, "prefix")
+	// Start launches a retry scan in the background. Give that scan an
+	// existing, nonnumeric epoch directory to upload before publishing any
+	// real epoch: receiving this upload proves the scan reached the probe,
+	// and retryMu orders the first epoch handler after the scan finishes.
+	// The nonnumeric suffix keeps the probe out of retention accounting.
+	const startupProbeName = "epoch-startup-probe"
+	startupProbeDir := filepath.Join(snapshotDir, startupProbeName)
+	require.NoError(t, os.Mkdir(startupProbeDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(startupProbeDir, "probe"), []byte("probe"), 0o600,
+	))
 
 	m := dblifecycle.NewManager(db, eb, config.DatabaseLifecycleConfig{
 		SnapshotEnabled:          true,
@@ -530,6 +536,14 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 	}, testManagerBlobPlugin, "sqlite", registry, nil)
 	require.NoError(t, m.Start(context.Background()))
 	defer m.Stop()
+	require.Equal(t, filepath.Join(cloudPrefixDir, startupProbeName),
+		testutil.RequireReceive(
+			t,
+			uploaded,
+			30*time.Second,
+			"startup cloud-mirror retry scan did not reach its probe",
+		),
+	)
 
 	for epoch := uint64(1); epoch <= 3; epoch++ {
 		publishEpochTransition(eb, epoch)
@@ -547,18 +561,17 @@ func TestManagerPruningDeletesCloudMirror(t *testing.T) {
 	}
 
 	// epoch-1 is beyond retention (2): both its local directory and its
-	// cloud mirror must be gone.
-	require.Equal(t, filepath.Join(cloudPrefixDir, "epoch-1"),
-		testutil.RequireReceive(
-			t,
-			deleted,
-			30*time.Second,
-			"automatic snapshot cloud prune did not complete",
-		),
-	)
-	// Delete reports the cloud operation itself. Stop is the manager's
-	// documented drain barrier and proves the same handler has completed
-	// the following local prune before inspecting either retained set.
+	// cloud mirror must be gone. Local removal is the observable completion
+	// point shared by both the fixed implementation and the old local-only
+	// pruning behavior, so the remote assertion below fails on the actual
+	// deletion defect rather than waiting for a notification the old code
+	// could never send.
+	testutil.WaitForCondition(t, func() bool {
+		_, err := os.Stat(filepath.Join(snapshotDir, "epoch-1"))
+		return os.IsNotExist(err)
+	}, 30*time.Second, "automatic snapshot local prune did not complete")
+	// Stop is the manager's drain barrier and proves the same handler has
+	// fully completed before inspecting either retained set.
 	require.NoError(t, m.Stop())
 	require.NoDirExists(t, filepath.Join(snapshotDir, "epoch-1"))
 	require.NoDirExists(t, filepath.Join(cloudPrefixDir, "epoch-1"))


### PR DESCRIPTION
Fixes #3709.

- isolates startup retry uploads from the normal epoch-processing upload
- asserts that pruning targets the expected local snapshot and cloud mirror
- keeps synchronization cancellation-aware and portable across platforms

## Validation

- focused test, 20 repetitions
- focused race test, 20 repetitions
- full `internal/dblifecycle` race tests
- package vet and Windows amd64 test cross-compile


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3709 by making the cloud pruning test deterministic and Windows-compatible. Previously the startup retry scan could race with epoch processing, making the upload and prune assertions flaky; now the test isolates the retry scan with a probe directory, waits for each upload on a channel, and uses `Manager.Stop` as a drain barrier before asserting both local and cloud snapshots are pruned. The test also uses `filepath` and context-aware sends so it runs on Windows. No production code changes.

<sup>Written for commit b3f04d457d1d0dc9cfd2be0c36c560e16ba9a306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

