### PR TITLE
perf(api): defer live stake rebuild during backfill

### DIFF
--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -219,13 +219,12 @@ RETURNING id`,
 				if err != nil {
 					return err
 				}
-				if err := s.refreshRewardLiveStakeRefs(
-					ctx,
-					db,
-					certificateRefs,
-					point.Slot,
-				); err != nil {
-					return err
+				if !historicalBackfill {
+					if err := s.refreshRewardLiveStakeRefs(
+						ctx, db, certificateRefs, point.Slot,
+					); err != nil {
+						return err
+					}
 				}
 			}
 			collateralReturn := transaction.CollateralReturn()
@@ -354,6 +353,9 @@ FROM utxo WHERE tx_id = ? AND output_idx = ?`,
 					input.Id().Bytes(),
 					input.Index(),
 				)
+			}
+			if historicalBackfill {
+				return nil
 			}
 			stakeRefs, err := queryUtxoStakeRefs(ctx, db, refs, false)
 			if err != nil {
@@ -910,13 +912,14 @@ ON CONFLICT (
 		); err != nil {
 			return err
 		}
-		if err := s.refreshRewardLiveStakeAggregate(
-			ctx,
-			db,
-			models.NewStakeCredentialRef(tag, stakeKey.Bytes()),
-			slot,
-		); err != nil {
-			return err
+		if !historicalBackfill {
+			if err := s.refreshRewardLiveStakeAggregate(
+				ctx, db,
+				models.NewStakeCredentialRef(tag, stakeKey.Bytes()),
+				slot,
+			); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -1077,6 +1077,24 @@ func (b *Backfill) Run(ctx context.Context) error {
 		saveCommittedCheckpoint()
 		return fmt.Errorf("flushing final backfill batch: %w", err)
 	}
+	// Do not start the potentially expensive aggregate rebuild after a caller
+	// has canceled the backfill. Re-check after it returns as well so callers
+	// observe cancellation before the completion checkpoint is persisted.
+	if err := ctx.Err(); err != nil {
+		saveCommittedCheckpoint()
+		return err
+	}
+	// Historical replay intentionally leaves the imported snapshot reward
+	// balances untouched and skips per-transaction live-stake refreshes. The
+	// derived aggregate is rebuilt once from canonical account and live-UTxO
+	// metadata after all historical rows are present, avoiding millions of
+	// repeated indexed UTxO sums during API backfill.
+	if err := b.db.RebuildRewardLiveStake(tipSlot, nil); err != nil {
+		return fmt.Errorf("rebuilding reward live stake after backfill: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.maybeLogProgress(
 		cp, processedBlocks, processedTxs,
 		tipSlot, startSlot, startTime, &lastLogTime,

--- a/internal/node/backfill.go
+++ b/internal/node/backfill.go
@@ -1090,9 +1090,11 @@ func (b *Backfill) Run(ctx context.Context) error {
 	// metadata after all historical rows are present, avoiding millions of
 	// repeated indexed UTxO sums during API backfill.
 	if err := b.db.RebuildRewardLiveStake(tipSlot, nil); err != nil {
+		saveCommittedCheckpoint()
 		return fmt.Errorf("rebuilding reward live stake after backfill: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
+		saveCommittedCheckpoint()
 		return err
 	}
 	b.maybeLogProgress(


### PR DESCRIPTION
## Summary
- defer historical live-stake aggregate refresh until backfill completes
- apply SQLite bulk-load pragmas for the historical API replay, restoring normal durability afterward

## Validation
- focused sqlstore/internal-node tests pass where the sandbox permits socket tests; socket-listener tests require host networking
- profiled Preview API Mithril run completed successfully on lv5
- baseline: ~20h53m19s
- optimized: 7h36m07s end-to-end (63.6% faster)
- backfill: 6h49m07s; final DB: ~46 GB; retained Mithril cache: ~30 GB