### PR TITLE
fix(ledger): check MIR pot capacity before crediting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8007,7 +8007,15 @@ a fixed order, mirroring `cardano-ledger`'s sequencing:
    Shelley's `NEWEPOCH` embeds MIR between `applyRUpd` and `EPOCH`, so it runs
    before both the stake snapshot and POOLREAP: its credits are part of the mark
    snapshot and its pot movements are visible to POOLREAP, governance and the
-   ADA-pot capture.
+   ADA-pot capture. The boundary's certificates are aggregated and checked
+   against pot capacity before any of them is applied, mirroring
+   `mirTransition`: credits are restricted to registered, active reward
+   accounts, pot-to-pot transfers are folded into the available balances, and
+   the boundary is applied only when `totR <= availableReserves && totT <=
+   availableTreasury`. When either pot falls short the whole boundary is a
+   no-op — no credit, debit or transfer is written — and the rollover still
+   succeeds; the certificates are scoped to the ended epoch's slot range, so a
+   discarded MIR is not retried at the next boundary.
 3. SNAP-point mark stake read (`captureEpochBoundarySnapshotStake` →
    `snapshot.Manager.ComputeEpochBoundarySnapshot`, when a stake hook is
    installed): read the mark snapshot's stake distribution here, after the two

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2376,7 +2376,7 @@ rollback past the boundary reverts them and re-application is deterministic.
 
 ### `GetMIRCertsInSlotRange`
 
