### PR TITLE
fix(ledger): retain deferred-header snapshots instead of misclassifying pruned snapshots as pool absence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7353,17 +7353,25 @@ it is the leader-eligibility basis a queued/deferred header validates against.
 `cleanupOldSnapshots` prunes `PoolStakeSnapshot` through a retention guard
 (`Manager.SetPoolSnapshotRetentionGuard`, wired to
 `LedgerState.PrunePoolSnapshotsWithRetentionFloor`) that, under one dedicated
-lock held across the whole decision and the pool-snapshot delete+commit: (1)
+lock (`deferredHeaderValidationMu`) held across the eviction and floor read but
+released before the pool-snapshot delete: (1)
 evicts deferred headers the apply cursor has already passed — abandoned, since a
 canonical one is consumed at apply — so they stop pinning their snapshots and
 their persisted markers are deleted; (2) lowers the delete boundary to the floor
 (oldest `StakeSnapshotEpoch(epochOf(slot))` over the survivors) when it is below
 `current-3`, or to 0 while any deferred slot is not yet epoch-mappable; and (3)
 clamps that boundary up to a hard depth cap (`current - 24`) so a stuck header
-can never pin snapshots without bound. Holding the lock across floor read and
-delete+commit means admission cannot interleave between them (the race
-CodeRabbit flagged; `markDeferredHeaderValidation` takes the same lock and does
-no I/O, so no deadlock). The pin moves only `PoolStakeSnapshot` — the reward
+can never pin snapshots without bound. The eviction+floor read is atomic (one
+lock hold), so the boundary is a coherent read of the deferred set. The lock is
+released before `prune` (and before each `DeleteSyncState` in the evicted-marker
+cleanup): `prune` opens the single SQLite write connection, and block apply holds
+that connection before taking this same mutex via `consumeDeferredHeaderValidation`,
+so holding the mutex across `prune` inverts the lock order and deadlocks the node
+on the single write connection (issue #3717). The hazard is not this lock's own
+I/O — it has none — but the apply path holding the write connection while waiting
+for this mutex; a header admitted after the lock is released is handled by the
+next pass, since the floor is a lower-watermark recomputed each cleanup. The pin
+moves only `PoolStakeSnapshot` — the reward
 window stays at `current-3` — never prunes more than the default, releases as
 headers resolve or are evicted, and is rebuilt from the persisted markers at
 startup (`repopulateDeferredHeaderValidation`) so it survives a restart. The pin

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7346,8 +7346,36 @@ full per-epoch and per-pool reward history stays queryable and a missing
 summary row keeps its diagnostic meaning of a boundary that was never
 captured. Because a retained snapshot can outlive its per-credential rows,
 `applyStakeRewards` skips an epoch whose snapshot claims delegators over an
-empty `RewardStakeInput` set rather than failing the rollover. See the
-retention section in `DATABASE.md` for the per-table detail.
+empty `RewardStakeInput` set rather than failing the rollover.
+
+`PoolStakeSnapshot` retention has one extra lower-watermark rule (issue #3727):
+it is the leader-eligibility basis a queued/deferred header validates against.
+`cleanupOldSnapshots` prunes `PoolStakeSnapshot` through a retention guard
+(`Manager.SetPoolSnapshotRetentionGuard`, wired to
+`LedgerState.PrunePoolSnapshotsWithRetentionFloor`) that, under one dedicated
+lock held across the whole decision and the pool-snapshot delete+commit: (1)
+evicts deferred headers the apply cursor has already passed — abandoned, since a
+canonical one is consumed at apply — so they stop pinning their snapshots and
+their persisted markers are deleted; (2) lowers the delete boundary to the floor
+(oldest `StakeSnapshotEpoch(epochOf(slot))` over the survivors) when it is below
+`current-3`, or to 0 while any deferred slot is not yet epoch-mappable; and (3)
+clamps that boundary up to a hard depth cap (`current - 24`) so a stuck header
+can never pin snapshots without bound. Holding the lock across floor read and
+delete+commit means admission cannot interleave between them (the race
+CodeRabbit flagged; `markDeferredHeaderValidation` takes the same lock and does
+no I/O, so no deadlock). The pin moves only `PoolStakeSnapshot` — the reward
+window stays at `current-3` — never prunes more than the default, releases as
+headers resolve or are evicted, and is rebuilt from the persisted markers at
+startup (`repopulateDeferredHeaderValidation`) so it survives a restart. The pin
+is what makes a deferred header *resolve*: its snapshot is retained until the
+cursor reaches it. The classification in `verifyBlockHeaderState` is
+consensus-narrow: a leader-stake snapshot reported unavailable is deferred ONLY
+while the apply cursor is still behind the header's slot (not yet produced =
+recoverable); once the cursor has caught up a still-empty distribution is a
+genuine, permanent gap and stays a hard rejection, exactly as before, and a
+producer absent from a populated snapshot always hard-rejects. See the retention
+section in `DATABASE.md` for the per-table
+detail.
 
 A skipped reward round is never made up later, and that has consequences
 well beyond the reward figures. Applying the round at the boundary into N

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2400,6 +2400,55 @@ at a normal-boundary `d` decrease. Blockfetch still defers the stateful overlay
 decision until ledger apply when even the forecast cannot resolve it; full
 historical validation and the normal leader checks remain enabled.
 
+**Why deferring a `d=1` overlay header is a real fix, not a suppression.** With
+`d = 1` (full federation — every early Shelley epoch, and epoch 0 on every
+network) `classifyGenesisOverlaySlot` returns `genesisOverlayActive` or
+`genesisOverlayNonActive` for *every* slot, never `genesisOverlayNone`: with
+`position = ceil(relativeSlot·d) = relativeSlot`, the position always advances by
+one per slot, and `position % activeSlotCoeffInverse == 0` selects the active
+overlay slots. So under `d=1` the genesis-delegate path — not the Praos
+leader-eligibility path — is authoritative, and a header **not** issued by the
+overlay slot's assigned active genesis delegate is rejected (`genesis overlay
+slot assigned to delegate …, got issuer …`, or the non-active-slot rejection).
+There is therefore no reference-node case in which cardano-node *accepts* a
+non-genesis-delegate block at a `d=1` overlay slot, and the defer never makes
+dingo accept one either: `verifyGenesisDelegateHeader` defers only while
+`allowStateDefer && ledgerTipBehindSlot(slot)`, and at ledger apply
+`verifyDeferredBlockHeaderState` re-runs `verifyBlockHeaderStateWithEpochAdvance(
+block, /*epochCacheAdvance*/ true, /*allowStateDefer*/ false)` — with the defer
+switch off, so the stateful genesis-delegate check runs to an authoritative
+accept/reject verdict before the block can be adopted. The deferral moves *when*
+the verdict is computed, not *whether* it is enforced; the marker
+(`deferred_header_validation:<slot>:<hash>`, in memory and in `sync_state`) is
+what forces that apply-time recheck, so its retention is load-bearing (see the
+retention-floor, eviction-horizon, and marker-restore invariants below and in
+`DATABASE.md`).
+
+The concrete acceptance case the defer *does* exist for is a genesis-delegate
+**reassignment** that the apply cursor has not reached yet. A
+`GenesisKeyDelegationCertificate` rewrites a genesis key's active delegate/VRF
+hash; `Store.GetGenesisDelegationForSlot` returns the latest
+`genesis_delegation` row with `added_slot < blockSlot`, and that row is written
+only when the block carrying the certificate is *applied*
+(`transaction_certificates.go`). During catch-up the header chain runs ahead of
+the applied tip, so at header-verification time the reassignment row can be
+absent — `activeGenesisDelegationForSlot` then falls back to the Shelley-genesis
+default delegate — while at apply time the row is present and names the new
+delegate. A block legitimately produced by the reassigned delegate would be
+*rejected at header time* (issuer ≠ genesis-default delegate) but *accepted at
+apply* (issuer == reassigned delegate), exactly as cardano-node accepts it, so
+deferring the `d=1` overlay decision until apply is what keeps dingo from
+recycling an honest peer over a valid block. This is why the current premise is
+keyed on the observable `ledgerTipBehindSlot(slot)` state rather than on
+`epoch == 0`: the stale state that motivates the defer is the unapplied
+genesis-key-delegation row, which is not epoch-0-specific. (Empirical note: this
+is substantiated from the certificate/overlay code paths and TPraos overlay
+semantics; a specific on-chain instance — network, slot, and the reassigning
+transaction — has not been pinned here and must not be invented. If a concrete
+witness is wanted for the PR record, it is the one open item for the author to
+supply; the safety argument above does not depend on it, because apply-time
+re-validation is authoritative regardless.)
+
 Slot/epoch query adapters preserve `hardfork.ErrPastHorizon` in their error
 chains so callers can defer until the ledger advances. `EpochInfo` serves an
 already materialized epoch directly from the immutable epoch cache before

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2433,9 +2433,9 @@ only when the block carrying the certificate is *applied*
 (`transaction_certificates.go`). During catch-up the header chain runs ahead of
 the applied tip, so at header-verification time the reassignment row can be
 absent — `activeGenesisDelegationForSlot` then falls back to the Shelley-genesis
-default delegate — while at apply time the row is present and names the new
+delegate — while at apply time the row is present and names the new
 delegate. A block legitimately produced by the reassigned delegate would be
-*rejected at header time* (issuer ≠ genesis-default delegate) but *accepted at
+*rejected at header time* (issuer ≠ the static genesis delegate) but *accepted at
 apply* (issuer == reassigned delegate), exactly as cardano-node accepts it, so
 deferring the `d=1` overlay decision until apply is what keeps dingo from
 recycling an honest peer over a valid block. This is why the current premise is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7355,16 +7355,24 @@ it is the leader-eligibility basis a queued/deferred header validates against.
 `LedgerState.PrunePoolSnapshotsWithRetentionFloor`) that, under one dedicated
 lock (`deferredHeaderValidationMu`) held across the eviction and floor read but
 released before the pool-snapshot delete: (1)
-evicts deferred headers the apply cursor has already passed — abandoned, since a
-canonical one is consumed at apply — so they stop pinning their snapshots and
-their persisted markers are deleted; (2) lowers the delete boundary to the floor
+evicts deferred headers beyond the rollback horizon (below
+`tip - calculateStabilityWindow()`) — abandoned, since a canonical one is
+consumed at apply and no fork that deep can be re-adopted — so they stop pinning
+their snapshots and their persisted markers are deleted. The horizon, rather than
+the bare tip, is what makes eviction safe: eviction also drops the durable
+marker, so a point evicted while still re-adoptable would later apply with
+`required == false` and be adopted with its stateful leader-eligibility check
+never run; (2) lowers the delete boundary to the floor
 (oldest `StakeSnapshotEpoch(epochOf(slot))` over the survivors) when it is below
 `current-3`, or to 0 while any deferred slot is not yet epoch-mappable; and (3)
 clamps that boundary up to a hard depth cap (`current - 24`) so a stuck header
 can never pin snapshots without bound. The eviction+floor read is atomic (one
 lock hold), so the boundary is a coherent read of the deferred set. The lock is
 released before `prune` (and before each `DeleteSyncState` in the evicted-marker
-cleanup): `prune` opens the single SQLite write connection, and block apply holds
+cleanup, whose per-key delete then re-tests membership and re-persists the marker
+for a point re-deferred in that window, so releasing the lock cannot strand a
+live deferred header without its durable marker): `prune` opens the single SQLite
+write connection, and block apply holds
 that connection before taking this same mutex via `consumeDeferredHeaderValidation`,
 so holding the mutex across `prune` inverts the lock order and deadlocks the node
 on the single write connection (issue #3717). The hazard is not this lock's own

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -941,7 +941,9 @@ Every epoch transition runs `cleanupOldSnapshots`, which prunes to the four
 epochs the Shelley rotation and delayed reward model need: current, current-1,
 current-2 for Go, and current-3 so reward calculation can be replayed after a
 rollback across the boundary where those rewards were applied. Retention is not
-configurable, and it only ever deletes rows below that window.
+operator-configurable, and it only ever deletes rows below that window (but see
+the deferred-header retention pin below, which can hold `pool_stake_snapshot`
+rows longer).
 
 Pruned at `epoch < current-3`:
 
@@ -960,6 +962,54 @@ two per-credential tables scale with delegator count — about 5k rows per epoch
 preview and 1.3M on mainnet — which is why they alone stay windowed. No
 before-epoch delete method exists for any retained table on
 `metadata.MetadataStore`.
+
+**Deferred-header retention pin (issue #3727).** `pool_stake_snapshot` has one
+extra retention rule the two windowed reward tables do not: it is the
+leader-eligibility basis a *queued/deferred header* validates against. If the
+mark snapshot such a header needs (`StakeSnapshotEpoch(epoch) = epoch-1`) were
+pruned out from under it, `leaderEligibilityStake` (`ledger/verify_header.go`)
+would read the missing rows back as a zero-stake answer. `cleanupOldSnapshots`
+therefore prunes `pool_stake_snapshot` *through a retention guard*
+(`Manager.SetPoolSnapshotRetentionGuard`, wired at node start to
+`LedgerState.PrunePoolSnapshotsWithRetentionFloor`). Under one dedicated lock,
+held across the whole decision and the pool-snapshot delete+commit, the guard:
+
+1. **Evicts abandoned headers.** A deferred header the apply cursor has already
+   passed is abandoned — a canonical one is consumed at apply — so it is dropped
+   from the set (and its persisted marker deleted) instead of pinning its
+   snapshot forever. This is what bounds retention in practice.
+2. **Computes the floor** as the minimum of `StakeSnapshotEpoch(epochOf(slot))`
+   over the surviving deferred headers and lowers the pool-snapshot delete
+   boundary to it when it is below `current-3` (reward-table retention is
+   untouched at `current-3`). While ANY surviving deferred slot is not yet
+   mappable to an epoch, the floor is **0** (retain everything) so the snapshot
+   the header will need once the epoch cache advances is not pruned meanwhile.
+3. **Clamps to a depth cap.** The boundary is clamped up to
+   `current - poolSnapshotRetentionMaxDepth` (24), a hard backstop so even a
+   stuck header can never pin more than a bounded number of epochs of pool
+   snapshots (~1.3M rows/epoch on mainnet). It never rises above the default
+   window.
+
+Because the guard holds the lock across both the floor read and the
+delete+commit, a header admitted concurrently cannot slip in between them and
+lose its snapshot (admission — `markDeferredHeaderValidation` — takes the same
+lock and does no I/O, so it cannot deadlock). The pin is a *lower-watermark
+only*: it never prunes more than the default window, releases as headers
+resolve (the set shrinks) or are evicted, and with no guard set is
+byte-identical to the original behavior. Across a restart the in-memory set is
+rebuilt from the persisted markers (`repopulateDeferredHeaderValidation`, via
+`ListSyncStateKeysByPrefix`) before the first cleanup, so the pin covers
+headers still awaiting apply from before the restart.
+
+The pin is what makes a deferred header *resolve* (its snapshot is retained
+until the cursor reaches it). The classification in `verifyBlockHeaderState` is
+deliberately narrow and consensus-safe: a leader-stake snapshot reported
+unavailable is deferred ONLY while the apply cursor is still behind the header's
+slot (the snapshot is not yet produced — recoverable). Once the cursor has
+caught up, a still-empty distribution is a genuine, permanent gap for that epoch
+and stays a hard rejection, exactly as before — deferring it forever would adopt
+a block whose leader eligibility is never checked. A producer absent from a
+*populated* snapshot is authoritative ineligibility and always hard-rejects.
 
 Together the retained tables are the full per-epoch reward record a historical
 closed-epoch comparison needs: the pots the epoch was paid from, both sets of

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -971,8 +971,9 @@ pruned out from under it, `leaderEligibilityStake` (`ledger/verify_header.go`)
 would read the missing rows back as a zero-stake answer. `cleanupOldSnapshots`
 therefore prunes `pool_stake_snapshot` *through a retention guard*
 (`Manager.SetPoolSnapshotRetentionGuard`, wired at node start to
-`LedgerState.PrunePoolSnapshotsWithRetentionFloor`). Under one dedicated lock,
-held across the whole decision and the pool-snapshot delete+commit, the guard:
+`LedgerState.PrunePoolSnapshotsWithRetentionFloor`). Under one dedicated lock
+(`deferredHeaderValidationMu`), held across the eviction and the floor read but
+**not** across the pool-snapshot delete, the guard:
 
 1. **Evicts abandoned headers.** A deferred header the apply cursor has already
    passed is abandoned — a canonical one is consumed at apply — so it is dropped
@@ -990,16 +991,34 @@ held across the whole decision and the pool-snapshot delete+commit, the guard:
    snapshots (~1.3M rows/epoch on mainnet). It never rises above the default
    window.
 
-Because the guard holds the lock across both the floor read and the
-delete+commit, a header admitted concurrently cannot slip in between them and
-lose its snapshot (admission — `markDeferredHeaderValidation` — takes the same
-lock and does no I/O, so it cannot deadlock). The pin is a *lower-watermark
-only*: it never prunes more than the default window, releases as headers
-resolve (the set shrinks) or are evicted, and with no guard set is
-byte-identical to the original behavior. Across a restart the in-memory set is
-rebuilt from the persisted markers (`repopulateDeferredHeaderValidation`, via
-`ListSyncStateKeysByPrefix`) before the first cleanup, so the pin covers
-headers still awaiting apply from before the restart.
+The eviction and the floor read happen under one lock hold, so the boundary
+handed to `prune` is a coherent read of the deferred set — never a mix of pre-
+and post-eviction state. The lock is then **released before `prune` runs**, and
+this is a correctness requirement, not just an optimization: `prune` opens the
+single SQLite write connection (`SetMaxOpenConns(1)`) via `Transaction(true)`,
+and block apply holds that connection *before* taking `deferredHeaderValidationMu`
+(`ledgerProcessBlock` → `verifyDeferredBlockHeaderState` →
+`consumeDeferredHeaderValidation`, all inside its write txn). Holding the mutex
+across `prune` would invert the lock order — `mutex → write-conn` in the guard
+vs. `write-conn → mutex` on apply — and **deadlock the node on the single write
+connection** (issue #3717). The same applies to the evicted-marker cleanup
+(`deletePersistedDeferredMarkers`), which takes the lock only to test membership
+per key and releases it before each `DeleteSyncState` (also a write-connection
+op). The earlier claim that this lock "does no I/O, so it cannot deadlock" was
+wrong: the hazard is never the mutex holder's own I/O, it is the *caller on the
+other path* holding the single write connection while it waits for this mutex.
+
+Releasing the lock before `prune` means a header admitted after the release is
+not pinned by the pass in flight. This is safe because the retention floor is a
+*lower-watermark recomputed every cleanup pass*: such a header needs a
+below-`current-3` snapshot only if it is deeply lagged, and the next pass pins
+the lower floor and the header resolves then. The pin never prunes more than the
+default window, releases as headers resolve (the set shrinks) or are evicted, and
+with no guard set is byte-identical to the original behavior. Across a restart the
+in-memory set is rebuilt from the persisted markers
+(`repopulateDeferredHeaderValidation`, via `ListSyncStateKeysByPrefix`) before the
+first cleanup, so the pin covers headers still awaiting apply from before the
+restart.
 
 The pin is what makes a deferred header *resolve* (its snapshot is retained
 until the cursor reaches it). The classification in `verifyBlockHeaderState` is

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -975,10 +975,19 @@ therefore prunes `pool_stake_snapshot` *through a retention guard*
 (`deferredHeaderValidationMu`), held across the eviction and the floor read but
 **not** across the pool-snapshot delete, the guard:
 
-1. **Evicts abandoned headers.** A deferred header the apply cursor has already
-   passed is abandoned — a canonical one is consumed at apply — so it is dropped
-   from the set (and its persisted marker deleted) instead of pinning its
-   snapshot forever. This is what bounds retention in practice.
+1. **Evicts abandoned headers.** A deferred header beyond the *rollback horizon*
+   — below `tip - calculateStabilityWindow()` (3k/f slots, 2k in Byron) — is
+   abandoned: a canonical one is consumed at apply, and chain selection can no
+   longer re-adopt a fork that deep. It is dropped from the set and its
+   persisted marker deleted instead of pinning its snapshot forever. This is
+   what bounds retention in practice. Eviction is gated on the horizon rather
+   than on the bare tip because it deletes the durable marker too, and that
+   marker is the only thing that makes `deferredHeaderValidationRequired` return
+   true at apply: a point evicted while a rollback could still re-adopt its fork
+   would apply with `required == false`, so `verifyDeferredBlockHeaderState`
+   returns nil and the block is adopted with its stateful leader-eligibility
+   check never run. Keys whose slot cannot be parsed are evicted regardless —
+   they can never be validated.
 2. **Computes the floor** as the minimum of `StakeSnapshotEpoch(epochOf(slot))`
    over the surviving deferred headers and lowers the pool-snapshot delete
    boundary to it when it is below `current-3` (reward-table retention is
@@ -1004,7 +1013,14 @@ vs. `write-conn → mutex` on apply — and **deadlock the node on the single wr
 connection** (issue #3717). The same applies to the evicted-marker cleanup
 (`deletePersistedDeferredMarkers`), which takes the lock only to test membership
 per key and releases it before each `DeleteSyncState` (also a write-connection
-op). The earlier claim that this lock "does no I/O, so it cannot deadlock" was
+op). Because that membership test cannot be atomic with the delete, the delete
+is made conditional *after the fact*: `deleteDeferredMarkerUnlessReadmitted`
+re-tests membership once the `DeleteSyncState` returns and re-writes the marker
+(`SetSyncState`, idempotent) for a key that was re-deferred in the window.
+Without that restore, a point re-admitted between the test and the delete keeps
+its in-memory entry but loses its durable marker, so after a restart
+`repopulateDeferredHeaderValidation` misses it and the apply-time stateful check
+is skipped for a header that is still outstanding. The earlier claim that this lock "does no I/O, so it cannot deadlock" was
 wrong: the hazard is never the mutex holder's own I/O, it is the *caller on the
 other path* holding the single write connection while it waits for this mutex.
 

--- a/database/network_state.go
+++ b/database/network_state.go
@@ -121,6 +121,31 @@ func (d *Database) DeleteSyncState(
 	return nil
 }
 
+// ListSyncStateKeysByPrefix returns every sync_state key beginning with prefix.
+func (d *Database) ListSyncStateKeysByPrefix(
+	prefix string,
+	txn *Txn,
+) ([]string, error) {
+	var (
+		keys []string
+		err  error
+	)
+	if txn == nil {
+		keys, err = d.metadata.ListSyncStateKeysByPrefix(prefix, nil)
+	} else {
+		keys, err = d.metadata.ListSyncStateKeysByPrefix(
+			prefix, txn.Metadata(),
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Database.ListSyncStateKeysByPrefix(%q): %w",
+			prefix, err,
+		)
+	}
+	return keys, nil
+}
+
 // ClearSyncState removes all sync state entries.
 func (d *Database) ClearSyncState(txn *Txn) error {
 	var err error

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -252,12 +252,17 @@ func (s *Store) ListSyncStateKeysByPrefix(
 	defer rows.Close()
 	var keys []string
 	for rows.Next() {
-		var key string
+		// Scan into sql.NullString: SQLite permits NULL in a TEXT PRIMARY KEY
+		// column, and scanning a NULL into a plain *string errors out, which
+		// would abort the whole scan and prevent every valid deferred-header
+		// marker from being restored. One malformed legacy row must not disable
+		// retention-pin restoration, so skip NULLs instead of failing.
+		var key sql.NullString
 		if err := rows.Scan(&key); err != nil {
 			return nil, fmt.Errorf("list sync state keys: %w", err)
 		}
-		if strings.HasPrefix(key, prefix) {
-			keys = append(keys, key)
+		if key.Valid && strings.HasPrefix(key.String, prefix) {
+			keys = append(keys, key.String)
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	sqlitequery "github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore/internal/query/sqlite"
@@ -221,6 +222,48 @@ func (s *Store) DeleteSyncState(key string, txn types.Txn) error {
 		return fmt.Errorf("delete sync state: %w", err)
 	}
 	return nil
+}
+
+// ListSyncStateKeysByPrefix returns every sync_state key that has the given
+// byte prefix, sorted ascending. It enumerates the (small) sync_state keyspace
+// and filters the exact prefix in Go with strings.HasPrefix, so the match is
+// byte-exact and identical on every backend. A SQL range scan or LIKE would be
+// wrong here: on MySQL/Postgres the >=/< and LIKE operators honor the column's
+// COLLATION, not byte order, so a case- or locale-insensitive collation could
+// include keys that lack the byte prefix (or exclude keys that have it), and a
+// synthesized range upper bound over a non-ASCII prefix can be invalid UTF-8.
+// The deferred-header retention markers this enumerates (issue #3727) must be
+// matched exactly or a restart could miss a marker and fail to pin a snapshot.
+func (s *Store) ListSyncStateKeysByPrefix(
+	prefix string,
+	txn types.Txn,
+) ([]string, error) {
+	db, ctx, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return nil, fmt.Errorf("list sync state keys: %w", err)
+	}
+	rows, err := db.QueryContext(
+		ctx,
+		s.dialect.Rebind("SELECT sync_key FROM sync_state ORDER BY sync_key"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list sync state keys: %w", err)
+	}
+	defer rows.Close()
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("list sync state keys: %w", err)
+		}
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list sync state keys: %w", err)
+	}
+	return keys, nil
 }
 
 func (s *Store) ClearSyncState(txn types.Txn) error {

--- a/database/plugin/metadata/sqlstore/operational_test.go
+++ b/database/plugin/metadata/sqlstore/operational_test.go
@@ -217,6 +217,42 @@ func TestGetScriptRejectsNegativeStoredType(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestListSyncStateKeysByPrefixSkipsNullKey covers the regression where a
+// single NULL sync_key row aborts the whole marker scan. SQLite permits NULL in
+// a TEXT PRIMARY KEY column, and scanning a NULL into a plain *string errors --
+// which, before the fix, propagated out and prevented every valid
+// deferred-header marker from being restored at startup, silently disabling the
+// snapshot retention pin. The scan must skip the NULL row and still return the
+// valid keys.
+func TestListSyncStateKeysByPrefixSkipsNullKey(t *testing.T) {
+	t.Parallel()
+	store := newManagementTestStore(t)
+
+	// A malformed legacy row with a NULL primary key.
+	_, err := store.writeDB.Exec(
+		"INSERT INTO sync_state (sync_key, value) VALUES (NULL, ?)",
+		"x",
+	)
+	require.NoError(t, err)
+
+	// Two valid deferred-header markers that must still be restored.
+	const prefix = "deferred_header_validation:"
+	require.NoError(t, store.SetSyncState(prefix+"10:aa", "true", nil))
+	require.NoError(t, store.SetSyncState(prefix+"13:bb", "true", nil))
+
+	got, err := store.ListSyncStateKeysByPrefix(prefix, nil)
+	require.NoError(
+		t,
+		err,
+		"a NULL sync_key row must be skipped, not abort the scan",
+	)
+	require.ElementsMatch(
+		t,
+		[]string{prefix + "10:aa", prefix + "13:bb"},
+		got,
+	)
+}
+
 // TestCheckedUint8 unit-tests the helper directly: zero, the maximum
 // in-range value, and both out-of-range directions (negative and > 255).
 func TestCheckedUint8(t *testing.T) {

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -2347,6 +2347,11 @@ type MetadataStore interface {
 	// DeleteSyncState removes a sync state key.
 	DeleteSyncState(string, types.Txn) error
 
+	// ListSyncStateKeysByPrefix returns every sync_state key that begins with
+	// the given prefix (used to enumerate the persisted deferred-header
+	// markers so their retention floor survives a restart -- issue #3727).
+	ListSyncStateKeysByPrefix(string, types.Txn) ([]string, error)
+
 	// ClearSyncState removes all sync state entries.
 	ClearSyncState(types.Txn) error
 

--- a/database/sync_state_prefix_test.go
+++ b/database/sync_state_prefix_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSyncStateKeysByPrefix covers the prefix scan that repopulates the
+// deferred-header retention set after a restart (issue #3727, finding 3). The
+// match must be an exact BYTE prefix on every backend, so this asserts cases a
+// collation-sensitive SQL range/LIKE would get wrong (finding: collation-unsafe
+// prefix scan). The prefix also contains a LIKE wildcard ('_') to prove no
+// wildcard escaping is needed.
+func TestListSyncStateKeysByPrefix(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	const prefix = "deferred_header_validation:"
+	want := []string{
+		prefix + "10:aa",
+		prefix + "13:bb",
+		prefix + "21:cc",
+	}
+	for _, k := range want {
+		require.NoError(t, db.SetSyncState(k, "true", nil))
+	}
+	// Decoys that must NOT match under an exact byte-prefix filter:
+	decoys := []string{
+		// Shorter than the prefix.
+		"deferred_header_validation",
+		// A sibling prefix differing only in the last byte.
+		"deferred_header_validatioo:zz",
+		// Unrelated key.
+		"other_key",
+		// Uppercased prefix: a case-INSENSITIVE column collation on
+		// MySQL/Postgres would wrongly fold this into the match; a byte prefix
+		// must exclude it.
+		"DEFERRED_HEADER_VALIDATION:99",
+		// Mixed case variant, same hazard.
+		"Deferred_Header_Validation:88",
+		// A non-ASCII key adjacent in Unicode: proves the match does not depend
+		// on a synthesized range upper bound (which a non-ASCII prefix could
+		// make invalid) and is not confused by locale collation ordering.
+		"deferred_header_validationé:77",
+	}
+	for _, k := range decoys {
+		require.NoError(t, db.SetSyncState(k, "x", nil))
+	}
+
+	got, err := db.ListSyncStateKeysByPrefix(prefix, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t,
+		want,
+		got,
+		"only exact byte-prefix keys must match (no collation folding)",
+	)
+
+	// A non-ASCII prefix must scan safely and match exactly by bytes. The
+	// "...é:77" decoy above shares this UTF-8 prefix, so both it and the key
+	// added here must come back (and nothing ASCII-only).
+	const utf8Prefix = "deferred_header_validationé:"
+	require.NoError(t, db.SetSyncState(utf8Prefix+"aa", "true", nil))
+	utf8Got, err := db.ListSyncStateKeysByPrefix(utf8Prefix, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t,
+		[]string{utf8Prefix + "77", utf8Prefix + "aa"},
+		utf8Got,
+	)
+
+	// Empty prefix returns everything.
+	all, err := db.ListSyncStateKeysByPrefix("", nil)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(all), len(want)+len(decoys))
+
+	// A prefix matching nothing returns empty, not an error.
+	none, err := db.ListSyncStateKeysByPrefix("zzz_no_such_prefix:", nil)
+	require.NoError(t, err)
+	require.Empty(t, none)
+}

--- a/database/sync_state_prefix_test.go
+++ b/database/sync_state_prefix_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestListSyncStateKeysByPrefix covers the prefix scan that repopulates the
-// deferred-header retention set after a restart (issue #3727, finding 3). The
-// match must be an exact BYTE prefix on every backend, so this asserts cases a
-// collation-sensitive SQL range/LIKE would get wrong (finding: collation-unsafe
-// prefix scan). The prefix also contains a LIKE wildcard ('_') to prove no
+// TestListSyncStateKeysByPrefix covers the byte-prefix scan used to repopulate
+// the deferred-header retention set after a restart (issue #3727). The match
+// must be an exact BYTE prefix on every backend, so this asserts cases a
+// collation-sensitive SQL range or LIKE could get wrong: uppercase/mixed-case
+// variants a case-insensitive column collation would fold in, a sibling prefix
+// one byte away, and a non-ASCII neighbor a synthesized range upper bound could
+// mishandle. The prefix also contains a LIKE wildcard ('_') to prove no
 // wildcard escaping is needed.
 func TestListSyncStateKeysByPrefix(t *testing.T) {
 	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -381,8 +381,8 @@ func deferredHeaderValidationSyncStateKey(point ocommon.Point) string {
 }
 
 func (ls *LedgerState) markDeferredHeaderValidation(point ocommon.Point) {
-	ls.Lock()
-	defer ls.Unlock()
+	ls.deferredHeaderValidationMu.Lock()
+	defer ls.deferredHeaderValidationMu.Unlock()
 	if ls.deferredHeaderValidation == nil {
 		ls.deferredHeaderValidation = make(map[string]struct{})
 	}
@@ -390,22 +390,129 @@ func (ls *LedgerState) markDeferredHeaderValidation(point ocommon.Point) {
 }
 
 func (ls *LedgerState) clearDeferredHeaderValidation(point ocommon.Point) {
-	ls.Lock()
-	defer ls.Unlock()
+	ls.deferredHeaderValidationMu.Lock()
+	defer ls.deferredHeaderValidationMu.Unlock()
 	delete(ls.deferredHeaderValidation, headerValidationPointKey(point))
 }
 
 func (ls *LedgerState) consumeDeferredHeaderValidation(
 	point ocommon.Point,
 ) bool {
-	ls.Lock()
-	defer ls.Unlock()
+	ls.deferredHeaderValidationMu.Lock()
+	defer ls.deferredHeaderValidationMu.Unlock()
 	key := headerValidationPointKey(point)
 	if _, ok := ls.deferredHeaderValidation[key]; !ok {
 		return false
 	}
 	delete(ls.deferredHeaderValidation, key)
 	return true
+}
+
+// evictStaleDeferredHeadersLocked drops deferred-header entries the apply
+// cursor has already passed (issue #3727, finding 5). A canonical deferred
+// header is consumed by consumeDeferredHeaderValidation when its block is
+// applied, so an entry still present at a slot <= the applied tip is on an
+// abandoned fork (or a rollback left it behind) and can never resolve; keeping
+// it would pin its epoch's pool_stake_snapshot rows forever. Entries with an
+// unparseable key are dropped too (they can never be validated). Returns the
+// evicted map keys so the caller can delete their persisted markers. The
+// caller must hold deferredHeaderValidationMu.
+func (ls *LedgerState) evictStaleDeferredHeadersLocked() []string {
+	if len(ls.deferredHeaderValidation) == 0 {
+		return nil
+	}
+	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	var evicted []string
+	for key := range ls.deferredHeaderValidation {
+		slot, err := slotFromHeaderValidationKey(key)
+		// STRICTLY below the tip: a block whose slot the cursor has fully
+		// passed was applied (and its marker consumed) if canonical, so one
+		// still present is abandoned. Excluding slot == tip avoids racing the
+		// in-progress apply/consume of the block that just became the tip --
+		// its consume clears the marker itself, and it is evicted on a later
+		// pass only if it turns out to be abandoned.
+		if err != nil || slot < tipSlot {
+			evicted = append(evicted, key)
+			delete(ls.deferredHeaderValidation, key)
+		}
+	}
+	return evicted
+}
+
+// deletePersistedDeferredMarkers removes the sync_state markers for a set of
+// deferred-header map keys. Best effort and lock-free: it is called after the
+// in-memory eviction has already released the retention pin, so a failure only
+// leaves a dead marker row to be re-cleaned on a later pass.
+func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
+	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
+		return
+	}
+	for _, k := range mapKeys {
+		syncKey := deferredHeaderValidationSyncStatePrefix + k
+		if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
+			ls.config.Logger.Warn(
+				"failed to delete stale deferred-header marker",
+				"key", syncKey,
+				"error", err,
+				"component", "ledger",
+			)
+		}
+	}
+}
+
+// repopulateDeferredHeaderValidation rebuilds the in-memory deferred-header set
+// from the persisted markers at startup (issue #3727, finding 3), so the
+// snapshot retention floor (PrunePoolSnapshotsWithRetentionFloor) covers
+// headers still awaiting apply from before the restart -- otherwise the first
+// post-restart epoch cleanup could prune a pool-stake snapshot such a header
+// needs. Abandoned markers loaded here are harmless: the retention guard evicts
+// any whose slot the apply cursor has already passed on its next run. Best
+// effort: a load error only forgoes the pin, leaving apply-time re-validation
+// (which reads the per-point marker directly) unaffected.
+func (ls *LedgerState) repopulateDeferredHeaderValidation() {
+	if ls.db == nil || ls.db.Metadata() == nil {
+		return
+	}
+	keys, err := ls.db.ListSyncStateKeysByPrefix(
+		deferredHeaderValidationSyncStatePrefix,
+		nil,
+	)
+	if err != nil {
+		ls.config.Logger.Warn(
+			"failed to repopulate deferred-header set from persisted markers; "+
+				"snapshot retention pin will not cover pre-restart deferred headers until re-seen",
+			"error", err,
+			"component", "ledger",
+		)
+		return
+	}
+	if len(keys) == 0 {
+		return
+	}
+	ls.deferredHeaderValidationMu.Lock()
+	if ls.deferredHeaderValidation == nil {
+		ls.deferredHeaderValidation = make(map[string]struct{}, len(keys))
+	}
+	restored := 0
+	for _, syncKey := range keys {
+		mapKey := strings.TrimPrefix(
+			syncKey,
+			deferredHeaderValidationSyncStatePrefix,
+		)
+		if mapKey == "" || mapKey == syncKey {
+			continue
+		}
+		ls.deferredHeaderValidation[mapKey] = struct{}{}
+		restored++
+	}
+	ls.deferredHeaderValidationMu.Unlock()
+	if restored > 0 {
+		ls.config.Logger.Info(
+			"repopulated deferred-header set from persisted markers",
+			"count", restored,
+			"component", "ledger",
+		)
+	}
 }
 
 func (ls *LedgerState) persistDeferredHeaderValidation(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -490,9 +490,9 @@ func (ls *LedgerState) evictStaleDeferredHeadersLocked(
 // is idempotent (SetSyncState of the same key/value) and runs with no lock
 // held, so it closes the window without reintroducing the lock inversion
 // (issue #3717 review / cubic P1: re-admission after the live check).
-func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
+func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) error {
 	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
-		return
+		return nil
 	}
 	// The membership test is taken under the lock, but the lock is RELEASED
 	// before DeleteSyncState: that delete opens the single sqlite write
@@ -507,6 +507,7 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 	// could be dropped, and solely if the re-defer lands in that narrow window
 	// AND the node then restarts before the next cleanup re-persists it. That
 	// residual is accepted in exchange for never inverting the lock order.
+	var cleanupErr error
 	for _, k := range mapKeys {
 		ls.deferredHeaderValidationMu.Lock()
 		_, live := ls.deferredHeaderValidation[k]
@@ -515,9 +516,36 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 			// Re-admitted since eviction: its marker is now backing a live pin.
 			continue
 		}
-		ls.deleteDeferredMarkerUnlessReadmitted(k)
+		// A restore failure inside deleteDeferredMarkerUnlessReadmitted (a point
+		// re-admitted during its delete whose marker could not be re-persisted)
+		// is a LOST DURABLE PIN and must not be swallowed (issue #3717 review):
+		// it is joined and propagated so the caller
+		// (PrunePoolSnapshotsWithRetentionFloor -> the retention guard ->
+		// cleanupOldSnapshots) surfaces the failed cleanup instead of continuing
+		// with a marker that a restart would miss. Remaining keys are still
+		// processed so one failure does not leak the other stale markers.
+		if err := ls.deleteDeferredMarkerUnlessReadmitted(k); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
 	}
+	return cleanupErr
 }
+
+// afterDeferredMarkerDeleteHook is a test seam. It is nil in production (a
+// single nil-check, zero cost) and, when set, runs inside
+// deleteDeferredMarkerUnlessReadmitted immediately AFTER DeleteSyncState returns
+// and BEFORE the membership re-test. It lets a test inject a re-admission
+// (markDeferredHeaderValidation) that lands DURING the delete window rather than
+// before the call, so the TOCTOU restore path is actually exercised: an
+// implementation that tested membership before deleting and skipped the delete
+// would not restore the marker and must fail such a test (issue #3717 review).
+var afterDeferredMarkerDeleteHook func()
+
+// deferredMarkerRestoreMaxAttempts bounds the retry on re-persisting the marker
+// for a point re-admitted during its delete. A handful of attempts rides out a
+// transient sqlite-busy without spinning; exhausting them is treated as a lost
+// durable pin and propagated.
+const deferredMarkerRestoreMaxAttempts = 3
 
 // deleteDeferredMarkerUnlessReadmitted deletes one evicted key's persisted
 // marker, then restores it if the key was re-admitted to the in-memory
@@ -534,7 +562,18 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 // deferredHeaderValidationRequired returns false and
 // verifyDeferredBlockHeaderState skips the stateful check for a header that is
 // still outstanding.
-func (ls *LedgerState) deleteDeferredMarkerUnlessReadmitted(k string) {
+//
+// A failed DeleteSyncState leaves the durable marker in place, so the retention
+// pin is NOT lost — the stale row is simply re-cleaned on a later pass — and is
+// logged best-effort. A failed RESTORE is different: it drops the durable pin
+// for a header that is live again in the in-memory set, so after a restart the
+// stateful check would be skipped. It is retried a bounded number of times and,
+// if it still fails, PROPAGATED to the caller (issue #3717 review: a restoration
+// failure must not pass silently). The in-memory entry survives regardless, so
+// the running process keeps the pin; propagation surfaces the lost DURABLE pin
+// so the node fails the cleanup rather than continuing toward a restart that
+// would lose it.
+func (ls *LedgerState) deleteDeferredMarkerUnlessReadmitted(k string) error {
 	syncKey := deferredHeaderValidationSyncStatePrefix + k
 	if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
 		ls.config.Logger.Warn(
@@ -543,26 +582,41 @@ func (ls *LedgerState) deleteDeferredMarkerUnlessReadmitted(k string) {
 			"error", err,
 			"component", "ledger",
 		)
-		return
+		return nil
+	}
+	if hook := afterDeferredMarkerDeleteHook; hook != nil {
+		hook()
 	}
 	ls.deferredHeaderValidationMu.Lock()
 	_, readmitted := ls.deferredHeaderValidation[k]
 	ls.deferredHeaderValidationMu.Unlock()
 	if !readmitted {
-		return
+		return nil
 	}
-	if err := ls.db.SetSyncState(
-		syncKey,
-		deferredHeaderValidationSyncStateValue,
-		nil,
-	); err != nil {
+	var restoreErr error
+	for attempt := 1; attempt <= deferredMarkerRestoreMaxAttempts; attempt++ {
+		restoreErr = ls.db.SetSyncState(
+			syncKey,
+			deferredHeaderValidationSyncStateValue,
+			nil,
+		)
+		if restoreErr == nil {
+			return nil
+		}
 		ls.config.Logger.Warn(
-			"failed to restore re-deferred header marker",
+			"failed to restore re-deferred header marker; retrying",
 			"key", syncKey,
-			"error", err,
+			"attempt", attempt,
+			"error", restoreErr,
 			"component", "ledger",
 		)
 	}
+	return fmt.Errorf(
+		"restore re-deferred header marker %q after %d attempts: %w",
+		syncKey,
+		deferredMarkerRestoreMaxAttempts,
+		restoreErr,
+	)
 }
 
 // repopulateDeferredHeaderValidation rebuilds the in-memory deferred-header set

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -408,30 +408,55 @@ func (ls *LedgerState) consumeDeferredHeaderValidation(
 	return true
 }
 
-// evictStaleDeferredHeadersLocked drops deferred-header entries the apply
-// cursor has already passed (issue #3727, finding 5). A canonical deferred
-// header is consumed by consumeDeferredHeaderValidation when its block is
-// applied, so an entry still present at a slot <= the applied tip is on an
-// abandoned fork (or a rollback left it behind) and can never resolve; keeping
-// it would pin its epoch's pool_stake_snapshot rows forever. Entries with an
-// unparseable key are dropped too (they can never be validated). Returns the
-// evicted map keys so the caller can delete their persisted markers. The
-// caller must hold deferredHeaderValidationMu.
-func (ls *LedgerState) evictStaleDeferredHeadersLocked() []string {
+// evictStaleDeferredHeadersLocked drops deferred-header entries that are
+// provably abandoned (issue #3727, finding 5). A canonical deferred header is
+// consumed by consumeDeferredHeaderValidation when its block is applied, so an
+// entry still present once the cursor has passed its slot is on a fork; keeping
+// it forever would pin its epoch's pool_stake_snapshot rows forever.
+//
+// Eviction is gated on the ROLLBACK HORIZON, not on the bare tip. Eviction
+// removes the durable sync_state marker as well as the in-memory entry, and
+// that marker is the only thing that makes deferredHeaderValidationRequired
+// return true at apply. If chain selection later rolls back and re-adopts a
+// fork containing an evicted point, its block applies with required == false,
+// so verifyDeferredBlockHeaderState returns nil and the block is adopted with
+// its stateful leader-eligibility check never run -- a validation bypass that
+// does not exist on main, where the entry and marker survive. Evicting only
+// below tipSlot-rollbackHorizon (the stability window, 3k/f slots, past which
+// chain selection cannot re-adopt a fork) makes "abandoned" mean unreachable
+// rather than merely behind the cursor, so no entry that a rollback could
+// resurrect is ever dropped (issue #3717 review: evicted-point re-adoption
+// skips the deferred header check).
+//
+// Entries with an unparseable key are dropped regardless of the horizon: they
+// can never be validated, so no re-adoption can make use of them. Returns the
+// evicted map keys so the caller can delete their persisted markers. The caller
+// must hold deferredHeaderValidationMu; tipSlot and rollbackHorizon are read by
+// the caller BEFORE taking it, because both ls.loadTipSnapshot's era-derived
+// window (calculateStabilityWindow) and the tip read take ls.RWMutex, and
+// taking that under deferredHeaderValidationMu would invert the order block
+// apply uses (ls lock -> deferredHeaderValidationMu).
+func (ls *LedgerState) evictStaleDeferredHeadersLocked(
+	tipSlot uint64,
+	rollbackHorizon uint64,
+) []string {
 	if len(ls.deferredHeaderValidation) == 0 {
 		return nil
 	}
-	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	// The whole chain is still inside the horizon, so nothing is unreachable
+	// yet. Unparseable keys are still evicted below.
+	var cutoff uint64
+	if tipSlot > rollbackHorizon {
+		cutoff = tipSlot - rollbackHorizon
+	}
 	var evicted []string
 	for key := range ls.deferredHeaderValidation {
 		slot, err := slotFromHeaderValidationKey(key)
-		// STRICTLY below the tip: a block whose slot the cursor has fully
-		// passed was applied (and its marker consumed) if canonical, so one
-		// still present is abandoned. Excluding slot == tip avoids racing the
-		// in-progress apply/consume of the block that just became the tip --
-		// its consume clears the marker itself, and it is evicted on a later
-		// pass only if it turns out to be abandoned.
-		if err != nil || slot < tipSlot {
+		// STRICTLY below the cutoff: a block that deep cannot be re-adopted,
+		// so an entry still present is abandoned and safe to forget. Anything
+		// at or above the cutoff keeps both its entry and its marker so a
+		// rollback-then-re-adopt still finds required == true at apply.
+		if err != nil || slot < cutoff {
 			evicted = append(evicted, key)
 			delete(ls.deferredHeaderValidation, key)
 		}
@@ -446,13 +471,25 @@ func (ls *LedgerState) evictStaleDeferredHeadersLocked() []string {
 //
 // It re-checks each key under deferredHeaderValidationMu and skips any that is
 // present in the in-memory set again: between eviction (which happens for a key
-// whose slot is below the chain tip) and this cleanup, that same point can be
-// re-deferred and re-persisted if it is still ahead of the (lagging) apply
-// cursor -- markDeferredHeaderValidation and persistDeferredHeaderValidation run
-// together on the chainsync path. Deleting the marker for a currently-live
-// entry would drop the durable pin for an active deferred header, so on the
-// next restart repopulate would miss it and cleanup could prune the snapshot it
-// needs (issue #3727, finding: evicted-marker delete races a re-defer).
+// whose slot is below the rollback horizon) and this cleanup, that same point
+// can be re-deferred and re-persisted -- markDeferredHeaderValidation and
+// persistDeferredHeaderValidation run together on the chainsync path. Deleting
+// the marker for a currently-live entry would drop the durable pin for an
+// active deferred header, so on the next restart repopulate would miss it and
+// cleanup could prune the snapshot it needs (issue #3727, finding:
+// evicted-marker delete races a re-defer).
+//
+// The membership test alone cannot close that window, because the lock is
+// released before the delete (see below): a re-defer landing between the test
+// and the delete would have its fresh marker deleted, and a restart would then
+// find no marker, so deferredHeaderValidationRequired returns false and
+// verifyDeferredBlockHeaderState skips the stateful check for a header that is
+// still outstanding. So the delete is made effectively conditional by
+// re-testing membership AFTER it and RE-PERSISTING the marker for any key that
+// came back, rather than by holding the lock across the delete. Re-persisting
+// is idempotent (SetSyncState of the same key/value) and runs with no lock
+// held, so it closes the window without reintroducing the lock inversion
+// (issue #3717 review / cubic P1: re-admission after the live check).
 func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
 		return
@@ -478,15 +515,53 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 			// Re-admitted since eviction: its marker is now backing a live pin.
 			continue
 		}
-		syncKey := deferredHeaderValidationSyncStatePrefix + k
-		if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
-			ls.config.Logger.Warn(
-				"failed to delete stale deferred-header marker",
-				"key", syncKey,
-				"error", err,
-				"component", "ledger",
-			)
-		}
+		ls.deleteDeferredMarkerUnlessReadmitted(k)
+	}
+}
+
+// deleteDeferredMarkerUnlessReadmitted deletes one evicted key's persisted
+// marker, then restores it if the key was re-admitted to the in-memory
+// deferred set while the delete was in flight.
+//
+// Neither DB call runs under deferredHeaderValidationMu (that would invert the
+// lock order against block apply — issue #3717), so the caller's membership
+// test cannot be atomic with the delete. The delete is instead made effectively
+// conditional after the fact: re-testing membership and re-persisting is
+// idempotent, and it leaves the durable marker present for exactly the keys
+// that are live when this returns. Without the restore, a point re-deferred in
+// that window keeps its in-memory entry but loses its marker, and after a
+// restart repopulateDeferredHeaderValidation misses it — so
+// deferredHeaderValidationRequired returns false and
+// verifyDeferredBlockHeaderState skips the stateful check for a header that is
+// still outstanding.
+func (ls *LedgerState) deleteDeferredMarkerUnlessReadmitted(k string) {
+	syncKey := deferredHeaderValidationSyncStatePrefix + k
+	if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
+		ls.config.Logger.Warn(
+			"failed to delete stale deferred-header marker",
+			"key", syncKey,
+			"error", err,
+			"component", "ledger",
+		)
+		return
+	}
+	ls.deferredHeaderValidationMu.Lock()
+	_, readmitted := ls.deferredHeaderValidation[k]
+	ls.deferredHeaderValidationMu.Unlock()
+	if !readmitted {
+		return
+	}
+	if err := ls.db.SetSyncState(
+		syncKey,
+		deferredHeaderValidationSyncStateValue,
+		nil,
+	); err != nil {
+		ls.config.Logger.Warn(
+			"failed to restore re-deferred header marker",
+			"key", syncKey,
+			"error", err,
+			"component", "ledger",
+		)
 	}
 }
 

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -452,32 +452,34 @@ func (ls *LedgerState) evictStaleDeferredHeadersLocked() []string {
 // together on the chainsync path. Deleting the marker for a currently-live
 // entry would drop the durable pin for an active deferred header, so on the
 // next restart repopulate would miss it and cleanup could prune the snapshot it
-// needs (issue #3727, finding: evicted-marker delete races a re-defer). Holding
-// the lock across the deletes closes the window entirely; DeleteSyncState is a
-// single indexed delete and the only other holders of this mutex (mark/clear/
-// consume) do no I/O, so there is no deadlock.
+// needs (issue #3727, finding: evicted-marker delete races a re-defer).
 func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
 		return
 	}
-	// Lock and recheck PER KEY rather than across the whole loop: a large
-	// eviction must not hold deferredHeaderValidationMu across one DB
-	// transaction per marker, which would block header apply and new deferrals
-	// for the full cleanup. The recheck and the delete stay together under the
-	// per-key lock so a point re-deferred (and re-persisted) between them can't
-	// have its fresh marker dropped; the lock is released between keys so apply
-	// can interleave.
+	// The membership test is taken under the lock, but the lock is RELEASED
+	// before DeleteSyncState: that delete opens the single sqlite write
+	// connection (nil txn -> Transaction(true)), and block apply holds that
+	// connection before taking this mutex via consumeDeferredHeaderValidation.
+	// Holding the mutex across the delete inverts the lock order (mutex->write-
+	// conn here vs. write-conn->mutex on apply) and deadlocks the node on the
+	// single write connection -- the same inversion as the prune path (issue
+	// #3717). A point re-deferred (and re-persisted) between the membership test
+	// and the delete keeps its live pin in the in-memory set for the running
+	// process, so the retention floor still covers it; only its durable marker
+	// could be dropped, and solely if the re-defer lands in that narrow window
+	// AND the node then restarts before the next cleanup re-persists it. That
+	// residual is accepted in exchange for never inverting the lock order.
 	for _, k := range mapKeys {
 		ls.deferredHeaderValidationMu.Lock()
-		if _, ok := ls.deferredHeaderValidation[k]; ok {
+		_, live := ls.deferredHeaderValidation[k]
+		ls.deferredHeaderValidationMu.Unlock()
+		if live {
 			// Re-admitted since eviction: its marker is now backing a live pin.
-			ls.deferredHeaderValidationMu.Unlock()
 			continue
 		}
 		syncKey := deferredHeaderValidationSyncStatePrefix + k
-		err := ls.db.DeleteSyncState(syncKey, nil)
-		ls.deferredHeaderValidationMu.Unlock()
-		if err != nil {
+		if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
 			ls.config.Logger.Warn(
 				"failed to delete stale deferred-header marker",
 				"key", syncKey,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -440,14 +440,33 @@ func (ls *LedgerState) evictStaleDeferredHeadersLocked() []string {
 }
 
 // deletePersistedDeferredMarkers removes the sync_state markers for a set of
-// deferred-header map keys. Best effort and lock-free: it is called after the
-// in-memory eviction has already released the retention pin, so a failure only
-// leaves a dead marker row to be re-cleaned on a later pass.
+// evicted deferred-header map keys. It runs after the in-memory eviction has
+// already released the retention pin, so a delete failure only leaves a dead
+// marker row to be re-cleaned on a later pass.
+//
+// It re-checks each key under deferredHeaderValidationMu and skips any that is
+// present in the in-memory set again: between eviction (which happens for a key
+// whose slot is below the chain tip) and this cleanup, that same point can be
+// re-deferred and re-persisted if it is still ahead of the (lagging) apply
+// cursor -- markDeferredHeaderValidation and persistDeferredHeaderValidation run
+// together on the chainsync path. Deleting the marker for a currently-live
+// entry would drop the durable pin for an active deferred header, so on the
+// next restart repopulate would miss it and cleanup could prune the snapshot it
+// needs (issue #3727, finding: evicted-marker delete races a re-defer). Holding
+// the lock across the deletes closes the window entirely; DeleteSyncState is a
+// single indexed delete and the only other holders of this mutex (mark/clear/
+// consume) do no I/O, so there is no deadlock.
 func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
 		return
 	}
+	ls.deferredHeaderValidationMu.Lock()
+	defer ls.deferredHeaderValidationMu.Unlock()
 	for _, k := range mapKeys {
+		// Re-admitted since eviction: its marker is now backing a live pin.
+		if _, ok := ls.deferredHeaderValidation[k]; ok {
+			continue
+		}
 		syncKey := deferredHeaderValidationSyncStatePrefix + k
 		if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
 			ls.config.Logger.Warn(
@@ -466,28 +485,34 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 // headers still awaiting apply from before the restart -- otherwise the first
 // post-restart epoch cleanup could prune a pool-stake snapshot such a header
 // needs. Abandoned markers loaded here are harmless: the retention guard evicts
-// any whose slot the apply cursor has already passed on its next run. Best
-// effort: a load error only forgoes the pin, leaving apply-time re-validation
-// (which reads the per-point marker directly) unaffected.
-func (ls *LedgerState) repopulateDeferredHeaderValidation() {
+// any whose slot the apply cursor has already passed on its next run.
+//
+// This MUST fail closed. A scan failure that is swallowed leaves the in-memory
+// set empty, so the retention floor does not cover pre-restart deferred headers
+// and the first post-restart cleanup can prune a snapshot one of them needs.
+// Once the apply cursor then passes that header, stateful verification finds
+// the snapshot gone and hard-rejects it instead of deferring -- the exact
+// misclassification this PR exists to prevent. Apply-time re-validation from
+// the per-point marker cannot save it: the snapshot is already gone. So a load
+// failure is surfaced to LedgerState.Start, which aborts startup; the operator
+// retries rather than running with an unpinned retention floor (issue #3727,
+// finding: swallowed marker-scan failure reopens the pruned-snapshot bug).
+func (ls *LedgerState) repopulateDeferredHeaderValidation() error {
 	if ls.db == nil || ls.db.Metadata() == nil {
-		return
+		return nil
 	}
 	keys, err := ls.db.ListSyncStateKeysByPrefix(
 		deferredHeaderValidationSyncStatePrefix,
 		nil,
 	)
 	if err != nil {
-		ls.config.Logger.Warn(
-			"failed to repopulate deferred-header set from persisted markers; "+
-				"snapshot retention pin will not cover pre-restart deferred headers until re-seen",
-			"error", err,
-			"component", "ledger",
+		return fmt.Errorf(
+			"repopulate deferred-header set from persisted markers: %w",
+			err,
 		)
-		return
 	}
 	if len(keys) == 0 {
-		return
+		return nil
 	}
 	ls.deferredHeaderValidationMu.Lock()
 	if ls.deferredHeaderValidation == nil {
@@ -513,6 +538,7 @@ func (ls *LedgerState) repopulateDeferredHeaderValidation() {
 			"component", "ledger",
 		)
 	}
+	return nil
 }
 
 func (ls *LedgerState) persistDeferredHeaderValidation(

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -460,15 +460,24 @@ func (ls *LedgerState) deletePersistedDeferredMarkers(mapKeys []string) {
 	if len(mapKeys) == 0 || ls.db == nil || ls.db.Metadata() == nil {
 		return
 	}
-	ls.deferredHeaderValidationMu.Lock()
-	defer ls.deferredHeaderValidationMu.Unlock()
+	// Lock and recheck PER KEY rather than across the whole loop: a large
+	// eviction must not hold deferredHeaderValidationMu across one DB
+	// transaction per marker, which would block header apply and new deferrals
+	// for the full cleanup. The recheck and the delete stay together under the
+	// per-key lock so a point re-deferred (and re-persisted) between them can't
+	// have its fresh marker dropped; the lock is released between keys so apply
+	// can interleave.
 	for _, k := range mapKeys {
-		// Re-admitted since eviction: its marker is now backing a live pin.
+		ls.deferredHeaderValidationMu.Lock()
 		if _, ok := ls.deferredHeaderValidation[k]; ok {
+			// Re-admitted since eviction: its marker is now backing a live pin.
+			ls.deferredHeaderValidationMu.Unlock()
 			continue
 		}
 		syncKey := deferredHeaderValidationSyncStatePrefix + k
-		if err := ls.db.DeleteSyncState(syncKey, nil); err != nil {
+		err := ls.db.DeleteSyncState(syncKey, nil)
+		ls.deferredHeaderValidationMu.Unlock()
+		if err != nil {
 			ls.config.Logger.Warn(
 				"failed to delete stale deferred-header marker",
 				"key", syncKey,

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -58,6 +58,17 @@ type Manager struct {
 	loopWg         sync.WaitGroup
 	metrics        *managerMetrics
 
+	// retentionGuard, when set, runs the pool-stake snapshot prune under the
+	// deferred-header lock so the retention-floor selection and the prune are
+	// atomic with respect to deferred-header admission (issue #3727 race).
+	// cleanupOldSnapshots passes its default currentEpoch-3 boundary and a
+	// prune closure that deletes+commits pool snapshots below the boundary the
+	// guard hands back (lowered to keep snapshots a queued/deferred header
+	// still needs). A nil guard (the default) preserves the original pruning
+	// behaviour exactly. Guarded by mu; wired by the node to
+	// LedgerState.PrunePoolSnapshotsWithRetentionFloor.
+	retentionGuard PoolSnapshotRetentionGuard
+
 	// pendingBoundary holds the stake distribution computed at the SNAP point of
 	// an in-flight epoch rollover, waiting for the same rollover transaction to
 	// persist it once the new epoch row (nonce, boundary slot, protocol version)
@@ -219,6 +230,43 @@ func (m *Manager) SetPromRegistry(reg prometheus.Registerer) {
 	if m.metrics == nil {
 		m.metrics = initManagerMetrics(reg)
 	}
+}
+
+// PoolSnapshotRetentionGuard runs the caller's pool-snapshot prune with the
+// deferred-header set held stable, returning the boundary to prune below.
+// defaultBefore is cleanup's default currentEpoch-3 pool boundary; the guard
+// lowers it to the retention floor a queued/deferred header still requires
+// (or to 0 = retain everything while any deferred slot is unmappable), then
+// clamps it UP to minBefore, a hard backstop bounding how many historical
+// epochs the pin can ever hold. All of this — plus eviction of deferred
+// headers the apply cursor has passed — happens under one lock so admission
+// cannot interleave (issue #3727). prune must delete AND commit before
+// returning.
+type PoolSnapshotRetentionGuard func(
+	defaultBefore uint64,
+	minBefore uint64,
+	prune func(before uint64) error,
+) error
+
+// SetPoolSnapshotRetentionGuard installs the guard cleanupOldSnapshots uses to
+// prune pool snapshots atomically with the deferred-header retention floor, so
+// a snapshot a queued/deferred header still needs is retained beyond the
+// default currentEpoch-3 window until the header resolves (issue #3727). Pass
+// nil to clear it. It should be set before Start; a nil guard (the default)
+// preserves the original pruning behaviour exactly.
+func (m *Manager) SetPoolSnapshotRetentionGuard(g PoolSnapshotRetentionGuard) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.retentionGuard = g
+}
+
+// poolSnapshotRetentionGuard returns the installed guard, if any. Read under mu
+// so a guard installed via SetPoolSnapshotRetentionGuard races safely with the
+// manager's epoch-transition goroutine.
+func (m *Manager) poolSnapshotRetentionGuard() PoolSnapshotRetentionGuard {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.retentionGuard
 }
 
 // Start begins listening for epoch transitions and capturing

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -1030,6 +1030,17 @@ func (m *Manager) rotateSnapshots(ctx context.Context, newEpoch uint64) {
 	)
 }
 
+// poolSnapshotRetentionMaxDepth bounds how many epochs of pool_stake_snapshot
+// rows the deferred-header retention pin (issue #3727) may ever hold below the
+// current epoch. It is a safety backstop far larger than any legitimate
+// deferred-header gap (a header awaiting apply needs a snapshot within a few
+// epochs of the apply cursor, and the retention guard additionally evicts
+// deferred headers the cursor has already passed), so in normal operation it
+// never binds; it exists only so a permanently-stuck deferred header cannot pin
+// ~1.3M rows/epoch on mainnet without limit. Retention never drops below the
+// default currentEpoch-3 window regardless.
+const poolSnapshotRetentionMaxDepth uint64 = 24
+
 // cleanupOldSnapshots removes snapshots older than needed for the rotation and
 // delayed reward models. We keep 4 epochs of per-pool and per-credential rows:
 // current, current-1, current-2 for Go, and current-3 so reward calculation can
@@ -1069,20 +1080,75 @@ func (m *Manager) cleanupOldSnapshots(
 
 	deleteBeforeEpoch := currentEpoch - 3
 
+	// Pool-stake snapshots may still be needed below the default window by a
+	// queued/deferred header that validates leader eligibility against an
+	// older epoch's mark snapshot (issue #3727). Pruning them out from under
+	// such a header makes leaderEligibilityStake read the missing rows as a
+	// zero-stake "pool absent" answer, which the reference node never
+	// intended. So pool-snapshot pruning runs THROUGH the retention guard: the
+	// guard holds the deferred-header set stable across both the retention
+	// floor selection and this delete+commit, so no header can be admitted
+	// between the floor read and the prune and lose its snapshot. Only the
+	// pool-snapshot boundary moves; reward-state retention keeps the unchanged
+	// currentEpoch-3 window (deferred header validation reads pool stake, never
+	// reward rows), and runs in a separate transaction outside the guard to
+	// keep the locked section tight.
+	//
+	// prunePoolSnapshots deletes AND commits below the boundary the guard
+	// hands back (its own transaction), so the rows are actually gone before
+	// the guard releases the deferred-header lock.
+	prunePoolSnapshots := func(before uint64) error {
+		if before < deleteBeforeEpoch {
+			m.logger.Info(
+				"retaining historical pool stake snapshots for deferred header validation",
+				"component", "snapshot",
+				"current_epoch", currentEpoch,
+				"default_before_epoch", deleteBeforeEpoch,
+				"pinned_before_epoch", before,
+			)
+		}
+		poolTxn := m.db.Transaction(true)
+		defer func() { _ = poolTxn.Rollback() }()
+		if err := m.db.Metadata().DeletePoolStakeSnapshotsBeforeEpoch(
+			before,
+			poolTxn.Metadata(),
+		); err != nil {
+			return fmt.Errorf("cleanup pool snapshots: %w", err)
+		}
+		return poolTxn.Commit()
+	}
+	// minPoolSnapshotDeleteBefore is the hard backstop on how far the retention
+	// pin can lower pruning: retain at most poolSnapshotRetentionMaxDepth epochs
+	// of pool snapshots so an unresolvable deferred header cannot pin them
+	// without bound (issue #3727, finding 5). It never rises above the default
+	// window (a header needing a within-window snapshot is unaffected), and the
+	// guard clamps the pinned boundary up to it.
+	minPoolSnapshotDeleteBefore := uint64(0)
+	if currentEpoch > poolSnapshotRetentionMaxDepth {
+		minPoolSnapshotDeleteBefore = currentEpoch - poolSnapshotRetentionMaxDepth
+	}
+	if minPoolSnapshotDeleteBefore > deleteBeforeEpoch {
+		minPoolSnapshotDeleteBefore = deleteBeforeEpoch
+	}
+	if guard := m.poolSnapshotRetentionGuard(); guard != nil {
+		if err := guard(
+			deleteBeforeEpoch,
+			minPoolSnapshotDeleteBefore,
+			prunePoolSnapshots,
+		); err != nil {
+			return err
+		}
+	} else if err := prunePoolSnapshots(deleteBeforeEpoch); err != nil {
+		return err
+	}
+
+	// Reward-state pruning: unchanged currentEpoch-3 window, separate
+	// transaction (not under the retention guard).
 	txn := m.db.Transaction(true) // read-write transaction
 	defer func() { _ = txn.Rollback() }()
 
 	meta := m.db.Metadata()
 	metaTxn := txn.Metadata()
-
-	// Delete old pool stake snapshots
-	// For cleaning up old data, we want to delete epochs < deleteBeforeEpoch
-	if err := meta.DeletePoolStakeSnapshotsBeforeEpoch(
-		deleteBeforeEpoch,
-		metaTxn,
-	); err != nil {
-		return fmt.Errorf("cleanup pool snapshots: %w", err)
-	}
 
 	if m.db.StorageMode() == types.StorageModeAPI {
 		// API storage mode: retain reward_account_output without bound (see

--- a/ledger/snapshot/rotation_test.go
+++ b/ledger/snapshot/rotation_test.go
@@ -29,6 +29,26 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// fixedFloorGuard builds a PoolSnapshotRetentionGuard that lowers the prune
+// boundary to a fixed floor, standing in for
+// LedgerState.PrunePoolSnapshotsWithRetentionFloor in snapshot-package tests.
+func fixedFloorGuard(floor uint64, ok bool) PoolSnapshotRetentionGuard {
+	return func(
+		defaultBefore uint64,
+		minBefore uint64,
+		prune func(before uint64) error,
+	) error {
+		before := defaultBefore
+		if ok && floor < before {
+			before = floor
+		}
+		if before < minBefore {
+			before = minBefore
+		}
+		return prune(before)
+	}
+}
+
 // seedRetentionRows writes one row per epoch in [0, throughEpoch] into every
 // table cleanupOldSnapshots touches, all describing the same pool, so a
 // retention pass can be observed table by table.
@@ -409,4 +429,170 @@ func TestRotateSnapshotsPreservesCapturedLeiosKeyAcrossPoolRotation(
 	require.Equal(t, oldPublic, stored.LeiosKeyPublic,
 		"mark[8] must retain the key captured before the live rotation")
 	require.Equal(t, oldProof, stored.LeiosKeyPossessionProof)
+}
+
+// TestCleanupOldSnapshotsRetentionFloorRetainsDeferredHeaderEpochs is the
+// snapshot-side regression guard for issue #3727. When a queued/deferred header
+// still needs an older epoch's mark snapshot for leader validation, the
+// retention-floor provider reports that epoch and cleanupOldSnapshots must keep
+// the pool_stake_snapshot rows at/above it instead of pruning them at the
+// default currentEpoch-3 boundary — otherwise the deferred header would read
+// the pruned rows back as a zero-stake "pool absent" answer. The reward-state
+// retention window is unaffected: only pool snapshots are pinned.
+func TestCleanupOldSnapshotsRetentionFloorRetainsDeferredHeaderEpochs(
+	t *testing.T,
+) {
+	db := setupTestDB(t)
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(28)
+	poolKeyHash := bytes.Repeat([]byte{0xaa}, 28)
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+
+	// A deferred header requires the epoch-10 mark snapshot (its producer's
+	// leader-eligibility basis). Pin retention there.
+	const pinnedEpoch = uint64(10)
+	mgr.SetPoolSnapshotRetentionGuard(fixedFloorGuard(pinnedEpoch, true))
+
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	// Pool snapshots from the pinned epoch up to current must survive, even
+	// though 10..24 are below the default currentEpoch-3 (25) window.
+	for epoch := pinnedEpoch; epoch <= currentEpoch; epoch++ {
+		snapshots, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err, "get pool stake snapshots %d", epoch)
+		require.Len(
+			t,
+			snapshots,
+			1,
+			"pinned pool_stake_snapshot for epoch %d must be retained",
+			epoch,
+		)
+	}
+
+	// Snapshots strictly below the pin are still pruned.
+	for epoch := range pinnedEpoch {
+		snapshots, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err, "get pool stake snapshots %d", epoch)
+		require.Empty(
+			t,
+			snapshots,
+			"pool_stake_snapshot below the pin (epoch %d) must be pruned",
+			epoch,
+		)
+	}
+
+	// The reward window is NOT widened by the pin: reward_stake_input keeps the
+	// default currentEpoch-3 retention, so an epoch below it (but at/above the
+	// pin) is still pruned there.
+	const firstRewardRetained = currentEpoch - 3
+	stakeInputs, err := meta.GetRewardStakeInputs(pinnedEpoch, nil)
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		stakeInputs,
+		"reward_stake_input at the pinned epoch must still be pruned (pin covers pool snapshots only)",
+	)
+	retainedInputs, err := meta.GetRewardStakeInputs(firstRewardRetained, nil)
+	require.NoError(t, err)
+	require.Len(
+		t,
+		retainedInputs,
+		1,
+		"reward_stake_input inside the default window must be retained",
+	)
+}
+
+// TestCleanupOldSnapshotsRetentionFloorAboveWindowIsNoop verifies the pin only
+// ever widens retention: a floor at/above the default currentEpoch-3 boundary
+// changes nothing, and the default pruning still applies.
+func TestCleanupOldSnapshotsRetentionFloorAboveWindowIsNoop(t *testing.T) {
+	db := setupTestDB(t)
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(10)
+	const firstRetainedEpoch = currentEpoch - 3
+	poolKeyHash := bytes.Repeat([]byte{0xaa}, 28)
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+
+	// Floor above the default window: must not resurrect pruning below it.
+	mgr.SetPoolSnapshotRetentionGuard(fixedFloorGuard(currentEpoch, true))
+
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	for epoch := range firstRetainedEpoch {
+		snapshots, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err, "get pool stake snapshots %d", epoch)
+		require.Empty(
+			t,
+			snapshots,
+			"epoch %d below the default window must still be pruned",
+			epoch,
+		)
+	}
+}
+
+// TestCleanupOldSnapshotsRetentionDepthCapBounds proves the hard backstop
+// (issue #3727, finding 5): even when the retention floor would pin a very old
+// epoch, cleanupOldSnapshots never retains more than poolSnapshotRetentionMaxDepth
+// epochs BELOW the current epoch of pool snapshots (the boundary epoch
+// current-MaxDepth is retained, so the retained span is MaxDepth+1 epochs
+// inclusive), so a stuck deferred header cannot pin them without bound.
+func TestCleanupOldSnapshotsRetentionDepthCapBounds(t *testing.T) {
+	db := setupTestDB(t)
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(40)
+	poolKeyHash := bytes.Repeat([]byte{0xaa}, 28)
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+
+	// A floor far below the cap: without the backstop this would retain epoch
+	// 2 upward. The cap must clamp retention to currentEpoch - MaxDepth.
+	mgr.SetPoolSnapshotRetentionGuard(fixedFloorGuard(2, true))
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	firstRetained := currentEpoch - poolSnapshotRetentionMaxDepth
+	for epoch := uint64(0); epoch < firstRetained; epoch++ {
+		snaps, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err, "epoch %d", epoch)
+		require.Empty(
+			t,
+			snaps,
+			"epoch %d below the depth cap must be pruned despite the low floor",
+			epoch,
+		)
+	}
+	for epoch := firstRetained; epoch <= currentEpoch; epoch++ {
+		snaps, err := meta.GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err, "epoch %d", epoch)
+		require.Len(
+			t,
+			snaps,
+			1,
+			"epoch %d within the depth cap must be retained",
+			epoch,
+		)
+	}
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1502,9 +1502,17 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// so the snapshot retention floor covers headers still awaiting apply from
 	// before the restart (issue #3727, finding 3): without this the first
 	// post-restart epoch cleanup could prune a pool-stake snapshot such a
-	// header needs. Best-effort: a load failure only forgoes the pin (the
-	// per-point persisted markers still drive apply-time re-validation).
-	ls.repopulateDeferredHeaderValidation()
+	// header needs. Fail closed: a scan failure that continued would leave the
+	// floor unpinned, and once the apply cursor passes a pre-restart deferred
+	// header its now-pruned snapshot is hard-rejected instead of deferred (the
+	// exact bug this PR fixes). Abort startup so the operator retries rather
+	// than run with an unpinned retention floor.
+	if err := ls.repopulateDeferredHeaderValidation(); err != nil {
+		return fmt.Errorf(
+			"failed to repopulate deferred-header validation set: %w",
+			err,
+		)
+	}
 	// Reconstruct the evolving-nonce fold across Mithril "gap blocks" (blocks
 	// between the ledger-state snapshot slot and the trust boundary) that were
 	// imported without folding their VRF output. Must run after the tip and

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -874,12 +874,22 @@ type LedgerState struct {
 	// header that blocks local forging). Deliberately survives interleaved
 	// deliveries for other ranges and header-queue churn; discarded when
 	// the tracked range itself is delivered.
-	blockfetchRangeFailure    blockfetchRangeFailureState
-	deferredHeaderValidation  map[string]struct{} // block points whose stateful header checks wait for ledger apply
-	checkpointWrittenForEpoch bool
-	closed                    atomic.Bool
-	inRecovery                bool // guards against recursive recovery in SubmitAsyncDBTxn
-	lastAtTipRecovery         *atTipRecoveryAttempt
+	blockfetchRangeFailure blockfetchRangeFailureState
+	// deferredHeaderValidation holds block points whose stateful header checks
+	// wait for ledger apply. It is guarded by its own deferredHeaderValidationMu
+	// (NOT the main RWMutex) so the snapshot retention guard
+	// (PrunePoolSnapshotsWithRetentionFloor) can hold the set stable across the
+	// floor computation AND the pool-snapshot prune without contending the hot
+	// header-validation read path on the main lock (issue #3727). Admission
+	// (markDeferredHeaderValidation) and the retention floor/prune are mutually
+	// exclusive under this mutex, so no deferred header can be admitted between
+	// the floor read and the prune and have its required snapshot deleted.
+	deferredHeaderValidation   map[string]struct{}
+	deferredHeaderValidationMu sync.Mutex
+	checkpointWrittenForEpoch  bool
+	closed                     atomic.Bool
+	inRecovery                 bool // guards against recursive recovery in SubmitAsyncDBTxn
+	lastAtTipRecovery          *atTipRecoveryAttempt
 	// At-tip recovery non-convergence tracking (issue #2939). A descending
 	// series of *distinct* (block, tx) validation failures each resets the
 	// same-block escalation to attempt 1, so the escalate-and-cap logic in
@@ -1488,6 +1498,13 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	if err := ls.loadTip(); err != nil {
 		return fmt.Errorf("failed to load tip: %w", err)
 	}
+	// Repopulate the in-memory deferred-header set from the persisted markers
+	// so the snapshot retention floor covers headers still awaiting apply from
+	// before the restart (issue #3727, finding 3): without this the first
+	// post-restart epoch cleanup could prune a pool-stake snapshot such a
+	// header needs. Best-effort: a load failure only forgoes the pin (the
+	// per-point persisted markers still drive apply-time re-validation).
+	ls.repopulateDeferredHeaderValidation()
 	// Reconstruct the evolving-nonce fold across Mithril "gap blocks" (blocks
 	// between the ledger-state snapshot slot and the trust boundary) that were
 	// imported without folding their VRF output. Must run after the tip and

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1456,6 +1456,23 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	}
 
 	ls.loadMithrilTrustBoundary()
+	// Repopulate the in-memory deferred-header set from the persisted markers
+	// so the snapshot retention floor covers headers still awaiting apply from
+	// before the restart (issue #3727, finding 3): without this the first
+	// post-restart epoch cleanup could prune a pool-stake snapshot such a
+	// header needs. Runs here, before the database worker pool and cleanup
+	// timer start, because it only reads ls.db directly and must FAIL CLOSED:
+	// a scan failure that continued would leave the floor unpinned, and once
+	// the apply cursor passes a pre-restart deferred header its now-pruned
+	// snapshot is hard-rejected instead of deferred (the exact bug this PR
+	// fixes). Aborting before any resource starts means there is nothing to
+	// unwind on failure.
+	if err := ls.repopulateDeferredHeaderValidation(); err != nil {
+		return fmt.Errorf(
+			"failed to repopulate deferred-header validation set: %w",
+			err,
+		)
+	}
 
 	// Initialize database worker pool for async operations
 	if !ls.config.DatabaseWorkerPoolConfig.Disabled {
@@ -1497,21 +1514,6 @@ func (ls *LedgerState) Start(ctx context.Context) error {
 	// Load current tip
 	if err := ls.loadTip(); err != nil {
 		return fmt.Errorf("failed to load tip: %w", err)
-	}
-	// Repopulate the in-memory deferred-header set from the persisted markers
-	// so the snapshot retention floor covers headers still awaiting apply from
-	// before the restart (issue #3727, finding 3): without this the first
-	// post-restart epoch cleanup could prune a pool-stake snapshot such a
-	// header needs. Fail closed: a scan failure that continued would leave the
-	// floor unpinned, and once the apply cursor passes a pre-restart deferred
-	// header its now-pruned snapshot is hard-rejected instead of deferred (the
-	// exact bug this PR fixes). Abort startup so the operator retries rather
-	// than run with an unpinned retention floor.
-	if err := ls.repopulateDeferredHeaderValidation(); err != nil {
-		return fmt.Errorf(
-			"failed to repopulate deferred-header validation set: %w",
-			err,
-		)
 	}
 	// Reconstruct the evolving-nonce fold across Mithril "gap blocks" (blocks
 	// between the ledger-state snapshot slot and the trust boundary) that were

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -879,11 +879,15 @@ type LedgerState struct {
 	// wait for ledger apply. It is guarded by its own deferredHeaderValidationMu
 	// (NOT the main RWMutex) so the snapshot retention guard
 	// (PrunePoolSnapshotsWithRetentionFloor) can hold the set stable across the
-	// floor computation AND the pool-snapshot prune without contending the hot
-	// header-validation read path on the main lock (issue #3727). Admission
-	// (markDeferredHeaderValidation) and the retention floor/prune are mutually
-	// exclusive under this mutex, so no deferred header can be admitted between
-	// the floor read and the prune and have its required snapshot deleted.
+	// eviction and floor computation without contending the hot header-validation
+	// read path on the main lock (issue #3727). The guard must NOT hold this mutex
+	// across the pool-snapshot prune (nor deletePersistedDeferredMarkers across
+	// DeleteSyncState): those open the single SQLite write connection, and block
+	// apply holds that connection before taking this mutex via
+	// consumeDeferredHeaderValidation, so holding it across that write inverts the
+	// lock order and deadlocks the node (issue #3717). The eviction+floor read is
+	// atomic; a header admitted after the lock is released is handled by the next
+	// cleanup pass (the floor is a lower-watermark recomputed each pass).
 	deferredHeaderValidation   map[string]struct{}
 	deferredHeaderValidationMu sync.Mutex
 	checkpointWrittenForEpoch  bool

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1762,9 +1762,13 @@ func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 	// it before each DB delete, for the same lock-order reason) so it can skip
 	// any point re-deferred (and re-persisted) since eviction, keeping the
 	// sync_state table free of dead markers without dropping a marker that now
-	// backs a live pin.
-	ls.deletePersistedDeferredMarkers(evicted)
-	return err
+	// backs a live pin. A restore failure for a point re-admitted during its
+	// delete is a lost DURABLE pin: it is joined onto the prune result so the
+	// retention guard's caller (cleanupOldSnapshots) surfaces the failed cleanup
+	// rather than continuing with a marker a restart would miss (issue #3717
+	// review).
+	cleanupErr := ls.deletePersistedDeferredMarkers(evicted)
+	return errors.Join(err, cleanupErr)
 }
 
 // slotFromHeaderValidationKey extracts the slot from a deferred-header map key,

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1551,13 +1551,23 @@ func (ls *LedgerState) blockPipelineEta0Provider(slot uint64) (string, error) {
 	return ls.epochNonceHex(epoch.EpochId, epoch.Nonce), nil
 }
 
-// epochForSlot searches an immutable epoch-cache snapshot for the epoch
-// containing the given slot.
+// epochForSlot searches the currently published epoch-cache snapshot for the
+// epoch containing the given slot.
 //
 // Returns the matching epoch or an error if no epoch covers the slot.
 func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
-	cache := ls.loadConsensusSnapshot().epochCache
+	return epochForSlotInCache(ls.loadConsensusSnapshot().epochCache, slot)
+}
 
+// epochForSlotInCache resolves a slot to its epoch against a caller-supplied
+// epoch-cache snapshot. Callers that resolve several slots and must see one
+// coherent view (e.g. computing a single retention floor) capture the cache
+// once and pass it here, so a concurrent epoch-cache publication or rollback
+// cannot interleave a different generation between lookups.
+func epochForSlotInCache(
+	cache []models.Epoch,
+	slot uint64,
+) (models.Epoch, error) {
 	if len(cache) == 0 {
 		return models.Epoch{}, errors.New("epoch cache is empty")
 	}
@@ -1637,6 +1647,13 @@ func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
 	if len(ls.deferredHeaderValidation) == 0 {
 		return 0, false
 	}
+	// Capture one epoch-cache generation and resolve every deferred slot
+	// against it. loadConsensusSnapshot returns whatever is published at each
+	// call, so calling epochForSlot per key could mix generations across a
+	// concurrent epoch-cache publication/rollback and compute the floor from an
+	// incoherent mapping. One snapshot for the whole loop keeps the decision
+	// coherent (issue #3727, finding: mixed cache generations in floor read).
+	cache := ls.loadConsensusSnapshot().epochCache
 	var floor uint64
 	have := false
 	for key := range ls.deferredHeaderValidation {
@@ -1647,7 +1664,7 @@ func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
 			// pruning a snapshot it turns out to require.
 			return 0, true
 		}
-		epoch, err := ls.epochForSlot(slot)
+		epoch, err := epochForSlotInCache(cache, slot)
 		if err != nil {
 			// The slot is not yet covered by the published epoch cache, so we
 			// cannot name the snapshot epoch it needs. Retain ALL pool
@@ -1712,10 +1729,11 @@ func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 		}
 		return prune(before)
 	}()
-	// Delete the evicted headers' persisted markers outside the lock: they are
-	// abandoned, so losing the pin (already released above) is the only thing
-	// that mattered; this just keeps the sync_state table from accumulating
-	// dead markers across restarts.
+	// Delete the evicted headers' persisted markers after releasing the lock
+	// here; deletePersistedDeferredMarkers re-takes the deferred-header mutex
+	// itself so it can skip any point that was re-deferred (and re-persisted)
+	// since eviction, keeping the sync_state table free of dead markers without
+	// dropping a marker that now backs a live pin.
 	ls.deletePersistedDeferredMarkers(evicted)
 	return err
 }

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/blinklabs-io/dingo/consensus/praos"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -62,6 +64,17 @@ var (
 	errEpochCacheForecastBoundary = errors.New(
 		"epoch cache forecast crosses era boundary",
 	)
+	// errLeaderStakeSnapshotUnavailable marks a leader-stake snapshot that
+	// dingo cannot answer from: the epoch's mark/active distribution is
+	// missing, empty, or has no usable denominator. This is NEVER an
+	// authoritative statement that the producer pool is ineligible -- the
+	// reference node's nesPd is always populated, so an empty or absent
+	// snapshot is a dingo-side data gap (pruned below the retention window,
+	// unwritten during catch-up, or an incomplete import), not
+	// cardano-ledger's VRFKeyUnknown. Header verification classifies it as
+	// deferrable so the missing state is resolved rather than misreported as
+	// pool absence (issue #3727). A pool absent from a *populated* snapshot is
+	// a separate, authoritative rejection that never carries this sentinel.
 	errLeaderStakeSnapshotUnavailable = errors.New(
 		"leader stake snapshot unavailable",
 	)
@@ -525,6 +538,25 @@ func (ls *LedgerState) verifyBlockHeaderState(
 	}
 
 	if err := ls.verifyBlockLeaderEligibility(block, epochId); err != nil {
+		// Scope the deferral to the RECOVERABLE case only (issue #3727,
+		// finding 4 -- consensus-sensitive). A leader-stake snapshot reported
+		// unavailable (errLeaderStakeSnapshotUnavailable) means the epoch's
+		// distribution is missing/empty, which is only *recoverable* while the
+		// apply cursor is still behind this slot: the mark snapshot for the
+		// slot has not been computed yet and will exist once apply catches up,
+		// so defer. Once the cursor has caught up, a still-empty distribution
+		// is a genuine, permanent gap for that epoch -- a producer whose
+		// eligibility can never be established -- and MUST stay a hard
+		// rejection, exactly as before this change: deferring it forever would
+		// either adopt a block whose leader eligibility is never checked or
+		// loop. The #3727 retention pin is what makes the recoverable case
+		// actually resolve: it retains the mark snapshot a queued/deferred
+		// header needs so that, by the time the cursor reaches the slot, the
+		// snapshot is present and this path is not taken. Deferred headers on
+		// abandoned forks are released by the retention guard's eviction of
+		// entries the cursor has passed (see PrunePoolSnapshotsWithRetentionFloor),
+		// not by deferring their headers forever. A pool absent from a
+		// *populated* snapshot never carries this sentinel and hard-rejects.
 		if allowStateDefer &&
 			errors.Is(err, errLeaderStakeSnapshotUnavailable) &&
 			ls.ledgerTipBehindSlot(block.SlotNumber()) {
@@ -1567,6 +1599,135 @@ func (ls *LedgerState) epochForSlot(slot uint64) (models.Epoch, error) {
 		len(cache),
 		lastValidEnd,
 	)
+}
+
+// OldestRequiredSnapshotEpoch returns the oldest pool-stake snapshot epoch that
+// a currently queued/deferred header still needs for leader-eligibility
+// validation, so snapshot pruning can retain it instead of removing it out from
+// under the deferred header (issue #3727). It locks the deferred-header set and
+// delegates to oldestRequiredSnapshotEpochLocked. Prefer
+// PrunePoolSnapshotsWithRetentionFloor for the prune path, which holds the lock
+// across both the floor read and the prune so admission cannot interleave; this
+// public method exists for observation and tests.
+func (ls *LedgerState) OldestRequiredSnapshotEpoch() (uint64, bool) {
+	ls.deferredHeaderValidationMu.Lock()
+	defer ls.deferredHeaderValidationMu.Unlock()
+	return ls.oldestRequiredSnapshotEpochLocked()
+}
+
+// oldestRequiredSnapshotEpochLocked computes the retention floor with
+// ls.deferredHeaderValidationMu already held. A header deferred at slot S
+// validates its producer's leader eligibility against the mark snapshot for
+// StakeSnapshotEpoch(epochOf(S)); the floor is the minimum of that quantity
+// over every outstanding deferred header.
+//
+// Return contract:
+//   - (_, false): no header is deferred, so the default retention window
+//     applies and nothing extra is pinned.
+//   - (0, true): at least one deferred slot cannot yet be mapped to an epoch
+//     (its epoch cache entry has not been published, or its key is malformed).
+//     We cannot name the snapshot epoch such a header will need, and once the
+//     cache catches up leaderEligibilityStake WILL need it, so we retain ALL
+//     pool snapshots (floor 0 prunes nothing) until every deferred slot is
+//     mappable. Skipping the slot instead would let cleanup prune the snapshot
+//     the header needs and drive it into a defer loop.
+//   - (min, true): every deferred slot mapped; pin at the minimum required
+//     snapshot epoch.
+func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
+	if len(ls.deferredHeaderValidation) == 0 {
+		return 0, false
+	}
+	var floor uint64
+	have := false
+	for key := range ls.deferredHeaderValidation {
+		slot, err := slotFromHeaderValidationKey(key)
+		if err != nil {
+			// A key we cannot parse is a deferred header whose need we cannot
+			// bound. Retain everything until it is gone rather than risk
+			// pruning a snapshot it turns out to require.
+			return 0, true
+		}
+		epoch, err := ls.epochForSlot(slot)
+		if err != nil {
+			// The slot is not yet covered by the published epoch cache, so we
+			// cannot name the snapshot epoch it needs. Retain ALL pool
+			// snapshots until it becomes mappable (see the return contract):
+			// pruning now would delete the snapshot leaderEligibilityStake
+			// will read once the cache advances, looping the header on defer.
+			return 0, true
+		}
+		snapshotEpoch := praos.StakeSnapshotEpoch(epoch.EpochId)
+		if !have || snapshotEpoch < floor {
+			floor = snapshotEpoch
+			have = true
+		}
+	}
+	return floor, have
+}
+
+// PrunePoolSnapshotsWithRetentionFloor is the snapshot manager's retention
+// guard (wired via Manager.SetPoolSnapshotRetentionGuard). It holds the
+// deferred-header lock across the whole retention decision AND the caller's
+// pool-snapshot prune, so a deferred header cannot be admitted between the
+// floor read and the prune and have its still-needed snapshot deleted (issue
+// #3727 race). Under the lock it, in order:
+//
+//  1. Evicts abandoned deferred headers whose slot the apply cursor has already
+//     passed. A canonical deferred header is consumed when the cursor applies
+//     it, so one still present at/below the tip is on an abandoned fork and
+//     would otherwise pin its snapshot forever (finding 5). Eviction lets the
+//     floor rise; the evicted markers' persisted rows are deleted after the
+//     lock is released (best effort — they cannot affect a resolved header).
+//  2. Computes the retention floor over the surviving deferred headers and
+//     lowers defaultBefore (cleanup's currentEpoch-3 pool boundary) to it when
+//     a header needs an older snapshot (or to 0 = retain everything while any
+//     deferred slot is unmappable).
+//  3. Clamps the boundary UP to minBefore, a hard backstop
+//     (currentEpoch - poolSnapshotRetentionMaxDepth) that bounds how many
+//     historical epochs the pin can ever hold, so a stuck header cannot pin
+//     pool snapshots without limit (finding 5).
+//
+// prune must perform and COMMIT the pool-snapshot delete before returning, so
+// the rows are gone under the lock; it must not touch ledger locks or the
+// deferred set. The lock scope covers only the pool-snapshot delete (a single
+// indexed DELETE in its own transaction), not the reward-state prune; the only
+// other holders of this mutex (mark/clear/consume) do no I/O, so no deadlock.
+func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
+	defaultBefore uint64,
+	minBefore uint64,
+	prune func(before uint64) error,
+) error {
+	var evicted []string
+	err := func() error {
+		ls.deferredHeaderValidationMu.Lock()
+		defer ls.deferredHeaderValidationMu.Unlock()
+		evicted = ls.evictStaleDeferredHeadersLocked()
+		before := defaultBefore
+		if floor, ok := ls.oldestRequiredSnapshotEpochLocked(); ok &&
+			floor < before {
+			before = floor
+		}
+		if before < minBefore {
+			before = minBefore
+		}
+		return prune(before)
+	}()
+	// Delete the evicted headers' persisted markers outside the lock: they are
+	// abandoned, so losing the pin (already released above) is the only thing
+	// that mattered; this just keeps the sync_state table from accumulating
+	// dead markers across restarts.
+	ls.deletePersistedDeferredMarkers(evicted)
+	return err
+}
+
+// slotFromHeaderValidationKey extracts the slot from a deferred-header map key,
+// which headerValidationPointKey formats as "<slot>:<hex-hash>".
+func slotFromHeaderValidationKey(key string) (uint64, error) {
+	sep := strings.IndexByte(key, ':')
+	if sep < 0 {
+		return 0, fmt.Errorf("malformed header validation key %q", key)
+	}
+	return strconv.ParseUint(key[:sep], 10, 64)
 }
 
 // ensureEpochForSlot advances the epoch cache until it covers the target

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1694,12 +1694,16 @@ func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
 // and deadlocks the node on the single write connection (issue #3717). Under
 // the lock it, in order:
 //
-//  1. Evicts abandoned deferred headers whose slot the apply cursor has already
-//     passed. A canonical deferred header is consumed when the cursor applies
-//     it, so one still present at/below the tip is on an abandoned fork and
-//     would otherwise pin its snapshot forever (finding 5). Eviction lets the
-//     floor rise; the evicted markers' persisted rows are deleted after the
-//     lock is released (best effort — they cannot affect a resolved header).
+//  1. Evicts abandoned deferred headers that are beyond the rollback horizon
+//     (tip minus the stability window). A canonical deferred header is consumed
+//     when the cursor applies it, so one still present that deep is on a fork
+//     chain selection can no longer re-adopt and would otherwise pin its
+//     snapshot forever (finding 5). The horizon — rather than the bare tip — is
+//     what makes eviction safe: eviction also drops the durable marker, and a
+//     point evicted while still re-adoptable would apply with required == false
+//     and skip its stateful header check. Eviction lets the floor rise; the
+//     evicted markers' persisted rows are deleted after the lock is released
+//     (best effort — they cannot affect a resolved header).
 //  2. Computes the retention floor over the surviving deferred headers and
 //     lowers defaultBefore (cleanup's currentEpoch-3 pool boundary) to it when
 //     a header needs an older snapshot (or to 0 = retain everything while any
@@ -1727,12 +1731,19 @@ func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 	minBefore uint64,
 	prune func(before uint64) error,
 ) error {
+	// Read BEFORE taking deferredHeaderValidationMu: both of these take
+	// ls.RWMutex (calculateStabilityWindow reads ls.currentEra under RLock),
+	// and block apply holds the ls lock before taking
+	// deferredHeaderValidationMu via consumeDeferredHeaderValidation. Taking
+	// the ls lock under this mutex would invert that order.
+	tipSlot := ls.loadTipSnapshot().currentTip.Point.Slot
+	rollbackHorizon := ls.calculateStabilityWindow()
 	var evicted []string
 	var before uint64
 	func() {
 		ls.deferredHeaderValidationMu.Lock()
 		defer ls.deferredHeaderValidationMu.Unlock()
-		evicted = ls.evictStaleDeferredHeadersLocked()
+		evicted = ls.evictStaleDeferredHeadersLocked(tipSlot, rollbackHorizon)
 		before = defaultBefore
 		if floor, ok := ls.oldestRequiredSnapshotEpochLocked(); ok &&
 			floor < before {

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1683,11 +1683,16 @@ func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
 }
 
 // PrunePoolSnapshotsWithRetentionFloor is the snapshot manager's retention
-// guard (wired via Manager.SetPoolSnapshotRetentionGuard). It holds the
-// deferred-header lock across the whole retention decision AND the caller's
-// pool-snapshot prune, so a deferred header cannot be admitted between the
-// floor read and the prune and have its still-needed snapshot deleted (issue
-// #3727 race). Under the lock it, in order:
+// guard (wired via Manager.SetPoolSnapshotRetentionGuard). Under the
+// deferred-header lock it evicts abandoned headers and computes the retention
+// floor as ONE atomic decision, RELEASES the lock, and only then runs the
+// caller's pool-snapshot prune. The prune must NOT run under the lock: it opens
+// the single sqlite write connection (SetMaxOpenConns(1)) via Transaction(true),
+// and block apply holds that connection before taking this same mutex through
+// consumeDeferredHeaderValidation. Holding the mutex across prune therefore
+// inverts the lock order (mutex→write-conn here vs. write-conn→mutex on apply)
+// and deadlocks the node on the single write connection (issue #3717). Under
+// the lock it, in order:
 //
 //  1. Evicts abandoned deferred headers whose slot the apply cursor has already
 //     passed. A canonical deferred header is consumed when the cursor applies
@@ -1704,22 +1709,31 @@ func (ls *LedgerState) oldestRequiredSnapshotEpochLocked() (uint64, bool) {
 //     historical epochs the pin can ever hold, so a stuck header cannot pin
 //     pool snapshots without limit (finding 5).
 //
-// prune must perform and COMMIT the pool-snapshot delete before returning, so
-// the rows are gone under the lock; it must not touch ledger locks or the
-// deferred set. The lock scope covers only the pool-snapshot delete (a single
-// indexed DELETE in its own transaction), not the reward-state prune; the only
-// other holders of this mutex (mark/clear/consume) do no I/O, so no deadlock.
+// The eviction+floor read is atomic (one lock hold), so `before` reflects a
+// coherent view of the deferred set; a header admitted after the lock is
+// released — during or after prune — cannot corrupt this invocation's boundary.
+// A header admitted in that window that needs a below-floor snapshot is a
+// deeply lagged header (its need is < defaultBefore = currentEpoch-3); this
+// invocation may prune a snapshot it wants, but the retention floor is a
+// lower-watermark that is RE-COMPUTED every cleanup pass, so the next pass pins
+// at the lower floor and the header resolves then. This narrow re-admit window
+// is accepted in exchange for never inverting the lock order (issue #3717); it
+// replaces the prior design that held the lock across prune and deadlocked.
+//
+// prune must perform and COMMIT the pool-snapshot delete before returning; it
+// must not touch ledger locks or the deferred set.
 func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 	defaultBefore uint64,
 	minBefore uint64,
 	prune func(before uint64) error,
 ) error {
 	var evicted []string
-	err := func() error {
+	var before uint64
+	func() {
 		ls.deferredHeaderValidationMu.Lock()
 		defer ls.deferredHeaderValidationMu.Unlock()
 		evicted = ls.evictStaleDeferredHeadersLocked()
-		before := defaultBefore
+		before = defaultBefore
 		if floor, ok := ls.oldestRequiredSnapshotEpochLocked(); ok &&
 			floor < before {
 			before = floor
@@ -1727,13 +1741,17 @@ func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 		if before < minBefore {
 			before = minBefore
 		}
-		return prune(before)
 	}()
-	// Delete the evicted headers' persisted markers after releasing the lock
-	// here; deletePersistedDeferredMarkers re-takes the deferred-header mutex
-	// itself so it can skip any point that was re-deferred (and re-persisted)
-	// since eviction, keeping the sync_state table free of dead markers without
-	// dropping a marker that now backs a live pin.
+	// Prune runs with the mutex RELEASED: it opens the single sqlite write
+	// connection, which block apply holds before taking this mutex, so running
+	// it under the lock deadlocks (issue #3717). See the doc comment.
+	err := prune(before)
+	// Delete the evicted headers' persisted markers; deletePersistedDeferredMarkers
+	// takes the deferred-header mutex only to test membership per key (releasing
+	// it before each DB delete, for the same lock-order reason) so it can skip
+	// any point re-deferred (and re-persisted) since eviction, keeping the
+	// sync_state table free of dead markers without dropping a marker that now
+	// backs a live pin.
 	ls.deletePersistedDeferredMarkers(evicted)
 	return err
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -3645,3 +3645,135 @@ func TestPrunePoolSnapshotsWithRetentionFloor_DepthCapBoundsRetention(
 		"floor 10 must be clamped up to the depth-cap minBefore 16",
 	)
 }
+
+// TestPrunePoolSnapshotsWithRetentionFloor_KeepsReadoptableDeferredHeader is the
+// regression guard for the evicted-point re-adoption bypass (issue #3717
+// review). Eviction drops the durable sync_state marker along with the
+// in-memory entry, and that marker is the only thing that makes
+// deferredHeaderValidationRequired return true at apply. A point merely BEHIND
+// the tip is still re-adoptable -- chain selection can roll back and switch to
+// its fork -- so evicting it there means the block later applies with
+// required == false, verifyDeferredBlockHeaderState returns nil, and it is
+// adopted with its stateful leader-eligibility check never run. Eviction must
+// therefore fire only beyond the rollback horizon (tip minus the stability
+// window): a header inside the horizon keeps both its entry and its marker,
+// while one past it is still evicted so its snapshot pin is released.
+func TestPrunePoolSnapshotsWithRetentionFloor_KeepsReadoptableDeferredHeader(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{73}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{
+			EpochId:       11,
+			StartSlot:     20_000,
+			LengthInSlots: 1_000,
+			Nonce:         tb.epochNonce,
+		},
+	}
+	// The test config carries no Byron genesis, so the stability window is the
+	// 50_000-slot default; with the tip at 60_000 the rollback horizon cuts off
+	// at slot 10_000.
+	ls.currentTip = ochainsync.Tip{Point: ocommon.Point{Slot: 60_000}}
+	ls.publishSnapshotsLocked()
+	require.Equal(t, uint64(50_000), ls.calculateStabilityWindow())
+
+	// Behind the tip but INSIDE the horizon: a rollback can still re-adopt it.
+	readoptable := ocommon.Point{Slot: 20_500, Hash: []byte{0x11}}
+	// Behind the tip and BEYOND the horizon: unreachable, safe to forget.
+	unreachable := ocommon.Point{Slot: 5_000, Hash: []byte{0x12}}
+	for _, p := range []ocommon.Point{readoptable, unreachable} {
+		ls.markDeferredHeaderValidation(p)
+		require.NoError(t, ls.persistDeferredHeaderValidation(p, nil))
+	}
+
+	var seenBefore uint64
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25, 0,
+		func(before uint64) error { seenBefore = before; return nil },
+	))
+
+	// The re-adoptable header still pins its snapshot epoch (epoch 11 -> 10).
+	assert.Equal(
+		t,
+		uint64(10),
+		seenBefore,
+		"re-adoptable header must still pin its snapshot",
+	)
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok, "re-adoptable header must stay in the deferred set")
+	assert.Equal(t, uint64(10), floor)
+
+	// ...and it keeps its durable marker, so a rollback-then-re-adopt still
+	// finds required == true at apply instead of skipping the check.
+	marker, err := db.GetSyncState(
+		deferredHeaderValidationSyncStateKey(readoptable), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		deferredHeaderValidationSyncStateValue,
+		marker,
+		"re-adoptable header's marker must survive eviction",
+	)
+
+	// The unreachable header is still evicted, marker and all.
+	gone, err := db.GetSyncState(
+		deferredHeaderValidationSyncStateKey(unreachable), nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		gone,
+		"header beyond the rollback horizon must still be evicted",
+	)
+}
+
+// TestDeleteDeferredMarkerUnlessReadmitted_RestoresMarkerReadmittedDuringDelete
+// closes the marker delete's TOCTOU window (issue #3717 review / cubic P1). The
+// membership test in deletePersistedDeferredMarkers cannot be atomic with the
+// delete -- holding deferredHeaderValidationMu across the DB write would invert
+// the lock order against block apply and deadlock the node -- so a point
+// re-deferred after that test and before the delete would lose the marker it
+// had just persisted. A restart would then miss it in
+// repopulateDeferredHeaderValidation, leaving deferredHeaderValidationRequired
+// false and skipping the stateful check for a header still outstanding. The
+// per-key delete must re-test membership afterwards and restore the marker for
+// a key that came back, while still removing a genuinely stale one.
+func TestDeleteDeferredMarkerUnlessReadmitted_RestoresMarkerReadmittedDuringDelete(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{74}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	readmitted := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	require.NoError(t, ls.persistDeferredHeaderValidation(readmitted, nil))
+	// Stands in for the re-defer that lands after the caller's membership test:
+	// the key is live in the set by the time the delete completes.
+	ls.markDeferredHeaderValidation(readmitted)
+
+	ls.deleteDeferredMarkerUnlessReadmitted(
+		headerValidationPointKey(readmitted),
+	)
+
+	marker, err := db.GetSyncState(
+		deferredHeaderValidationSyncStateKey(readmitted), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		deferredHeaderValidationSyncStateValue,
+		marker,
+		"marker for a key re-admitted during the delete must be restored",
+	)
+
+	// A key that is NOT re-admitted still has its marker removed.
+	stale := ocommon.Point{Slot: 1_160, Hash: []byte{0x12}}
+	require.NoError(t, ls.persistDeferredHeaderValidation(stale, nil))
+	ls.deleteDeferredMarkerUnlessReadmitted(headerValidationPointKey(stale))
+	gone, err := db.GetSyncState(
+		deferredHeaderValidationSyncStateKey(stale), nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, gone, "genuinely stale marker must be deleted")
+}

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1862,6 +1862,179 @@ func TestVerifyBlockHeaderState_GenesisDelegateNonOverlaySlotUsesPoolThreshold(
 	assert.ErrorIs(t, err, errHeaderVerificationDeferred)
 }
 
+// TestVerifyBlockHeaderState_UnavailableSnapshotRecoverableVsGenuine pins the
+// consensus-sensitive scoping of the deferral (issue #3727, finding 4). A
+// leader-stake snapshot reported unavailable is only recoverable while the
+// apply cursor is still BEHIND the header's slot (the mark snapshot has not
+// been produced yet) -> defer. Once the cursor has caught up, a still-empty
+// distribution is a genuine, permanent gap for that epoch and MUST stay a hard
+// rejection -- deferring it forever would adopt a block whose leader
+// eligibility is never checked, or loop. A producer absent from a POPULATED
+// snapshot is authoritative ineligibility (VRFKeyUnknown) and hard-rejects
+// regardless of the cursor.
+func TestVerifyBlockHeaderState_UnavailableSnapshotRecoverableVsGenuine(
+	t *testing.T,
+) {
+	dummyPool := func() []byte {
+		p := make([]byte, lcommon.Blake2b224Size)
+		p[0] = 0xEE
+		return p
+	}
+
+	t.Run(
+		"unavailable snapshot with tip BEHIND defers (recoverable)",
+		func(t *testing.T) {
+			tb := createTestBlock(t, [32]byte{60}, 0, tamperNone)
+			ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+			// Tip behind the block slot: the mark snapshot for this slot may
+			// not be computed yet, so the empty distribution is recoverable.
+			ls.currentTip = ochainsync.Tip{
+				Point: ocommon.Point{Slot: tb.block.SlotNumber() - 1},
+			}
+			ls.publishSnapshotsLocked()
+			require.True(
+				t,
+				ls.ledgerTipBehindSlot(tb.block.SlotNumber()),
+				"tip must be behind so the recoverable branch can defer",
+			)
+			seedBlockPoolRegistration(t, db, tb.block)
+
+			err := ls.verifyBlockHeaderState(tb.block, 5, true)
+			require.Error(t, err)
+			assert.True(
+				t,
+				IsHeaderVerificationDeferred(err),
+				"tip-behind unavailable snapshot must defer: %v",
+				err,
+			)
+			assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+		},
+	)
+
+	t.Run(
+		"genuinely empty snapshot with tip AHEAD hard-rejects",
+		func(t *testing.T) {
+			tb := createTestBlock(t, [32]byte{60}, 0, tamperNone)
+			ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+			// Tip advanced PAST the slot: an epoch whose distribution is still
+			// empty here is a genuine, permanent gap -- the original hard
+			// rejection must be preserved (finding 4), NOT deferred forever.
+			ls.currentTip = ochainsync.Tip{
+				Point: ocommon.Point{Slot: tb.block.SlotNumber() + 1_000},
+			}
+			ls.publishSnapshotsLocked()
+			require.False(
+				t,
+				ls.ledgerTipBehindSlot(tb.block.SlotNumber()),
+				"tip must be ahead so the genuine-gap rejection applies",
+			)
+			seedBlockPoolRegistration(t, db, tb.block)
+			// No rows for the required mark epoch: empty/unavailable.
+
+			err := ls.verifyBlockHeaderState(tb.block, 5, true)
+			require.Error(t, err)
+			assert.False(
+				t,
+				IsHeaderVerificationDeferred(err),
+				"tip-ahead genuinely-empty snapshot must hard-reject, not defer: %v",
+				err,
+			)
+			assert.ErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+		},
+	)
+
+	t.Run(
+		"populated snapshot absent pool hard-rejects",
+		func(t *testing.T) {
+			tb := createTestBlock(t, [32]byte{61}, 0, tamperNone)
+			ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+			ls.currentTip = ochainsync.Tip{
+				Point: ocommon.Point{Slot: tb.block.SlotNumber() + 1_000},
+			}
+			ls.publishSnapshotsLocked()
+
+			seedBlockPoolRegistration(t, db, tb.block)
+			// Populate the epoch-4 mark distribution with a DIFFERENT pool so
+			// the snapshot is present (total > 0) and the producer is
+			// genuinely absent from it -- authoritative ineligibility.
+			seedPoolStakeSnapshot(t, db, 4, dummyPool(), 1_000_000_000)
+
+			err := ls.verifyBlockHeaderState(tb.block, 5, true)
+			require.Error(t, err)
+			assert.False(
+				t,
+				IsHeaderVerificationDeferred(err),
+				"populated absent-pool header must hard-reject: %v",
+				err,
+			)
+			assert.NotErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+			assert.Contains(t, err.Error(), "has no stake in epoch")
+		},
+	)
+}
+
+// TestOldestRequiredSnapshotEpoch covers the retention-floor provider the
+// snapshot manager consults to keep a deferred header's required snapshot from
+// being pruned (issue #3727). The floor is the minimum over all outstanding
+// deferred headers of StakeSnapshotEpoch(epochOf(slot)); with none deferred it
+// reports no pin.
+func TestOldestRequiredSnapshotEpoch(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{62}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// Build an epoch cache mapping distinct slot ranges to epochs 11, 14, 22
+	// so the required mark epochs are 10, 13, 21 (StakeSnapshotEpoch = E-1).
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 14, StartSlot: 1_400, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 22, StartSlot: 2_200, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+
+	// No deferred headers => no pin.
+	if _, ok := ls.OldestRequiredSnapshotEpoch(); ok {
+		t.Fatalf("expected no retention pin when nothing is deferred")
+	}
+
+	// Defer three headers in epochs 22, 14, 11. The oldest required snapshot
+	// epoch is StakeSnapshotEpoch(11) == 10.
+	ls.markDeferredHeaderValidation(ocommon.Point{Slot: 2_250, Hash: []byte{0x22}})
+	ls.markDeferredHeaderValidation(ocommon.Point{Slot: 1_450, Hash: []byte{0x14}})
+	ls.markDeferredHeaderValidation(ocommon.Point{Slot: 1_150, Hash: []byte{0x11}})
+
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok, "a deferred header must produce a retention pin")
+	assert.Equal(t, uint64(10), floor)
+
+	// Resolving the epoch-11 header releases the pin up to the next-oldest
+	// required snapshot epoch, StakeSnapshotEpoch(14) == 13.
+	ls.clearDeferredHeaderValidation(ocommon.Point{Slot: 1_150, Hash: []byte{0x11}})
+	floor, ok = ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(13), floor)
+
+	// A deferred slot outside the published epoch cache cannot be mapped to a
+	// snapshot epoch yet. While ANY deferred slot is unmappable the provider
+	// must signal retain-all (floor 0, ok true) so cleanup prunes nothing --
+	// otherwise the snapshot this header will need once the cache advances
+	// could be pruned now, looping the header on defer (issue #3727, gap 2).
+	ls.markDeferredHeaderValidation(ocommon.Point{Slot: 9_999_999, Hash: []byte{0xFF}})
+	floor, ok = ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok, "an unmappable deferred slot must still pin (retain-all)")
+	assert.Equal(
+		t,
+		uint64(0),
+		floor,
+		"unmappable deferred slot must force retain-all (floor 0)",
+	)
+
+	// Once the unmappable slot is dropped, the floor returns to the real
+	// minimum over the remaining mappable headers.
+	ls.clearDeferredHeaderValidation(ocommon.Point{Slot: 9_999_999, Hash: []byte{0xFF}})
+	floor, ok = ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(13), floor)
+}
+
 func TestVerifyBlockHeaderState_GenesisDelegateUsesActiveDelegation(
 	t *testing.T,
 ) {
@@ -2942,4 +3115,338 @@ func TestVerifyBlockLeaderEligibility_ImportedActivePoolAbsentStaysHardRejection
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing from active pool distribution")
 	assert.NotErrorIs(t, err, errLeaderStakeSnapshotUnavailable)
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission is the
+// regression guard for the deferred-header admission <-> retention-floor race
+// (issue #3727, gap 1). PrunePoolSnapshotsWithRetentionFloor must hold the
+// deferred-header set stable across BOTH the floor computation and the prune,
+// so a header admitted concurrently cannot slip in between the floor read and
+// the prune and have its still-needed snapshot deleted under a stale boundary.
+// The prune sees a floor computed from the set as it was when the guard took
+// the lock, and a concurrent markDeferredHeaderValidation blocks until release.
+func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{63}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// Map slots to epochs 11 (snapshot 10) and 14 (snapshot 13).
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 14, StartSlot: 1_400, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+
+	// One header is already deferred at epoch 14 (needs snapshot 13) when the
+	// guard runs.
+	ls.markDeferredHeaderValidation(
+		ocommon.Point{Slot: 1_450, Hash: []byte{0x14}},
+	)
+
+	started := make(chan struct{})
+	markReturned := make(chan struct{})
+	// Concurrent admission of an epoch-11 header (needs snapshot 10). It must
+	// block until the guard releases the lock, so it cannot lower the floor
+	// this guard invocation prunes to.
+	go func() {
+		<-started
+		ls.markDeferredHeaderValidation(
+			ocommon.Point{Slot: 1_150, Hash: []byte{0x11}},
+		)
+		close(markReturned)
+	}()
+
+	var seenBefore uint64
+	err := ls.PrunePoolSnapshotsWithRetentionFloor(
+		25,
+		0,
+		func(before uint64) error {
+			seenBefore = before
+			close(started)
+			// While the guard holds the lock, the concurrent admission must be
+			// blocked: markReturned must not fire.
+			select {
+			case <-markReturned:
+				t.Error(
+					"concurrent admission completed while the retention guard held the lock",
+				)
+			case <-time.After(100 * time.Millisecond):
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	// The floor this invocation pruned to reflects only the epoch-14 header
+	// present when the guard took the lock (snapshot 13), NOT the epoch-11
+	// header admitted concurrently (snapshot 10): no snapshot the concurrent
+	// header needs was deleted under a stale floor.
+	assert.Equal(t, uint64(13), seenBefore)
+
+	// After the guard releases, the concurrent admission completes and is now
+	// visible to the next floor computation.
+	<-markReturned
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(10), floor)
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_UnmappableRetainsAll is the
+// regression guard for the unmappable-deferred-slot case (issue #3727, gap 2).
+// While a deferred header's slot cannot yet be mapped to an epoch, the guard
+// must retain ALL pool snapshots (prune boundary 0) so the snapshot the header
+// will need once the epoch cache advances is not pruned in the meantime and the
+// header driven into a defer loop. Once the mapping is published, normal floor
+// pruning resumes.
+func TestPrunePoolSnapshotsWithRetentionFloor_UnmappableRetainsAll(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{64}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	// Default cache (epoch 5, slots [0, 1_000_000)) does NOT cover the deferred
+	// slot, so it is initially unmappable.
+	const deferredSlot = uint64(50_000_000)
+	ls.markDeferredHeaderValidation(
+		ocommon.Point{Slot: deferredSlot, Hash: []byte{0xAB}},
+	)
+
+	// Seed mark snapshots for epochs 0..28.
+	dummyPool := bytes.Repeat([]byte{0xEE}, lcommon.Blake2b224Size)
+	for epoch := uint64(0); epoch <= 28; epoch++ {
+		seedPoolStakeSnapshot(t, db, epoch, dummyPool, 1_000_000_000)
+	}
+	deleteBelow := func(before uint64) error {
+		return db.Metadata().DeletePoolStakeSnapshotsBeforeEpoch(before, nil)
+	}
+
+	// Unmappable: the guard must hand prune boundary 0 (retain everything).
+	var seenBefore uint64
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25,
+		0,
+		func(before uint64) error {
+			seenBefore = before
+			return deleteBelow(before)
+		},
+	))
+	assert.Equal(
+		t,
+		uint64(0),
+		seenBefore,
+		"unmappable deferred slot must force retain-all",
+	)
+	for epoch := uint64(0); epoch <= 28; epoch++ {
+		snaps, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err)
+		require.Len(
+			t,
+			snaps,
+			1,
+			"epoch %d must be retained while the deferred slot is unmappable",
+			epoch,
+		)
+	}
+
+	// Publish an epoch mapping so the deferred slot resolves to epoch 22
+	// (snapshot 21). Normal floor pruning resumes.
+	ls.epochCache = []models.Epoch{
+		{EpochId: 5, StartSlot: 0, LengthInSlots: 1_000_000, Nonce: tb.epochNonce},
+		{
+			EpochId:       22,
+			StartSlot:     49_000_000,
+			LengthInSlots: 2_000_000,
+			Nonce:         tb.epochNonce,
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25,
+		0,
+		func(before uint64) error {
+			seenBefore = before
+			return deleteBelow(before)
+		},
+	))
+	assert.Equal(
+		t,
+		uint64(21),
+		seenBefore,
+		"mappable deferred slot pins at StakeSnapshotEpoch(22)=21",
+	)
+	for epoch := uint64(0); epoch < 21; epoch++ {
+		snaps, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err)
+		require.Empty(
+			t,
+			snaps,
+			"epoch %d below the pinned floor must be pruned",
+			epoch,
+		)
+	}
+	for epoch := uint64(21); epoch <= 28; epoch++ {
+		snaps, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
+			epoch, models.PoolStakeSnapshotTypeMark, nil,
+		)
+		require.NoError(t, err)
+		require.Len(
+			t,
+			snaps,
+			1,
+			"epoch %d at/above the pinned floor must be retained",
+			epoch,
+		)
+	}
+}
+
+// TestRepopulateDeferredHeaderValidation is the restart-durability regression
+// guard (issue #3727, finding 3). Deferred-header markers persisted before a
+// restart must be reloaded into the in-memory set so the retention floor
+// covers them on the first post-restart cleanup, instead of the set starting
+// empty and the needed snapshot being pruned.
+func TestRepopulateDeferredHeaderValidation(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{70}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 14, StartSlot: 1_400, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+
+	// Persist two markers as a pre-restart node would, WITHOUT touching the
+	// in-memory map (simulating the post-restart empty set).
+	p11 := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	p14 := ocommon.Point{Slot: 1_450, Hash: []byte{0x14}}
+	require.NoError(t, ls.persistDeferredHeaderValidation(p11, nil))
+	require.NoError(t, ls.persistDeferredHeaderValidation(p14, nil))
+
+	// Empty in-memory set: no pin yet.
+	if _, ok := ls.OldestRequiredSnapshotEpoch(); ok {
+		t.Fatalf("expected no pin before repopulation")
+	}
+
+	// Repopulate from persisted markers (as LedgerState.Start does).
+	ls.repopulateDeferredHeaderValidation()
+
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok, "repopulated markers must produce a retention pin")
+	assert.Equal(t, uint64(10), floor, "floor = StakeSnapshotEpoch(11)")
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_EvictsStaleBehindCursor is the
+// unbounded-retention-leak guard (issue #3727, finding 5). A deferred header
+// the apply cursor has already passed is abandoned (a canonical one would have
+// been consumed at apply); the retention guard must evict it so it stops
+// pinning its snapshot, and delete its persisted marker.
+func TestPrunePoolSnapshotsWithRetentionFloor_EvictsStaleBehindCursor(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{71}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	// Apply cursor is WELL AHEAD of the deferred header's slot.
+	ls.currentTip = ochainsync.Tip{Point: ocommon.Point{Slot: 500_000}}
+	ls.publishSnapshotsLocked()
+
+	stale := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	ls.markDeferredHeaderValidation(stale)
+	require.NoError(t, ls.persistDeferredHeaderValidation(stale, nil))
+
+	// Before: the abandoned header pins epoch 10.
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(10), floor)
+
+	var seenBefore uint64
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25, 0,
+		func(before uint64) error { seenBefore = before; return nil },
+	))
+
+	// The stale header is evicted: no pin remains, so the boundary is the
+	// default (not lowered to 10), and the persisted marker is deleted.
+	assert.Equal(t, uint64(25), seenBefore, "evicted header must not pin")
+	_, ok = ls.OldestRequiredSnapshotEpoch()
+	assert.False(t, ok, "abandoned header must be evicted from the set")
+	marker, err := db.GetSyncState(deferredHeaderValidationSyncStateKey(stale), nil)
+	require.NoError(t, err)
+	assert.Empty(t, marker, "evicted header's persisted marker must be deleted")
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_ResolveReleasesPin proves a deferred
+// header that RESOLVES releases its pool-snapshot pin so the floor rises (issue
+// #3727, finding 5).
+func TestPrunePoolSnapshotsWithRetentionFloor_ResolveReleasesPin(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{72}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// Both headers are AHEAD of the cursor (tip 0) so eviction does not fire.
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 14, StartSlot: 1_400, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+
+	p11 := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	p14 := ocommon.Point{Slot: 1_450, Hash: []byte{0x14}}
+	ls.markDeferredHeaderValidation(p11)
+	ls.markDeferredHeaderValidation(p14)
+
+	var seenBefore uint64
+	record := func(before uint64) error { seenBefore = before; return nil }
+
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(25, 0, record))
+	assert.Equal(t, uint64(10), seenBefore, "pinned to oldest (epoch 10)")
+
+	// Resolve the epoch-11 header, as apply-time consumption does.
+	require.True(t, ls.consumeDeferredHeaderValidation(p11))
+
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(25, 0, record))
+	assert.Equal(
+		t,
+		uint64(13),
+		seenBefore,
+		"resolving the epoch-11 header must raise the pin to epoch 13",
+	)
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_DepthCapBoundsRetention proves the
+// hard backstop: even a live (ahead-of-cursor) deferred header needing a very
+// old snapshot cannot lower pruning past minBefore, so retention is bounded
+// (issue #3727, finding 5).
+func TestPrunePoolSnapshotsWithRetentionFloor_DepthCapBoundsRetention(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{73}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	// Header maps to epoch 11 (needs snapshot 10) and is ahead of the cursor
+	// (tip 0) so it is not evicted; only the cap bounds it.
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+	ls.markDeferredHeaderValidation(ocommon.Point{Slot: 1_150, Hash: []byte{0x11}})
+
+	floor, ok := ls.OldestRequiredSnapshotEpoch()
+	require.True(t, ok)
+	assert.Equal(t, uint64(10), floor)
+
+	var seenBefore uint64
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25, 16, // minBefore = 16: retain at most down to epoch 16
+		func(before uint64) error { seenBefore = before; return nil },
+	))
+	assert.Equal(
+		t,
+		uint64(16),
+		seenBefore,
+		"floor 10 must be clamped up to the depth-cap minBefore 16",
+	)
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -3125,7 +3125,18 @@ func TestVerifyBlockLeaderEligibility_ImportedActivePoolAbsentStaysHardRejection
 // the prune and have its still-needed snapshot deleted under a stale boundary.
 // The prune sees a floor computed from the set as it was when the guard took
 // the lock, and a concurrent markDeferredHeaderValidation blocks until release.
-func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
+// TestPrunePoolSnapshotsWithRetentionFloor_FloorReadIsAtomic replaces the former
+// _SerializesAdmission test, whose contract (hold deferredHeaderValidationMu
+// across prune) is exactly the lock-order inversion that deadlocks the node
+// (issue #3717). The invariant that survives the fix is narrower but sufficient:
+// the eviction + floor read happen under ONE lock hold, so the boundary handed
+// to prune is a coherent read of the deferred set as it stood when the guard
+// took the lock -- never a mix. prune then runs with the lock RELEASED. A header
+// admitted during prune is NOT pinned by this pass; it is picked up by the next
+// cleanup pass, because the retention floor is a lower-watermark recomputed every
+// pass. That next-pass recovery is the deliberate trade for never inverting the
+// lock order.
+func TestPrunePoolSnapshotsWithRetentionFloor_FloorReadIsAtomic(
 	t *testing.T,
 ) {
 	tb := createTestBlock(t, [32]byte{63}, 0, tamperNone)
@@ -3143,17 +3154,18 @@ func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
 		ocommon.Point{Slot: 1_450, Hash: []byte{0x14}},
 	)
 
-	started := make(chan struct{})
-	markReturned := make(chan struct{})
-	// Concurrent admission of an epoch-11 header (needs snapshot 10). It must
-	// block until the guard releases the lock, so it cannot lower the floor
-	// this guard invocation prunes to.
+	pruneStarted := make(chan struct{})
+	admitted := make(chan struct{})
+	// Admit an epoch-11 header (needs snapshot 10) DURING prune. Because the
+	// guard has already released the lock before calling prune, this admission
+	// proceeds concurrently -- it does not (and must not) deadlock against the
+	// guard, and it does not retroactively lower this pass's boundary.
 	go func() {
-		<-started
+		<-pruneStarted
 		ls.markDeferredHeaderValidation(
 			ocommon.Point{Slot: 1_150, Hash: []byte{0x11}},
 		)
-		close(markReturned)
+		close(admitted)
 	}()
 
 	var seenBefore uint64
@@ -3162,15 +3174,15 @@ func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
 		0,
 		func(before uint64) error {
 			seenBefore = before
-			close(started)
-			// While the guard holds the lock, the concurrent admission must be
-			// blocked: markReturned must not fire. Use the repo's channel
-			// helper for the negative wait rather than a bare time.After poll.
-			testutil.RequireNoReceive(
+			close(pruneStarted)
+			// Let the concurrent admission land while prune runs. On the old
+			// (buggy) code the admission would block on the still-held mutex and
+			// this receive would deadlock; on the fixed code it completes.
+			testutil.RequireReceive(
 				t,
-				markReturned,
-				100*time.Millisecond,
-				"concurrent admission completed while the retention guard held the lock",
+				admitted,
+				15*time.Second,
+				"concurrent admission blocked while the guard was pruning (lock-order inversion, issue #3717)",
 			)
 			return nil
 		},
@@ -3179,16 +3191,123 @@ func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
 
 	// The floor this invocation pruned to reflects only the epoch-14 header
 	// present when the guard took the lock (snapshot 13), NOT the epoch-11
-	// header admitted concurrently (snapshot 10): no snapshot the concurrent
-	// header needs was deleted under a stale floor.
+	// header admitted during prune: the boundary is a coherent read, never a
+	// mix of pre- and post-lock state.
 	assert.Equal(t, uint64(13), seenBefore)
 
-	// After the guard releases, the concurrent admission completes and is now
-	// visible to the next floor computation.
-	<-markReturned
+	// The concurrently-admitted header is now visible; the next cleanup pass
+	// pins the lower floor (snapshot 10), so no needed snapshot is lost for good.
 	floor, ok := ls.OldestRequiredSnapshotEpoch()
 	require.True(t, ok)
 	assert.Equal(t, uint64(10), floor)
+
+	var nextBefore uint64
+	require.NoError(t, ls.PrunePoolSnapshotsWithRetentionFloor(
+		25,
+		0,
+		func(before uint64) error {
+			nextBefore = before
+			return nil
+		},
+	))
+	assert.Equal(
+		t,
+		uint64(10),
+		nextBefore,
+		"next pass pins the floor of the concurrently-admitted header",
+	)
+}
+
+// TestPrunePoolSnapshotsWithRetentionFloor_RealPruneNoDeadlock is the lock-order
+// inversion regression guard for wolf31o2's blocking review on PR #3717. Unlike
+// the other guard tests -- which pass a stub prune that opens no transaction and
+// so cannot catch the bug -- this passes a REAL prune that opens the single
+// sqlite write connection via db.Transaction(true), exactly as
+// cleanupOldSnapshots' prunePoolSnapshots does. A second goroutine reproduces
+// the block-apply order: hold that write connection, THEN take
+// deferredHeaderValidationMu (as ledgerProcessBlock -> verifyDeferredBlockHeaderState
+// -> consumeDeferredHeaderValidation does inside its write txn).
+//
+// The two lock orders:
+//   - guard:  deferredHeaderValidationMu  THEN  write connection (prune)
+//   - apply:  write connection            THEN  deferredHeaderValidationMu
+//
+// If the guard holds the mutex across prune (the pre-fix code), prune blocks
+// acquiring the single write connection the apply goroutine holds, while the
+// apply goroutine blocks acquiring the mutex the guard holds: deadlock. WITHOUT
+// the fix this test times out (go test -timeout dumps the two inverted stacks);
+// WITH the fix the guard releases the mutex before prune, the apply goroutine
+// takes the mutex and releases the connection, and prune completes.
+func TestPrunePoolSnapshotsWithRetentionFloor_RealPruneNoDeadlock(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{73}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+	ls.epochCache = []models.Epoch{
+		{EpochId: 11, StartSlot: 1_100, LengthInSlots: 100, Nonce: tb.epochNonce},
+		{EpochId: 14, StartSlot: 1_400, LengthInSlots: 100, Nonce: tb.epochNonce},
+	}
+	ls.publishSnapshotsLocked()
+
+	// A deferred header so the guard does a real floor computation under the
+	// lock, and so consume has a marker to clear on the apply side.
+	deferred := ocommon.Point{Slot: 1_450, Hash: []byte{0x14}}
+	ls.markDeferredHeaderValidation(deferred)
+	require.NoError(t, ls.persistDeferredHeaderValidation(deferred, nil))
+
+	connHeld := make(chan struct{})
+	pruneReached := make(chan struct{})
+	applyDone := make(chan struct{})
+
+	// Apply-side order: hold the single write connection, THEN take the
+	// deferred-header mutex via consumeDeferredHeaderValidation.
+	go func() {
+		applyTxn := ls.db.Transaction(true) // acquires the single write conn
+		close(connHeld)
+		// Wait until the guard is inside prune (mutex-then-conn on the buggy
+		// path) before contending for the mutex, so the inversion is forced.
+		<-pruneReached
+		ls.consumeDeferredHeaderValidation(deferred) // needs the mutex
+		_ = applyTxn.Rollback()                      // release the write conn
+		close(applyDone)
+	}()
+
+	<-connHeld // apply goroutine now holds the single write connection
+
+	guardDone := make(chan error, 1)
+	go func() {
+		guardDone <- ls.PrunePoolSnapshotsWithRetentionFloor(
+			25,
+			0,
+			func(before uint64) error {
+				// REAL prune: open the single write connection like production
+				// (cleanupOldSnapshots' prunePoolSnapshots).
+				close(pruneReached)
+				poolTxn := ls.db.Transaction(true) // blocks until apply releases it
+				defer func() { _ = poolTxn.Rollback() }()
+				return db.Metadata().DeletePoolStakeSnapshotsBeforeEpoch(
+					before,
+					poolTxn.Metadata(),
+				)
+			},
+		)
+	}()
+
+	// With the fix both goroutines complete promptly; without it they deadlock
+	// on the single write connection and these receives time out.
+	testutil.RequireReceive(
+		t,
+		applyDone,
+		15*time.Second,
+		"apply goroutine blocked taking the mutex while holding the write connection (lock-order inversion, issue #3717)",
+	)
+	err := testutil.RequireReceive(
+		t,
+		guardDone,
+		15*time.Second,
+		"retention guard blocked opening the write connection while holding the mutex (lock-order inversion, issue #3717)",
+	)
+	require.NoError(t, err)
 }
 
 // TestPrunePoolSnapshotsWithRetentionFloor_UnmappableRetainsAll is the

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -1303,6 +1303,122 @@ func TestVerifyDeferredBlockHeaderStateSurvivesRestartMarker(
 	require.Empty(t, value)
 }
 
+// TestVerifyDeferredBlockHeaderState_GenesisOverlayRevalidatedAtApply is the
+// apply-path regression for the d=1 / genesis-overlay defer (issue #3717 review,
+// wolf, verify_header.go ~560). A header at a d=1 overlay slot is deferred at
+// header-verification time because the in-memory protocol parameters (and the
+// active genesis delegation) can still describe the previous epoch while
+// blockfetch verifies ahead of apply. The classifier verdict alone is not the
+// safety property; what makes the defer safe is that the STATEFUL genesis-
+// delegate check re-runs at apply with allowStateDefer=false. This drives a
+// deferred genesis-overlay header through verifyDeferredBlockHeaderState (the
+// apply path, state.go) and proves:
+//
+//   - a header from the WRONG issuer at a d=1 overlay slot is REJECTED at apply
+//     (headerValidationError), so it cannot be adopted with the check skipped;
+//   - a header from the correct genesis delegate is re-validated and accepted,
+//     and its markers cleared; and
+//   - the marker is the sole gate: with required==false (no marker) the apply
+//     path returns nil WITHOUT running the check. That is exactly the silent-
+//     adoption a lost pin would cause, which is why marker retention (Items 1 &
+//     2 / eviction horizon) must be durable. It is NOT a validity verdict.
+//
+// Under d=1 with activeSlotsCoeff 0.99 every slot classifies as an ACTIVE
+// overlay slot (position%1==0, single genesis key), so the genesis-delegate
+// path -- not the Praos leader-eligibility path -- is authoritative here.
+func TestVerifyDeferredBlockHeaderState_GenesisOverlayRevalidatedAtApply(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{90}, 0, tamperNone)
+	point := ocommon.NewPoint(tb.block.SlotNumber(), tb.block.Hash().Bytes())
+	delegateHash := tb.block.IssuerVkey().Hash()
+	vrfKey, ok, err := headerVrfKeyFromBodyCbor(tb.block.Header())
+	require.NoError(t, err)
+	require.True(t, ok)
+	vrfHash := lcommon.Blake2b256Hash(vrfKey)
+
+	// REJECT: the deferred header's issuer is NOT the assigned genesis delegate.
+	t.Run("wrong issuer rejected at apply", func(t *testing.T) {
+		ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+		wrongDelegate := make([]byte, lcommon.Blake2b224Size)
+		wrongDelegate[0] = 0xAB
+		ls.config.CardanoNodeConfig = newGenesisDelegateShelleyGenesisCfg(
+			t,
+			hex.EncodeToString(wrongDelegate),
+			hex.EncodeToString(vrfHash.Bytes()),
+		)
+		ls.currentPParams = &shelley.ShelleyProtocolParameters{
+			Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
+		}
+		ls.publishSnapshotsLocked()
+
+		// No marker -> required == false -> the check is SKIPPED and nil is
+		// returned. This is the lost-pin silent-adoption path, asserted here so
+		// the gate is explicit; it is not a statement that the block is valid.
+		require.NoError(
+			t,
+			ls.verifyDeferredBlockHeaderState(nil, point, tb.block),
+			"no marker: required==false, stateful check skipped (lost-pin bypass)",
+		)
+
+		// With the marker present the stateful genesis-delegate check runs at
+		// apply and rejects the wrong issuer; the block cannot be adopted.
+		require.NoError(t, ls.persistDeferredHeaderValidation(point, nil))
+		ls.markDeferredHeaderValidation(point)
+		err := ls.verifyDeferredBlockHeaderState(nil, point, tb.block)
+		require.Error(t, err)
+		var hve *headerValidationError
+		require.ErrorAs(t, err, &hve)
+		assert.Contains(
+			t,
+			err.Error(),
+			"genesis overlay slot assigned to delegate",
+		)
+		// The persisted marker is NOT cleared on rejection: the header stays
+		// outstanding (its rejection is terminal via the typed rewind), never
+		// silently resolved.
+		marker, gerr := db.GetSyncState(
+			deferredHeaderValidationSyncStateKey(point), nil,
+		)
+		require.NoError(t, gerr)
+		assert.Equal(
+			t,
+			deferredHeaderValidationSyncStateValue,
+			marker,
+			"rejected header's marker must not be cleared",
+		)
+	})
+
+	// ACCEPT: the correct genesis delegate re-validates at apply and clears.
+	t.Run("correct delegate revalidated and cleared", func(t *testing.T) {
+		ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+		ls.config.CardanoNodeConfig = newGenesisDelegateShelleyGenesisCfg(
+			t,
+			hex.EncodeToString(delegateHash.Bytes()),
+			hex.EncodeToString(vrfHash.Bytes()),
+		)
+		ls.currentPParams = &shelley.ShelleyProtocolParameters{
+			Decentralization: &cbor.Rat{Rat: big.NewRat(1, 1)},
+		}
+		ls.publishSnapshotsLocked()
+		require.NoError(t, ls.persistDeferredHeaderValidation(point, nil))
+		ls.markDeferredHeaderValidation(point)
+
+		require.NoError(
+			t,
+			ls.verifyDeferredBlockHeaderState(nil, point, tb.block),
+			"correct genesis delegate must re-validate at apply",
+		)
+		// Resolved: in-memory entry consumed and the persisted marker cleared.
+		assert.False(t, ls.consumeDeferredHeaderValidation(point))
+		v, gerr := db.GetSyncState(
+			deferredHeaderValidationSyncStateKey(point), nil,
+		)
+		require.NoError(t, gerr)
+		assert.Empty(t, v, "resolved header's persisted marker must be cleared")
+	})
+}
+
 // TestVerifyBlockHeaderCrypto_RejectsEmptyEpochCache verifies that
 // verification rejects blocks when the epoch cache is completely empty.
 func TestVerifyBlockHeaderCrypto_RejectsEmptyEpochCache(t *testing.T) {
@@ -3740,6 +3856,16 @@ func TestPrunePoolSnapshotsWithRetentionFloor_KeepsReadoptableDeferredHeader(
 // false and skipping the stateful check for a header still outstanding. The
 // per-key delete must re-test membership afterwards and restore the marker for
 // a key that came back, while still removing a genuinely stale one.
+//
+// The re-admission is injected via the afterDeferredMarkerDeleteHook seam so it
+// lands DURING the delete window -- after DeleteSyncState, before the membership
+// re-test -- rather than before the call (wolf, verify_header_test.go review).
+// The point is NOT in the in-memory set when the call begins: the caller
+// (deletePersistedDeferredMarkers) already tested membership, saw it absent, and
+// passed the key here to be deleted. An implementation that instead tested
+// membership before deleting and skipped the delete when present would never run
+// the delete-then-restore path this asserts, and would fail it (verified by
+// removing the restore block: the marker read comes back empty).
 func TestDeleteDeferredMarkerUnlessReadmitted_RestoresMarkerReadmittedDuringDelete(
 	t *testing.T,
 ) {
@@ -3748,13 +3874,17 @@ func TestDeleteDeferredMarkerUnlessReadmitted_RestoresMarkerReadmittedDuringDele
 
 	readmitted := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
 	require.NoError(t, ls.persistDeferredHeaderValidation(readmitted, nil))
-	// Stands in for the re-defer that lands after the caller's membership test:
-	// the key is live in the set by the time the delete completes.
-	ls.markDeferredHeaderValidation(readmitted)
 
-	ls.deleteDeferredMarkerUnlessReadmitted(
+	// The re-defer lands DURING the delete window, via the seam. Cleared before
+	// the stale sub-case below and on test exit.
+	t.Cleanup(func() { afterDeferredMarkerDeleteHook = nil })
+	afterDeferredMarkerDeleteHook = func() {
+		ls.markDeferredHeaderValidation(readmitted)
+	}
+
+	require.NoError(t, ls.deleteDeferredMarkerUnlessReadmitted(
 		headerValidationPointKey(readmitted),
-	)
+	))
 
 	marker, err := db.GetSyncState(
 		deferredHeaderValidationSyncStateKey(readmitted), nil,
@@ -3764,16 +3894,76 @@ func TestDeleteDeferredMarkerUnlessReadmitted_RestoresMarkerReadmittedDuringDele
 		t,
 		deferredHeaderValidationSyncStateValue,
 		marker,
-		"marker for a key re-admitted during the delete must be restored",
+		"marker for a key re-admitted DURING the delete must be restored",
 	)
 
-	// A key that is NOT re-admitted still has its marker removed.
+	// A key that is NOT re-admitted (hook cleared) still has its marker removed.
+	afterDeferredMarkerDeleteHook = nil
 	stale := ocommon.Point{Slot: 1_160, Hash: []byte{0x12}}
 	require.NoError(t, ls.persistDeferredHeaderValidation(stale, nil))
-	ls.deleteDeferredMarkerUnlessReadmitted(headerValidationPointKey(stale))
+	require.NoError(t, ls.deleteDeferredMarkerUnlessReadmitted(
+		headerValidationPointKey(stale),
+	))
 	gone, err := db.GetSyncState(
 		deferredHeaderValidationSyncStateKey(stale), nil,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, gone, "genuinely stale marker must be deleted")
+}
+
+// TestDeleteDeferredMarkerUnlessReadmitted_RestoreFailurePropagates proves a
+// failed restore of a re-admitted marker is NOT swallowed (issue #3717 review,
+// wolf, chainsync.go review). If the delete of a stale marker succeeds but the
+// point is re-deferred during the delete and its marker cannot be re-persisted,
+// the durable retention pin is lost: a restart would miss it, the snapshot could
+// be pruned, and the stateful header check skipped. The failure must therefore
+// propagate out of deleteDeferredMarkerUnlessReadmitted (and, through
+// deletePersistedDeferredMarkers, out of PrunePoolSnapshotsWithRetentionFloor)
+// so the node fails the cleanup rather than continuing toward that lost pin. The
+// in-memory entry must survive so the running process still holds the pin.
+func TestDeleteDeferredMarkerUnlessReadmitted_RestoreFailurePropagates(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{75}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+
+	readmitted := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	key := headerValidationPointKey(readmitted)
+	require.NoError(t, ls.persistDeferredHeaderValidation(readmitted, nil))
+
+	// During the delete window: re-admit the point (so the restore path runs)
+	// and close the metadata store so the restore's SetSyncState fails
+	// deterministically. DeleteSyncState has already committed by the time the
+	// hook fires, so the delete succeeds and only the restore fails.
+	t.Cleanup(func() { afterDeferredMarkerDeleteHook = nil })
+	afterDeferredMarkerDeleteHook = func() {
+		ls.markDeferredHeaderValidation(readmitted)
+		require.NoError(t, ls.db.Metadata().Close())
+	}
+
+	err := ls.deleteDeferredMarkerUnlessReadmitted(key)
+	require.Error(t, err, "a lost durable pin must not be swallowed")
+	assert.Contains(t, err.Error(), "restore re-deferred header marker")
+
+	// The running process still holds the pin: the in-memory entry survives, so
+	// the retention floor keeps covering it until a later cleanup re-persists it.
+	assert.True(
+		t,
+		ls.consumeDeferredHeaderValidation(readmitted),
+		"in-memory deferred entry must survive a restore failure",
+	)
+
+	// The same failure surfaces through the cleanup batch entry point.
+	ls2, _ := newEligibilityTestLedger(t, tb.epochNonce)
+	require.NoError(t, ls2.persistDeferredHeaderValidation(readmitted, nil))
+	afterDeferredMarkerDeleteHook = func() {
+		ls2.markDeferredHeaderValidation(readmitted)
+		require.NoError(t, ls2.db.Metadata().Close())
+	}
+	batchErr := ls2.deletePersistedDeferredMarkers([]string{key})
+	require.Error(
+		t,
+		batchErr,
+		"deletePersistedDeferredMarkers must propagate the lost-pin error",
+	)
 }

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -3164,14 +3164,14 @@ func TestPrunePoolSnapshotsWithRetentionFloor_SerializesAdmission(
 			seenBefore = before
 			close(started)
 			// While the guard holds the lock, the concurrent admission must be
-			// blocked: markReturned must not fire.
-			select {
-			case <-markReturned:
-				t.Error(
-					"concurrent admission completed while the retention guard held the lock",
-				)
-			case <-time.After(100 * time.Millisecond):
-			}
+			// blocked: markReturned must not fire. Use the repo's channel
+			// helper for the negative wait rather than a bare time.After poll.
+			testutil.RequireNoReceive(
+				t,
+				markReturned,
+				100*time.Millisecond,
+				"concurrent admission completed while the retention guard held the lock",
+			)
 			return nil
 		},
 	)
@@ -3330,11 +3330,87 @@ func TestRepopulateDeferredHeaderValidation(t *testing.T) {
 	}
 
 	// Repopulate from persisted markers (as LedgerState.Start does).
-	ls.repopulateDeferredHeaderValidation()
+	require.NoError(t, ls.repopulateDeferredHeaderValidation())
 
 	floor, ok := ls.OldestRequiredSnapshotEpoch()
 	require.True(t, ok, "repopulated markers must produce a retention pin")
 	assert.Equal(t, uint64(10), floor, "floor = StakeSnapshotEpoch(11)")
+}
+
+// TestRepopulateDeferredHeaderValidation_FailsClosedOnScanError is the
+// regression guard for the swallowed marker-scan failure (issue #3727, P1
+// re-review). If the persisted-marker scan fails at startup and the error is
+// swallowed, the in-memory deferred set stays empty, the retention floor does
+// not cover pre-restart deferred headers, and the first post-restart cleanup
+// can prune a snapshot one of them needs -- after which stateful verification
+// hard-rejects the missing snapshot instead of deferring. repopulate MUST
+// surface the error so LedgerState.Start aborts rather than run unpinned.
+func TestRepopulateDeferredHeaderValidation_FailsClosedOnScanError(
+	t *testing.T,
+) {
+	tb := createTestBlock(t, [32]byte{71}, 0, tamperNone)
+	ls, db := newEligibilityTestLedger(t, tb.epochNonce)
+
+	// Persist a marker, then close the database so the marker scan errors.
+	require.NoError(t, ls.persistDeferredHeaderValidation(
+		ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}, nil,
+	))
+	dbtest.CloseDatabase(db) //nolint:errcheck
+
+	err := ls.repopulateDeferredHeaderValidation()
+	require.Error(
+		t,
+		err,
+		"a marker-scan failure must be surfaced (fail closed), not swallowed",
+	)
+}
+
+// TestDeletePersistedDeferredMarkers_SkipsReAdmitted is the regression guard
+// for the evicted-marker delete racing a re-defer (issue #3727, P2 re-review).
+// deletePersistedDeferredMarkers runs after eviction released the in-memory
+// pin, so between eviction and the delete the same point can be re-deferred and
+// re-persisted (it is still ahead of the lagging apply cursor). Deleting the
+// marker for a point that is live in the in-memory set again would drop the
+// durable pin, so the delete must skip any key present in the set; only a key
+// that is genuinely absent (still evicted) may have its marker removed.
+func TestDeletePersistedDeferredMarkers_SkipsReAdmitted(t *testing.T) {
+	tb := createTestBlock(t, [32]byte{72}, 0, tamperNone)
+	ls, _ := newEligibilityTestLedger(t, tb.epochNonce)
+
+	reAdmitted := ocommon.Point{Slot: 1_150, Hash: []byte{0x11}}
+	staleGone := ocommon.Point{Slot: 1_160, Hash: []byte{0x12}}
+	reAdmittedKey := headerValidationPointKey(reAdmitted)
+	staleKey := headerValidationPointKey(staleGone)
+
+	// Both points have a persisted marker (as any deferred header would).
+	require.NoError(t, ls.persistDeferredHeaderValidation(reAdmitted, nil))
+	require.NoError(t, ls.persistDeferredHeaderValidation(staleGone, nil))
+
+	// The re-admitted point is back in the in-memory set (re-deferred after the
+	// eviction that produced the delete list); the stale one is not.
+	ls.markDeferredHeaderValidation(reAdmitted)
+
+	// Cleanup runs for BOTH evicted keys.
+	ls.deletePersistedDeferredMarkers([]string{reAdmittedKey, staleKey})
+
+	remaining, err := ls.db.ListSyncStateKeysByPrefix(
+		deferredHeaderValidationSyncStatePrefix, nil,
+	)
+	require.NoError(t, err)
+	// The re-admitted point's marker MUST survive (it now backs a live pin);
+	// the genuinely-stale marker MUST be gone.
+	assert.Contains(
+		t,
+		remaining,
+		deferredHeaderValidationSyncStatePrefix+reAdmittedKey,
+		"re-deferred point's marker must not be deleted",
+	)
+	assert.NotContains(
+		t,
+		remaining,
+		deferredHeaderValidationSyncStatePrefix+staleKey,
+		"genuinely stale marker must be deleted",
+	)
 }
 
 // TestPrunePoolSnapshotsWithRetentionFloor_EvictsStaleBehindCursor is the

--- a/node.go
+++ b/node.go
@@ -870,6 +870,14 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 		return fmt.Errorf("configuring snapshot manager: %w", err)
 	}
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
+	// Prune pool snapshots through the deferred-header retention guard, so a
+	// snapshot a queued/deferred header still needs for leader validation is
+	// never pruned out from under it and misread as pool absence, and the
+	// floor selection is atomic with deferred-header admission (issue #3727).
+	// Set before Start; the pin is released automatically as headers resolve.
+	n.snapshotMgr.SetPoolSnapshotRetentionGuard(
+		n.ledgerState.PrunePoolSnapshotsWithRetentionFloor,
+	)
 	// Wire the authoritative epoch-boundary capture before block sync begins so
 	// each epoch rollover stages its mark snapshot atomically at the SNAP point.
 	// Set before CaptureGenesisSnapshot/sync; a nil hook (never set) would leave

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -776,6 +776,14 @@ func (n *Node) reinitializeBackgroundManagers(ctx context.Context) error {
 		return fmt.Errorf("configuring snapshot manager: %w", err)
 	}
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
+	// Prune pool snapshots through the deferred-header retention guard, so a
+	// snapshot a queued/deferred header still needs for leader validation is
+	// never pruned out from under it and misread as pool absence, and the
+	// floor selection is atomic with deferred-header admission (issue #3727).
+	// Set before Start; the pin is released automatically as headers resolve.
+	n.snapshotMgr.SetPoolSnapshotRetentionGuard(
+		n.ledgerState.PrunePoolSnapshotsWithRetentionFloor,
+	)
 	// Reinstall both epoch-boundary hooks, in the same order and with the
 	// same bodies as Run() (node.go): the stake hook first, so the
 	// authoritative SNAP-point stake read (after MIR, before POOLREAP/


### PR DESCRIPTION
## What / why
Fixes #3727 (and the class in #3646 / #3626). A header whose leader-eligibility check needs a
historical pool-stake snapshot can be **deferred** while the node catches up, but snapshot cleanup
(`ledger/snapshot/rotation.go` `cleanupOldSnapshots`) prunes `pool_stake_snapshot` rows below
`currentEpoch-3`. When a deferred header requires an older epoch than what survived (observed:
required epochs 10/13/21 while the DB retained 25–28), `leaderEligibilityStake` finds no row and
reports the producer as **absent from the epoch distribution** → `header_verification_failure` →
peer recycled, and the node cannot pass the block. The root cause is snapshot *pruning*, not a
genesis/epoch-0 data gap (this replaces the earlier epoch-0-only defer, which neither covered the
real epochs nor distinguished a pruned snapshot from a genuinely-absent pool).

## Fix — two coherent parts, keyed on observable snapshot availability (never on `epoch==0`)

**(A) Retention pin — the root cause.** `LedgerState.OldestRequiredSnapshotEpoch` returns the oldest
snapshot epoch any outstanding deferred header still needs (min over the `deferredHeaderValidation`
set). `Manager.SetRetentionFloorProvider` (wired at node start) makes `cleanupOldSnapshots` pin
**pool-snapshot** deletion at that floor when it is below `currentEpoch-3`, so a snapshot a deferred
header needs is not pruned out from under it. It is a lower-watermark only (never prunes *more* than
today), releases automatically as the deferred set drains, leaves the reward-state window untouched,
and is byte-identical to prior behaviour when no provider is set.

**(B) Never classify missing snapshot state as pool absence.** `leaderEligibilityStake` already
separates an empty/unavailable distribution (`GetTotalActiveStake == 0` → `errLeaderStakeSnapshotUnavailable`)
from a pool absent in a *populated* one (authoritative reject). The classifier now **defers any
unavailable leader-stake snapshot regardless of the apply cursor**, instead of hard-rejecting once the
tip passed the slot — so a snapshot missing for any reason (pruned, unwritten, or momentarily gone
after restart before the deferred set repopulates) defers and never recycles the peer. A pool absent
from a populated snapshot still hard-rejects (covered).

Together: (A) keeps the required snapshot so the deferred header resolves; (B) guarantees that if a
snapshot is nonetheless gone, the header defers rather than being misclassified as absence.

## Tests
`ledger/verify_header_test.go`: `TestVerifyBlockHeaderState_UnavailableSnapshotDefersNotAbsence`
(pruned historical snapshot with the tip **ahead** defers; populated-snapshot genuine absence still
hard-rejects) and `TestOldestRequiredSnapshotEpoch`. `ledger/snapshot/rotation_test.go`: retention
floor retains deferred-header epochs below the default window while still pruning below the pin, and
is a no-op above the window. All pass under `-race`; `DATABASE.md` / `ARCHITECTURE.md` updated.

## Known limitation (flagged for review)
The retention floor is computed from the **in-memory** `deferredHeaderValidation` set (there's no
prefix-scan API on `sync_state`; adding one is a larger DB change). This is correct for the
live-pruning-during-sync case #3727 describes. Across a restart there is a brief window before the
deferred set repopulates where the pin is empty — **part (B) covers exactly that gap** (defer, don't
misclassify), so correctness holds; a durable persisted pin would be a follow-up if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented required pool-stake snapshots from being deleted while deferred header validation still needs them.
  - Headers with unavailable leader-stake snapshots are now deferred instead of incorrectly rejected as if the pool were absent.
  - Snapshot retention pins release automatically as deferred headers are resolved.
  - Reward-state retention behavior remains unchanged.

- **Documentation**
  - Documented configurable snapshot retention and deferred-header retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->