### PR TITLE
fix(mempool): bound relay caches by bytes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3764,10 +3764,12 @@ them import backend state. Cardano-compatible metrics and `mempool.add_tx` /
 selected backend.
 
 Each transaction-submission consumer retains a bounded cache of transaction
-bodies. Retained CBOR is limited both per consumer and in aggregate to the
-configured mempool capacity; a secondary 1,024-entry default bound remains,
-and `MempoolConfig.ConsumerCacheSize` can lower or raise that count for embedded
-users. The bounds are enforced by declining to advertise, not by eviction: a
+bodies. Retained CBOR is limited per consumer to one quarter of the configured
+mempool capacity by default, and in aggregate to the full capacity.
+`MempoolConfig.ConsumerCacheBytes` can override the per-consumer budget for
+embedded users. A secondary 1,024-entry default bound remains, and
+`MempoolConfig.ConsumerCacheSize` can override that count. The bounds are
+enforced by declining to advertise, not by eviction: a
 body is only ever served to the peer from this cache, and
 dropping one already advertised would silently omit a transaction the peer
 legitimately requested. A non-blocking `NextTx` returns nil once the cache is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3764,9 +3764,11 @@ them import backend state. Cardano-compatible metrics and `mempool.add_tx` /
 selected backend.
 
 Each transaction-submission consumer retains a bounded cache of transaction
-bodies (1,024 entries by default; `MempoolConfig.ConsumerCacheSize` can lower or
-raise it for embedded users). The bound is enforced by declining to advertise,
-not by eviction: a body is only ever served to the peer from this cache, and
+bodies. Retained CBOR is limited both per consumer and in aggregate to the
+configured mempool capacity; a secondary 1,024-entry default bound remains,
+and `MempoolConfig.ConsumerCacheSize` can lower or raise that count for embedded
+users. The bounds are enforced by declining to advertise, not by eviction: a
+body is only ever served to the peer from this cache, and
 dropping one already advertised would silently omit a transaction the peer
 legitimately requested. A non-blocking `NextTx` returns nil once the cache is
 full; a blocking one parks until a slot frees rather than answering empty, since

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3772,7 +3772,10 @@ embedded users. A secondary 1,024-entry default bound remains, and
 enforced by declining to advertise, not by eviction: a
 body is only ever served to the peer from this cache, and
 dropping one already advertised would silently omit a transaction the peer