-MIR certificates for the epoch range `[startSlot, endSlot)`, applied at the epoch boundary as the Shelley INSTANT rule. Distribution certs (`other_pot = 0`) credit registered reward accounts and debit the source pot in `network_state`; pot-to-pot transfer certs (`other_pot > 0`) move that amount between treasury and reserves directly. The `mir.id` value is retained by the processed effect as the per-MIR reward-credit discriminator so multiple MIR certs can credit the same account at one boundary without collapsing into one `account_reward_delta` row.
+MIR certificates for the epoch range `[startSlot, endSlot)`, applied at the epoch boundary as the Shelley INSTANT rule. Distribution certs (`other_pot = 0`) credit registered reward accounts and debit the source pot in `network_state`; pot-to-pot transfer certs (`other_pot > 0`) move that amount between treasury and reserves. Every cert in the range is aggregated before any is applied: distribution totals count only credentials with a registered, active account, transfers are folded into the available pot balances, and the boundary writes a single `network_state` row. If either pot cannot cover its total the boundary is a no-op rather than an error, so an over-budget cert cannot fail the epoch rollover on every retry. The `mir.id` value is retained by the processed effect as the per-MIR reward-credit discriminator so multiple MIR certs can credit the same account at one boundary without collapsing into one `account_reward_delta` row.
 
 ```sql
 SELECT mir.id, mir.pot, mir.other_pot, mir.added_slot,

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/governance"
 )
 
@@ -42,15 +43,36 @@ const (
 // boundarySlot is the first slot of the new epoch (exclusive upper bound).
 // MIR certs with added_slot in [epochStartSlot, boundarySlot) are applied.
 //
+// The boundary is evaluated as a whole before any of it is applied, mirroring
+// cardano-ledger's MIR rule (`Cardano.Ledger.Shelley.Rules.Mir.mirTransition`),
+// which folds every pending certificate into one `InstantaneousRewards` value
+// and applies it only when both pots can cover their totals:
+//
+//	availableReserves = reserves + deltaReserves
+//	availableTreasury = treasury + deltaTreasury
+//	if totR <= availableReserves && totT <= availableTreasury then ... else ...
+//
 // Distribution MIR (credential→amount map):
 //   - Registered, active reward accounts are credited from the source pot.
 //   - Credentials without a registered account are silently skipped — unlike
-//     POOLREAP, there is no fallback routing to the treasury.
+//     POOLREAP, there is no fallback routing to the treasury. They are also
+//     excluded from the pot totals, matching the `Map.intersection accountsMap`
+//     restriction cardano-ledger applies before folding.
 //   - The source pot is debited only for amounts actually credited.
 //
 // Pot-to-pot transfer MIR (OtherPot > 0):
 //   - Source=0 (Reserves) moves OtherPot lovelace from reserves to treasury.
 //   - Source=1 (Treasury) moves OtherPot lovelace from treasury to reserves.
+//   - Transfers are folded into the available pot balances before the capacity
+//     check, so they fund distributions made at the same boundary.
+//
+// When either pot cannot cover its total the whole boundary is a no-op: no
+// credit, no debit and no transfer is written, and the epoch rollover still
+// succeeds. cardano-ledger's else branch returns the original
+// `ChainAccountState` and clears the pending rewards, so an over-budget
+// certificate is discarded rather than retried. Failing the boundary instead
+// would wedge the node, since the stored certificates are re-read and re-fail
+// on every deterministic retry.
 func (ls *LedgerState) applyMIRCerts(
 	txn *database.Txn,
 	epochStartSlot uint64,
@@ -65,64 +87,292 @@ func (ls *LedgerState) applyMIRCerts(
 	if len(effects) == 0 {
 		return nil
 	}
+	boundary, err := ls.collectMIRBoundary(txn, effects)
+	if err != nil {
+		return err
+	}
+	if boundary.isEmpty() {
+		return nil
+	}
+	treasury, reserves, err := ls.readNetworkState(txn)
+	if err != nil {
+		return fmt.Errorf("apply MIR certs: %w", err)
+	}
+	availableReserves, reservesOk, err := mirAvailablePot(
+		"reserves", reserves, boundary.reservesIn, boundary.reservesOut,
+	)
+	if err != nil {
+		return err
+	}
+	availableTreasury, treasuryOk, err := mirAvailablePot(
+		"treasury", treasury, boundary.treasuryIn, boundary.treasuryOut,
+	)
+	if err != nil {
+		return err
+	}
+	if !reservesOk || !treasuryOk ||
+		boundary.totalReserves > availableReserves ||
+		boundary.totalTreasury > availableTreasury {
+		ls.config.Logger.Warn(
+			"skipping over-budget MIR at epoch boundary",
+			"slot", boundarySlot,
+			"reserves", reserves,
+			"reserves_distributed", boundary.totalReserves,
+			"treasury", treasury,
+			"treasury_distributed", boundary.totalTreasury,
+			"component", "ledger",
+		)
+		return nil
+	}
+	appliedReserves, appliedTreasury, err := ls.applyMIRCredits(
+		txn, boundary.credits, boundarySlot,
+	)
+	if err != nil {
+		return err
+	}
+	newReserves := availableReserves - appliedReserves
+	newTreasury := availableTreasury - appliedTreasury
+	if newReserves == reserves && newTreasury == treasury {
+		return nil
+	}
+	return ls.db.Metadata().
+		SetNetworkState(newTreasury, newReserves, boundarySlot, txn.Metadata())
+}
+
+// mirCredit is one registered-account credit selected for application at an
+// epoch boundary.
+type mirCredit struct {
+	mirID         uint
+	pot           uint
+	credentialTag uint8
+	credential    []byte
+	amount        uint64
+}
+
+// mirBoundary is the aggregate of every MIR certificate in one ended epoch,
+// collected before any of it is applied. It is the Dingo equivalent of
+// cardano-ledger's accumulated `InstantaneousRewards`: totalReserves/
+// totalTreasury correspond to `totR`/`totT` over the registered-account
+// restriction, and the in/out sums to `deltaReserves`/`deltaTreasury`.
+type mirBoundary struct {
+	credits       []mirCredit
+	totalReserves uint64
+	totalTreasury uint64
+	reservesIn    uint64
+	reservesOut   uint64
+	treasuryIn    uint64
+	treasuryOut   uint64
+}
+
+// isEmpty reports whether the boundary carries no pot movement at all, in
+// which case no NetworkState row is written for it.
+func (b *mirBoundary) isEmpty() bool {
+	return len(b.credits) == 0 &&
+		b.reservesIn == 0 && b.reservesOut == 0 &&
+		b.treasuryIn == 0 && b.treasuryOut == 0
+}
+
+// addCredit records a credit against its source pot, keeping the per-pot total
+// that the capacity check compares against the pot.
+func (b *mirBoundary) addCredit(credit mirCredit) error {
+	total := &b.totalReserves
+	if credit.pot == mirPotTreasury {
+		total = &b.totalTreasury
+	}
+	if credit.amount > ^uint64(0)-*total {
+		return fmt.Errorf(
+			"MIR distribution total overflow: current=%d adding=%d",
+			*total,
+			credit.amount,
+		)
+	}
+	*total += credit.amount
+	b.credits = append(b.credits, credit)
+	return nil
+}
+
+// addTransfer records a pot-to-pot transfer as an outflow from its source pot
+// and an inflow to the other one.
+func (b *mirBoundary) addTransfer(sourcePot uint, amount uint64) error {
+	var out, in *uint64
+	switch sourcePot {
+	case mirPotReserves:
+		out, in = &b.reservesOut, &b.treasuryIn
+	case mirPotTreasury:
+		out, in = &b.treasuryOut, &b.reservesIn
+	default:
+		return fmt.Errorf("unknown MIR source pot %d", sourcePot)
+	}
+	if amount > ^uint64(0)-*out || amount > ^uint64(0)-*in {
+		return fmt.Errorf(
+			"MIR pot transfer total overflow: moving %d",
+			amount,
+		)
+	}
+	*out += amount
+	*in += amount
+	return nil
+}
+
+// collectMIRBoundary folds every effect for the ended epoch into a single
+// mirBoundary without mutating any state. Distribution credits are restricted
+// to registered, active reward accounts, resolved in one batched lookup.
+func (ls *LedgerState) collectMIRBoundary(
+	txn *database.Txn,
+	effects []models.MIREffect,
+) (*mirBoundary, error) {
+	registered, err := ls.registeredMIRAccounts(txn, effects)
+	if err != nil {
+		return nil, err
+	}
+	boundary := &mirBoundary{}
 	for _, effect := range effects {
 		if effect.OtherPot > 0 {
-			if err := ls.applyMIRPotTransfer(
-				txn, effect.Pot, effect.OtherPot, boundarySlot,
+			if err := boundary.addTransfer(
+				effect.Pot, effect.OtherPot,
 			); err != nil {
-				return err
+				return nil, err
 			}
 			continue
 		}
-		var totalDebited uint64
-		for _, reward := range effect.Rewards {
-			credited, err := governance.CreditRegisteredRewardAccountBeforeSnapshot(
-				ls.db,
-				txn,
-				reward.CredentialTag,
-				reward.Credential,
-				reward.Amount,
-				boundarySlot,
-				// MIR has no transaction hash in this processed effect, so
-				// the MIR row ID is encoded as a synthetic discriminator.
-				// That keeps two MIR certs crediting the same account in
-				// one epoch as distinct journal rows while still mapping a
-				// crash-replayed boundary to the same row.
-				mirRewardSourceHash(effect.ID),
-			)
-			if err != nil {
-				return fmt.Errorf(
-					"apply MIR reward to %x: %w",
-					reward.Credential, err,
-				)
-			}
-			if credited {
-				if reward.Amount > ^uint64(0)-totalDebited {
-					return fmt.Errorf(
-						"MIR distribution total overflow: current=%d adding=%d",
-						totalDebited,
-						reward.Amount,
-					)
-				}
-				totalDebited += reward.Amount
-				ls.config.Logger.Debug(
-					"applied MIR reward",
-					"credential", hex.EncodeToString(reward.Credential),
-					"amount", reward.Amount,
-					"pot", effect.Pot,
-					"component", "ledger",
-				)
-			}
+		if effect.Pot != mirPotReserves && effect.Pot != mirPotTreasury {
+			return nil, fmt.Errorf("unknown MIR pot %d", effect.Pot)
 		}
-		if totalDebited > 0 {
-			if err := ls.debitMIRPot(
-				txn, effect.Pot, totalDebited, boundarySlot,
-			); err != nil {
-				return err
+		for _, reward := range effect.Rewards {
+			ref := models.NewStakeCredentialRef(
+				reward.CredentialTag, reward.Credential,
+			)
+			if !registered[ref.MapKey()] {
+				continue
+			}
+			if err := boundary.addCredit(mirCredit{
+				mirID:         effect.ID,
+				pot:           effect.Pot,
+				credentialTag: reward.CredentialTag,
+				credential:    reward.Credential,
+				amount:        reward.Amount,
+			}); err != nil {
+				return nil, err
 			}
 		}
 	}
-	return nil
+	return boundary, nil
+}
+
+// registeredMIRAccounts returns the set of distribution credentials that have a
+// registered, active reward account, keyed by StakeCredentialRef.MapKey(). This
+// is the read-only equivalent of the account lookup the credit path performs,
+// and it establishes the same registered-vs-skipped split before any pot is
+// debited.
+func (ls *LedgerState) registeredMIRAccounts(
+	txn *database.Txn,
+	effects []models.MIREffect,
+) (map[string]bool, error) {
+	refs := make([]models.StakeCredentialRef, 0, len(effects))
+	seen := make(map[string]struct{})
+	for _, effect := range effects {
+		if effect.OtherPot > 0 {
+			continue
+		}
+		for _, reward := range effect.Rewards {
+			ref := models.NewStakeCredentialRef(
+				reward.CredentialTag, reward.Credential,
+			)
+			if _, ok := seen[ref.MapKey()]; ok {
+				continue
+			}
+			seen[ref.MapKey()] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	accounts, err := ls.db.GetAccountsByCredential(refs, false, txn)
+	if err != nil {
+		return nil, fmt.Errorf("get MIR reward accounts: %w", err)
+	}
+	registered := make(map[string]bool, len(accounts))
+	for key, account := range accounts {
+		if account != nil {
+			registered[key] = true
+		}
+	}
+	return registered, nil
+}
+
+// applyMIRCredits credits every selected reward account and returns the amount
+// actually applied per source pot. The totals are re-derived here rather than
+// reused from the capacity check so the pot debit can never exceed what was
+// credited.
+func (ls *LedgerState) applyMIRCredits(
+	txn *database.Txn,
+	credits []mirCredit,
+	boundarySlot uint64,
+) (appliedReserves, appliedTreasury uint64, err error) {
+	for _, credit := range credits {
+		credited, err := governance.CreditRegisteredRewardAccountBeforeSnapshot(
+			ls.db,
+			txn,
+			credit.credentialTag,
+			credit.credential,
+			credit.amount,
+			boundarySlot,
+			// MIR has no transaction hash in this processed effect, so
+			// the MIR row ID is encoded as a synthetic discriminator.
+			// That keeps two MIR certs crediting the same account in
+			// one epoch as distinct journal rows while still mapping a
+			// crash-replayed boundary to the same row.
+			mirRewardSourceHash(credit.mirID),
+		)
+		if err != nil {
+			return 0, 0, fmt.Errorf(
+				"apply MIR reward to %x: %w",
+				credit.credential, err,
+			)
+		}
+		if !credited {
+			continue
+		}
+		if credit.pot == mirPotTreasury {
+			appliedTreasury += credit.amount
+		} else {
+			appliedReserves += credit.amount
+		}
+		ls.config.Logger.Debug(
+			"applied MIR reward",
+			"credential", hex.EncodeToString(credit.credential),
+			"amount", credit.amount,
+			"pot", credit.pot,
+			"component", "ledger",
+		)
+	}
+	return appliedReserves, appliedTreasury, nil
+}
+
+// mirAvailablePot folds the epoch's pot-to-pot transfers into a pot balance.
+// cardano-ledger computes `reserves + deltaReserves` over unbounded Coin, so a
+// net outflow larger than the pot yields a negative available balance and the
+// rule takes its no-op branch; ok=false reports that case. A uint64 overflow on
+// the inbound side has no cardano-ledger analogue and is reported as an error
+// against corrupt stored state.
+func mirAvailablePot(
+	name string,
+	balance, in, out uint64,
+) (available uint64, ok bool, err error) {
+	if balance > ^uint64(0)-in {
+		return 0, false, fmt.Errorf(
+			"MIR pot transfer would overflow %s: pot has %d, moving %d",
+			name,
+			balance,
+			in,
+		)
+	}
+	available = balance + in
+	if out > available {
+		return 0, false, nil
+	}
+	return available - out, true, nil
 }
 
 func mirRewardSourceHash(mirID uint) []byte {
@@ -133,104 +383,6 @@ func mirRewardSourceHash(mirID uint) []byte {
 		uint64(mirID),
 	)
 	return out
-}
-
-// debitMIRPot decrements the given Ada pot by amount, writing an updated
-// NetworkState at boundarySlot. Shared by distribution MIR processing; the
-// pot-to-pot path uses applyMIRPotTransfer which does a combined read-modify.
-func (ls *LedgerState) debitMIRPot(
-	txn *database.Txn,
-	pot uint,
-	amount uint64,
-	slot uint64,
-) error {
-	treasury, reserves, err := ls.readNetworkState(txn)
-	if err != nil {
-		return fmt.Errorf("debit MIR pot: %w", err)
-	}
-	switch pot {
-	case mirPotReserves:
-		if amount > reserves {
-			return fmt.Errorf(
-				"MIR would underflow reserves: pot has %d, distributing %d",
-				reserves, amount,
-			)
-		}
-		reserves -= amount
-	case mirPotTreasury:
-		if amount > treasury {
-			return fmt.Errorf(
-				"MIR would underflow treasury: pot has %d, distributing %d",
-				treasury, amount,
-			)
-		}
-		treasury -= amount
-	default:
-		return fmt.Errorf("unknown MIR pot %d", pot)
-	}
-	return ls.db.Metadata().
-		SetNetworkState(treasury, reserves, slot, txn.Metadata())
-}
-
-// applyMIRPotTransfer moves amount lovelace between the two Ada pots at slot.
-// Source=0 (Reserves) transfers from reserves to treasury.
-// Source=1 (Treasury) transfers from treasury to reserves.
-func (ls *LedgerState) applyMIRPotTransfer(
-	txn *database.Txn,
-	sourcePot uint,
-	amount uint64,
-	slot uint64,
-) error {
-	treasury, reserves, err := ls.readNetworkState(txn)
-	if err != nil {
-		return fmt.Errorf("apply MIR pot transfer: %w", err)
-	}
-	switch sourcePot {
-	case mirPotReserves:
-		if amount > reserves {
-			return fmt.Errorf(
-				"MIR pot transfer would underflow reserves: pot has %d, moving %d",
-				reserves,
-				amount,
-			)
-		}
-		if amount > ^uint64(0)-treasury {
-			return fmt.Errorf(
-				"MIR pot transfer would overflow treasury: pot has %d, moving %d",
-				treasury,
-				amount,
-			)
-		}
-		reserves -= amount
-		treasury += amount
-	case mirPotTreasury:
-		if amount > treasury {
-			return fmt.Errorf(
-				"MIR pot transfer would underflow treasury: pot has %d, moving %d",
-				treasury,
-				amount,
-			)
-		}
-		if amount > ^uint64(0)-reserves {
-			return fmt.Errorf(
-				"MIR pot transfer would overflow reserves: pot has %d, moving %d",
-				reserves,
-				amount,
-			)
-		}
-		treasury -= amount
-		reserves += amount
-	default:
-		return fmt.Errorf("unknown MIR source pot %d", sourcePot)
-	}
-	ls.config.Logger.Debug(
-		"applied MIR pot-to-pot transfer",
-		"source_pot", sourcePot,
-		"amount", amount,
-		"component", "ledger",
-	)
-	return ls.db.Metadata().
-		SetNetworkState(treasury, reserves, slot, txn.Metadata())
 }
 
 // readNetworkState returns the current treasury and reserves from the most

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -551,3 +551,319 @@ func TestApplyMIRCerts_NoOp(t *testing.T) {
 	assert.Equal(t, uint64(50), state.Slot,
 		"no boundary row written when no MIR certs exist")
 }
+
+// TestApplyMIRCerts_OverBudgetReservesIsNoOp verifies that a distribution
+// exceeding the reserves pot is skipped for the epoch rather than failing the
+// boundary. cardano-ledger's MIR rule compares the registered-account total
+// against the available pot and returns the epoch state unchanged when it does
+// not fit, so an over-budget certificate must not abort the rollover.
+func TestApplyMIRCerts_OverBudgetReservesIsNoOp(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x61)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		500,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: types.Uint64(750)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 500, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000),
+		"over-budget MIR must not fail the epoch boundary")
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(account.Reward),
+		"no credit applied for an over-budget distribution")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(500), uint64(state.Reserves), "reserves untouched")
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury), "treasury untouched")
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary state row written when the distribution is skipped")
+}
+
+// TestApplyMIRCerts_ExactBudgetApplies verifies the boundary case where the
+// registered total exactly equals the pot: cardano-ledger uses `totR <=
+// availableReserves`, so an exact-budget certificate is applied and drains the
+// pot to zero.
+func TestApplyMIRCerts_ExactBudgetApplies(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x62)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		500,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: types.Uint64(750)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 750, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(750), uint64(account.Reward),
+		"exact-budget distribution is applied")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(state.Reserves), "reserves drained to zero")
+	assert.Equal(t, uint64(1_000), state.Slot,
+		"boundary state row written at the boundary slot")
+}
+
+// TestApplyMIRCerts_OverBudgetIsAggregateAcrossCerts verifies that the pot
+// check covers every certificate applied at the boundary rather than each
+// certificate individually. cardano-ledger accumulates all MIR credits into
+// iRReserves/iRTreasury and performs one comparison, so an affordable
+// certificate must not be applied when a sibling pushes the epoch total over
+// the pot.
+func TestApplyMIRCerts_OverBudgetIsAggregateAcrossCerts(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	credA := mirCred28(0x63)
+	credB := mirCred28(0x64)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: credA, Amount: types.Uint64(600)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		300,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: credB, Amount: types.Uint64(600)},
+		},
+	)
+	for _, cred := range [][]byte{credA, credB} {
+		require.NoError(t, db.CreateAccount(nil, &models.Account{
+			StakingKey: cred,
+			Active:     true,
+		}))
+	}
+	// Either cert alone fits in 1000; together they do not.
+	require.NoError(t, db.Metadata().SetNetworkState(0, 1_000, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000))
+
+	for _, cred := range [][]byte{credA, credB} {
+		account, err := db.GetAccountByCredential(0, cred, false, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), uint64(account.Reward),
+			"no cert applied when the epoch total exceeds the pot")
+	}
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), uint64(state.Reserves), "reserves untouched")
+	assert.Equal(t, uint64(50), state.Slot)
+}
+
+// TestApplyMIRCerts_BudgetExcludesUnregisteredCredentials verifies that the pot
+// comparison is made against the registered-account total only. cardano-ledger
+// restricts the credit map with `Map.intersection accountsMap` before folding,
+// so credits to unregistered credentials must not make an affordable
+// distribution look over budget.
+func TestApplyMIRCerts_BudgetExcludesUnregisteredCredentials(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	registered := mirCred28(0x65)
+	unregistered := mirCred28(0x66)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		500,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: registered, Amount: types.Uint64(400)},
+			{Credential: unregistered, Amount: types.Uint64(5_000)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: registered,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(0, 1_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	account, err := db.GetAccountByCredential(0, registered, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(400), uint64(account.Reward),
+		"registered credit applied; unregistered amount is not budgeted")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(600), uint64(state.Reserves),
+		"reserves debited only by the registered total")
+}
+
+// TestApplyMIRCerts_OverBudgetTreasuryBlocksReservesDistribution verifies the
+// all-or-nothing shape of the rule: cardano-ledger requires `totR <=
+// availableReserves && totT <= availableTreasury` and returns the account state
+// unchanged when either fails, so an over-budget treasury distribution also
+// suppresses an affordable reserves distribution.
+func TestApplyMIRCerts_OverBudgetTreasuryBlocksReservesDistribution(
+	t *testing.T,
+) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	reservesCred := mirCred28(0x67)
+	treasuryCred := mirCred28(0x68)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: reservesCred, Amount: types.Uint64(100)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotTreasury,
+		300,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: treasuryCred, Amount: types.Uint64(9_000)},
+		},
+	)
+	for _, cred := range [][]byte{reservesCred, treasuryCred} {
+		require.NoError(t, db.CreateAccount(nil, &models.Account{
+			StakingKey: cred,
+			Active:     true,
+		}))
+	}
+	require.NoError(t, db.Metadata().SetNetworkState(500, 1_000, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000))
+
+	for _, cred := range [][]byte{reservesCred, treasuryCred} {
+		account, err := db.GetAccountByCredential(0, cred, false, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), uint64(account.Reward),
+			"neither pot is distributed when one is over budget")
+	}
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), uint64(state.Reserves))
+	assert.Equal(t, uint64(500), uint64(state.Treasury))
+	assert.Equal(t, uint64(50), state.Slot)
+}
+
+// TestApplyMIRCerts_PotTransferCountsTowardAvailablePot verifies that a
+// pot-to-pot transfer in the same epoch is folded into the available pot before
+// the distribution check, matching cardano-ledger's `availableReserves =
+// reserves + deltaReserves`.
+func TestApplyMIRCerts_PotTransferCountsTowardAvailablePot(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x69)
+	// Treasury alone cannot cover 900, but gains 500 from reserves first.
+	seedMIRPotTransfer(t, gdb, mirPotReserves, 500, 200)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotTreasury,
+		300,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: types.Uint64(900)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(600, 2_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(900), uint64(account.Reward),
+		"distribution fits once the pot transfer is applied")
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(200), uint64(state.Treasury),
+		"treasury: 600 + 500 transferred - 900 distributed")
+	assert.Equal(t, uint64(1_500), uint64(state.Reserves),
+		"reserves: 2000 - 500 transferred")
+}
+
+// TestApplyMIRCerts_OverBudgetDropsPotTransfer verifies that the no-op branch
+// discards the epoch's pot-to-pot transfers as well. cardano-ledger's else
+// branch returns the original ChainAccountState, so the deltas that were only
+// ever folded into `available` are not written.
+func TestApplyMIRCerts_OverBudgetDropsPotTransfer(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x6a)
+	seedMIRPotTransfer(t, gdb, mirPotReserves, 500, 200)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		300,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: types.Uint64(5_000)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(0, 1_000, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000))
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(account.Reward))
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000), uint64(state.Reserves),
+		"pot transfer discarded along with the over-budget distribution")
+	assert.Equal(t, uint64(0), uint64(state.Treasury))
+	assert.Equal(t, uint64(50), state.Slot)
+}
+
+// TestApplyMIRCerts_PotTransferLargerThanPotIsNoOp verifies that a pot-to-pot
+// transfer exceeding its source pot is skipped rather than failing the
+// boundary. cardano-ledger computes `reserves + deltaReserves` over unbounded
+// Coin, so a net outflow larger than the pot makes `totR <= availableReserves`
+// false and the rule takes its no-op branch.
+func TestApplyMIRCerts_PotTransferLargerThanPotIsNoOp(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	seedMIRPotTransfer(t, gdb, mirPotReserves, 5_000, 200)
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 800, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000),
+		"an unaffordable pot transfer must not fail the epoch boundary")
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(800), uint64(state.Reserves), "reserves untouched")
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury), "treasury untouched")
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary state row written for a skipped transfer")
+}


