### PR TITLE
fix(chain): defer chain-update publication past the ledger mutex to prevent a drain deadlock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1284,7 +1284,13 @@ All event types follow the `subsystem.snake_case_name` convention.
   a parent still holds either mutex. The invariant is checked by
   `TestNoEventBusPublishWhileHoldingChainsyncMutex` and
   `TestChainsyncResyncPublishPathsUnderLock` in
-  `ledger/publish_under_lock_test.go`. Register the flush with `defer`
+  `ledger/publish_under_lock_test.go`. The first test also treats a call to an
+  inline-publishing `chain.Chain` method as a publish
+  (`inlinePublishingChainMethods`: `AddBlock`, `AddLocalBlock`,
+  `AddBlockWithPoint` and siblings, plus `Rollback`), because those publish
+  `ChainUpdateEventType` / rollback events to the same bus from inside the
+  chain package — an `ls.chain.*` call under a guarded mutex is the same
+  deadlock as a direct `EventBus.Publish`. Register the flush with `defer`
   *before* taking the lock so LIFO order runs it last.
 - `ledger` also must not invoke an external `BlockfetchRequestRangeFunc` while
   holding `chainsyncBlockfetchMutex`. The blockfetch client can wait in

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -507,7 +507,7 @@ full ordered lane regardless of whether a subscriber later drains or its
 lifecycle removes it.
 
 This is also the one deliberate exception to the publish-under-lock rule
-above. `rollbackChainAndState` runs under `chainsyncMutex` — it is reached
+above. `rollbackChainAndStateDeferred` runs under `chainsyncMutex` — it is reached
 through the `pendingPublishes` call chain — and emits undo events from there,
 because the ordering requires them to be enqueued before the truncation and
 the truncation happens under that same lock; deferring them to
@@ -3436,7 +3436,7 @@ records are cleared from `rollbackHistory` on the successful cross
 rollback does not accumulate toward the threshold. Second, even when a point
 does reach the threshold, the detector only breaks the loop if the rollback is
 genuinely un-crossable: `rollbackIsAppliable` mirrors the pre-checks
