### PR TITLE
fix(ci): install bash for Antithesis instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY . .
 RUN make build
 
 FROM build AS antithesis-build
+RUN apk add --no-cache bash
 RUN go get github.com/antithesishq/antithesis-sdk-go@latest
 RUN go install github.com/antithesishq/antithesis-sdk-go/tools/antithesis-go-instrumentor@latest
 RUN make mod-tidy


### PR DESCRIPTION
Closes #3707.

Installs bash only in the Antithesis instrumentation builder stage. The normal runtime image graph is unchanged.

Validation:
- native arm64 full Antithesis target fails before at the production instrumentation step because bash is missing and passes after
- normal final-stage base and candidate images are identical
- Dockerfile check and diff check pass

Local linux/amd64 execution was not completed because QEMU crashed and then hung; hosted native-amd64 CI is the remaining platform-specific gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Antithesis instrumentation build failing on arm64 by installing `bash` in the `antithesis-build` stage only. The normal runtime image graph is unchanged, and final-stage base and candidate images remain identical.

<sup>Written for commit 5f536023d011ae626d28e7dd0a41b5560fe72c93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

