### PR TITLE
fix(ledger): stop and drain consumed-UTxO cleanup during shutdown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1420,6 +1420,18 @@ triggers are single-flight; once the node is near the upstream tip, each run
 deletes at most one bounded batch of eligible rows using the era's stability
 window. Later runs continue the cleanup, keeping SQLite occupancy bounded.
 
+`LedgerState.Close` stops that timer and waits for a run already in flight,
+under a dedicated mutex rather than the `LedgerState` `RWMutex` (an in-flight
+run still takes `RLock` to read the tip, so draining under the ledger lock
+would deadlock). Both are required: the timer callback re-arms itself, so a
+`Close` that only stopped it would let an in-flight run install a fresh timer
+behind `Close`'s back, and `time.Timer.Stop` never waits for an `AfterFunc`
+callback that has already fired. Both triggers also refuse to start once
+`Close` has set the closed flag, which is what constrains the epoch
+transition's own `go ls.cleanupConsumedUtxos()` — stopping the timer does not
+reach that goroutine. `LedgerState` does not own the database, and its owner
+closes it as soon as `Close` returns.
+
 ### Midnight gRPC Server
 
 In `storageMode: api` with `midnight.serverEnabled: true` and a non-zero

--- a/ledger/cleanup_consumed_utxos_shutdown_test.go
+++ b/ledger/cleanup_consumed_utxos_shutdown_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+)
+
+// shrinkCleanupConsumedUtxosInterval makes the periodic cleanup timer fire on
+// a test timescale. The package var is restored on cleanup, so these tests
+// must not run in parallel with each other.
+func shrinkCleanupConsumedUtxosInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := cleanupConsumedUtxosInterval
+	cleanupConsumedUtxosInterval = d
+	t.Cleanup(func() { cleanupConsumedUtxosInterval = prev })
+}
+
+// newCleanupTimerFireSignal returns a hook that reports each timer fire on the
+// returned channel. The send is non-blocking so an unread fire never stalls
+// the timer callback itself.
+func newCleanupTimerFireSignal() (func(), <-chan struct{}) {
+	fires := make(chan struct{}, 64)
+	return func() {
+		select {
+		case fires <- struct{}{}:
+		default:
+		}
+	}, fires
+}
+
+// drainCleanupTimerFires discards every fire already buffered. Close has
+// stopped and drained the timer by the time this is called, so all of them
+// happened before it returned; only a fire arriving afterwards is a defect.
+// Draining fully -- rather than discarding a single fire -- is what keeps the
+// absence assertion from depending on how many intervals elapsed while the
+// test was between receives.
+func drainCleanupTimerFires(fires <-chan struct{}) {
+	for {
+		select {
+		case <-fires:
+		default:
+			return
+		}
+	}
+}
+
+// TestCleanupConsumedUtxos_TimerStopsOnClose covers the first half of issue
+// #3439: the cleanup timer callback re-arms itself via
+// scheduleCleanupConsumedUtxos, so a Close that does not stop it leaves a
+// self-perpetuating timer running against a database its owner closes
+// immediately after Close returns (LedgerState does not own the database --
+// see the note at the end of Close).
+func TestCleanupConsumedUtxos_TimerStopsOnClose(t *testing.T) {
+	shrinkCleanupConsumedUtxosInterval(t, 5*time.Millisecond)
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	ls := newLedgerStateForCleanup(db, 100_000)
+
+	hook, fires := newCleanupTimerFireSignal()
+	ls.cleanupConsumedUtxosTimerFiredHook = hook
+
+	ls.scheduleCleanupConsumedUtxos()
+	// Two fires prove the callback re-armed itself at least once, so the
+	// absence check below is measuring a stopped timer rather than one that
+	// simply never started.
+	testutil.RequireReceive(
+		t, fires, 5*time.Second,
+		"cleanup timer must fire while the ledger state is open",
+	)
+	testutil.RequireReceive(
+		t, fires, 5*time.Second,
+		"cleanup timer must re-arm itself while the ledger state is open",
+	)
+
+	require.NoError(t, ls.Close())
+
+	drainCleanupTimerFires(fires)
+
+	// 200ms is ~40 shrunken intervals. The assertion is that a stopped timer
+	// fires zero times, not that a running one fires within a deadline, so
+	// runner load cannot turn this into a flake.
+	testutil.RequireNoReceive(
+		t, fires, 200*time.Millisecond,
+		"cleanup timer must not fire after Close returns",
+	)
+}
+
+// TestCleanupConsumedUtxos_CloseWaitsForActiveCallback covers the drain half
+// of the acceptance criteria. Stopping a time.Timer does not wait for an
+// AfterFunc callback that has already started, so Close must join the
+// in-flight run; otherwise it returns while cleanup is still issuing database
+// work, and the owner closes the database out from under it.
+func TestCleanupConsumedUtxos_CloseWaitsForActiveCallback(t *testing.T) {
+	shrinkCleanupConsumedUtxosInterval(t, 5*time.Millisecond)
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	ls := newLedgerStateForCleanup(db, 100_000)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	// The run hook, not the timer-fired hook: this must block inside the
+	// region that has already registered with the drain, which is what Close
+	// is required to wait for.
+	ls.cleanupConsumedUtxosRunHook = func() {
+		once.Do(func() {
+			close(entered)
+			<-release
+		})
+	}
+
+	ls.scheduleCleanupConsumedUtxos()
+	testutil.RequireReceive(
+		t, entered, 5*time.Second,
+		"cleanup timer callback must start before Close is called",
+	)
+
+	closeReturned := make(chan error, 1)
+	go func() { closeReturned <- ls.Close() }()
+
+	testutil.RequireNoReceive(
+		t, closeReturned, 200*time.Millisecond,
+		"Close must not return while a cleanup callback is in flight",
+	)
+
+	close(release)
+	err := testutil.RequireReceive(
+		t, closeReturned, 10*time.Second,
+		"Close must return once the in-flight cleanup callback finishes",
+	)
+	require.NoError(t, err)
+}
+
+// TestCleanupConsumedUtxos_NoDatabaseWorkAfterClose covers the second
+// acceptance criterion for the path that has no timer at all: the epoch
+// transition fires cleanup as a bare `go ls.cleanupConsumedUtxos()`
+// (state.go), which can lose the race with shutdown. Stopping the timer alone
+// does not constrain that goroutine.
+//
+// TestCleanupConsumedUtxos_CoreModePrunes is the positive control: the same
+// seeded row and tip are deleted by the same call on an open ledger state, so
+// a passing result here cannot come from cleanup being inert.
+func TestCleanupConsumedUtxos_NoDatabaseWorkAfterClose(t *testing.T) {
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	txId := bytes.Repeat([]byte{0xC5}, 32)
+	const (
+		addedSlot   uint64 = 1_000
+		deletedSlot uint64 = 5_000
+		tipSlot     uint64 = 100_000 // > 50_000 default stability window
+	)
+	seedSpentUtxoForCleanup(t, db, txId, 0, addedSlot, deletedSlot)
+
+	ls := newLedgerStateForCleanup(db, tipSlot)
+	require.NoError(t, ls.Close())
+
+	ls.cleanupConsumedUtxos()
+
+	post, err := db.Metadata().GetUtxoIncludingSpent(txId, 0, nil)
+	require.NoError(t, err)
+	assert.NotNil(
+		t, post,
+		"cleanup must not begin database work after Close returns",
+	)
+}
+
+// TestCleanupConsumedUtxos_RepeatedCloseIsSafe covers the repeated-close half
+// of the third acceptance criterion. A drain built on sync.WaitGroup is easy
+// to get wrong on the second call, and Close is genuinely called twice on the
+// live restore/truncate path.
+func TestCleanupConsumedUtxos_RepeatedCloseIsSafe(t *testing.T) {
+	shrinkCleanupConsumedUtxosInterval(t, 5*time.Millisecond)
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	ls := newLedgerStateForCleanup(db, 100_000)
+
+	hook, fires := newCleanupTimerFireSignal()
+	ls.cleanupConsumedUtxosTimerFiredHook = hook
+
+	ls.scheduleCleanupConsumedUtxos()
+	testutil.RequireReceive(
+		t, fires, 5*time.Second,
+		"cleanup timer must fire while the ledger state is open",
+	)
+
+	require.NoError(t, ls.Close())
+	require.NoError(t, ls.Close(), "repeated Close must remain a no-op")
+
+	drainCleanupTimerFires(fires)
+	testutil.RequireNoReceive(
+		t, fires, 200*time.Millisecond,
+		"cleanup timer must stay stopped across repeated Close calls",
+	)
+}
+
+// TestCleanupConsumedUtxos_ScheduleAfterCloseDoesNotArm covers the re-arm
+// window directly: the timer callback calls scheduleCleanupConsumedUtxos
+// after running cleanup, so a callback that was already in flight when Close
+// stopped the timer would otherwise install a fresh one behind Close's back.
+func TestCleanupConsumedUtxos_ScheduleAfterCloseDoesNotArm(t *testing.T) {
+	shrinkCleanupConsumedUtxosInterval(t, 5*time.Millisecond)
+	db := newTestDBForCleanup(t, types.StorageModeCore)
+	ls := newLedgerStateForCleanup(db, 100_000)
+
+	hook, fires := newCleanupTimerFireSignal()
+	ls.cleanupConsumedUtxosTimerFiredHook = hook
+
+	require.NoError(t, ls.Close())
+	ls.scheduleCleanupConsumedUtxos()
+
+	testutil.RequireNoReceive(
+		t, fires, 200*time.Millisecond,
+		"scheduling cleanup after Close must not arm a timer",
+	)
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -60,8 +60,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// cleanupConsumedUtxosInterval is the period between consumed-UTxO cleanup
+// runs. A var, like the Close* drain timeouts below, so lifecycle tests can
+// shrink it instead of waiting on a real multi-minute timer.
+var cleanupConsumedUtxosInterval = 5 * time.Minute
+
 const (
-	cleanupConsumedUtxosInterval = 5 * time.Minute
 	// Keep each cleanup transaction short enough that it cannot monopolize
 	// SQLite while blockfetch handlers persist sync state during shutdown or
 	// catch-up. Later timer or epoch-boundary runs continue the cleanup.
@@ -831,6 +835,14 @@ type LedgerState struct {
 	slotClock                          *SlotClock
 	slotTickChan                       <-chan SlotTick
 	ctx                                context.Context
+	// cleanupMu owns timerCleanupConsumedUtxos and serializes cleanup-run
+	// registration against Close. Deliberately not the LedgerState RWMutex:
+	// Close waits on cleanupWG while an in-flight run still needs RLock to
+	// read the tip, so draining under the ledger lock would deadlock.
+	cleanupMu sync.Mutex
+	// cleanupWG counts consumed-UTxO cleanup runs that have passed the
+	// closed check, so Close can join one already touching the database.
+	cleanupWG sync.WaitGroup
 	// leiosBackfill prefetches historical Leios endorser blocks by point ahead
 	// of the apply cursor (nil when no endorser-block fetcher is configured).
 	leiosBackfill *leiosBackfiller
@@ -1097,6 +1109,14 @@ type LedgerState struct {
 	// Test hook called after Close releases the blockfetch continuation mutex
 	// and before it waits for continuation workers.
 	blockfetchContinuationSchedulingHook func()
+	// Test hook called at the top of the consumed-UTxO cleanup timer
+	// callback, before any shutdown check, so a lifecycle test can observe
+	// whether the timer itself is still armed.
+	cleanupConsumedUtxosTimerFiredHook func()
+	// Test hook called inside a cleanup run that has registered with
+	// cleanupWG, so a lifecycle test can hold a run in flight and assert
+	// that Close drains it.
+	cleanupConsumedUtxosRunHook func()
 }
 
 // upstreamSyncState is one connection-generation snapshot. Consumers must not
@@ -2005,6 +2025,26 @@ func (ls *LedgerState) Close() error {
 		ls.Scheduler.Stop()
 	}
 
+	// Stop the periodic consumed-UTxO cleanup timer and drain a run already
+	// under way. Timer.Stop does not wait for an AfterFunc callback that has
+	// already fired, so the Wait is what keeps Close from returning while
+	// cleanup is still issuing deletes. closed was set above, so
+	// beginCleanupConsumedUtxosRun now rejects every new run and the timer
+	// callback cannot re-arm itself.
+	//
+	// Unconditional, like the header-replay and reward-precompute waits
+	// below and unlike this function's bounded ones: returning early here
+	// would reintroduce exactly the use-after-close this is meant to
+	// prevent. A run is bounded by cleanupConsumedUtxoBatchSize -- one short
+	// delete transaction, deliberately sized so it cannot monopolize
+	// SQLite -- so there is no unbounded drain to guard against.
+	ls.cleanupMu.Lock()
+	if ls.timerCleanupConsumedUtxos != nil {
+		ls.timerCleanupConsumedUtxos.Stop()
+	}
+	ls.cleanupMu.Unlock()
+	ls.cleanupWG.Wait()
+
 	// Stop the decode pipeline at the same time as the block-processing
 	// goroutine. decodeReadChainBatch drains the pipeline's Results channel
 	// without a context select once a batch has been submitted; waiting for
@@ -2634,14 +2674,25 @@ func nearUpstreamTip(slot, upstreamTip, stabilityWindow uint64) bool {
 }
 
 func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
-	ls.Lock()
-	defer ls.Unlock()
+	ls.cleanupMu.Lock()
+	defer ls.cleanupMu.Unlock()
+	// The timer callback re-arms itself, so a run already in flight when
+	// Close stopped the timer would otherwise install a fresh one behind
+	// Close's back -- leaving a self-perpetuating timer firing every
+	// interval, for the rest of the process, against a database the owner
+	// closes as soon as Close returns.
+	if ls.closed.Load() {
+		return
+	}
 	if ls.timerCleanupConsumedUtxos != nil {
 		ls.timerCleanupConsumedUtxos.Stop()
 	}
 	ls.timerCleanupConsumedUtxos = time.AfterFunc(
 		cleanupConsumedUtxosInterval,
 		func() {
+			if ls.cleanupConsumedUtxosTimerFiredHook != nil {
+				ls.cleanupConsumedUtxosTimerFiredHook()
+			}
 			ls.cleanupConsumedUtxos()
 			// Schedule the next run
 			ls.scheduleCleanupConsumedUtxos()
@@ -2649,7 +2700,35 @@ func (ls *LedgerState) scheduleCleanupConsumedUtxos() {
 	)
 }
 
+// beginCleanupConsumedUtxosRun registers a consumed-UTxO cleanup run with the
+// shutdown drain, reporting false once Close has begun. Both cleanup triggers
+// go through it: the periodic timer, and the epoch transition's bare
+// `go ls.cleanupConsumedUtxos()`, which stopping the timer does not constrain.
+//
+// closed is set before Close takes cleanupMu, and this re-checks it under that
+// same mutex, so no run can register after Close has started waiting.
+func (ls *LedgerState) beginCleanupConsumedUtxosRun() bool {
+	ls.cleanupMu.Lock()
+	defer ls.cleanupMu.Unlock()
+	if ls.closed.Load() {
+		return false
+	}
+	ls.cleanupWG.Add(1)
+	return true
+}
+
 func (ls *LedgerState) cleanupConsumedUtxos() {
+	// Refuse to begin database work once Close has started, and keep Close
+	// waiting for this run otherwise. LedgerState does not own the database
+	// (see the note at the end of Close); its owner closes it immediately
+	// after Close returns.
+	if !ls.beginCleanupConsumedUtxosRun() {
+		return
+	}
+	defer ls.cleanupWG.Done()
+	if ls.cleanupConsumedUtxosRunHook != nil {
+		ls.cleanupConsumedUtxosRunHook()
+	}
 	// Cleanup is advisory pruning. Never let the periodic timer and the epoch
 	// transition trigger occupy SQLite's single write connection at the same
 	// time. Each invocation handles one bounded batch so cleanup remains


### PR DESCRIPTION
## What / why

`LedgerState.Close` never stopped the consumed-UTxO cleanup timer. The timer
callback re-arms itself via `scheduleCleanupConsumedUtxos`, so after `Close`
returned it kept firing every 5 minutes for the rest of the process, calling
`ls.db.StorageMode()` and `ls.db.UtxosDeleteConsumed(...)`. `LedgerState` does
not own the database (see the note at the end of `Close`); its owner closes it
as soon as `Close` returns.

Three separate gaps:

1. The timer is never stopped, and re-arms itself.
2. `time.Timer.Stop` does not wait for an `AfterFunc` callback that has already
   fired, so stopping alone would still let `Close` return mid-delete.
3. The epoch transition triggers cleanup as a bare `go ls.cleanupConsumedUtxos()`
   (`ledger/state.go`), which stopping the timer does not reach.

The existing `ls.ctx` check in `cleanupConsumedUtxos` does not cover this:
`ls.ctx` is the caller's context from `Start`, and `Close` never cancels it — a
live restore/truncate closes the ledger while the node context stays alive.

## Fix

`Close` stops the timer and waits for a run already in flight. Both are owned by
a dedicated `cleanupMu` rather than the `LedgerState` `RWMutex`: an in-flight run
still takes `RLock` to read the tip, so draining under the ledger lock would
deadlock.

Both triggers register through `beginCleanupConsumedUtxosRun`, which reports
false once `Close` has set the closed flag. That is what constrains the epoch
transition's goroutine, and what stops an in-flight callback from installing a
fresh timer behind `Close`'s back.

The drain is unconditional, like this function's header-replay and
reward-precompute waits and unlike its bounded ones — returning early would
reintroduce the use-after-close it prevents. A run is bounded by
`cleanupConsumedUtxoBatchSize`, so there is no unbounded wait to guard against.

## Test

`ledger/cleanup_consumed_utxos_shutdown_test.go`, five tests covering the issue's
acceptance criteria: timer stopped on `Close`, `Close` drains an active callback,
no database work after `Close` (the epoch-transition path), repeated `Close`, and
schedule-after-`Close` not arming. All five fail with the fix reverted and the
test seams kept.

`TestCleanupConsumedUtxos_CoreModePrunes` is the positive control for the
no-work-after-close test: the same seeded row and tip are deleted by the same
call on an open ledger state, so a pass cannot come from cleanup being inert.

## Validation

- `go test -race ./ledger/` — ok, 360s
- `go vet ./ledger/`, `golangci-lint run ./ledger/...` — clean, 0 issues
- `make import-boundaries`, `make docs-parity` — ok
- `go test ./internal/test/conformance/` — 48 failures, identical set to an
  `origin/main` baseline run at `be3cf843` (pre-existing; #3722 targets them)
- `internal/test/devnet/run-tests.sh --accelerated` — fails identically on an
  `origin/main` baseline at `be3cf843`: all four nodes stay at
  `tip=slot 0/block 0` and the readiness phase times out. Pre-existing, filed
  separately.

Not run: `nilaway`, `modernize`, `golines` (not installed locally; `gofmt` clean
and all added lines are within 80 characters). `make sql-check` does not apply —
no SQL or `sqlc.yaml` change.

## Documentation

`ARCHITECTURE.md` updated in the storage-modes section, where the consumed-UTxO
pruner is documented, to record the shutdown contract. `DATABASE.md` checked and
not affected: pruning behavior is unchanged, only when the timer stops.

Fixes #3439

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `LedgerState.Close` so the consumed-UTxO cleanup timer is stopped and any in-flight cleanup run is drained before shutdown completes, preventing database use-after-close.

**Bug Fixes**

- Stops the timer and waits for a cleanup run already in flight; `time.Timer.Stop` alone doesn't wait for a fired callback.
- Both cleanup triggers (the periodic timer and the epoch-transition goroutine) now refuse to start once `Close` has begun.
- The drain uses a dedicated mutex instead of the ledger `RWMutex` to avoid deadlocking with an in-flight cleanup run.
- Adds `ledger/cleanup_consumed_utxos_shutdown_test.go` covering timer stop, drain, no database work after close, repeated close, and schedule-after-close.
- Updates `ARCHITECTURE.md` to document the shutdown contract.

Fixes #3439.

<sup>Written for commit f0beeff9d624cd024084aed3910556cd4b2cfedf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger shutdown handling for consumed-UTXO cleanup.
  * Cleanup timers now stop reliably when the ledger closes.
  * In-progress cleanup operations finish safely before shutdown completes.
  * Prevented cleanup work from starting or accessing storage after closure.
  * Repeated shutdown calls are now safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->