-legitimately requested. A non-blocking `NextTx` returns nil once the cache is
+legitimately requested. A body larger than the consumer's entire byte budget
+is skipped for that consumer because it can never become cacheable; this keeps
+it from permanently blocking the cursor and prevents it from starving later,
+relayable transactions. A non-blocking `NextTx` returns nil once the cache is
 full; a blocking one parks until a slot frees rather than answering empty, since
 the peer's pull loop has no backoff for an empty reply and would spin
 request/reply without pacing. Shutdown or connection cleanup releases a parked

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -54,6 +54,22 @@ func newConsumer(
 	if cacheLimitBytes <= 0 {
 		cacheLimitBytes = mempool.config.MempoolCapacity /
 			defaultConsumerCacheShare
+		// A budget this small would permanently exclude ordinary transaction
+		// bodies from relay with no other visible symptom, so the derived
+		// default (unlike an operator's explicit ConsumerCacheBytes) is
+		// floored to a size that comfortably holds one.
+		if cacheLimitBytes < minConsumerCacheBytes {
+			mempool.logger.Warn(
+				"derived default consumer relay cache byte budget is below "+
+					"the floor; raising it to avoid silently excluding "+
+					"ordinary transaction bodies from relay",
+				"component", "mempool",
+				"mempool_capacity", mempool.config.MempoolCapacity,
+				"derived_bytes", cacheLimitBytes,
+				"floor_bytes", int64(minConsumerCacheBytes),
+			)
+			cacheLimitBytes = minConsumerCacheBytes
+		}
 	}
 	return &MempoolConsumer{
 		mempool:         mempool,
@@ -99,9 +115,22 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 				// become cacheable. Skip it so it cannot permanently pin the
 				// cursor and prevent later transactions from being relayed.
 				if int64(len(poolTx.Cbor)) > m.cacheLimitBytes {
+					hash := poolTx.Hash
+					size := len(poolTx.Cbor)
+					limit := m.cacheLimitBytes
 					m.nextTxIdx++
 					m.nextTxIdxMu.Unlock()
 					m.mempool.RUnlock()
+					m.mempool.metrics.consumerCacheBytesSkipped.Inc()
+					m.mempool.logger.Warn(
+						"skipping transaction that exceeds this consumer's "+
+							"relay cache byte budget; it will never be "+
+							"relayed to this consumer",
+						"component", "mempool",
+						"tx_hash", hash,
+						"tx_size_bytes", size,
+						"cache_limit_bytes", limit,
+					)
 					continue
 				}
 				cached, aggregateChanged := m.cacheTransaction(poolTx)

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -95,6 +95,15 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 		if m.nextTxIdx < len(m.mempool.transactions) {
 			poolTx := m.mempool.transactions[m.nextTxIdx]
 			if poolTx != nil {
+				// A body larger than this consumer's total byte budget can never
+				// become cacheable. Skip it so it cannot permanently pin the
+				// cursor and prevent later transactions from being relayed.
+				if int64(len(poolTx.Cbor)) > m.cacheLimitBytes {
+					m.nextTxIdx++
+					m.nextTxIdxMu.Unlock()
+					m.mempool.RUnlock()
+					continue
+				}
 				cached, aggregateChanged := m.cacheTransaction(poolTx)
 				if !cached {
 					m.nextTxIdxMu.Unlock()
@@ -171,8 +180,9 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 }
 
 // cacheTransaction reserves both the per-consumer and aggregate retained-byte
-// budgets before storing an advertised body. The caller keeps the cursor on
-// this transaction when reservation fails, preserving later retransmission.
+// budgets before storing an advertised body. Permanently oversized bodies are
+// filtered by NextTx; temporary reservation failures keep the cursor on the
+// transaction, preserving later retransmission.
 func (m *MempoolConsumer) cacheTransaction(
 	tx *MempoolTransaction,
 ) (bool, <-chan struct{}) {

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -28,11 +28,13 @@ type MempoolConsumer struct {
 	// blocking: a pending wake-up is all a waiter needs, since it re-checks the
 	// cache after waking. A channel rather than a sync.Cond so the wait can also
 	// select on mempool shutdown.
-	cacheSlot   chan struct{}
-	cacheLimit  int
-	nextTxIdx   int
-	cacheMutex  sync.Mutex
-	nextTxIdxMu sync.Mutex
+	cacheSlot       chan struct{}
+	cacheLimit      int
+	cacheBytes      int64
+	cacheLimitBytes int64
+	nextTxIdx       int
+	cacheMutex      sync.Mutex
+	nextTxIdxMu     sync.Mutex
 	// onWaitForTx is a test-only hook invoked after a blocking NextTx has
 	// subscribed for additions and is ready to be cancelled.
 	onWaitForTx func()
@@ -43,11 +45,12 @@ func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
 		cacheLimit = DefaultConsumerCacheSize
 	}
 	return &MempoolConsumer{
-		mempool:    mempool,
-		cache:      make(map[string]*MempoolTransaction),
-		done:       make(chan struct{}),
-		cacheSlot:  make(chan struct{}, 1),
-		cacheLimit: cacheLimit,
+		mempool:         mempool,
+		cache:           make(map[string]*MempoolTransaction),
+		done:            make(chan struct{}),
+		cacheSlot:       make(chan struct{}, 1),
+		cacheLimit:      cacheLimit,
+		cacheLimitBytes: mempool.config.MempoolCapacity,
 	}
 }
 
@@ -72,37 +75,6 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 		default:
 		}
 
-		// Stop handing out transactions once the body cache is full. NextTx is
-		// what puts a tx id on the wire, and the body is served to the peer
-		// later from this cache only. Dropping a cached body to make room would
-		// silently omit a tx the peer legitimately asked for, so bound the
-		// cache by declining to advertise instead. The peer's acknowledgement
-		// clears the cache and reopens the window. The protocol window
-		// (txsubmissionRequestTxIdsCount) is far below the default limit, so
-		// this is a backstop against an aggressive peer, not a normal path.
-		m.cacheMutex.Lock()
-		cacheFull := len(m.cache) >= m.cacheLimit
-		m.cacheMutex.Unlock()
-		if cacheFull {
-			if !blocking {
-				return nil
-			}
-			// A blocking request must wait, not answer empty. Returning nil
-			// here would have the peer immediately re-request -- its pull loop
-			// has no backoff for an empty reply -- producing an unpaced
-			// request/reply spin exactly in the aggressive-peer case this
-			// bound exists to contain. Park until a body is served or the
-			// peer acknowledges ids, which frees a slot.
-			select {
-			case <-m.cacheSlot:
-				continue
-			case <-m.done:
-				return nil
-			case <-m.mempool.done:
-				return nil
-			}
-		}
-
 		m.mempool.RLock()
 		m.nextTxIdxMu.Lock()
 
@@ -110,19 +82,31 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 		if m.nextTxIdx < len(m.mempool.transactions) {
 			poolTx := m.mempool.transactions[m.nextTxIdx]
 			if poolTx != nil {
+				cached, aggregateChanged := m.cacheTransaction(poolTx)
+				if !cached {
+					m.nextTxIdxMu.Unlock()
+					m.mempool.RUnlock()
+					if !blocking {
+						return nil
+					}
+					select {
+					case <-m.cacheSlot:
+						continue
+					case <-aggregateChanged:
+						continue
+					case <-m.done:
+						return nil
+					case <-m.mempool.done:
+						return nil
+					}
+				}
 				// Clone while holding the pool read lock so neither the caller
 				// nor the consumer cache shares mutable CBOR with pool storage.
 				nextTx := cloneMempoolTransaction(poolTx)
-				cachedTx := cloneMempoolTransaction(poolTx)
 				// Increment next TX index atomically with reading it
 				m.nextTxIdx++
 				m.nextTxIdxMu.Unlock()
 				m.mempool.RUnlock()
-
-				// Add transaction to cache (outside of locks)
-				m.cacheMutex.Lock()
-				m.cache[cachedTx.Hash] = cachedTx
-				m.cacheMutex.Unlock()
 
 				return nextTx
 			}
@@ -173,6 +157,31 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 	}
 }
 
+// cacheTransaction reserves both the per-consumer and aggregate retained-byte
+// budgets before storing an advertised body. The caller keeps the cursor on
+// this transaction when reservation fails, preserving later retransmission.
+func (m *MempoolConsumer) cacheTransaction(
+	tx *MempoolTransaction,
+) (bool, <-chan struct{}) {
+	size := int64(len(tx.Cbor))
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+	if _, exists := m.cache[tx.Hash]; exists {
+		return true, nil
+	}
+	if len(m.cache) >= m.cacheLimit ||
+		size > m.cacheLimitBytes-m.cacheBytes {
+		return false, nil
+	}
+	reserved, aggregateChanged := m.mempool.reserveRelayCacheBytes(size)
+	if !reserved {
+		return false, aggregateChanged
+	}
+	m.cache[tx.Hash] = cloneMempoolTransaction(tx)
+	m.cacheBytes += size
+	return true, nil
+}
+
 func (m *MempoolConsumer) GetTxFromCache(hash string) *MempoolTransaction {
 	if m != nil {
 		m.cacheMutex.Lock()
@@ -187,7 +196,10 @@ func (m *MempoolConsumer) ClearCache() {
 	if m != nil {
 		m.cacheMutex.Lock()
 		defer m.cacheMutex.Unlock()
+		released := m.cacheBytes
 		m.cache = make(map[string]*MempoolTransaction)
+		m.cacheBytes = 0
+		m.mempool.releaseRelayCacheBytes(released)
 		m.signalCacheSlotLocked()
 	}
 }
@@ -196,8 +208,11 @@ func (m *MempoolConsumer) RemoveTxFromCache(hash string) {
 	if m != nil {
 		m.cacheMutex.Lock()
 		defer m.cacheMutex.Unlock()
-		if _, existed := m.cache[hash]; existed {
+		if tx, existed := m.cache[hash]; existed {
 			delete(m.cache, hash)
+			size := int64(len(tx.Cbor))
+			m.cacheBytes -= size
+			m.mempool.releaseRelayCacheBytes(size)
 			m.signalCacheSlotLocked()
 		}
 	}

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -38,6 +38,9 @@ type MempoolConsumer struct {
 	// onWaitForTx is a test-only hook invoked after a blocking NextTx has
 	// subscribed for additions and is ready to be cancelled.
 	onWaitForTx func()
+	// onCacheCleared is a test-only hook invoked after ClearCache releases
+	// the cache lifecycle lock.
+	onCacheCleared func()
 }
 
 func newConsumer(
@@ -210,12 +213,15 @@ func (m *MempoolConsumer) GetTxFromCache(hash string) *MempoolTransaction {
 func (m *MempoolConsumer) ClearCache() {
 	if m != nil {
 		m.cacheMutex.Lock()
-		defer m.cacheMutex.Unlock()
 		released := m.cacheBytes
 		m.cache = make(map[string]*MempoolTransaction)
 		m.cacheBytes = 0
 		m.mempool.releaseRelayCacheBytes(released)
 		m.signalCacheSlotLocked()
+		m.cacheMutex.Unlock()
+		if m.onCacheCleared != nil {
+			m.onCacheCleared()
+		}
 	}
 }
 

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -40,9 +40,17 @@ type MempoolConsumer struct {
 	onWaitForTx func()
 }
 
-func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
+func newConsumer(
+	mempool *Mempool,
+	cacheLimit int,
+	cacheLimitBytes int64,
+) *MempoolConsumer {
 	if cacheLimit <= 0 {
 		cacheLimit = DefaultConsumerCacheSize
+	}
+	if cacheLimitBytes <= 0 {
+		cacheLimitBytes = mempool.config.MempoolCapacity /
+			defaultConsumerCacheShare
 	}
 	return &MempoolConsumer{
 		mempool:         mempool,
@@ -50,7 +58,7 @@ func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
 		done:            make(chan struct{}),
 		cacheSlot:       make(chan struct{}, 1),
 		cacheLimit:      cacheLimit,
-		cacheLimitBytes: mempool.config.MempoolCapacity,
+		cacheLimitBytes: cacheLimitBytes,
 	}
 }
 
@@ -59,6 +67,8 @@ func newConsumer(mempool *Mempool, cacheLimit int) *MempoolConsumer {
 // race with other lifecycle paths.
 func (m *MempoolConsumer) cancel() {
 	if m != nil {
+		m.cacheMutex.Lock()
+		defer m.cacheMutex.Unlock()
 		m.doneOnce.Do(func() { close(m.done) })
 	}
 }
@@ -166,6 +176,11 @@ func (m *MempoolConsumer) cacheTransaction(
 	size := int64(len(tx.Cbor))
 	m.cacheMutex.Lock()
 	defer m.cacheMutex.Unlock()
+	select {
+	case <-m.done:
+		return false, nil
+	default:
+	}
 	if _, exists := m.cache[tx.Hash]; exists {
 		return true, nil
 	}

--- a/mempool/dag_test.go
+++ b/mempool/dag_test.go
@@ -686,3 +686,40 @@ func TestMempoolProvidersIncludeFIFOAndDAG(t *testing.T) {
 	assert.Equal(t, ImplementationDAG, dagPool.implementation)
 	require.NoError(t, host.Stop(context.Background()))
 }
+
+// TestMempoolProviderConfigWiresConsumerCacheBytes verifies that
+// ConsumerCacheBytes set through the plugin config map (as an operator would
+// via YAML) reaches the constructed Mempool's config, and from there a new
+// consumer's cacheLimitBytes. ProviderConfig previously had no field for it,
+// so a configured consumerCacheBytes key either failed strict decoding or
+// was silently ignored in favor of the derived default.
+func TestMempoolProviderConfigWiresConsumerCacheBytes(t *testing.T) {
+	host := plugin.NewHost()
+	require.NoError(t, RegisterFIFOProvider(host))
+
+	service, err := plugin.Resolve[Service](
+		context.Background(),
+		host,
+		plugin.CapabilityMempool,
+		"fifo",
+		map[string]any{
+			"capacity":           1 << 20,
+			"consumerCacheBytes": 4096,
+		},
+		ProviderDependencies{
+			PromRegistry: prometheus.NewRegistry(),
+			Validator:    newMockValidator(),
+		},
+	)
+	require.NoError(t, err)
+	fifoPool, ok := service.(*FIFO)
+	require.True(t, ok)
+
+	assert.Equal(t, int64(4096), fifoPool.config.ConsumerCacheBytes)
+	relayConsumer := fifoPool.AddConsumer(newTestConnectionId(0))
+	consumer, ok := relayConsumer.(*MempoolConsumer)
+	require.True(t, ok)
+	assert.Equal(t, int64(4096), consumer.cacheLimitBytes)
+
+	require.NoError(t, host.Stop(context.Background()))
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -47,6 +47,7 @@ const (
 	DefaultCleanupInterval      = 1 * time.Minute
 	DefaultRevalidationDeltaCap = 64
 	DefaultConsumerCacheSize    = 1024
+	defaultConsumerCacheShare   = 4
 	// defaultRevalidationJournalCap bounds the mutation journal a revalidation
 	// pass may accumulate. A mempoolMutation is 40 bytes, so the backing slice
 	// tops out near 42 MiB, and each entry additionally pins the transaction it
@@ -134,7 +135,10 @@ type MempoolConfig struct {
 	// ConsumerCacheSize bounds the number of transaction bodies retained per
 	// transaction-submission consumer. Zero uses DefaultConsumerCacheSize.
 	ConsumerCacheSize int
-	CurrentSlotFunc   func() uint64 // returns current slot for early TX rejection
+	// ConsumerCacheBytes bounds retained transaction body bytes per consumer.
+	// Zero uses one quarter of MempoolCapacity.
+	ConsumerCacheBytes int64
+	CurrentSlotFunc    func() uint64 // returns current slot for early TX rejection
 }
 
 type Mempool struct {
@@ -703,7 +707,11 @@ func (m *Mempool) AddConsumer(connId ouroboros.ConnectionId) *MempoolConsumer {
 	if consumer := m.consumers[connId]; consumer != nil {
 		return consumer
 	}
-	consumer := newConsumer(m, m.config.ConsumerCacheSize)
+	consumer := newConsumer(
+		m,
+		m.config.ConsumerCacheSize,
+		m.config.ConsumerCacheBytes,
+	)
 	m.consumers[connId] = consumer
 	return consumer
 }
@@ -726,8 +734,8 @@ func (m *Mempool) RemoveConsumer(connId ouroboros.ConnectionId) {
 	delete(m.consumers, connId)
 	m.consumersMutex.Unlock()
 	if consumer != nil {
-		consumer.ClearCache()
 		consumer.cancel()
+		consumer.ClearCache()
 	}
 }
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -883,6 +883,10 @@ type ProviderConfig struct {
 	EvictionWatermark    float64 `yaml:"evictionWatermark"`
 	RejectionWatermark   float64 `yaml:"rejectionWatermark"`
 	RevalidationDeltaCap int     `yaml:"revalidationDeltaCap"`
+	// ConsumerCacheBytes bounds retained transaction body bytes per relay
+	// consumer. Zero uses one quarter of Capacity; see
+	// MempoolConfig.ConsumerCacheBytes.
+	ConsumerCacheBytes int64 `yaml:"consumerCacheBytes"`
 }
 
 // ProviderDependencies are runtime dependencies assembled after ledger and
@@ -940,6 +944,7 @@ func registerProvider(
 				EvictionWatermark:    cfg.EvictionWatermark,
 				RejectionWatermark:   cfg.RejectionWatermark,
 				RevalidationDeltaCap: cfg.RevalidationDeltaCap,
+				ConsumerCacheBytes:   cfg.ConsumerCacheBytes,
 				CurrentSlotFunc:      deps.CurrentSlotFunc,
 			}
 			var (

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -178,11 +178,14 @@ type Mempool struct {
 	// actually timed out rather than whichever caller happens to check it.
 	stopTimeoutErr atomic.Pointer[error]
 
-	workerWG        sync.WaitGroup
-	consumersMutex  sync.Mutex
-	overlay         *utxoOverlay
-	dag             *transactionDAG
-	headroomChanged chan struct{}
+	workerWG          sync.WaitGroup
+	consumersMutex    sync.Mutex
+	relayCacheMutex   sync.Mutex
+	relayCacheBytes   int64
+	relayCacheChanged chan struct{}
+	overlay           *utxoOverlay
+	dag               *transactionDAG
+	headroomChanged   chan struct{}
 
 	// rebuildMutex permits one double-buffer rebuild at a time. mutationSeq and
 	// mutationJournal are protected by mutationMutex and let that rebuild catch
@@ -588,6 +591,7 @@ func newMempool(
 		implementation:         implementation,
 		config:                 config,
 		done:                   make(chan struct{}),
+		relayCacheChanged:      make(chan struct{}),
 		transactionTTL:         transactionTTL,
 		cleanupInterval:        cleanupInterval,
 		evictionWatermark:      evictionWatermark,
@@ -721,7 +725,38 @@ func (m *Mempool) RemoveConsumer(connId ouroboros.ConnectionId) {
 	consumer := m.consumers[connId]
 	delete(m.consumers, connId)
 	m.consumersMutex.Unlock()
-	consumer.cancel()
+	if consumer != nil {
+		consumer.ClearCache()
+		consumer.cancel()
+	}
+}
+
+// reserveRelayCacheBytes charges retained transaction bytes across every
+// consumer. A consumer also applies this same limit independently, so neither
+// one connection nor all connections together can retain more transaction
+// body data than the configured mempool capacity.
+func (m *Mempool) reserveRelayCacheBytes(size int64) (bool, <-chan struct{}) {
+	m.relayCacheMutex.Lock()
+	defer m.relayCacheMutex.Unlock()
+	if size > m.config.MempoolCapacity-m.relayCacheBytes {
+		return false, m.relayCacheChanged
+	}
+	m.relayCacheBytes += size
+	return true, nil
+}
+
+func (m *Mempool) releaseRelayCacheBytes(size int64) {
+	if size <= 0 {
+		return
+	}
+	m.relayCacheMutex.Lock()
+	m.relayCacheBytes -= size
+	if m.relayCacheBytes < 0 {
+		m.relayCacheBytes = 0
+	}
+	close(m.relayCacheChanged)
+	m.relayCacheChanged = make(chan struct{})
+	m.relayCacheMutex.Unlock()
 }
 
 func (m *Mempool) Stop(ctx context.Context) error {

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -48,6 +48,15 @@ const (
 	DefaultRevalidationDeltaCap = 64
 	DefaultConsumerCacheSize    = 1024
 	defaultConsumerCacheShare   = 4
+	// minConsumerCacheBytes floors the per-consumer relay cache budget derived
+	// from MempoolCapacity when ConsumerCacheBytes is left at zero. NextTx
+	// permanently skips any body whose size exceeds this budget, so an
+	// unfloored default derived from a small MempoolCapacity silently and
+	// permanently excludes ordinary transactions from relay to that consumer.
+	// 16 KiB comfortably holds a typical single transaction body without
+	// coupling the mempool package to a ledger protocol parameter. An
+	// operator's explicit ConsumerCacheBytes is left as configured.
+	minConsumerCacheBytes = 16 * 1024
 	// defaultRevalidationJournalCap bounds the mutation journal a revalidation
 	// pass may accumulate. A mempoolMutation is 40 bytes, so the backing slice
 	// tops out near 42 MiB, and each entry additionally pins the transaction it
@@ -149,6 +158,11 @@ type Mempool struct {
 		txsEvicted      prometheus.Counter
 		txsExpired      prometheus.Counter
 		implementation  prometheus.Gauge
+		// consumerCacheBytesSkipped counts transaction bodies permanently
+		// skipped by a consumer's relay cursor for exceeding its per-consumer
+		// byte budget. A nonzero rate means relay to that consumer has gone
+		// silent for those transactions with no other visible symptom.
+		consumerCacheBytesSkipped prometheus.Counter
 	}
 	validator              TxValidator
 	implementation         Implementation
@@ -654,6 +668,12 @@ func newMempool(
 		prometheus.CounterOpts{
 			Name: "dingo_metrics_txsExpiredNum_int",
 			Help: "total transactions expired from mempool by TTL",
+		},
+	)
+	m.metrics.consumerCacheBytesSkipped = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_metrics_consumerCacheBytesSkippedNum_int",
+			Help: "total tx bodies skipped for exceeding a consumer's byte budget",
 		},
 	)
 	m.metrics.implementation = promautoFactory.NewGauge(

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1385,8 +1385,9 @@ func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 	assert.Equal(t, int64(0), retainedConsumerCacheBytes(second), "consumer removal releases bytes")
 }
 
-// TestMempoolConsumer_RemovalRejectsLaterCacheWrites verifies that cancellation
-// prevents a removed consumer from reserving bytes or repopulating its cache.
+// TestMempoolConsumer_RemovalRejectsLaterCacheWrites directly verifies the
+// cacheTransaction cancellation guard: a removed consumer cannot reserve bytes
+// or repopulate its cache even if an insertion is attempted after cancellation.
 func TestMempoolConsumer_RemovalRejectsLaterCacheWrites(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -4207,10 +4208,12 @@ func TestMempoolConsumer_BlockingNextTxReleasedOnConsumerRemoval(t *testing.T) {
 	))
 }
 
-// TestMempoolConsumer_RemovalCannotRepopulateFullCache verifies that a NextTx
-// blocked on a full cache cannot race the final removal clear, insert another
-// body, and leak its aggregate byte reservation.
-func TestMempoolConsumer_RemovalCannotRepopulateFullCache(t *testing.T) {
+// TestMempoolConsumer_ConcurrentRemovalReleasesRetainedBytes verifies the
+// concurrent-removal end state: a NextTx blocked on a full cache is released
+// without another advertisement, and the final clear releases both byte
+// counters. TestMempoolConsumer_RemovalRejectsLaterCacheWrites separately
+// exercises the post-cancellation cacheTransaction guard.
+func TestMempoolConsumer_ConcurrentRemovalReleasesRetainedBytes(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EventBus:          event.NewEventBus(nil, nil),

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1309,6 +1309,38 @@ func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	assert.NotNil(t, consumer.GetTxFromCache("large"))
 }
 
+func TestMempoolConsumer_OversizedTransactionDoesNotBlockCursor(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    10,
+		ConsumerCacheSize:  10,
+		ConsumerCacheBytes: 4,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	m.transactions = append(m.transactions,
+		&MempoolTransaction{Hash: "oversized", Cbor: make([]byte, 5)},
+		&MempoolTransaction{Hash: "relayable", Cbor: make([]byte, 3)},
+	)
+
+	nonBlocking := mustAddConsumer(t, m, newTestConnectionId(10))
+	tx := nonBlocking.NextTx(false)
+	require.NotNil(t, tx)
+	assert.Equal(t, "relayable", tx.Hash)
+	assert.Equal(t, 2, nonBlocking.nextTxIdx)
+	assert.Nil(t, nonBlocking.GetTxFromCache("oversized"))
+
+	blocking := mustAddConsumer(t, m, newTestConnectionId(11))
+	tx = blocking.NextTx(true)
+	require.NotNil(t, tx)
+	assert.Equal(t, "relayable", tx.Hash)
+	assert.Equal(t, 2, blocking.nextTxIdx)
+}
+
 func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1347,6 +1347,74 @@ func TestMempoolConsumer_OversizedTransactionDoesNotBlockCursor(t *testing.T) {
 	assert.Equal(t, 2, blocking.nextTxIdx)
 }
 
+// TestMempoolConsumer_DefaultCacheBudgetHasFloor verifies that the
+// per-consumer byte budget derived from MempoolCapacity (ConsumerCacheBytes
+// left at zero) cannot truncate below minConsumerCacheBytes. Without the
+// floor, a realistic-but-small MempoolCapacity yields a derived budget
+// smaller than an ordinary transaction body, and NextTx would then skip it
+// forever.
+func TestMempoolConsumer_DefaultCacheBudgetHasFloor(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:          event.NewEventBus(nil, nil),
+		PromRegistry:      prometheus.NewRegistry(),
+		Validator:         newMockValidator(),
+		MempoolCapacity:   1000,
+		ConsumerCacheSize: 10,
+		// ConsumerCacheBytes intentionally left at zero: the naive derivation
+		// (MempoolCapacity/4 = 250) is smaller than the 300-byte body below.
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	tx := &MempoolTransaction{Hash: "typical", Cbor: make([]byte, 300)}
+	m.transactions = append(m.transactions, tx)
+	consumer := mustAddConsumer(t, m, newTestConnectionId(0))
+
+	require.Greater(
+		t, consumer.cacheLimitBytes, int64(300),
+		"unfloored derivation (capacity/4=250) would permanently skip this body",
+	)
+
+	skippedBefore := testutil.ToFloat64(m.metrics.consumerCacheBytesSkipped)
+	got := consumer.NextTx(false)
+	require.NotNil(t, got, "a realistic-size body must not be skipped forever")
+	assert.Equal(t, "typical", got.Hash)
+	skippedAfter := testutil.ToFloat64(m.metrics.consumerCacheBytesSkipped)
+	assert.Equal(
+		t, skippedBefore, skippedAfter,
+		"a relayed body must not also be counted as skipped",
+	)
+}
+
+// TestMempoolConsumer_OversizedSkipIsObservable verifies that a permanently
+// skipped oversized body increments the consumerCacheBytesSkipped counter,
+// so this failure mode is visible instead of looking like a healthy idle
+// relay.
+func TestMempoolConsumer_OversizedSkipIsObservable(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    10,
+		ConsumerCacheSize:  10,
+		ConsumerCacheBytes: 4,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	m.transactions = append(m.transactions,
+		&MempoolTransaction{Hash: "oversized", Cbor: make([]byte, 5)},
+	)
+	consumer := mustAddConsumer(t, m, newTestConnectionId(0))
+
+	skippedBefore := testutil.ToFloat64(m.metrics.consumerCacheBytesSkipped)
+	assert.Nil(t, consumer.NextTx(false))
+	skippedAfter := testutil.ToFloat64(m.metrics.consumerCacheBytesSkipped)
+	assert.Equal(t, skippedBefore+1, skippedAfter)
+}
+
 // TestMempoolConsumer_CachesShareAggregateByteLimit verifies that retained
 // copies across consumers share one aggregate budget and that releasing one
 // consumer's copy allows another consumer to advertise the transaction.

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -238,6 +238,16 @@ func mustAddConsumer(
 	return consumer
 }
 
+func retainedConsumerCacheBytes(consumer *MempoolConsumer) int64 {
+	consumer.cacheMutex.Lock()
+	defer consumer.cacheMutex.Unlock()
+	var ret int64
+	for _, tx := range consumer.cache {
+		ret += int64(len(tx.Cbor))
+	}
+	return ret
+}
+
 // newTestMempoolWithValidator creates a mempool with a specific validator
 func newTestMempoolWithValidator(
 	t *testing.T,
@@ -1261,6 +1271,75 @@ func TestMempoolConsumer_CacheIsBounded(t *testing.T) {
 	assert.Equal(t, txs[2].Hash, third.Hash)
 	assert.NotNil(t, consumer.GetTxFromCache(txs[2].Hash))
 	assert.Len(t, consumer.cache, 2)
+}
+
+func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:          event.NewEventBus(nil, nil),
+		PromRegistry:      prometheus.NewRegistry(),
+		Validator:         newMockValidator(),
+		MempoolCapacity:   10,
+		ConsumerCacheSize: 10,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	txs := []*MempoolTransaction{
+		{Hash: "small", Cbor: make([]byte, 4)},
+		{Hash: "large", Cbor: make([]byte, 7)},
+	}
+	m.transactions = append(m.transactions, txs...)
+	consumer := mustAddConsumer(t, m, newTestConnectionId(0))
+
+	first := consumer.NextTx(false)
+	require.NotNil(t, first)
+	require.Equal(t, "small", first.Hash)
+	assert.Nil(t, consumer.NextTx(false), "11 retained bytes exceed the limit")
+	assert.Equal(t, int64(4), retainedConsumerCacheBytes(consumer))
+	assert.Equal(t, 1, consumer.nextTxIdx, "unadvertised tx stays at the cursor")
+	assert.NotNil(t, consumer.GetTxFromCache("small"))
+
+	consumer.RemoveTxFromCache("small")
+	next := consumer.NextTx(false)
+	require.NotNil(t, next)
+	assert.Equal(t, "large", next.Hash)
+	assert.Equal(t, int64(7), retainedConsumerCacheBytes(consumer))
+	assert.NotNil(t, consumer.GetTxFromCache("large"))
+}
+
+func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:          event.NewEventBus(nil, nil),
+		PromRegistry:      prometheus.NewRegistry(),
+		Validator:         newMockValidator(),
+		MempoolCapacity:   10,
+		ConsumerCacheSize: 10,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	tx := &MempoolTransaction{Hash: "shared", Cbor: make([]byte, 6)}
+	m.transactions = append(m.transactions, tx)
+	firstID := newTestConnectionId(1)
+	secondID := newTestConnectionId(2)
+	first := mustAddConsumer(t, m, firstID)
+	second := mustAddConsumer(t, m, secondID)
+
+	require.NotNil(t, first.NextTx(false))
+	assert.Nil(t, second.NextTx(false), "two retained copies exceed aggregate limit")
+	assert.Equal(t, 0, second.nextTxIdx, "aggregate backpressure preserves cursor")
+	assert.Equal(t, int64(6), retainedConsumerCacheBytes(first)+retainedConsumerCacheBytes(second))
+	assert.NotNil(t, first.GetTxFromCache(tx.Hash), "advertised body is retransmittable")
+
+	first.RemoveTxFromCache(tx.Hash)
+	require.NotNil(t, second.NextTx(false))
+	assert.Equal(t, int64(6), retainedConsumerCacheBytes(first)+retainedConsumerCacheBytes(second))
+	assert.NotNil(t, second.GetTxFromCache(tx.Hash))
+
+	m.RemoveConsumer(secondID)
+	assert.Equal(t, int64(0), retainedConsumerCacheBytes(second), "consumer removal releases bytes")
 }
 
 func TestMempoolConsumer_ClearCache(t *testing.T) {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1273,6 +1273,9 @@ func TestMempoolConsumer_CacheIsBounded(t *testing.T) {
 	assert.Len(t, consumer.cache, 2)
 }
 
+// TestMempoolConsumer_CacheIsBoundedByRetainedBytes verifies that temporary
+// per-consumer byte pressure preserves the cursor until retained bytes are
+// released, while keeping every advertised body available for retransmission.
 func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -1309,6 +1312,9 @@ func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	assert.NotNil(t, consumer.GetTxFromCache("large"))
 }
 
+// TestMempoolConsumer_OversizedTransactionDoesNotBlockCursor verifies that a
+// body which can never fit the consumer budget is skipped instead of wedging
+// blocking or non-blocking consumers behind it.
 func TestMempoolConsumer_OversizedTransactionDoesNotBlockCursor(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -1341,6 +1347,9 @@ func TestMempoolConsumer_OversizedTransactionDoesNotBlockCursor(t *testing.T) {
 	assert.Equal(t, 2, blocking.nextTxIdx)
 }
 
+// TestMempoolConsumer_CachesShareAggregateByteLimit verifies that retained
+// copies across consumers share one aggregate budget and that releasing one
+// consumer's copy allows another consumer to advertise the transaction.
 func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -1376,6 +1385,8 @@ func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 	assert.Equal(t, int64(0), retainedConsumerCacheBytes(second), "consumer removal releases bytes")
 }
 
+// TestMempoolConsumer_RemovalRejectsLaterCacheWrites verifies that cancellation
+// prevents a removed consumer from reserving bytes or repopulating its cache.
 func TestMempoolConsumer_RemovalRejectsLaterCacheWrites(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
@@ -4196,6 +4207,9 @@ func TestMempoolConsumer_BlockingNextTxReleasedOnConsumerRemoval(t *testing.T) {
 	))
 }
 
+// TestMempoolConsumer_RemovalCannotRepopulateFullCache verifies that a NextTx
+// blocked on a full cache cannot race the final removal clear, insert another
+// body, and leak its aggregate byte reservation.
 func TestMempoolConsumer_RemovalCannotRepopulateFullCache(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
 		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1275,19 +1275,20 @@ func TestMempoolConsumer_CacheIsBounded(t *testing.T) {
 
 func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
-		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:          event.NewEventBus(nil, nil),
-		PromRegistry:      prometheus.NewRegistry(),
-		Validator:         newMockValidator(),
-		MempoolCapacity:   10,
-		ConsumerCacheSize: 10,
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    10,
+		ConsumerCacheSize:  10,
+		ConsumerCacheBytes: 6,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
 
 	txs := []*MempoolTransaction{
 		{Hash: "small", Cbor: make([]byte, 4)},
-		{Hash: "large", Cbor: make([]byte, 7)},
+		{Hash: "large", Cbor: make([]byte, 3)},
 	}
 	m.transactions = append(m.transactions, txs...)
 	consumer := mustAddConsumer(t, m, newTestConnectionId(0))
@@ -1295,7 +1296,7 @@ func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	first := consumer.NextTx(false)
 	require.NotNil(t, first)
 	require.Equal(t, "small", first.Hash)
-	assert.Nil(t, consumer.NextTx(false), "11 retained bytes exceed the limit")
+	assert.Nil(t, consumer.NextTx(false), "7 retained bytes exceed the per-consumer limit")
 	assert.Equal(t, int64(4), retainedConsumerCacheBytes(consumer))
 	assert.Equal(t, 1, consumer.nextTxIdx, "unadvertised tx stays at the cursor")
 	assert.NotNil(t, consumer.GetTxFromCache("small"))
@@ -1304,18 +1305,19 @@ func TestMempoolConsumer_CacheIsBoundedByRetainedBytes(t *testing.T) {
 	next := consumer.NextTx(false)
 	require.NotNil(t, next)
 	assert.Equal(t, "large", next.Hash)
-	assert.Equal(t, int64(7), retainedConsumerCacheBytes(consumer))
+	assert.Equal(t, int64(3), retainedConsumerCacheBytes(consumer))
 	assert.NotNil(t, consumer.GetTxFromCache("large"))
 }
 
 func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 	m, err := NewMempool(MempoolConfig{
-		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		EventBus:          event.NewEventBus(nil, nil),
-		PromRegistry:      prometheus.NewRegistry(),
-		Validator:         newMockValidator(),
-		MempoolCapacity:   10,
-		ConsumerCacheSize: 10,
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:           event.NewEventBus(nil, nil),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    10,
+		ConsumerCacheSize:  10,
+		ConsumerCacheBytes: 10,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
@@ -1340,6 +1342,32 @@ func TestMempoolConsumer_CachesShareAggregateByteLimit(t *testing.T) {
 
 	m.RemoveConsumer(secondID)
 	assert.Equal(t, int64(0), retainedConsumerCacheBytes(second), "consumer removal releases bytes")
+}
+
+func TestMempoolConsumer_RemovalRejectsLaterCacheWrites(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:             slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		PromRegistry:       prometheus.NewRegistry(),
+		Validator:          newMockValidator(),
+		MempoolCapacity:    10,
+		ConsumerCacheBytes: 10,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	connID := newTestConnectionId(3)
+	consumer := mustAddConsumer(t, m, connID)
+	m.RemoveConsumer(connID)
+
+	cached, _ := consumer.cacheTransaction(&MempoolTransaction{
+		Hash: "after-removal",
+		Cbor: make([]byte, 6),
+	})
+	assert.False(t, cached, "cancelled consumer must reject cache writes")
+	assert.Equal(t, int64(0), retainedConsumerCacheBytes(consumer))
+	m.relayCacheMutex.Lock()
+	assert.Equal(t, int64(0), m.relayCacheBytes)
+	m.relayCacheMutex.Unlock()
 }
 
 func TestMempoolConsumer_ClearCache(t *testing.T) {

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -4164,6 +4164,55 @@ func TestMempoolConsumer_BlockingNextTxReleasedOnConsumerRemoval(t *testing.T) {
 	))
 }
 
+func TestMempoolConsumer_RemovalCannotRepopulateFullCache(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:          event.NewEventBus(nil, nil),
+		PromRegistry:      prometheus.NewRegistry(),
+		Validator:         newMockValidator(),
+		MempoolCapacity:   1024 * 1024,
+		ConsumerCacheSize: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, m.Stop(context.Background())) })
+
+	addMockTransactions(t, m, 2)
+	connID := newTestConnectionId(1)
+	consumer := mustAddConsumer(t, m, connID)
+	require.NotNil(t, consumer.NextTx(false))
+
+	got := make(chan *MempoolTransaction, 1)
+	go func() { got <- consumer.NextTx(true) }()
+	dingotestutil.RequireNoReceive(t, got, 100*time.Millisecond, "cache is full")
+
+	cacheCleared := make(chan struct{})
+	releaseClear := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseClear) }) }
+	defer release()
+	consumer.onCacheCleared = func() {
+		close(cacheCleared)
+		<-releaseClear
+	}
+	removed := make(chan struct{})
+	go func() {
+		m.RemoveConsumer(connID)
+		close(removed)
+	}()
+	dingotestutil.RequireReceive(t, cacheCleared, 2*time.Second, "final cache clear")
+
+	assert.Nil(t, dingotestutil.RequireReceive(
+		t, got, 2*time.Second, "blocking NextTx released by removal",
+	), "cancelled consumer must not advertise another transaction")
+	release()
+	dingotestutil.RequireReceive(t, removed, 2*time.Second, "consumer removal")
+	assert.Equal(t, int64(0), retainedConsumerCacheBytes(consumer))
+	m.relayCacheMutex.Lock()
+	assert.Equal(t, int64(0), m.relayCacheBytes)
+	m.relayCacheMutex.Unlock()
+}
+
 // blockingRejectingValidator blocks until released like
 // blockingSessionValidator, then reports one designated transaction invalid so
 // a test can observe whether revalidation actually published its result.


### PR DESCRIPTION
Closes #3518.

- Bound each relay consumer's retained CBOR by mempool capacity.
- Bound retained CBOR across all relay consumers by the same aggregate budget.
- Keep unadvertised transactions at the consumer cursor until acknowledgements or body delivery release capacity.
- Preserve advertised bodies for retransmission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #3518. Bounds mempool relay caches by retained bytes so a single consumer or all consumers together can't hold more transaction body data than the configured mempool capacity.

- The per-consumer byte budget defaults to one quarter of `MempoolCapacity` (`ConsumerCacheBytes` overrides it) and is floored at 16 KiB when derived; the aggregate budget defaults to full capacity, and the existing 1,024-entry count bound still applies.
- While a budget is full, `NextTx` keeps unadvertised transactions at the cursor until acknowledgement or body delivery frees capacity.
- Bodies too large for a consumer's budget are skipped so they can't pin the cursor and starve later transactions; each skip logs a warning and bumps a counter so silent relay loss stays observable.
- Removing a consumer releases its retained bytes and marks it cancelled so it can't re-fill the cache; `ARCHITECTURE.md` documents the limits.
- `ConsumerCacheBytes` is now wired through `ProviderConfig` so operators can set it via YAML.

<sup>Written for commit 526907f21ccdcc1cd3f2b897e2679d3b58cd59ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction relay caches are now bounded by both entry count and retained data size.
  * Added configurable per-consumer cache size limits, with sensible defaults and a shared aggregate limit.
  * Transactions too large to fit a consumer’s cache are skipped instead of blocking later relayable transactions.
  * Transactions are no longer advertised when cache capacity is unavailable; advertising resumes as space is released.
  * Removing cached transactions or consumers now correctly frees retained capacity and prevents stale cache reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->