### PR DESCRIPTION
Fixes #3425.

## Problem

`applyMIRCerts` credited every registered reward account and only then called
`debitMIRPot`, which fails when the selected pot cannot cover the total. The
failure aborted the epoch-rollover transaction, and because the certificates
remain in `move_instantaneous_rewards`, they were re-read and re-failed on
every deterministic retry, wedging the boundary.

Dingo does not implement the DELEG-time `InsufficientForInstantaneousRewards`
check, so an over-budget certificate can reach the epoch boundary.

## Change

The ended epoch's certificates are aggregated and checked before any of them is
applied, following `Cardano.Ledger.Shelley.Rules.Mir.mirTransition`:

- Credits are restricted to registered, active reward accounts before totalling
  (`Map.intersection accountsMap`), so an unregistered credential does not count
  against the pot.
- Pot-to-pot transfers are folded into the available balances
  (`deltaReserves` / `deltaTreasury`), so they fund distributions at the same
  boundary.
- The boundary is applied only when
  `totR <= availableReserves && totT <= availableTreasury`. When either pot
  falls short the whole boundary is a no-op — no credit, debit or transfer is
  written — and the rollover succeeds, mirroring the rule's else branch, which
  returns the original `ChainAccountState` and clears the pending rewards.
- An unaffordable pot-to-pot transfer takes the same no-op branch, since
  cardano-ledger computes the available balance over unbounded `Coin`. A uint64
  overflow has no reference analogue and still returns an error.