-`rollbackChainAndState` uses (target block present and within the security
+`rollbackChainAndStateDeferred` uses (target block present and within the security
 parameter K via `chain.ValidateRollback`, and at/above the Mithril anchor),
 and a rollback that would succeed is applied even on the repeat rather than
 suppressed. Only a rollback the node cannot cross takes the skip path, which
@@ -3551,7 +3551,7 @@ That hold bounds the damage but cannot explain where an unresolvable producer
 came from, so a bounded diagnostic attributes it
 (`ledger/continuation_audit.go`). A local rollback that leaves the primary chain
 and applied ledger at the same point — chainsync rollback via
-`rollbackChainAndState`, or a replay-recovery rewind — arms a
+`rollbackChainAndStateDeferred`, or a replay-recovery rewind — arms a
 `continuationAuditWindow` there. A chainsync rollback point ahead of the applied
 ledger instead disarms any prior window because its fork point no longer
 describes the continuation being fetched. While armed, every body
@@ -8434,7 +8434,7 @@ not incremented in place from dingo's side.
 **Phase 5: rollback coordination.** `ledgerReadChainIterator` — the
 pipeline's only submitter — runs on its own goroutine, entirely decoupled
 from the goroutine that decides a rollback. That matters because
-`rollbackChainAndState` (`ledger/state.go`), which physically removes
+`rollbackChainAndStateDeferred` (`ledger/state.go`), which physically removes
 blocks from `ls.chain` and truncates ledger metadata, is reached from
 chainsync per-connection event handling (`handleEventChainsyncRollback`,
 `tryResolveFork` in `ledger/chainsync.go`) — never from `ledgerProcessBlocks`
@@ -8443,7 +8443,7 @@ goroutine has already gathered and submitted a batch of blocks — from that
 very fork — to the pipeline's decode/validate workers and is blocked
 draining `Results()` for it. `drainBlockPipelineBeforeRollback`
 (`ledger/state.go`) closes part of that window: called near the top of
-`rollbackChainAndState`, before `ls.chain.Rollback`, it waits (via
+`rollbackChainAndStateDeferred`, before `ls.chain.Rollback`, it waits (via
 `pipeline.BlockPipeline.WaitForDrain`/`PendingCount`, bounded by
 `BlockPipelineRollbackDrainTimeout`, default 5s) for `ls.blockPipeline`'s
 decode/validate backlog to empty before the physical rollback proceeds. A
@@ -8459,7 +8459,7 @@ rollback or otherwise, so nothing from that goroutine's own current attempt
 is still in flight when this runs; the wait there is expected to return
 immediately in practice.
 
-`rollbackChainAndState` sequences three steps in order, and the ordering is
+`rollbackChainAndStateDeferred` sequences three steps in order, and the ordering is
 load-bearing in both directions: `drainBlockPipelineBeforeRollback` first,
 then, while holding `transactionEventMutex`,
 `validateAndEmitRollbackUndo` (reject-then-emit-undo-events, from the
@@ -8492,7 +8492,7 @@ that returns real data, so the lock is never held across a call that is
 purely waiting for the chain to grow — doing so would deadlock a
 concurrent rollback's write-lock attempt against the very
 `ls.chain.Rollback` call that would otherwise wake the reader);
-`rollbackChainAndState` holds the write lock from before
+`rollbackChainAndStateDeferred` holds the write lock from before
 `drainBlockPipelineBeforeRollback` through `ls.chain.Rollback`, so no
 gather-then-submit cycle can start, and none already in flight can reach
 `Submit`, while a rollback is physically truncating the chain. Once

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -205,11 +205,17 @@ func (c *Chain) AddBlock(
 	block ledger.Block,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true, true)
+	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true)
 	if err != nil {
 		return err
 	}
-	// Publish event immediately for standalone (non-batched) calls
+	// Publish event immediately for standalone (non-batched) callers.
+	// forgeBlock reaches this on the scheduler goroutine, not under a ledger
+	// mutex, so a backpressured Publish here cannot stall the chainsync
+	// drain. The mutex-holding blockfetch drain uses AddBlockWithPointDeferred
+	// instead, which returns the event for the ledger to publish after it
+	// releases chainsyncBlockfetchMutex. See ledger.pendingPublishes and the
+	// blinklabs-io/dingo drain deadlock.
 	if c.eventBus != nil && evt.Type != "" {
 		c.eventBus.Publish(ChainUpdateEventType, evt)
 	}
@@ -224,7 +230,6 @@ func (c *Chain) AddLocalBlock(block ledger.Block) error {
 		block,
 		ocommon.Point{},
 		nil,
-		true,
 		false,
 	)
 	if err != nil {
@@ -244,7 +249,7 @@ func (c *Chain) AddBlockWithPoint(
 	point ocommon.Point,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, point, txn, true, true)
+	evt, err := c.addBlockInternal(block, point, txn, true)
 	if err != nil {
 		return err
 	}
@@ -252,6 +257,25 @@ func (c *Chain) AddBlockWithPoint(
 		c.eventBus.Publish(ChainUpdateEventType, evt)
 	}
 	return nil
+}
+
+// AddBlockWithPointDeferred adds a block exactly like AddBlockWithPoint but
+// returns the resulting chain.update event instead of publishing it, leaving
+// publication to the caller. The ledger's chainsync/blockfetch drain calls
+// this while holding chainsyncBlockfetchMutex and queues the event on its
+// pendingPublishes, so the (potentially backpressured) delivery runs only
+// after the mutex is released. Publishing inline under that mutex is what
+// deadlocked the node: a terminal chain.update subscriber that stopped
+// draining parked the publish with the mutex held, handleEventChainsync then
+// blocked on the same mutex, and the ledger.chainsync buffer filled
+// (blinklabs-io/dingo preview freeze). A returned event with an empty Type
+// means there is nothing to publish.
+func (c *Chain) AddBlockWithPointDeferred(
+	block ledger.Block,
+	point ocommon.Point,
+	txn *database.Txn,
+) (event.Event, error) {
+	return c.addBlockInternal(block, point, txn, true)
 }
 
 // addBlockInternal performs all block-adding logic but returns the event
@@ -262,7 +286,6 @@ func (c *Chain) addBlockInternal(
 	block ledger.Block,
 	point ocommon.Point,
 	txn *database.Txn,
-	notifyWaiters bool,
 	matchPendingHeader bool,
 ) (event.Event, error) {
 	if c == nil {
@@ -281,7 +304,7 @@ func (c *Chain) addBlockInternal(
 		block,
 		point,
 		txn,
-		notifyWaiters,
+		true,
 		matchPendingHeader,
 	)
 }
@@ -435,7 +458,9 @@ func (c *Chain) AddBlocks(blocks []ledger.Block) error {
 			return err
 		}
 		c.notifyWaitingIterators()
-		// Transaction committed successfully; publish all events
+		// Transaction committed successfully; publish all events. This
+		// bulk-import path (internal/node/load) does not run under a ledger
+		// mutex, so an inline Publish here cannot stall the chainsync drain.
 		if c.eventBus != nil {
 			for _, evt := range pendingEvents {
 				c.eventBus.Publish(ChainUpdateEventType, evt)
@@ -666,7 +691,8 @@ func (c *Chain) addRawBlocks(
 			return fmt.Errorf("add raw block batch: %w", err)
 		}
 		c.notifyWaitingIterators()
-		// Publish events (only when eventBus is set).
+		// Publish events (only when eventBus is set). Not reached under a
+		// ledger mutex, so an inline Publish is safe here.
 		if c.eventBus != nil {
 			for _, evt := range pendingEvents {
 				c.eventBus.Publish(
@@ -697,13 +723,36 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 		return err
 	}
 	// Publish events after locks are released to prevent deadlocks
-	// when subscribers call back into chain/manager state.
+	// when subscribers call back into chain/manager state. The
+	// mutex-holding ledger rollback path uses RollbackDeferred instead,
+	// which returns these events for the ledger to publish after it
+	// releases chainsyncMutex.
 	if c.eventBus != nil {
 		for _, evt := range pendingEvents {
 			c.eventBus.Publish(evt.Type, evt)
 		}
 	}
 	return nil
+}
+
+// RollbackDeferred rewinds the chain exactly like Rollback but returns the
+// resulting chain.update events instead of publishing them, leaving
+// publication to the caller. The ledger's rollbackChainAndState calls this
+// while holding chainsyncMutex and queues the events on its pendingPublishes,
+// so delivery (which can backpressure on a full subscriber buffer) runs only
+// after the mutex is released. Publishing inline under chainsyncMutex risks
+// the same drain deadlock described on AddBlockWithPointDeferred. The events
+// are returned in rollback order; a caller that queues them on one
+// pendingPublishes keeps this rollback's chain.update ahead of the block-add
+// chain.update events that follow it, which is the ordering rollbacks depend
+// on.
+func (c *Chain) RollbackDeferred(
+	point ocommon.Point,
+) ([]event.Event, error) {
+	if c == nil {
+		return nil, errors.New("chain is nil")
+	}
+	return c.rollbackLocked(point)
 }
 
 // rollbackForkDepth returns the number of blocks a rollback to

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -59,6 +59,33 @@ type Chain struct {
 	mutex                sync.RWMutex
 	waitingChanMutex     sync.Mutex
 	persistent           bool
+
+	// pendingUpdates is the chain-level sequencer for deferred chain.update
+	// / chain.fork publication. The mutex-holding ledger paths (blockfetch
+	// add under chainsyncBlockfetchMutex, rollback under chainsyncMutex) must
+	// not publish inline -- a back-pressured Publish there deadlocks the node
+	// (see ledger.pendingPublishes). They instead enqueue the event onto this
+	// single shared queue *atomically with the chain mutation, under c.mutex*
+	// (queueDeferredEventLocked), and drain it after releasing their outer
+	// mutex (PublishPendingChainUpdates).
+	//
+	// Because enqueue happens under c.mutex -- the same lock that serializes
+	// every chain mutation -- enqueue order equals mutation order, and a
+	// single FIFO drain therefore publishes in mutation order across BOTH
+	// handlers. A blockfetch add and a chainsync rollback can no longer invert
+	// (add queued, rollback published first) the way two independent
+	// per-handler queues could, which would have driven the chain.update
+	// subscriber's block apply/undo notifications out of order.
+	//
+	// pendingUpdatesMutex guards the slice for the brief enqueue/dequeue; it
+	// is never held across a Publish. publishMutex serializes drains so that,
+	// when two goroutines flush concurrently, their Publish calls stay in
+	// pop (FIFO) order rather than interleaving. Neither is a ledger mutex, so
+	// draining -- which only ever runs after the caller has released its outer
+	// ledger mutex -- cannot reintroduce the drain deadlock.
+	pendingUpdates      []event.Event
+	pendingUpdatesMutex sync.Mutex
+	publishMutex        sync.Mutex
 }
 
 type queuedHeader struct {
@@ -205,7 +232,7 @@ func (c *Chain) AddBlock(
 	block ledger.Block,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true)
+	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true, false)
 	if err != nil {
 		return err
 	}
@@ -231,6 +258,7 @@ func (c *Chain) AddLocalBlock(block ledger.Block) error {
 		ocommon.Point{},
 		nil,
 		false,
+		false,
 	)
 	if err != nil {
 		return err
@@ -249,7 +277,7 @@ func (c *Chain) AddBlockWithPoint(
 	point ocommon.Point,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, point, txn, true)
+	evt, err := c.addBlockInternal(block, point, txn, true, false)
 	if err != nil {
 		return err
 	}
@@ -259,23 +287,71 @@ func (c *Chain) AddBlockWithPoint(
 	return nil
 }
 
-// AddBlockWithPointDeferred adds a block exactly like AddBlockWithPoint but
-// returns the resulting chain.update event instead of publishing it, leaving
-// publication to the caller. The ledger's chainsync/blockfetch drain calls
-// this while holding chainsyncBlockfetchMutex and queues the event on its
-// pendingPublishes, so the (potentially backpressured) delivery runs only
-// after the mutex is released. Publishing inline under that mutex is what
-// deadlocked the node: a terminal chain.update subscriber that stopped
-// draining parked the publish with the mutex held, handleEventChainsync then
-// blocked on the same mutex, and the ledger.chainsync buffer filled
-// (blinklabs-io/dingo preview freeze). A returned event with an empty Type
-// means there is nothing to publish.
+// AddBlockWithPointDeferred adds a block exactly like AddBlockWithPoint but,
+// instead of publishing the resulting chain.update inline, enqueues it on the
+// chain-level sequencer under c.mutex and returns it (the return value is
+// retained for callers/tests that inspect it; publication happens only through
+// the sequencer). The ledger's chainsync/blockfetch drain calls this while
+// holding chainsyncBlockfetchMutex and then drains the sequencer after the
+// mutex is released, so the (potentially backpressured) delivery never runs
+// under the lock. Publishing inline under that mutex is what deadlocked the
+// node: a terminal chain.update subscriber that stopped draining parked the
+// publish with the mutex held, handleEventChainsync then blocked on the same
+// mutex, and the ledger.chainsync buffer filled (blinklabs-io/dingo preview
+// freeze). Enqueuing under c.mutex also keeps this add ordered against a
+// concurrent chainsync rollback in true chain-mutation order; see the
+// pendingUpdates field and PublishPendingChainUpdates. A returned event with an
+// empty Type means there is nothing to publish.
 func (c *Chain) AddBlockWithPointDeferred(
 	block ledger.Block,
 	point ocommon.Point,
 	txn *database.Txn,
 ) (event.Event, error) {
-	return c.addBlockInternal(block, point, txn, true)
+	return c.addBlockInternal(block, point, txn, true, true)
+}
+
+// queueDeferredEventLocked appends evt to the chain-level sequencer. The caller
+// must hold c.mutex, so the enqueue is atomic with the chain mutation that
+// produced evt: no other mutation can interleave between updating the tip and
+// recording its event, which is what makes enqueue order equal mutation order.
+// See the pendingUpdates field.
+func (c *Chain) queueDeferredEventLocked(evt event.Event) {
+	if c == nil || c.eventBus == nil || evt.Type == "" {
+		return
+	}
+	c.pendingUpdatesMutex.Lock()
+	c.pendingUpdates = append(c.pendingUpdates, evt)
+	c.pendingUpdatesMutex.Unlock()
+}
+
+// PublishPendingChainUpdates drains the chain-level sequencer, publishing every
+// queued deferred event strictly FIFO -- i.e. in chain-mutation order. It is
+// safe to call from any goroutine and must be called only after the caller has
+// released its outer ledger mutex (chainsyncMutex / chainsyncBlockfetchMutex);
+// a drain may publish an event another handler enqueued, so publishing under a
+// ledger mutex would reintroduce the drain deadlock.
+//
+// publishMutex serializes concurrent drains so their Publish calls preserve pop
+// order; pendingUpdatesMutex is dropped before each (potentially
+// back-pressured) Publish so an enqueue never blocks behind delivery.
+func (c *Chain) PublishPendingChainUpdates() {
+	if c == nil || c.eventBus == nil {
+		return
+	}
+	c.publishMutex.Lock()
+	defer c.publishMutex.Unlock()
+	for {
+		c.pendingUpdatesMutex.Lock()
+		if len(c.pendingUpdates) == 0 {
+			c.pendingUpdates = nil
+			c.pendingUpdatesMutex.Unlock()
+			return
+		}
+		evt := c.pendingUpdates[0]
+		c.pendingUpdates = c.pendingUpdates[1:]
+		c.pendingUpdatesMutex.Unlock()
+		c.eventBus.Publish(evt.Type, evt)
+	}
 }
 
 // addBlockInternal performs all block-adding logic but returns the event
@@ -287,6 +363,7 @@ func (c *Chain) addBlockInternal(
 	point ocommon.Point,
 	txn *database.Txn,
 	matchPendingHeader bool,
+	deferred bool,
 ) (event.Event, error) {
 	if c == nil {
 		return event.Event{}, errors.New("chain is nil")
@@ -300,13 +377,25 @@ func (c *Chain) addBlockInternal(
 	if err := c.reconcile(); err != nil {
 		return event.Event{}, fmt.Errorf("reconcile chain: %w", err)
 	}
-	return c.addBlockLocked(
+	evt, err := c.addBlockLocked(
 		block,
 		point,
 		txn,
 		true,
 		matchPendingHeader,
 	)
+	if err != nil {
+		return event.Event{}, err
+	}
+	// Deferred callers (the mutex-holding blockfetch drain) publish through the
+	// chain-level sequencer rather than inline. Enqueue while c.mutex is still
+	// held so this add is sequenced ahead of any mutation that acquires the
+	// lock after it; the caller drains after releasing its outer ledger mutex.
+	// See the pendingUpdates field and PublishPendingChainUpdates.
+	if deferred {
+		c.queueDeferredEventLocked(evt)
+	}
+	return evt, nil
 }
 
 func (c *Chain) addBlockLocked(
@@ -718,7 +807,7 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	if c == nil {
 		return errors.New("chain is nil")
 	}
-	pendingEvents, err := c.rollbackLocked(point)
+	pendingEvents, err := c.rollbackLocked(point, false)
 	if err != nil {
 		return err
 	}
@@ -735,24 +824,29 @@ func (c *Chain) Rollback(point ocommon.Point) error {
 	return nil
 }
 
-// RollbackDeferred rewinds the chain exactly like Rollback but returns the
-// resulting chain.update events instead of publishing them, leaving
-// publication to the caller. The ledger's rollbackChainAndState calls this
-// while holding chainsyncMutex and queues the events on its pendingPublishes,
-// so delivery (which can backpressure on a full subscriber buffer) runs only
-// after the mutex is released. Publishing inline under chainsyncMutex risks
-// the same drain deadlock described on AddBlockWithPointDeferred. The events
-// are returned in rollback order; a caller that queues them on one
-// pendingPublishes keeps this rollback's chain.update ahead of the block-add
-// chain.update events that follow it, which is the ordering rollbacks depend
-// on.
+// RollbackDeferred rewinds the chain exactly like Rollback but, instead of
+// publishing the resulting chain.update / chain.fork events inline, enqueues
+// them on the chain-level sequencer under c.mutex and returns them (the return
+// value is retained for callers/tests that inspect it; publication happens only
+// through the sequencer). The ledger's rollbackChainAndStateDeferred calls this
+// while holding chainsyncMutex and then drains the sequencer after the mutex is
+// released, so delivery (which can backpressure on a full subscriber buffer)
+// never runs under the lock. Publishing inline under chainsyncMutex risks the
+// same drain deadlock described on AddBlockWithPointDeferred.
+//
+// Enqueuing under c.mutex is what keeps this rollback's chain.update correctly
+// ordered against a concurrent blockfetch add: the two run under different
+// ledger mutexes and once flushed independent per-handler queues, so a rollback
+// that mutated the chain after an add could otherwise be published before it.
+// The shared sequencer preserves true chain-mutation order across both. See the
+// pendingUpdates field and PublishPendingChainUpdates.
 func (c *Chain) RollbackDeferred(
 	point ocommon.Point,
 ) ([]event.Event, error) {
 	if c == nil {
 		return nil, errors.New("chain is nil")
 	}
-	return c.rollbackLocked(point)
+	return c.rollbackLocked(point, true)
 }
 
 // rollbackForkDepth returns the number of blocks a rollback to
@@ -955,6 +1049,7 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 // events to be published by the caller after locks are released.
 func (c *Chain) rollbackLocked(
 	point ocommon.Point,
+	deferred bool,
 ) ([]event.Event, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -1151,6 +1246,19 @@ func (c *Chain) rollbackLocked(
 					},
 				),
 			)
+		}
+	}
+	// Deferred callers (the mutex-holding chainsync rollback path) publish
+	// through the chain-level sequencer rather than inline. Enqueue while
+	// c.mutex is still held so this rollback is sequenced against concurrent
+	// blockfetch adds in true mutation order -- the rollback's chain.update
+	// then cannot be published ahead of an add that mutated the chain before
+	// it, or behind one that mutated after. The caller drains after releasing
+	// chainsyncMutex. See the pendingUpdates field and
+	// PublishPendingChainUpdates.
+	if deferred {
+		for _, evt := range pendingEvents {
+			c.queueDeferredEventLocked(evt)
 		}
 	}
 	return pendingEvents, nil

--- a/chain/deferred_publish_ordering_test.go
+++ b/chain/deferred_publish_ordering_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	testfixtures "github.com/blinklabs-io/dingo/internal/test/fixtures"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// publishMode selects how a handler publishes the chain.update it deferred while
+// holding its mutex, so one scenario can model both the pre-fix and post-fix
+// ledger callers exactly.
+type publishMode int
+
+const (
+	// perHandlerFlush is the pre-fix caller: each handler publishes ITS OWN
+	// returned chain.update event(s) from its OWN pendingPublishes after
+	// releasing its mutex. The two handlers' queues are independent, so a
+	// handler that mutated the chain later can still flush first.
+	perHandlerFlush publishMode = iota
+	// sharedSequencer is the fix: each handler drains the chain-level
+	// sequencer (chain.PublishPendingChainUpdates). Whichever handler flushes
+	// first publishes the WHOLE queue in enqueue (== mutation) order, so the
+	// two handlers can no longer invert.
+	sharedSequencer
+)
+
+// observedUpdate labels a published chain.update by kind so the test can assert
+// the block-add update and the rollback update come out in mutation order.
+type observedUpdate string
+
+const (
+	updateAdd      observedUpdate = "add"
+	updateRollback observedUpdate = "rollback"
+)
+
+// runDeferredOrderingScenario drives the exact concurrency wolf31o2 flagged: a
+// blockfetch-style deferred add and a chainsync-style deferred rollback, each
+// mutating the primary chain under its OWN mutex (the real handlers hold two
+// different mutexes -- chainsyncBlockfetchMutex and chainsyncMutex -- so they do
+// not mutually exclude), then publishing their deferred chain.update AFTER
+// releasing that mutex.
+//
+// The interleaving is pinned deterministically with channels, no sleeps:
+//
+//  1. the add mutates the chain first (tip -> block C), enqueuing update "add";
+//  2. the rollback then mutates the chain (tip C -> block B, discarding C),
+//     enqueuing update "rollback"; so the true chain-mutation order is
+//     [add, rollback];
+//  3. the rollback PUBLISHES first, then the add publishes.
+//
+// Step 3 is the inversion trigger: the handler that mutated second publishes
+// first. With perHandlerFlush each handler emits only its own event, so the
+// subscriber observes [rollback, add] -- the reverse of the mutation order.
+// With sharedSequencer the rollback's flush drains the shared queue in
+// enqueue order and emits [add, rollback]; the add's later flush finds the
+// queue already empty.
+//
+// It returns the chain.update kinds in the exact order the subscriber received
+// them.
+func runDeferredOrderingScenario(
+	t *testing.T,
+	mode publishMode,
+) []observedUpdate {
+	t.Helper()
+
+	eventBus := event.NewEventBus(nil, nil)
+	t.Cleanup(eventBus.Stop)
+
+	cm, err := chain.NewManager(nil, eventBus)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	blocks, err := testfixtures.GenerateConwayChain(3)
+	require.NoError(t, err)
+	require.Len(t, blocks, 3)
+
+	pointOf := func(i int) ocommon.Point {
+		return ocommon.Point{
+			Slot: blocks[i].SlotNumber(),
+			Hash: blocks[i].Hash().Bytes(),
+		}
+	}
+
+	// Seed the chain up to block B (blocks[1]) BEFORE subscribing, so the
+	// scenario's subscriber records only the add/rollback under test and not
+	// the seed updates.
+	require.NoError(t, c.AddBlock(blocks[0], nil))
+	require.NoError(t, c.AddBlock(blocks[1], nil))
+	require.Equal(t, blocks[1].SlotNumber(), c.Tip().Point.Slot)
+
+	// Lossless subscriber with generous buffer: it never drops and preserves
+	// per-subscriber delivery order, so the slice it records is the true
+	// publish order.
+	subId, ch := eventBus.SubscribeWithBufferPolicy(
+		chain.ChainUpdateEventType,
+		16,
+		event.SubscriberBackpressureBlock,
+	)
+	require.NotZero(t, subId)
+
+	classify := func(evt event.Event) (observedUpdate, bool) {
+		switch evt.Data.(type) {
+		case chain.ChainBlockEvent:
+			return updateAdd, true
+		case chain.ChainRollbackEvent:
+			return updateRollback, true
+		default:
+			return "", false
+		}
+	}
+
+	// Two independent mutexes standing in for chainsyncBlockfetchMutex
+	// (add) and chainsyncMutex (rollback): the point of the bug is that these
+	// are DIFFERENT locks, so the two handlers' critical sections and their
+	// deferred publishes are not serialized against each other.
+	var addMutex, rollbackMutex sync.Mutex
+
+	addMutated := make(chan struct{})        // add finished its chain mutation
+	rollbackPublished := make(chan struct{}) // rollback finished publishing
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Blockfetch-style deferred add: extend the chain with block C
+	// (blocks[2]) on top of block B.
+	go func() {
+		defer wg.Done()
+		addMutex.Lock()
+		addEvt, addErr := c.AddBlockWithPointDeferred(
+			blocks[2],
+			pointOf(2),
+			nil,
+		)
+		addMutex.Unlock()
+		require.NoError(t, addErr)
+		require.Equal(
+			t,
+			event.EventType(chain.ChainUpdateEventType),
+			addEvt.Type,
+		)
+		// The chain was mutated first; signal the rollback to proceed.
+		close(addMutated)
+		// Publish only AFTER the rollback has published, forcing the
+		// second-mutating handler to publish first.
+		<-rollbackPublished
+		switch mode {
+		case perHandlerFlush:
+			eventBus.Publish(addEvt.Type, addEvt)
+		case sharedSequencer:
+			c.PublishPendingChainUpdates()
+		}
+	}()
+
+	// Chainsync-style deferred rollback: rewind block C, back to block B.
+	go func() {
+		defer wg.Done()
+		<-addMutated // ensure the add mutated the chain first
+		rollbackMutex.Lock()
+		rbEvts, rbErr := c.RollbackDeferred(pointOf(1))
+		rollbackMutex.Unlock()
+		require.NoError(t, rbErr)
+		require.NotEmpty(t, rbEvts)
+		switch mode {
+		case perHandlerFlush:
+			for _, evt := range rbEvts {
+				eventBus.Publish(evt.Type, evt)
+			}
+		case sharedSequencer:
+			c.PublishPendingChainUpdates()
+		}
+		close(rollbackPublished)
+	}()
+
+	wg.Wait()
+	// The chain really ended at block B: the add was applied then rolled back.
+	require.Equal(t, blocks[1].SlotNumber(), c.Tip().Point.Slot)
+
+	// Collect exactly the two chain.update events the scenario publishes.
+	var got []observedUpdate
+	deadline := time.After(5 * time.Second)
+	for len(got) < 2 {
+		select {
+		case evt := <-ch:
+			if kind, ok := classify(evt); ok {
+				got = append(got, kind)
+			}
+		case <-deadline:
+			t.Fatalf(
+				"timed out: observed %d of 2 chain.update events (%v)",
+				len(got), got,
+			)
+		}
+	}
+	// No third chain.update may follow (exactly-once, no duplicate drain).
+	select {
+	case evt := <-ch:
+		if kind, ok := classify(evt); ok {
+			t.Fatalf("unexpected extra chain.update published: %s", kind)
+		}
+	case <-time.After(200 * time.Millisecond):
+	}
+	return got
+}
+
+// TestDeferredChainUpdatesPublishInChainMutationOrder is the regression guard
+// for wolf31o2's blocking review (ledger/chainsync.go:531): deferred chain.update
+// publication must follow chain-mutation order across the blockfetch-add and
+// chainsync-rollback handlers, which hold different mutexes and previously
+// flushed independent pendingPublishes queues.
+//
+// The shared chain-level sequencer makes the handler that flushes first publish
+// the whole queue in enqueue (== mutation) order, so the observed order is
+// [add, rollback] -- the order the chain was actually mutated -- regardless of
+// which handler flushes first.
+//
+// To see this FAIL against the pre-fix per-instance-queue behaviour, change the
+// mode below to perHandlerFlush: the second-mutating rollback flushes its own
+// queue first and the subscriber observes [rollback, add], the inverse of the
+// chain-mutation order. TestDeferredPerHandlerFlushInvertsAcrossHandlers pins
+// that inversion so this guard is not vacuous.
+func TestDeferredChainUpdatesPublishInChainMutationOrder(t *testing.T) {
+	got := runDeferredOrderingScenario(t, sharedSequencer)
+	require.Equal(
+		t,
+		[]observedUpdate{updateAdd, updateRollback},
+		got,
+		"deferred chain.update publication must match chain-mutation order "+
+			"[add, rollback] across the two handlers",
+	)
+}
+
+// TestDeferredPerHandlerFlushInvertsAcrossHandlers proves the concurrency the
+// fix addresses is real, not hypothetical: with the pre-fix per-handler flush,
+// the identical interleaving publishes the rollback BEFORE the add even though
+// the chain was mutated add-then-rollback. This is the exact ordering that
+// drove the chain.update subscriber's block apply/undo notifications out of
+// order, and it is what the shared sequencer (asserted above) prevents.
+func TestDeferredPerHandlerFlushInvertsAcrossHandlers(t *testing.T) {
+	got := runDeferredOrderingScenario(t, perHandlerFlush)
+	require.Equal(
+		t,
+		[]observedUpdate{updateRollback, updateAdd},
+		got,
+		"per-handler flush is expected to invert publish order relative to "+
+			"chain-mutation order; if this no longer inverts the guard test "+
+			"has stopped exercising the race",
+	)
+}

--- a/chain/deferred_publish_test.go
+++ b/chain/deferred_publish_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	testfixtures "github.com/blinklabs-io/dingo/internal/test/fixtures"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeferredAddAndRollbackDoNotPublish is the chain-package half of the
+// chainsync/blockfetch drain deadlock fix.
+//
+// The ledger calls into the chain while holding chainsyncBlockfetchMutex /
+// chainsyncMutex. To keep a backpressured publish from stalling under those
+// locks, the mutex-holding paths use AddBlockWithPointDeferred and
+// RollbackDeferred, which return the chain.update event(s) for the ledger to
+// publish AFTER the mutex is released (see ledger.pendingPublishes) instead of
+// publishing inline.
+//
+// This test installs a lossless (SubscriberBackpressureBlock) chain.update
+// subscriber whose single buffer slot is filled and never drained: any inline
+// Publish would block on it forever. It then drives blocks and a rollback
+// through the deferred methods and requires each to return promptly and to
+// publish nothing. A regression that published inline from these methods would
+// block on the stalled subscriber and fail the timeout, or would leak an event
+// onto the subscriber channel and fail the "published nothing" check.
+func TestDeferredAddAndRollbackDoNotPublish(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	t.Cleanup(eventBus.Stop)
+
+	subId, ch := eventBus.SubscribeWithBufferPolicy(
+		chain.ChainUpdateEventType,
+		1,
+		event.SubscriberBackpressureBlock,
+	)
+	require.NotZero(t, subId)
+	require.NotNil(t, ch)
+
+	// Fill the subscriber's only buffer slot; from here an inline Publish
+	// blocks.
+	eventBus.Publish(
+		chain.ChainUpdateEventType,
+		event.NewEvent(chain.ChainUpdateEventType, chain.ChainBlockEvent{}),
+	)
+
+	cm, err := chain.NewManager(nil, eventBus)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	blocks, err := testfixtures.GenerateConwayChain(2)
+	require.NoError(t, err)
+	require.Len(t, blocks, 2)
+
+	pointOf := func(i int) ocommon.Point {
+		return ocommon.Point{
+			Slot: blocks[i].SlotNumber(),
+			Hash: blocks[i].Hash().Bytes(),
+		}
+	}
+
+	// Add both blocks through the deferred API. Each call must return promptly
+	// (it never touches the bus) and hand back a populated chain.update event.
+	for i := range blocks {
+		type result struct {
+			evt event.Event
+			err error
+		}
+		done := make(chan result, 1)
+		go func() {
+			evt, addErr := c.AddBlockWithPointDeferred(blocks[i], pointOf(i), nil)
+			done <- result{evt: evt, err: addErr}
+		}()
+		select {
+		case r := <-done:
+			require.NoError(t, r.err)
+			require.Equal(
+				t,
+				event.EventType(chain.ChainUpdateEventType),
+				r.evt.Type,
+				"deferred add must return the chain.update event to publish",
+			)
+		case <-time.After(5 * time.Second):
+			t.Fatalf(
+				"AddBlockWithPointDeferred(%d) blocked: it must return the "+
+					"event, not publish it inline under a stalled subscriber",
+				i,
+			)
+		}
+	}
+	require.Equal(t, blocks[1].SlotNumber(), c.Tip().Point.Slot)
+
+	// Roll back the newest block through the deferred API. It must also return
+	// promptly and hand back its chain.update event(s).
+	rbDone := make(chan []event.Event, 1)
+	rbErr := make(chan error, 1)
+	go func() {
+		evts, err := c.RollbackDeferred(pointOf(0))
+		rbErr <- err
+		rbDone <- evts
+	}()
+	select {
+	case err := <-rbErr:
+		require.NoError(t, err)
+		evts := <-rbDone
+		require.NotEmpty(t, evts)
+	case <-time.After(5 * time.Second):
+		t.Fatal(
+			"RollbackDeferred blocked: it must return the events, not publish " +
+				"them inline under a stalled subscriber",
+		)
+	}
+	require.Equal(t, blocks[0].SlotNumber(), c.Tip().Point.Slot)
+
+	// Nothing beyond the single pre-fill event may have reached the subscriber:
+	// the deferred methods published nothing.
+	select {
+	case <-ch:
+		// the pre-fill event
+	default:
+		t.Fatal("expected the pre-fill event in the subscriber buffer")
+	}
+	select {
+	case extra := <-ch:
+		t.Fatalf(
+			"deferred add/rollback published %v to the chain.update "+
+				"subscriber; they must defer publication to the caller",
+			extra.Type,
+		)
+	default:
+	}
+}

--- a/ledger/benchmark_test.go
+++ b/ledger/benchmark_test.go
@@ -2105,12 +2105,12 @@ func BenchmarkBlockfetchNearTipThroughput(b *testing.B) {
 			Type:  block.Type,
 		}
 
-		if err := ledgerState.handleEventBlockfetchBlock(evt); err != nil {
+		if err := ledgerState.handleEventBlockfetchBlockDeferred(evt, nil); err != nil {
 			b.Fatalf("handleEventBlockfetchBlock failed: %v", err)
 		}
 		// Flush after each block to simulate near-tip behavior where
 		// blocks are committed individually rather than batched.
-		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ledgerState.flushPendingBlockfetchBlocksDeferred(nil); err != nil {
 			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
 		}
 
@@ -2170,10 +2170,10 @@ func BenchmarkBlockfetchNearTipThroughputPredecoded(b *testing.B) {
 		}
 		blockIdx++
 
-		if err := ledgerState.handleEventBlockfetchBlock(evt); err != nil {
+		if err := ledgerState.handleEventBlockfetchBlockDeferred(evt, nil); err != nil {
 			b.Fatalf("handleEventBlockfetchBlock failed: %v", err)
 		}
-		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ledgerState.flushPendingBlockfetchBlocksDeferred(nil); err != nil {
 			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
 		}
 
@@ -2236,7 +2236,7 @@ func BenchmarkBlockfetchNearTipFlushOnlyPredecoded(b *testing.B) {
 		)
 		blockIdx++
 
-		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ledgerState.flushPendingBlockfetchBlocksDeferred(nil); err != nil {
 			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
 		}
 
@@ -2304,10 +2304,10 @@ func BenchmarkBlockfetchNearTipQueuedHeaderPredecoded(b *testing.B) {
 			Type:  uint(block.Type()),
 		}
 
-		if err := ledgerState.handleEventBlockfetchBlock(evt); err != nil {
+		if err := ledgerState.handleEventBlockfetchBlockDeferred(evt, nil); err != nil {
 			b.Fatalf("handleEventBlockfetchBlock failed: %v", err)
 		}
-		if err := ledgerState.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ledgerState.flushPendingBlockfetchBlocksDeferred(nil); err != nil {
 			b.Fatalf("flushPendingBlockfetchBlocks failed: %v", err)
 		}
 
@@ -2459,7 +2459,7 @@ func BenchmarkBlockfetchVerifiedHeaderDispatch(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		if err := ledgerState.handleEventBlockfetchBlock(evt); err != nil {
+		if err := ledgerState.handleEventBlockfetchBlockDeferred(evt, nil); err != nil {
 			b.Fatal(err)
 		}
 		ledgerState.pendingBlockfetchEvents = ledgerState.pendingBlockfetchEvents[:0]

--- a/ledger/block_event_ordering_test.go
+++ b/ledger/block_event_ordering_test.go
@@ -321,7 +321,7 @@ func TestRollbackWaitsForCommittedApplyPublication(t *testing.T) {
 
 	rollbackDone := make(chan error, 1)
 	go func() {
-		rollbackDone <- ls.rollbackChainAndState(fixture.ancestorTip.Point)
+		rollbackDone <- ls.rollbackChainAndStateDeferred(fixture.ancestorTip.Point, nil)
 	}()
 	testutil.RequireNoReceive(
 		t,
@@ -425,7 +425,7 @@ func TestBlockApplyRejectsRolledBackCandidate(t *testing.T) {
 	rolledBackCandidate := fixture.currentTip.Point
 	require.NoError(
 		t,
-		fixture.ls.rollbackChainAndState(fixture.ancestorTip.Point),
+		fixture.ls.rollbackChainAndStateDeferred(fixture.ancestorTip.Point, nil),
 	)
 
 	operationCalled := false
@@ -549,7 +549,7 @@ func TestRollbackChainAndStateEmitsUndoEventsBeforeTruncating(t *testing.T) {
 	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
 	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
 
-	require.NoError(t, ls.rollbackChainAndState(fixture.ancestorTip.Point))
+	require.NoError(t, ls.rollbackChainAndStateDeferred(fixture.ancestorTip.Point, nil))
 
 	// The block above the rollback point was visited by the undo emitter.
 	evt := testutil.RequireReceive(
@@ -597,7 +597,7 @@ func TestRejectedRollbackEmitsNoUndoEvents(t *testing.T) {
 		fixture.ancestorTip.Point.Slot,
 		testHashBytes("no-such-block"),
 	)
-	require.Error(t, ls.rollbackChainAndState(badPoint))
+	require.Error(t, ls.rollbackChainAndStateDeferred(badPoint, nil))
 
 	testutil.RequireNoReceive(
 		t, txCh, 250*time.Millisecond,
@@ -633,7 +633,7 @@ func TestBlocksAboveSlotServesLedgerErrorOnlySubscribers(t *testing.T) {
 	require.NotEqual(t, event.EventSubscriberId(0), errSubID)
 	t.Cleanup(func() { bus.Unsubscribe(LedgerErrorEventType, errSubID) })
 
-	require.NoError(t, ls.rollbackChainAndState(fixture.ancestorTip.Point))
+	require.NoError(t, ls.rollbackChainAndStateDeferred(fixture.ancestorTip.Point, nil))
 
 	evt := testutil.RequireReceive(
 		t, errCh, 2*time.Second,

--- a/ledger/block_pipeline_gather_mutex_test.go
+++ b/ledger/block_pipeline_gather_mutex_test.go
@@ -78,7 +78,7 @@ func (p *pausingLedgerReadIterator) Next(
 // reader actually holds it there (not just after Submit): while the
 // scripted iterator's second Next call is deliberately paused -- i.e. one
 // raw block already gathered, mid-way through gathering the next -- a
-// concurrent TryLock for the write side (the lock rollbackChainAndState
+// concurrent TryLock for the write side (the lock rollbackChainAndStateDeferred
 // takes) must fail. Once the reader delivers its batch and the mutex is no
 // longer needed, TryLock must succeed.
 func TestLedgerReadChainIteratorHoldsGatherMutexAcrossGather(t *testing.T) {
@@ -117,7 +117,7 @@ func TestLedgerReadChainIteratorHoldsGatherMutexAcrossGather(t *testing.T) {
 	)
 
 	// The reader is mid-gather with one raw block already collected. The
-	// write-side lock rollbackChainAndState takes must not be obtainable
+	// write-side lock rollbackChainAndStateDeferred takes must not be obtainable
 	// right now.
 	require.False(
 		t,

--- a/ledger/blockfetch_drain_deadlock_test.go
+++ b/ledger/blockfetch_drain_deadlock_test.go
@@ -61,8 +61,27 @@ func newChainUpdateEvent() event.Event {
 func TestBlockfetchDrainDefersChainUpdatePastLedgerMutex(t *testing.T) {
 	eventBus := event.NewEventBus(nil, nil)
 	// Stop releases the goroutines parked on the stalled subscriber / full
-	// lane at the end of the test.
-	t.Cleanup(eventBus.Stop)
+	// lane at the end of the test. Run it under a bounded wait: if Stop's
+	// shutdown path ever regresses and fails to release those parked
+	// publishers, an unbounded t.Cleanup(eventBus.Stop) would hang the whole
+	// `go test` binary in Stop with no diagnostic. Fail the test instead so
+	// the regression is visible.
+	t.Cleanup(func() {
+		stopped := make(chan struct{})
+		go func() {
+			eventBus.Stop()
+			close(stopped)
+		}()
+		select {
+		case <-stopped:
+		case <-time.After(10 * time.Second):
+			t.Error(
+				"eventBus.Stop did not return within 10s: it failed to " +
+					"release the publishers parked on the stalled subscriber / " +
+					"full ordered lane (shutdown backpressure-release regressed)",
+			)
+		}
+	})
 
 	// Terminal chain.update subscriber, buffer 1, deliberately never drained.
 	// Lossless (SubscriberBackpressureBlock) means a full buffer blocks the

--- a/ledger/blockfetch_drain_deadlock_test.go
+++ b/ledger/blockfetch_drain_deadlock_test.go
@@ -189,13 +189,25 @@ func TestBlockfetchDrainDefersChainUpdatePastLedgerMutex(t *testing.T) {
 		)
 	}
 
-	// The chain.update was deferred onto the caller's queue, not published:
-	// nothing reached the saturated bus under the lock.
-	require.Len(t, pubs.events, 1)
+	// The chain.update was deferred, not published: nothing reached the
+	// saturated bus under the lock. It is no longer requeued onto pubs.events;
+	// AddBlockWithPointDeferred enqueued it on the chain's shared sequencer
+	// under c.mutex, and the drain registered the chain on pubs.chainDrains so
+	// pubs.flush() publishes it (in chain-mutation order) after the mutex is
+	// released. That the chain is registered but not yet drained here is the
+	// deadlock-avoidance property: publication is deferred past the lock.
+	require.Empty(
+		t,
+		pubs.events,
+		"chain.update must not be requeued on the generic pending queue; it "+
+			"lives on the chain's shared sequencer",
+	)
 	require.Equal(
 		t,
-		event.EventType(chain.ChainUpdateEventType),
-		pubs.events[0].evt.Type,
+		[]*chain.Chain{c},
+		pubs.chainDrains,
+		"the drain must register the chain so its sequencer is flushed after "+
+			"the mutex is released",
 	)
 	// The block really was added to the chain (the drain did its job, it just
 	// did not publish).

--- a/ledger/blockfetch_drain_deadlock_test.go
+++ b/ledger/blockfetch_drain_deadlock_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+	testfixtures "github.com/blinklabs-io/dingo/internal/test/fixtures"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newChainUpdateEvent builds a throwaway chain.update event for saturating the
+// bus in the deadlock regression below.
+func newChainUpdateEvent() event.Event {
+	return event.NewEvent(chain.ChainUpdateEventType, chain.ChainBlockEvent{})
+}
+
+// TestBlockfetchDrainDefersChainUpdatePastLedgerMutex is the regression guard
+// for the chainsync/blockfetch drain deadlock (blinklabs-io/dingo preview
+// freeze), rewritten to exercise the lane-saturation path the six-block test
+// could not reach.
+//
+// The ledger drains fetched blocks via flushPendingBlockfetchBlocks while
+// holding chainsyncBlockfetchMutex. If that drain publishes chain.update
+// inline, a terminal chain.update subscriber that stops draining stalls the
+// publish WITH the mutex held; handleEventChainsync then blocks acquiring the
+// same mutex, the ledger.chainsync buffer fills, and the node deadlocks.
+//
+// This test puts the bus into the exact state that traps BOTH previously
+// attempted inline publishers:
+//
+//   - a lossless chain.update subscriber whose one buffer slot is filled and
+//     never drained, so a synchronous Publish (the original code) blocks; and
+//   - the ordered chain.update lane filled to capacity, so a PublishOrdered
+//     (the rejected under-lock fix) also blocks -- this is the saturation the
+//     maintainer flagged, which a handful of blocks never reaches.
+//
+// With the bus in that state the drain must still return promptly, because the
+// fix hands each block's chain.update back to the ledger's pendingPublishes to
+// publish AFTER the mutex is released rather than publishing it inline. Both
+// older approaches would block here and fail the timeout.
+func TestBlockfetchDrainDefersChainUpdatePastLedgerMutex(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	// Stop releases the goroutines parked on the stalled subscriber / full
+	// lane at the end of the test.
+	t.Cleanup(eventBus.Stop)
+
+	// Terminal chain.update subscriber, buffer 1, deliberately never drained.
+	// Lossless (SubscriberBackpressureBlock) means a full buffer blocks the
+	// publisher forever rather than dropping -- the stalled-subscriber
+	// condition behind the freeze.
+	subId, ch := eventBus.SubscribeWithBufferPolicy(
+		chain.ChainUpdateEventType,
+		1,
+		event.SubscriberBackpressureBlock,
+	)
+	require.NotZero(t, subId)
+	require.NotNil(t, ch)
+
+	// Fill the subscriber's single buffer slot so any further synchronous
+	// Publish blocks. Confirm the stall is real: a second inline Publish must
+	// not complete.
+	eventBus.Publish(chain.ChainUpdateEventType, newChainUpdateEvent())
+	directBlocked := make(chan struct{})
+	go func() {
+		eventBus.Publish(chain.ChainUpdateEventType, newChainUpdateEvent())
+		close(directBlocked)
+	}()
+	select {
+	case <-directBlocked:
+		t.Fatal(
+			"inline Publish did not block on the stalled subscriber; " +
+				"the test cannot exercise the deadlock condition",
+		)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Saturate the ordered chain.update lane to capacity. The lane worker
+	// parks on the stalled subscriber, so every enqueued event stays in the
+	// lane; once it is full a PublishOrdered blocks too.
+	go func() {
+		for range event.OrderedQueueSize + 8 {
+			eventBus.PublishOrdered(
+				chain.ChainUpdateEventType,
+				newChainUpdateEvent(),
+			)
+		}
+	}()
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			50*time.Millisecond,
+		)
+		defer cancel()
+		// A bounded publish that cannot enqueue reports false: the lane is
+		// full.
+		return !eventBus.PublishOrderedContext(
+			ctx,
+			chain.ChainUpdateEventType,
+			newChainUpdateEvent(),
+		)
+	}, 10*time.Second, 20*time.Millisecond,
+		"ordered chain.update lane never reached capacity",
+	)
+
+	// Real primary chain wired to the saturated bus, plus a minimal ledger
+	// state -- enough for the blockfetch drain path.
+	cm, err := chain.NewManager(nil, eventBus)
+	require.NoError(t, err)
+	c := cm.PrimaryChain()
+	require.NotNil(t, c)
+
+	ls := &LedgerState{
+		chain: c,
+		config: LedgerStateConfig{
+			Logger:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EventBus: eventBus,
+		},
+	}
+
+	blocks, err := testfixtures.GenerateConwayChain(1)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	ls.pendingBlockfetchEvents = []BlockfetchEvent{
+		{
+			Block: blocks[0],
+			Point: ocommon.Point{
+				Slot: blocks[0].SlotNumber(),
+				Hash: blocks[0].Hash().Bytes(),
+			},
+		},
+	}
+
+	// THE FIX. flushPendingBlockfetchBlocksDeferred runs on the mutex-holding
+	// drain path. It must add the block and return promptly, queueing the
+	// chain.update on pubs instead of publishing it into the saturated bus.
+	// Under the original synchronous Publish, or the rejected under-lock
+	// PublishOrdered, this call would block forever on the stalled subscriber
+	// / full lane and the timeout below would fire.
+	var pubs pendingPublishes
+	drained := make(chan error, 1)
+	go func() { drained <- ls.flushPendingBlockfetchBlocksDeferred(&pubs) }()
+	select {
+	case drainErr := <-drained:
+		require.NoError(t, drainErr)
+	case <-time.After(10 * time.Second):
+		t.Fatal(
+			"flushPendingBlockfetchBlocks blocked under a saturated " +
+				"chain.update lane: the block's chain.update must be deferred " +
+				"past chainsyncBlockfetchMutex, not published inline",
+		)
+	}
+
+	// The chain.update was deferred onto the caller's queue, not published:
+	// nothing reached the saturated bus under the lock.
+	require.Len(t, pubs.events, 1)
+	require.Equal(
+		t,
+		event.EventType(chain.ChainUpdateEventType),
+		pubs.events[0].evt.Type,
+	)
+	// The block really was added to the chain (the drain did its job, it just
+	// did not publish).
+	require.Equal(t, blocks[0].SlotNumber(), c.Tip().Point.Slot)
+}

--- a/ledger/byron_shelley_boundary_test.go
+++ b/ledger/byron_shelley_boundary_test.go
@@ -573,7 +573,7 @@ func TestRollbackChainAndStateClearsShelleyPParamsInsideByronPrefix(
 		lastByron.SlotNumber(),
 		lastByron.Hash().Bytes(),
 	)
-	require.NoError(t, ls.rollbackChainAndState(byronPoint))
+	require.NoError(t, ls.rollbackChainAndStateDeferred(byronPoint, nil))
 
 	assert.Equal(t, byronPoint, ls.currentTip.Point)
 	assert.Equal(t, eras.ByronEraDesc.Id, ls.currentEra.Id)

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -528,7 +528,7 @@ func (ls *LedgerState) handleEventBlockfetch(evt event.Event) {
 			)
 		}
 	} else if e.Block != nil {
-		if err := ls.handleEventBlockfetchBlock(e); err != nil {
+		if err := ls.handleEventBlockfetchBlockDeferred(e, &pending); err != nil {
 			if strings.Contains(
 				err.Error(),
 				"block header crypto verification failed",
@@ -1998,7 +1998,7 @@ func (ls *LedgerState) handleEventChainsyncRollback(
 			),
 		)
 	}
-	if err := ls.rollbackChainAndState(e.Point); err != nil {
+	if err := ls.rollbackChainAndStateDeferred(e.Point, pending); err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			// Missing rollback point can happen when local state and peer
 			// chainsync cursor drift. Recover by forcing re-intersect.
@@ -3472,7 +3472,7 @@ func (ls *LedgerState) tryResolveFork(
 		"connection_id", e.ConnectionId.String(),
 	)
 
-	if err := ls.rollbackChainAndState(rollbackPoint); err != nil {
+	if err := ls.rollbackChainAndStateDeferred(rollbackPoint, pending); err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			// The ancestor resolved but the chain no longer holds it at that
 			// index, so rolling back would splice a continuation onto a parent
@@ -3618,8 +3618,15 @@ func (ls *LedgerState) tryResolveFork(
 	return true, nil
 }
 
-//nolint:unparam
-func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
+// handleEventBlockfetchBlockDeferred is handleEventBlockfetchBlock that threads
+// the caller's pendingPublishes queue into flushPendingBlockfetchBlocksDeferred,
+// so chain.update events emitted while chainsyncBlockfetchMutex is held are
+// published only after it is released. A nil pubs preserves the standalone
+// immediate-publish behaviour for test callers.
+func (ls *LedgerState) handleEventBlockfetchBlockDeferred(
+	e BlockfetchEvent,
+	pubs *pendingPublishes,
+) error {
 	// Process blocks in small commit batches so they appear on the
 	// chain promptly without paying a full blob transaction cost for
 	// every single block. We still flush well before BatchDone to
@@ -3669,7 +3676,7 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 		)
 		if !headerAlreadyVerified &&
 			!ls.hasCachedEpochNonceForSlot(e.Point.Slot) {
-			if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+			if err := ls.flushPendingBlockfetchBlocksDeferred(pubs); err != nil {
 				return err
 			}
 			headerAlreadyVerified = ls.chain.FirstVerifiedHeaderMatchesPoint(
@@ -3717,7 +3724,7 @@ func (ls *LedgerState) handleEventBlockfetchBlock(e BlockfetchEvent) error {
 	// range is fetchable after all and its failure record is stale.
 	ls.noteBlockfetchRangeProgress(e.Point)
 	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {
-		if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ls.flushPendingBlockfetchBlocksDeferred(pubs); err != nil {
 			return err
 		}
 	}
@@ -3768,7 +3775,7 @@ func (ls *LedgerState) restartQueuedBlockfetchAfterForkLocked(
 			ls.chainsyncBlockfetchReadyChan = nil
 		}
 		ls.chainsyncBlockfetchReadyMutex.Unlock()
-		if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+		if err := ls.flushPendingBlockfetchBlocksDeferred(pending); err != nil {
 			ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 			ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 			return fmt.Errorf(
@@ -4317,7 +4324,19 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 	}()
 }
 
-func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
+// flushPendingBlockfetchBlocksDeferred is flushPendingBlockfetchBlocks that
+// queues each committed block's chain.update onto pubs instead of letting the
+// chain publish it inline. The blockfetch drain runs under
+// chainsyncBlockfetchMutex; an inline, back-pressured chain.update publish
+// there can park the drain with the mutex held, which then blocks
+// handleEventChainsync on the same mutex and fills the ledger.chainsync buffer
+// -- the preview drain deadlock. Queueing on the caller's pendingPublishes
+// moves publication to after the mutex is released. A nil pubs publishes
+// immediately (the unlocked / test path), per pendingPublishes' nil-receiver
+// contract.
+func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
+	pubs *pendingPublishes,
+) error {
 	if len(ls.pendingBlockfetchEvents) == 0 {
 		return nil
 	}
@@ -4328,12 +4347,18 @@ func (ls *LedgerState) flushPendingBlockfetchBlocks() error {
 	// already-advanced in-memory tip can strand the node on a fork when ancestor
 	// lookups hit uncommitted state.
 	for _, pendingEvent := range pending {
-		addBlockErr := ls.chain.AddBlockWithPoint(
+		evt, addBlockErr := ls.chain.AddBlockWithPointDeferred(
 			pendingEvent.Block,
 			pendingEvent.Point,
 			nil,
 		)
 		if addBlockErr == nil {
+			// Defer this block's chain.update past chainsyncBlockfetchMutex
+			// rather than publishing inline. See
+			// flushPendingBlockfetchBlocksDeferred and pendingPublishes.
+			if evt.Type != "" {
+				pubs.add(ls.config.EventBus, evt.Type, evt)
+			}
 			// Audit only after the body has extended the queued chain. A body
 			// from an abandoned fetch may still be delivered after a fork
 			// restart; auditing it here would poison producedTxs with stale
@@ -6353,7 +6378,7 @@ func (ls *LedgerState) handleEventBlockfetchBatchDone(
 	}
 	ls.chainsyncBlockfetchTimerGeneration++
 	receivedBlockCount := ls.batchBlocksReceived
-	if err := ls.flushPendingBlockfetchBlocks(); err != nil {
+	if err := ls.flushPendingBlockfetchBlocksDeferred(pending); err != nil {
 		ls.blockfetchRequestRangeCleanup()
 		ls.activeBlockfetchConnId = ouroboros.ConnectionId{}
 		return err

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2179,9 +2179,9 @@ func (ls *LedgerState) handleEventChainsyncRollback(
 	return nil
 }
 
-// rollbackIsAppliable reports whether rollbackChainAndState(point) would
+// rollbackIsAppliable reports whether rollbackChainAndStateDeferred(point) would
 // succeed right now, without mutating any state. It mirrors the pre-checks
-// rollbackChainAndState relies on for its block-not-found / exceeds-K /
+// rollbackChainAndStateDeferred relies on for its block-not-found / exceeds-K /
 // exceeds-Mithril failures: the point must sit at or above the Mithril trust
 // anchor, and the chain must be able to roll back to it (target block present
 // and within the security parameter K, verified via chain.ValidateRollback).
@@ -4354,10 +4354,15 @@ func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
 		)
 		if addBlockErr == nil {
 			// Defer this block's chain.update past chainsyncBlockfetchMutex
-			// rather than publishing inline. See
-			// flushPendingBlockfetchBlocksDeferred and pendingPublishes.
+			// rather than publishing inline. AddBlockWithPointDeferred has
+			// already enqueued evt on the chain's shared sequencer under
+			// c.mutex (so it is ordered against a concurrent rollback in true
+			// mutation order); register the chain so the caller drains that
+			// sequencer once the mutex is released. See
+			// flushPendingBlockfetchBlocksDeferred, pendingPublishes and
+			// chain.Chain.PublishPendingChainUpdates.
 			if evt.Type != "" {
-				pubs.add(ls.config.EventBus, evt.Type, evt)
+				pubs.drainChain(ls.chain)
 			}
 			// Audit only after the body has extended the queued chain. A body
 			// from an abandoned fetch may still be delivered after a fork

--- a/ledger/chainsync_pinned_tip_test.go
+++ b/ledger/chainsync_pinned_tip_test.go
@@ -31,7 +31,7 @@ import (
 // header tip sits ahead of the block tip. If the peer then sends a
 // RollBackward to the block tip, the no-op shortcut in
 // handleEventChainsyncRollback compares the rollback point against
-// HeaderTip and falls through to rollbackChainAndState, which calls
+// HeaderTip and falls through to rollbackChainAndStateDeferred, which calls
 // ls.rollback and publishes a spurious "local ledger rollback" event
 // even though the ledger never advanced past the block tip in the
 // first place. That event drives RecoverAfterLocalRollback every cycle,

--- a/ledger/chainsync_pipeline_validate_admission_test.go
+++ b/ledger/chainsync_pipeline_validate_admission_test.go
@@ -97,7 +97,7 @@ func TestHandleEventBlockfetchBlockKeepsAdmissionCryptoWhenPipelineValidates(
 
 	// Without a validating pipeline, the tampered VRF proof is caught
 	// directly here as a genuine (non-deferred) crypto failure.
-	err := ls.handleEventBlockfetchBlock(evt)
+	err := ls.handleEventBlockfetchBlockDeferred(evt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "crypto verification failed")
 	assert.Empty(t, ls.pendingBlockfetchEvents)
@@ -110,7 +110,7 @@ func TestHandleEventBlockfetchBlockKeepsAdmissionCryptoWhenPipelineValidates(
 	ls.blockPipeline = pipeline.NewBlockPipeline()
 	ls.config.BlockPipelineValidateEnabled = true
 
-	err = ls.handleEventBlockfetchBlock(evt)
+	err = ls.handleEventBlockfetchBlockDeferred(evt, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "crypto verification failed")
 	assert.Empty(t, ls.pendingBlockfetchEvents)
@@ -134,14 +134,14 @@ func TestHandleEventBlockfetchBlockRejectsInvalidOpCertWhenPipelineValidates(
 	ls.config.BlockPipelineValidateEnabled = true
 	ls.publishSnapshotsLocked()
 
-	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	err := ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: connId,
 		Block:        tb.block,
 		Point: ocommon.Point{
 			Slot: tb.block.SlotNumber(),
 			Hash: tb.block.Hash().Bytes(),
 		},
-	})
+	}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "opcert cold-key signature invalid")
 	assert.Empty(t, ls.pendingBlockfetchEvents)

--- a/ledger/chainsync_recycle_test.go
+++ b/ledger/chainsync_recycle_test.go
@@ -344,11 +344,11 @@ func TestBlockfetchStatefulHeaderVerificationDefersUntilLedgerApply(
 	ls.chain = &chain.Chain{}
 
 	point := ocommon.NewPoint(tb.block.SlotNumber(), tb.block.Hash().Bytes())
-	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	err := ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: connId,
 		Block:        tb.block,
 		Point:        point,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, ls.pendingBlockfetchEvents, 1)
 	assert.True(t, ls.consumeDeferredHeaderValidation(point))

--- a/ledger/chainsync_resync_deferred_publish_test.go
+++ b/ledger/chainsync_resync_deferred_publish_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// These two tests close the gap the converted rollback tests left open: they
+// all pass a nil *pendingPublishes, which takes pendingPublishes.add's
+// immediate-publish branch, so none of them can tell a deferred publish from
+// an inline one. Reverting requestChainsyncResync's pending.add(...) back to a
+// direct ls.config.EventBus.Publish(...) leaves the whole ledger suite green
+// because nothing exercises the deferred path with a real queue and a real
+// subscriber that needs the held mutex.
+//
+// Each test below hands requestChainsyncResync a NON-nil queue while holding a
+// guarded mutex, with a ChainsyncResyncEventType subscriber that reaches for
+// that same mutex from its handler — exactly the cycle pendingPublishes.go
+// documents (the real subscriber is RecoverAfterLocalRollback, which takes
+// chainsyncMutex and nests chainsyncBlockfetchMutex under it). With the fix the
+// event is queued and only published after the unlock, so it completes. Revert
+// the publish to inline and it parks forever: the subscriber buffer is full and
+// its only reader is the handler waiting for the mutex the publisher still
+// holds. The 5s guard turns that hang into a failure instead of wedging the
+// whole test binary.
+
+// runResyncDeferredPublishScenario drives requestChainsyncResync under the
+// mutex selected by lock/unlock, with a resync subscriber whose handler takes
+// that same mutex. It fails if the publish happens inline (deadlock) rather
+// than being deferred until after the unlock.
+func runResyncDeferredPublishScenario(
+	t *testing.T,
+	mu *sync.Mutex,
+	mutexName string,
+) {
+	t.Helper()
+
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Stop()
+
+	ls := &LedgerState{
+		config: LedgerStateConfig{EventBus: bus},
+	}
+
+	// entered is signalled from inside the handler, before it blocks on the
+	// mutex. Receiving from it proves the dispatch goroutine has pulled an
+	// event off the channel and is now committed to a handler call — so it
+	// will not read another event until that handler returns, which it cannot
+	// until the publisher releases the mutex.
+	entered := make(chan struct{}, 4)
+	// SubscriberBackpressureBlock models a lossless subscriber (the production
+	// resync subscriber is one): a full buffer parks the publisher forever
+	// rather than detaching after a timeout, which is what makes an inline
+	// publish a true deadlock instead of an eventually-dropped event. Buffer 1
+	// is the smallest that lets one priming event occupy the reader while a
+	// second fills the channel, so the next publish has nowhere to go.
+	bus.SubscribeFuncWithBufferPolicy(
+		event.ChainsyncResyncEventType,
+		1,
+		event.SubscriberBackpressureBlock,
+		func(event.Event) {
+			entered <- struct{}{}
+			mu.Lock()
+			mu.Unlock()
+		},
+	)
+
+	connId := testChainsyncConnId(6000, 7000)
+	primer := func() event.Event {
+		return event.NewEvent(
+			event.ChainsyncResyncEventType,
+			event.ChainsyncResyncEvent{ConnectionId: connId},
+		)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mu.Lock()
+		// First primer: consumed by the dispatch goroutine, whose handler
+		// then parks on the mutex we hold. Waiting on entered guarantees it
+		// has left the channel before the buffer is filled below.
+		bus.Publish(event.ChainsyncResyncEventType, primer())
+		<-entered
+		// Second primer: fills the now-empty single buffer slot. The reader
+		// is still parked in the first handler, so this event just sits there
+		// and the subscriber has no free capacity left.
+		bus.Publish(event.ChainsyncResyncEventType, primer())
+		// With the fix this queues onto pending and returns immediately.
+		// Reverted to an inline ls.config.EventBus.Publish it blocks here: the
+		// buffer is full and its only reader is the parked handler.
+		var pending pendingPublishes
+		ls.requestChainsyncResync(connId, "test resync", &pending)
+		mu.Unlock()
+		// Only reached once the publish did NOT happen under the lock.
+		pending.flush()
+	}()
+
+	select {
+	case <-done:
+		// Deferred: the queued event was published after the unlock, the
+		// handler took the mutex, and everything drained.
+	case <-time.After(5 * time.Second):
+		t.Fatalf(
+			"requestChainsyncResync published ChainsyncResyncEventType inline"+
+				" while holding %s: the publish parked on a full subscriber"+
+				" buffer whose handler was waiting for that same mutex"+
+				" (deadlock). Queue it with pendingPublishes and flush after"+
+				" the unlock — see pending_publish.go.",
+			mutexName,
+		)
+	}
+}
+
+// TestRequestChainsyncResyncDefersPublishUnderChainsyncMutex fails (hangs to
+// the 5s guard) if requestChainsyncResync publishes inline while chainsyncMutex
+// is held, and passes when the publish is deferred through pendingPublishes.
+func TestRequestChainsyncResyncDefersPublishUnderChainsyncMutex(t *testing.T) {
+	ls := &LedgerState{}
+	runResyncDeferredPublishScenario(t, &ls.chainsyncMutex, "chainsyncMutex")
+}
+
+// TestRequestChainsyncResyncDefersPublishUnderChainsyncBlockfetchMutex is the
+// same guard for the blockfetch lock: the resync subscriber nests
+// chainsyncBlockfetchMutex under chainsyncMutex, so holding the blockfetch lock
+// alone across an inline publish deadlocks the same way.
+func TestRequestChainsyncResyncDefersPublishUnderChainsyncBlockfetchMutex(
+	t *testing.T,
+) {
+	ls := &LedgerState{}
+	runResyncDeferredPublishScenario(
+		t, &ls.chainsyncBlockfetchMutex, "chainsyncBlockfetchMutex",
+	)
+}

--- a/ledger/chainsync_shadow_test.go
+++ b/ledger/chainsync_shadow_test.go
@@ -233,11 +233,11 @@ func TestStartQueuedBlockfetchAfterForkRestartClearsShadowState(t *testing.T) {
 
 	// A block delivered on the previous shadow connection must be rejected
 	// because it is no longer the shadow for the active batch.
-	require.NoError(t, ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	require.NoError(t, ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: staleShadow,
 		Block:        &mockBabbageBlock{slot: 99},
 		Point:        ocommon.Point{Slot: 99, Hash: []byte("stale-shadow")},
-	}))
+	}, nil))
 	require.Empty(
 		t,
 		ls.pendingBlockfetchEvents,

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -454,11 +454,11 @@ func TestHandleEventBlockfetchBlockAllowsBlocksFromActiveBatch(t *testing.T) {
 		},
 	}
 
-	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	err := ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: connId1,
 		Block:        &mockBabbageBlock{slot: 2},
 		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, ls.pendingBlockfetchEvents, 1)
 	assert.Equal(t, connId1, ls.pendingBlockfetchEvents[0].ConnectionId)
@@ -545,11 +545,11 @@ func TestHandleEventBlockfetchBlockAllowsEquivalentConnectionId(t *testing.T) {
 		},
 	}
 
-	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	err := ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: connId1Dup,
 		Block:        &mockBabbageBlock{slot: 2},
 		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, ls.pendingBlockfetchEvents, 1)
 	assert.True(
@@ -587,11 +587,11 @@ func TestHandleEventBlockfetchBlockDropsBlocksFromStaleConnection(
 		},
 	}
 
-	err := ls.handleEventBlockfetchBlock(BlockfetchEvent{
+	err := ls.handleEventBlockfetchBlockDeferred(BlockfetchEvent{
 		ConnectionId: connId1,
 		Block:        &mockBabbageBlock{slot: 2},
 		Point:        ocommon.Point{Slot: 2, Hash: []byte("block-2")},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Empty(t, ls.pendingBlockfetchEvents)
 }

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -30,7 +30,7 @@ import (
 //
 // Cost and gating. A full per-input producer probe on every fetched body would
 // add a database round trip per input to the steady-state blockfetch path, so
-// the audit is armed only by a local rollback (rollbackChainAndState and the
+// the audit is armed only by a local rollback (rollbackChainAndStateDeferred and the
 // replay-recovery rewind) and then runs for a bounded number of blocks. That is
 // exactly the fork-churn / recovery regime where the splice appears.
 //

--- a/ledger/crossfork_splice_test.go
+++ b/ledger/crossfork_splice_test.go
@@ -284,7 +284,7 @@ func TestRollbackAheadOfLedgerDoesNotArmContinuationAudit(t *testing.T) {
 	ls.Unlock()
 	require.NoError(t, ls.db.SetTip(fixture.ancestorTip, nil))
 
-	require.NoError(t, ls.rollbackChainAndState(fixture.currentTip.Point))
+	require.NoError(t, ls.rollbackChainAndStateDeferred(fixture.currentTip.Point, nil))
 
 	assert.Nil(
 		t,
@@ -421,7 +421,7 @@ func TestContinuationAuditIgnoresAbandonedFetchedBodies(t *testing.T) {
 		Point:        ocommon.NewPoint(stale.slot, stale.hash.Bytes()),
 	}}
 
-	require.NoError(t, ls.flushPendingBlockfetchBlocks())
+	require.NoError(t, ls.flushPendingBlockfetchBlocksDeferred(nil))
 	window := ls.continuationAudit.Load()
 	require.NotNil(t, window)
 	assert.Equal(t, 0, window.blocksSeen)

--- a/ledger/pending_publish.go
+++ b/ledger/pending_publish.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
 )
 
@@ -58,6 +59,15 @@ import (
 // preserved.
 type pendingPublishes struct {
 	events []pendingPublish
+	// chainDrains holds chains whose chain-level sequencer must be drained
+	// after this queue flushes. The mutex-holding paths that add a block or
+	// roll back the chain no longer hand their chain.update event back for
+	// requeueing here; the chain enqueues it on its own shared sequencer under
+	// c.mutex (so publication order matches chain-mutation order across every
+	// handler), and the caller registers the chain here so flush() drains that
+	// sequencer once the outer ledger mutex is released. See
+	// chain.Chain.PublishPendingChainUpdates and drainChain.
+	chainDrains []*chain.Chain
 }
 
 type pendingPublish struct {
@@ -93,10 +103,41 @@ func (p *pendingPublishes) add(
 	})
 }
 
-// flush publishes everything queued, in the order it was added.
+// drainChain registers a chain whose deferred chain.update / chain.fork events
+// must be published once the caller's outer mutex is released. Registration is
+// idempotent per chain: the block-add drain enqueues several blocks' events but
+// only needs one drain.
+//
+// A nil receiver drains immediately, matching add's nil-receiver contract: the
+// unlocked / test path holds no deadlock-prone mutex, so publishing inline is
+// safe. A nil chain is ignored.
+func (p *pendingPublishes) drainChain(c *chain.Chain) {
+	if c == nil {
+		return
+	}
+	if p == nil {
+		c.PublishPendingChainUpdates()
+		return
+	}
+	for _, existing := range p.chainDrains {
+		if existing == c {
+			return
+		}
+	}
+	p.chainDrains = append(p.chainDrains, c)
+}
+
+// flush publishes everything queued, in the order it was added, then drains any
+// registered chain sequencers. The chain drains run last and only after every
+// directly-queued event has been published; each publishes its own events FIFO
+// in chain-mutation order (see chain.Chain.PublishPendingChainUpdates).
 func (p *pendingPublishes) flush() {
 	for _, pub := range p.events {
 		pub.bus.Publish(pub.eventType, pub.evt)
 	}
 	p.events = nil
+	for _, c := range p.chainDrains {
+		c.PublishPendingChainUpdates()
+	}
+	p.chainDrains = nil
 }

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -147,7 +147,7 @@ func callGraphInlineChainPublishers(files []*ast.File) map[string]bool {
 // knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
 // must always pass its pending queue; a nil queue would publish inline.
 //
-// The ledger.tx undo emit reached from rollbackChainAndState is covered by
+// The ledger.tx undo emit reached from rollbackChainAndStateDeferred is covered by
 // neither test, and deliberately so. This scan is intra-procedural and that
 // path holds the lock and the publish in different functions, so it does not
 // match here; TestChainsyncResyncPublishPathsUnderLock does not match it

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -42,6 +42,28 @@ var guardedMutexes = []string{
 	"chainsyncBlockfetchMutex",
 }
 
+// inlinePublishingChainMethods are the exported chain.Chain methods that
+// publish to the EventBus inline (chain/chain.go): the Add* paths emit
+// ChainUpdateEventType and Rollback emits the rollback/fork events. Calling
+// one of these as ls.chain.<method> while holding a guarded mutex is the same
+// deadlock as publishing directly -- the event's subscriber can need the
+// mutex -- so this scan treats an ls.chain.<method> call as a publish.
+//
+// AddBlockWithPoint is on the list even though no lock holder calls it today
+// (its one production caller, flushPendingBlockfetchBlocks, runs unlocked):
+// it still publishes inline, so guarding it now stops a future lock holder
+// from silently reopening the cycle. Keep this in sync with the
+// c.eventBus.Publish call sites in chain/chain.go.
+var inlinePublishingChainMethods = []string{
+	"AddBlock",
+	"AddLocalBlock",
+	"AddBlockWithPoint",
+	"AddBlocks",
+	"AddRawBlocks",
+	"AddRawBlocksWithCallback",
+	"Rollback",
+}
+
 // knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
 // must always pass its pending queue; a nil queue would publish inline.
 //
@@ -293,6 +315,27 @@ func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 			// included for the same reason against their per-event-type
 			// lane.
 			if inner.Sel.Name != "EventBus" {
+				return true
+			}
+			events = append(events, lockEvent{
+				pos: call.Pos(), kind: "publish",
+			})
+		default:
+			// A publish reached indirectly through the chain layer is just as
+			// unsafe as a direct EventBus.Publish. ls.chain.AddBlockWithPoint
+			// and its siblings call c.eventBus.Publish inline from inside the
+			// chain package (see inlinePublishingChainMethods), so holding a
+			// guarded mutex across one closes the same cycle -- a subscriber
+			// to ChainUpdateEventType or the rollback events that needs the
+			// mutex parks, the buffer fills, the publisher never returns. The
+			// direct-EventBus scan above cannot see these because the receiver
+			// is ls.chain, not ...EventBus. Match only ls.chain.* so an
+			// unrelated type's same-named method (a db txn's Rollback, say) is
+			// left alone.
+			if inner.Sel.Name != "chain" ||
+				!slices.Contains(
+					inlinePublishingChainMethods, sel.Sel.Name,
+				) {
 				return true
 			}
 			events = append(events, lockEvent{

--- a/ledger/publish_under_lock_test.go
+++ b/ledger/publish_under_lock_test.go
@@ -64,6 +64,86 @@ var inlinePublishingChainMethods = []string{
 	"Rollback",
 }
 
+// callGraphInlineChainPublishers returns the set of functions that reach an
+// inline-publishing chain method (inlinePublishingChainMethods) either by
+// calling it directly as ls.chain.<method> or through any chain of ls.<helper>
+// calls. It is the transitive closure the intra-procedural ls.chain.<method>
+// guard in violations cannot see on its own: a lock holder that reaches
+// ls.chain.Rollback through a helper -- rollbackPrimaryChainInSecurityParamWindows
+// in replay_recovery.go, say -- is just as deadlock-prone as one that calls it
+// directly, since the helper runs inside the caller's held lock.
+//
+// It mirrors the ChainsyncResyncEventType closure in
+// TestChainsyncResyncPublishPathsUnderLock, but ranges over the whole package
+// rather than chainsync.go alone, because the chain-method publishers and the
+// recovery helpers that reach them are spread across several files. The call
+// graph follows ls.<method> receivers only, matching the rest of this file;
+// a publish reached through a stored func value or a non-ls receiver is
+// outside its fidelity, exactly as it is for the resync scan.
+func callGraphInlineChainPublishers(files []*ast.File) map[string]bool {
+	directPublisher := map[string]bool{}
+	callees := map[string]map[string]bool{}
+	var order []string
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			name := fn.Name.Name
+			if _, seen := callees[name]; !seen {
+				order = append(order, name)
+				callees[name] = map[string]bool{}
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				// ls.chain.<inlineMethod>(...): a direct inline publish.
+				if inner, ok := sel.X.(*ast.SelectorExpr); ok {
+					if id, ok := inner.X.(*ast.Ident); ok &&
+						id.Name == "ls" && inner.Sel.Name == "chain" &&
+						slices.Contains(
+							inlinePublishingChainMethods, sel.Sel.Name,
+						) {
+						directPublisher[name] = true
+					}
+				}
+				// ls.<method>(...): an intra-package call edge.
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == "ls" {
+					callees[name][sel.Sel.Name] = true
+				}
+				return true
+			})
+		}
+	}
+
+	reaches := map[string]bool{}
+	for name := range directPublisher {
+		reaches[name] = true
+	}
+	// Fixed point: |order| passes suffice, one edge relaxed per pass.
+	for range order {
+		for name, cs := range callees {
+			if reaches[name] {
+				continue
+			}
+			for c := range cs {
+				if reaches[c] {
+					reaches[name] = true
+					break
+				}
+			}
+		}
+	}
+	return reaches
+}
+
 // knownNilQueuePublishersUnderLock is intentionally empty. A guarded caller
 // must always pass its pending queue; a nil queue would publish inline.
 //
@@ -106,10 +186,18 @@ var knownNilQueuePublishersUnderLock []string
 // Queue the event with pendingPublishes and flush it after the unlock
 // instead.
 //
-// The check is intra-procedural, which is not the whole story: a lock
-// holder can also reach a publish through a helper. Those paths are
-// enumerated by TestChainsyncResyncPublishPathsUnderLock rather than left
-// to be assumed safe.
+// The direct EventBus.Publish check is intra-procedural, which is not the
+// whole story: a lock holder can also reach such a publish through a helper.
+// Those paths are enumerated by TestChainsyncResyncPublishPathsUnderLock
+// rather than left to be assumed safe.
+//
+// The ls.chain.<method> check gets the same transitive treatment here, and
+// for the same reason: a lock holder that never names an inline-publishing
+// chain method itself but reaches one through a helper (e.g. ls.chain.Rollback
+// via rollbackPrimaryChainInSecurityParamWindows) is still holding the lock
+// across the publish. callGraphInlineChainPublishers computes that closure and
+// violations treats a call to any member as a publish, so source order still
+// decides whether the lock is actually held at the call site.
 func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -138,6 +226,11 @@ func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 		"no *pendingPublishes parameter found anywhere in the package;"+
 			" the nil-queue check would silently pass on everything")
 
+	transitivePublishers := callGraphInlineChainPublishers(files)
+	require.NotEmpty(t, transitivePublishers,
+		"no function reaches an inline-publishing chain method; the"+
+			" transitive ls.chain.<method> guard would pass on everything")
+
 	checked := 0
 	seenKnown := map[string]bool{}
 	for _, file := range files {
@@ -147,7 +240,7 @@ func TestNoEventBusPublishWhileHoldingChainsyncMutex(t *testing.T) {
 				return true
 			}
 			checked++
-			for _, v := range violations(fn, queueParam) {
+			for _, v := range violations(fn, queueParam, transitivePublishers) {
 				if slices.Contains(
 					knownNilQueuePublishersUnderLock, fn.Name.Name,
 				) {
@@ -255,7 +348,11 @@ type lockEvent struct {
 // release it around a specific region. A deferred unlock keeps the mutex
 // held to the end of the function, which is what makes a publish anywhere
 // after the Lock unsafe.
-func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
+func violations(
+	fn *ast.FuncDecl,
+	queueParam map[string]int,
+	transitivePublishers map[string]bool,
+) []violation {
 	deferred := map[token.Pos]bool{}
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		if d, ok := n.(*ast.DeferStmt); ok && d.Call != nil {
@@ -278,6 +375,24 @@ func violations(fn *ast.FuncDecl, queueParam map[string]int) []violation {
 		// is ls.method(...), whose receiver is a plain identifier, not a
 		// selector like ls.config.EventBus.
 		if nilQueueCall(call, sel, queueParam) {
+			events = append(events, lockEvent{
+				pos: call.Pos(), kind: "publish",
+			})
+			return true
+		}
+		// ls.<helper>(...) where the helper reaches an inline-publishing
+		// chain method directly or transitively (see
+		// callGraphInlineChainPublishers). This is the transitive extension of
+		// the ls.chain.<method> case below: a direct ls.chain.Rollback is
+		// caught there, a call that only reaches the publish through a helper
+		// is caught here. It is emitted at the call site, so the same source
+		// order tracking decides whether a guarded mutex is actually held --
+		// a helper call made before the Lock, like
+		// rejectRecoveryAtMithrilBoundary's rollback, is correctly not a
+		// violation. The receiver is a plain ls identifier, so this is
+		// checked before the ls.<x>.<y> assertion below, like nilQueueCall.
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == "ls" &&
+			transitivePublishers[sel.Sel.Name] {
 			events = append(events, lockEvent{
 				pos: call.Pos(), kind: "publish",
 			})

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -3155,9 +3155,20 @@ func (ls *LedgerState) drainBlockPipelineBeforeRollback(
 	)
 }
 
-// rollbackChainAndState rewinds the primary chain and then synchronizes the
-// metadata-backed ledger state to the same point.
-func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
+// rollbackChainAndStateDeferred is rollbackChainAndState that queues the
+// chain.update events produced by the primary-chain rewind onto pubs instead
+// of letting the chain publish them inline. This method is reached from
+// chainsync event handling (handleEventChainsyncRollback, tryResolveFork)
+// while chainsyncMutex is held; an inline, back-pressured chain.update publish
+// under that mutex is the drain deadlock (see pendingPublishes). Queueing on
+// the caller's pendingPublishes publishes after the mutex is released and,
+// because the caller threads one queue through the whole handler, keeps this
+// rollback's chain.update ahead of the block-add chain.update events that
+// follow it. A nil pubs publishes immediately (unlocked / test path).
+func (ls *LedgerState) rollbackChainAndStateDeferred(
+	point ocommon.Point,
+	pubs *pendingPublishes,
+) error {
 	ls.RLock()
 	mithrilLedgerSlot := ls.mithrilLedgerSlot
 	ls.RUnlock()
@@ -3212,16 +3223,29 @@ func (ls *LedgerState) rollbackChainAndState(point ocommon.Point) error {
 	// A database commit becomes visible before its AfterCommit callbacks run.
 	// Exclude that window so blocksAboveSlot can never publish an Undo for the
 	// new state before the matching Apply reaches the ordered lane.
+	var rollbackEvents []event.Event
 	err := func() error {
 		ls.transactionEventMutex.Lock()
 		defer ls.transactionEventMutex.Unlock()
 		if err := ls.validateAndEmitRollbackUndo(point); err != nil {
 			return err
 		}
-		return ls.chain.Rollback(point)
+		evts, rbErr := ls.chain.RollbackDeferred(point)
+		if rbErr != nil {
+			return rbErr
+		}
+		rollbackEvents = evts
+		return nil
 	}()
 	if err != nil {
 		return err
+	}
+	// Publish the rollback's chain.update after chainsyncMutex is released.
+	// Under the mutex an inline back-pressured publish deadlocks the drain;
+	// queueing on pubs (nil publishes immediately on the unlocked path) moves
+	// it past the unlock while preserving rollback-before-add ordering.
+	for _, evt := range rollbackEvents {
+		pubs.add(ls.config.EventBus, evt.Type, evt)
 	}
 	if err := ls.rollback(point); err != nil {
 		return fmt.Errorf("synchronize ledger rollback state: %w", err)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -985,7 +985,7 @@ type LedgerState struct {
 	// gather-then-submit sequence (collecting raw blocks via iter.Next(),
 	// then handing them to decodeReadChainBatch, which -- when blockPipeline
 	// is non-nil -- Submits every one of them and drains their Results()
-	// before returning) against rollbackChainAndState's out-of-band
+	// before returning) against rollbackChainAndStateDeferred's out-of-band
 	// rollback path.
 	//
 	// drainBlockPipelineBeforeRollback alone is not enough for that path:
@@ -996,13 +996,13 @@ type LedgerState struct {
 	// WaitForDrain observes an empty pipeline and returns immediately, and
 	// the reader can then Submit and apply those raw blocks, from the very
 	// fork chain-selection just decided to abandon, after the rollback
-	// already believed it was safe to proceed. rollbackChainAndState
+	// already believed it was safe to proceed. rollbackChainAndStateDeferred
 	// (reached from chainsync per-connection handling, never from
 	// ledgerProcessBlocks) has no other way to learn the reader is
 	// mid-gather.
 	//
 	// The reader holds the read lock for exactly the gather-plus-submit
-	// span (see ledgerReadChainIterator); rollbackChainAndState holds the
+	// span (see ledgerReadChainIterator); rollbackChainAndStateDeferred holds the
 	// write lock from before it calls drainBlockPipelineBeforeRollback
 	// through ls.chain.Rollback, so no gather-then-submit cycle can start,
 	// and none already in flight can reach Submit, while a rollback is
@@ -1026,7 +1026,7 @@ type LedgerState struct {
 	// Undo publication, and primary-chain truncation. Without it, a rollback
 	// can observe a newly committed block before its AfterCommit callback has
 	// reached the ordered lane, publishing Undo before Apply. See
-	// submitBlockApplyDBTxn and rollbackChainAndState.
+	// submitBlockApplyDBTxn and rollbackChainAndStateDeferred.
 	transactionEventMutex sync.Mutex
 
 	// publishCtx is cancelled at the top of Close so a ledger.tx publish
@@ -1953,7 +1953,7 @@ var (
 	CloseBlockfetchDrainTimeout    = 10 * time.Second
 	// BlockPipelineRollbackDrainTimeout bounds how long an asynchronous
 	// rollback (chainsync fork resolution or a peer-reported rollback --
-	// see rollbackChainAndState) waits for ls.blockPipeline to drain
+	// see rollbackChainAndStateDeferred) waits for ls.blockPipeline to drain
 	// in-flight decode/validate work before proceeding. See
 	// drainBlockPipelineBeforeRollback's doc comment for what this
 	// protects against and, just as importantly, what it does not.
@@ -3075,7 +3075,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 //
 // Why this matters (issue #1894 phase 5): ledgerReadChainIterator -- the
 // pipeline's only submitter -- runs on its own goroutine, entirely
-// decoupled from the goroutine that decides a rollback. rollbackChainAndState
+// decoupled from the goroutine that decides a rollback. rollbackChainAndStateDeferred
 // in particular is reached from chainsync per-connection handling
 // (handleEventChainsyncRollback, tryResolveFork), never from
 // ledgerProcessBlocks itself. Chain-selection can decide to abandon a fork
@@ -3111,7 +3111,7 @@ func (ls *LedgerState) rollback(point ocommon.Point) error {
 // cancellable context (e.g. processChainIteratorRollback, driven by
 // ledgerProcessBlocksFromSource's attempt context) does not block a
 // shutdown or restart on the fixed timeout. Callers with no context of
-// their own (rollbackChainAndState, reached from chainsync event handling
+// their own (rollbackChainAndStateDeferred, reached from chainsync event handling
 // with no ctx threaded through) pass context.Background(), matching
 // decodeReadChainBatch's identical, already-established choice for the
 // same reason.
@@ -3155,16 +3155,18 @@ func (ls *LedgerState) drainBlockPipelineBeforeRollback(
 	)
 }
 
-// rollbackChainAndStateDeferred is rollbackChainAndState that queues the
-// chain.update events produced by the primary-chain rewind onto pubs instead
-// of letting the chain publish them inline. This method is reached from
-// chainsync event handling (handleEventChainsyncRollback, tryResolveFork)
-// while chainsyncMutex is held; an inline, back-pressured chain.update publish
-// under that mutex is the drain deadlock (see pendingPublishes). Queueing on
-// the caller's pendingPublishes publishes after the mutex is released and,
-// because the caller threads one queue through the whole handler, keeps this
-// rollback's chain.update ahead of the block-add chain.update events that
-// follow it. A nil pubs publishes immediately (unlocked / test path).
+// rollbackChainAndStateDeferred rewinds the primary chain and ledger state,
+// deferring the chain.update events the rewind produces rather than letting the
+// chain publish them inline. This method is reached from chainsync event
+// handling (handleEventChainsyncRollback, tryResolveFork) while chainsyncMutex
+// is held; an inline, back-pressured chain.update publish under that mutex is
+// the drain deadlock (see pendingPublishes). RollbackDeferred enqueues those
+// events on the chain's shared sequencer under c.mutex, so they are ordered
+// against concurrent blockfetch adds in true chain-mutation order (the
+// rollback-before-add guarantee is now chain-wide, not merely within this
+// handler's queue); registering the chain on pubs.chainDrains drains that
+// sequencer after the mutex is released. A nil pubs drains immediately
+// (unlocked / test path).
 func (ls *LedgerState) rollbackChainAndStateDeferred(
 	point ocommon.Point,
 	pubs *pendingPublishes,
@@ -3241,11 +3243,16 @@ func (ls *LedgerState) rollbackChainAndStateDeferred(
 		return err
 	}
 	// Publish the rollback's chain.update after chainsyncMutex is released.
-	// Under the mutex an inline back-pressured publish deadlocks the drain;
-	// queueing on pubs (nil publishes immediately on the unlocked path) moves
-	// it past the unlock while preserving rollback-before-add ordering.
-	for _, evt := range rollbackEvents {
-		pubs.add(ls.config.EventBus, evt.Type, evt)
+	// Under the mutex an inline back-pressured publish deadlocks the drain.
+	// RollbackDeferred has already enqueued these events on the chain's shared
+	// sequencer under c.mutex, so they are ordered against concurrent
+	// blockfetch adds in true chain-mutation order (rollback-before-add is no
+	// longer merely a within-handler property); registering the chain drains
+	// that sequencer once the mutex is released (a nil pubs drains
+	// immediately on the unlocked path). See
+	// chain.Chain.PublishPendingChainUpdates.
+	if len(rollbackEvents) > 0 {
+		pubs.drainChain(ls.chain)
 	}
 	if err := ls.rollback(point); err != nil {
 		return fmt.Errorf("synchronize ledger rollback state: %w", err)
@@ -3319,7 +3326,7 @@ func (ls *LedgerState) rollbackChainAndStateDeferred(
 // its doc comment), so nothing from *this* attempt is still in flight
 // here. The call is kept anyway as a defensive invariant guard -- issue
 // #1894 phase 5's actual cross-goroutine race is closed in
-// rollbackChainAndState instead, which is reached from chainsync handling
+// rollbackChainAndStateDeferred instead, which is reached from chainsync handling
 // on a different goroutine and has no equivalent synchronous guarantee.
 func (ls *LedgerState) processChainIteratorRollback(
 	ctx context.Context,
@@ -6636,7 +6643,7 @@ func (ls *LedgerState) reconstructTransitionInfo() {
 		// Shelley block on chain is what establishes the real boundary.
 		//
 		// This is not redundant with the currentPParams == nil check below.
-		// rollbackChainAndState calls this immediately after setting
+		// rollbackChainAndStateDeferred calls this immediately after setting
 		// currentEra, and until ppComputed replaced the old nil test there a
 		// rollback into Byron left currentPParams holding its Shelley value
 		// under a Byron era -- exactly the shape this guard rejects. The guard

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -4952,7 +4952,7 @@ func TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing(t *testing.T) {
 // Byron guard as a backstop rather than a redundancy.
 //
 // It is not covered by the currentPParams == nil check that follows it. The
-// reachable shape is a rollback into Byron: rollbackChainAndState sets
+// reachable shape is a rollback into Byron: rollbackChainAndStateDeferred sets
 // currentEra to Byron and then calls this function, and before the ppComputed
 // change it skipped the currentPParams assignment whenever the recomputed
 // value was nil -- which is exactly what Byron computes. That left a Shelley


### PR DESCRIPTION
## What / why
A node syncing a busy chain can freeze with:

```
event delivery stalled: subscriber not draining  type=ledger.chainsync  buffer=100000  stalled_for=30s  blocked_publishers=15
```

The tip stops advancing while the host is ~68% idle (near-zero CPU/IO PSI) — a lock/back-pressure
deadlock, not a throughput limit.

### Root cause
`handleEventBlockfetch` holds `chainsyncBlockfetchMutex` and calls `chain.AddBlock` /
`AddBlockWithPoint` (via `flushPendingBlockfetchBlocks`), which publishes `ChainUpdateEventType`
through a **synchronous, back-pressured** `eventBus.Publish(...)` — *while still holding the mutex*.
If the terminal lane stops draining, that `Publish` parks holding `chainsyncBlockfetchMutex`;
`handleEventChainsync` then blocks acquiring the same mutex, stops draining the `ledger.chainsync`
queue, its 100000 buffer fills, and the ouroboros publishers park. Everything is on locks — hence
the idle host.

## Fix — defer the publication past the ledger mutex (not `PublishOrdered`)
The publish happens while the **ledger** holds its mutex, so only the ledger can move it out of the
lock. This PR uses the codebase's existing deferral mechanism, `ledger/pending_publish.go`'s
`pendingPublishes` (events collected under the lock, `Publish`ed from `flush()` which is `defer`red
*before* the lock so it runs *after* the unlock):

- `chain/chain.go` adds `AddBlockWithPointDeferred` / `RollbackDeferred` that **return** the
  chain-update event(s) instead of publishing them.
- `ledger/chainsync.go` / `ledger/state.go`: the blockfetch drain and rollback hand those events to
  the handler's `pendingPublishes` queue, which flushes them **after** `chainsyncMutex` /
  `chainsyncBlockfetchMutex` are released.
- The six standalone `chain.go` sites (forging, bulk import) keep plain `Publish` — they run on the
  scheduler goroutine, **not** under a ledger mutex, so a back-pressured publish there cannot cause
  the deadlock.

An earlier revision routed everything through `PublishOrdered`; that was **rejected** because the
ordered lane is itself bounded (10,000), so a stalled subscriber merely postpones the same deadlock
until the lane fills. Deferring past the mutex removes the hazard entirely: no back-pressured
publish ever runs while a ledger mutex is held. Per-type rollback-before-add ordering is preserved
because every chain-update — deferred or standalone — is delivered through `Publish` (in-order per
goroutine), and each handler threads a single `pendingPublishes` queue.

## Test
`ledger/blockfetch_drain_deadlock_test.go` fills the terminal chain.update lane to capacity on top of
a stalled lossless subscriber, runs the real drain, and asserts it returns promptly and deferred (did
not publish) the event. It **times out against both** the original inline `Publish` **and** inline
`PublishOrdered`, and passes only with the deferred fix. `chain/deferred_publish_test.go` covers the
`*Deferred` return/ordering. `go build/vet/test ./chain/... ./ledger/...`, `golangci-lint`, and
`gofmt` all pass.

## Related
- #3529 (EventBus-wide back-pressure) / #3550 (a sibling stalled-subscriber, the
  `chainselection.peer_activity` lane) — this PR removes one concrete instance (the `AddBlock` →
  `chain.update` publish under the ledger mutex).