### PR TITLE
fix(ci): restore governance test suites

### DIFF
--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -977,7 +977,7 @@ func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 	}
 
 	// Phase 2: ratify proposals that meet threshold requirements.
-	if err := m.ratifyProposals(txn, newEpoch); err != nil {
+	if err := m.ratifyProposals(txn, newEpoch, boundarySlot); err != nil {
 		return fmt.Errorf("ratify proposals: %w", err)
 	}
 
@@ -1005,6 +1005,7 @@ func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 func (m *DingoStateManager) ratifyProposals(
 	txn *database.Txn,
 	currentEpoch uint64,
+	boundarySlot uint64,
 ) error {
 	for id, proposal := range m.govState.Proposals {
 		if proposal.RatifiedEpoch != nil {
@@ -1018,7 +1019,9 @@ func (m *DingoStateManager) ratifyProposals(
 			epoch := currentEpoch
 			proposal.RatifiedEpoch = &epoch
 			m.govState.Proposals[id] = proposal
-			if err := m.persistRatification(txn, id, currentEpoch); err != nil {
+			if err := m.persistRatification(
+				txn, id, currentEpoch, boundarySlot,
+			); err != nil {
 				return err
 			}
 			continue
@@ -1064,28 +1067,34 @@ func (m *DingoStateManager) ratifyProposals(
 		epoch := currentEpoch
 		proposal.RatifiedEpoch = &epoch
 		m.govState.Proposals[id] = proposal
-		if err := m.persistRatification(txn, id, currentEpoch); err != nil {
+		if err := m.persistRatification(
+			txn, id, currentEpoch, boundarySlot,
+		); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// persistRatification sets the real governance_proposal row's
-// ratified_epoch. A proposal id with no matching real row (a synthetic
+// persistRatification sets the real governance_proposal row's ratification
+// epoch and boundary slot as one rollback-safe state transition. A proposal
+// id with no matching real row (a synthetic
 // initial-state seed with no originating transaction) is left as an
 // in-memory-only decision -- there is nothing to persist for it.
 func (m *DingoStateManager) persistRatification(
 	txn *database.Txn,
 	id string,
 	epoch uint64,
+	boundarySlot uint64,
 ) error {
 	proposal, err := m.lookupGovernanceProposal(txn, id)
 	if proposal == nil || err != nil {
 		return err
 	}
 	ratifiedEpoch := epoch
+	ratifiedSlot := boundarySlot
 	proposal.RatifiedEpoch = &ratifiedEpoch
+	proposal.RatifiedSlot = &ratifiedSlot
 	return m.db.SetGovernanceProposal(proposal, txn)
 }
 

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -1370,7 +1370,10 @@ func (m *DingoStateManager) proposalToModel(
 	}
 
 	if info.RatifiedEpoch != nil {
-		proposal.RatifiedEpoch = info.RatifiedEpoch
+		ratifiedEpoch := *info.RatifiedEpoch
+		ratifiedSlot := ratifiedEpoch * conformanceSlotsPerEpoch
+		proposal.RatifiedEpoch = &ratifiedEpoch
+		proposal.RatifiedSlot = &ratifiedSlot
 	}
 
 	return proposal

--- a/internal/test/conformance/state_manager_backend_test.go
+++ b/internal/test/conformance/state_manager_backend_test.go
@@ -74,6 +74,30 @@ func TestPersistRatificationStoresEpochAndBoundarySlot(t *testing.T) {
 	require.Equal(t, boundarySlot, *stored.RatifiedSlot)
 }
 
+func TestProposalToModelStoresRatificationPair(t *testing.T) {
+	m, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, m.Close()) }()
+
+	ratifiedEpoch := uint64(4)
+	model := m.proposalToModel(
+		hex.EncodeToString(testHash32(0xb1))+"#0",
+		conformance.GovActionInfo{
+			ActionType:     common.GovActionTypeInfo,
+			ExpiresAfter:   10,
+			RatifiedEpoch:  &ratifiedEpoch,
+			SubmittedEpoch: 1,
+		},
+	)
+	require.NotNil(t, model.RatifiedEpoch)
+	require.NotNil(t, model.RatifiedSlot)
+	require.Equal(
+		t,
+		ratifiedEpoch*conformanceSlotsPerEpoch,
+		*model.RatifiedSlot,
+	)
+}
+
 // testHash28 builds a deterministic, distinguishable-by-seed 28-byte hash
 // value (the size of a Blake2b224 credential/pool/DRep hash) for tests that
 // need a well-formed but otherwise arbitrary identity.

--- a/internal/test/conformance/state_manager_backend_test.go
+++ b/internal/test/conformance/state_manager_backend_test.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -30,6 +31,48 @@ import (
 	"github.com/blinklabs-io/ouroboros-mock/conformance"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPersistRatificationStoresEpochAndBoundarySlot(t *testing.T) {
+	m, err := NewDingoStateManager()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, m.Close()) }()
+
+	txHash := testHash32(0xa1)
+	proposal := &models.GovernanceProposal{
+		TxHash:        txHash,
+		ActionIndex:   0,
+		ActionType:    uint8(common.GovActionTypeInfo),
+		ProposedEpoch: 1,
+		ExpiresEpoch:  10,
+		AnchorURL:     "https://example.invalid/ratification-pair",
+		AnchorHash:    testHash32(0xa2),
+		ReturnAddress: bytes.Repeat([]byte{0xa3}, 29),
+		GovActionCbor: []byte{0x80},
+		AddedSlot:     1,
+	}
+	require.NoError(t, m.db.SetGovernanceProposal(proposal, nil))
+
+	const (
+		ratifiedEpoch = uint64(4)
+		boundarySlot  = uint64(400)
+	)
+	txn := m.db.Transaction(true)
+	defer txn.Release()
+	require.NoError(t, m.persistRatification(
+		txn,
+		hex.EncodeToString(txHash)+"#0",
+		ratifiedEpoch,
+		boundarySlot,
+	))
+	require.NoError(t, txn.Commit())
+
+	stored, err := m.db.GetGovernanceProposal(txHash, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, stored.RatifiedEpoch)
+	require.NotNil(t, stored.RatifiedSlot)
+	require.Equal(t, ratifiedEpoch, *stored.RatifiedEpoch)
+	require.Equal(t, boundarySlot, *stored.RatifiedSlot)
+}
 
 // testHash28 builds a deterministic, distinguishable-by-seed 28-byte hash
 // value (the size of a Blake2b224 credential/pool/DRep hash) for tests that

--- a/ledger/governance/spo_nonvoter_test.go
+++ b/ledger/governance/spo_nonvoter_test.go
@@ -272,8 +272,17 @@ func seedSPONonVoterProposal(
 	actionType lcommon.GovActionType,
 ) *models.GovernanceProposal {
 	t.Helper()
+	returnAddress, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeNoneKey,
+		lcommon.AddressNetworkTestnet,
+		nil,
+		testBytes(28, 0xF8),
+	)
+	require.NoError(t, err)
+	returnAddressBytes, err := returnAddress.Bytes()
+	require.NoError(t, err)
+
 	var actionCBOR []byte
-	var err error
 	switch actionType {
 	case lcommon.GovActionTypeHardForkInitiation:
 		action := &lcommon.HardForkInitiationGovAction{
@@ -301,7 +310,7 @@ func seedSPONonVoterProposal(
 		ProposedEpoch: stabilityTestEpoch - 1,
 		ExpiresEpoch:  stabilityTestEpoch + 10,
 		Deposit:       1_000,
-		ReturnAddress: testBytes(29, 0xF8),
+		ReturnAddress: returnAddressBytes,
 		AnchorURL:     "https://example.invalid/spo-nonvoter",
 		AnchorHash:    testBytes(32, 0xF9),
 		GovActionCbor: actionCBOR,


### PR DESCRIPTION
## Summary

- persist ratification epoch and boundary slot together for live and seeded conformance proposals
- use a valid reward return address so SPO non-voter vectors reach their threshold assertions

## Validation

- focused governance and conformance tests, normal and race
- full governance and conformance packages
- `go vet`, `golangci-lint`, and NilAway

Closes #3720
Closes #3721