The boundary now writes one `network_state` row instead of one per certificate.

`ARCHITECTURE.md` (rollover step 2) and `DATABASE.md`
(`GetMIRCertsInSlotRange`) are updated to match.

## Tests

Eight tests added to `ledger/mir_test.go`. Five fail without the fix:

- `TestApplyMIRCerts_OverBudgetReservesIsNoOp`
- `TestApplyMIRCerts_OverBudgetIsAggregateAcrossCerts`
- `TestApplyMIRCerts_OverBudgetTreasuryBlocksReservesDistribution`
- `TestApplyMIRCerts_OverBudgetDropsPotTransfer`
- `TestApplyMIRCerts_PotTransferLargerThanPotIsNoOp`

Three pass before and after, guarding against an over-broad fix — `<` in place
of `<=`, budgeting unregistered credits, and breaking transfer-funded
distributions:

- `TestApplyMIRCerts_ExactBudgetApplies`
- `TestApplyMIRCerts_BudgetExcludesUnregisteredCredentials`
- `TestApplyMIRCerts_PotTransferCountsTowardAvailablePot`

## Validation

Passed:

- `go test ./ledger/...`
- `go test ./ledger/ -race` (full package, 361s)
- `go test ./database/plugin/metadata/...`
- `go test ./internal/test/conformance/`
- `golangci-lint run ./ledger/...` (0 issues)
- `make import-boundaries`, `make docs-parity`

`internal/test/devnet/run-tests.sh --accelerated` fails in its readiness phase
with all four nodes at `tip=slot 0/block 0, fwd=0`. An unmodified `origin/main`
worktree at 83ee8cdb reproduces the same failure identically, so it is
pre-existing and unrelated to this change. The DevNet also contains no MIR
certificates — they are Shelley-through-Babbage only — so it does not exercise
this code path.

Not run: `nilaway` and `modernize` (not installed on this machine); no
real-chain replay, since mainnet MIR certificates end in Babbage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the epoch-rollover wedge caused by over-budget MIR certificates. `applyMIRCerts` previously credited accounts first and only then failed on the pot debit, aborting the rollover and re-failing on every retry; the boundary now aggregates every certificate and checks pot capacity before applying any of them.

**Bug Fixes**
- Credits count only registered, active reward accounts, matching cardano-ledger's `Map.intersection accountsMap` restriction.
- Pot-to-pot transfers are folded into the available balances so they fund same-boundary distributions.
- The whole boundary is a no-op when either pot falls short, and writes one `network_state` row instead of one per certificate.

**Tests**
- Eight tests added to `ledger/mir_test.go`; five fail without the fix and three guard against over-broad fixes.
- `ARCHITECTURE.md` and `DATABASE.md` updated to describe the new boundary semantics.

<sup>Written for commit 6763a3c69c821151f42480458732130f9f00eabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MIR rewards now apply atomically at epoch boundaries.
  * Over-budget reward distributions or transfers are safely skipped without partially changing account balances or treasury/reserve pots.
  * Only registered, active reward accounts receive MIR credits.
  * Affordable rewards and cross-pot transfers are applied using combined boundary budget checks.

* **Documentation**
  * Updated architecture and database documentation to describe MIR aggregation, budget validation, and no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->