### PR TITLE
test(devnet): constrain harness to Linux

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -142,14 +142,11 @@ jobs:
   # #3228) went unverified on real Windows CI before now. This job runs it on
   # every PR instead.
   #
-  # It stays scoped to ./mithril/... rather than ./..., deliberately: the
-  # release job's full-suite run currently fails on windows-latest for
-  # unrelated reasons (internal/test/devnet asserts a Unix-only UID:GID
-  # mapping; tracked separately), and running the same full suite here would
-  # block every PR on that pre-existing, unrelated breakage rather than on
-  # anything this job is meant to check. Widening this job's scope is
-  # follow-up work gated on auditing and fixing the rest of the suite for
-  # Windows, not something to do incidentally here.
+  # It stays scoped to ./mithril/... rather than ./..., deliberately. The
+  # Linux build constraint on internal/test/devnet keeps that native-Docker
+  # harness out of every macOS and Windows `go test ./...` invocation. This PR
+  # job stays scoped to Mithril so it remains fast and directly attributable to
+  # the Windows extraction behavior it guards.
   go-test-windows:
     name: go-test (Windows)
     strategy:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6656,6 +6656,17 @@ The package has no build tag, so `go test ./...` runs it on every platform in
 CI as well. Adding a documented value that a file in the tree already owns
 belongs in a rule here, not in a second hard-coded copy.
 
+### DevNet Platform Boundary
+
+`internal/test/devnet/` is a Linux-only integration harness. It requires a
+native Linux Docker engine, Bash, Linux container networking, and Unix
+ownership semantics; emulated or remote Docker clients on macOS and Windows do
+not provide an equivalent test environment. Every Go file in that tree carries
+a `linux` build constraint, so ordinary `go build ./...` and `go test ./...`
+retain their full commands while excluding the harness on unsupported hosts.
+`TestDevnetFilesStayLinuxOnly` enforces the constraint for newly added files.
+Native Linux is the authoritative platform for DevNet validation.
+
 ## Design Patterns
 
 ### Dependency Injection

--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,11 @@ container generates fresh pool keys and genesis files for either profile.
 
 ### Running the Automated Tests
 
-The test suite builds the Dingo Docker image, starts all containers, waits for health checks, and runs Go integration tests tagged with `//go:build devnet`:
+The test suite builds the Dingo Docker image, starts all containers, waits for
+health checks, and runs Linux-only Go integration tests tagged with
+`//go:build linux && devnet`. Conformance-only scenarios additionally require
+`devnet_conformance`, while Dingo-only scenarios require
+`!devnet_conformance`:
 
 ```bash
 cd internal/test/devnet/

--- a/internal/architecture/devnet_platform_test.go
+++ b/internal/architecture/devnet_platform_test.go
@@ -1,0 +1,212 @@
+package architecture_test
+
+import (
+	"bytes"
+	"errors"
+	"go/build/constraint"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDevnetFilesStayLinuxOnly keeps the platform boundary directory-wide.
+// Go build constraints are file-scoped, so a newly added untagged file would
+// otherwise silently put part of the Docker-backed harness into macOS and
+// Windows `go test ./...` runs again.
+func TestDevnetFilesStayLinuxOnly(t *testing.T) {
+	root := filepath.Join(findRepoRoot(t), "internal", "test", "devnet")
+	err := filepath.WalkDir(
+		root,
+		func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			expr, err := parseGoBuildConstraint(content)
+			if err != nil || !requiresBuildTag(expr, "linux") {
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					return relErr
+				}
+				t.Errorf(
+					"%s must have a build constraint that requires linux",
+					filepath.ToSlash(rel),
+				)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("check DevNet platform constraints: %v", err)
+	}
+}
+
+var (
+	errNoGoBuildConstraint = errors.New("no //go:build constraint")
+	errMultipleGoBuild     = errors.New("multiple //go:build constraints")
+)
+
+// parseGoBuildConstraint finds the //go:build directive in the portion of a
+// Go source file where the go command recognizes it. Leading line and block
+// comments may contain a license header; directives inside a block comment or
+// after the first non-comment token do not apply to the file.
+func parseGoBuildConstraint(content []byte) (constraint.Expr, error) {
+	var goBuild string
+	p := content
+	inBlockComment := false
+
+lines:
+	for len(p) > 0 {
+		line := p
+		if i := bytes.IndexByte(line, '\n'); i >= 0 {
+			line, p = line[:i], p[i+1:]
+		} else {
+			p = nil
+		}
+		line = bytes.TrimSpace(line)
+
+		if !inBlockComment && constraint.IsGoBuild(string(line)) {
+			if goBuild != "" {
+				return nil, errMultipleGoBuild
+			}
+			goBuild = string(line)
+		}
+
+	comments:
+		for len(line) > 0 {
+			if inBlockComment {
+				if i := bytes.Index(line, []byte("*/")); i >= 0 {
+					inBlockComment = false
+					line = bytes.TrimSpace(line[i+2:])
+					continue comments
+				}
+				continue lines
+			}
+			if bytes.HasPrefix(line, []byte("//")) {
+				continue lines
+			}
+			if bytes.HasPrefix(line, []byte("/*")) {
+				inBlockComment = true
+				line = bytes.TrimSpace(line[2:])
+				continue comments
+			}
+			break lines
+		}
+	}
+
+	if goBuild == "" {
+		return nil, errNoGoBuildConstraint
+	}
+	return constraint.Parse(goBuild)
+}
+
+// requiresBuildTag returns true only when the expression structurally proves
+// that tag must be true. It deliberately rejects expressions it cannot prove,
+// keeping additions such as "linux || windows" out of the DevNet tree.
+func requiresBuildTag(expr constraint.Expr, tag string) bool {
+	switch expr := expr.(type) {
+	case *constraint.TagExpr:
+		return expr.Tag == tag
+	case *constraint.NotExpr:
+		return false
+	case *constraint.AndExpr:
+		return requiresBuildTag(expr.X, tag) ||
+			requiresBuildTag(expr.Y, tag)
+	case *constraint.OrExpr:
+		return requiresBuildTag(expr.X, tag) &&
+			requiresBuildTag(expr.Y, tag)
+	default:
+		return false
+	}
+}
+
+func TestRequiresBuildTag(t *testing.T) {
+	tests := map[string]bool{
+		"//go:build linux":                                       true,
+		"//go:build linux && devnet":                             true,
+		"//go:build devnet && linux":                             true,
+		"//go:build (linux && devnet) || (linux && conformance)": true,
+		"//go:build windows":                                     false,
+		"//go:build devnet":                                      false,
+		"//go:build !windows":                                    false,
+		"//go:build linux || windows":                            false,
+	}
+	for line, want := range tests {
+		t.Run(line, func(t *testing.T) {
+			expr, err := constraint.Parse(line)
+			if err != nil {
+				t.Fatalf("parse constraint: %v", err)
+			}
+			if got := requiresBuildTag(expr, "linux"); got != want {
+				t.Fatalf("requiresBuildTag() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseGoBuildConstraint(t *testing.T) {
+	tests := map[string]struct {
+		content string
+		want    string
+		wantErr error
+	}{
+		"first line": {
+			content: "//go:build linux\n\npackage devnet\n",
+			want:    "linux",
+		},
+		"after line comment license": {
+			content: "// Copyright 2026 Blink Labs Software\n" +
+				"// Licensed under the Apache License, Version 2.0\n\n" +
+				"//go:build linux && devnet\n\npackage devnet\n",
+			want: "linux && devnet",
+		},
+		"after block comment license": {
+			content: "/* Copyright 2026 Blink Labs Software */\n\n" +
+				"//go:build linux && devnet\n\npackage devnet\n",
+			want: "linux && devnet",
+		},
+		"inside block comment": {
+			content: "/*\n//go:build linux\n*/\npackage devnet\n",
+			wantErr: errNoGoBuildConstraint,
+		},
+		"after package clause": {
+			content: "package devnet\n\n//go:build linux\n",
+			wantErr: errNoGoBuildConstraint,
+		},
+		"multiple constraints": {
+			content: "//go:build linux\n//go:build devnet\npackage devnet\n",
+			wantErr: errMultipleGoBuild,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			expr, err := parseGoBuildConstraint([]byte(test.content))
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf(
+					"parseGoBuildConstraint() error = %v, want %v",
+					err,
+					test.wantErr,
+				)
+			}
+			if test.wantErr != nil {
+				return
+			}
+			if got := expr.String(); got != test.want {
+				t.Fatalf(
+					"parseGoBuildConstraint() = %q, want %q",
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/test/devnet/README.md
+++ b/internal/test/devnet/README.md
@@ -21,16 +21,19 @@ Two networks are available, selected by a Docker Compose profile:
 The Go test harness lives alongside this directory: `internal/test/devnet/`
 (helpers and config loader at the top level, runnable scenarios under
 `internal/test/devnet/scenarios/`). The layout mirrors
-`internal/test/antithesis/`. Everything that talks to a running network is
-gated by the `devnet` build tag, and conformance-only tests additionally
-require `devnet_conformance` (see Test scenarios below).
+`internal/test/antithesis/`. Every Go file in the tree has a `linux` build
+constraint because the harness requires a native Linux Docker engine, Bash,
+Linux container networking, and Unix ownership semantics. Code that talks to
+a running network additionally requires the `devnet` build tag, and
+conformance-only tests also require `devnet_conformance` (see Test scenarios
+below).
 
 The pure logic the harness is built on — the network-spec loader and its
-validation, the observed-chain state machine, and the scenario plan — is
-deliberately **not** tagged, so its unit tests run in the ordinary
+validation, the observed-chain state machine, and the scenario plan — carries
+only the `linux` constraint, so its unit tests run in the ordinary Linux
 `go test ./...` with no Docker involved. That is what keeps an invalid
-accelerated spec or a broken rollback rule from only surfacing as a
-mysterious DevNet stall.
+accelerated spec or a broken rollback rule from only surfacing as a mysterious
+DevNet stall.
 
 ## Topology — dingo mode (default)
 
@@ -120,9 +123,9 @@ it, and both are derived from `k` and `f` rather than configured directly:
 `DevNetConfig.Validate()` enforces `4k/f < epochLength` and
 `3k/f < epochLength`, and `TestCheckedInSpecsAreValid` in
 `internal/test/devnet/config_test.go` runs it against every checked-in
-spec. That test carries **no build tag**, so an edit that shrinks an epoch
-without shrinking `k` fails in the ordinary `go test ./...` run instead of
-turning into a DevNet stall nobody can explain.
+spec. That test carries only the `linux` constraint, so an edit that shrinks an
+epoch without shrinking `k` fails in the ordinary Linux `go test ./...` run
+instead of turning into a DevNet stall nobody can explain.
 
 The canonical specs are deliberately *not* accelerated: they are what soak
 and canary runs use, and `TestCanonicalSpecsKeepCanonicalTiming` fails if
@@ -250,7 +253,7 @@ node's NtC endpoint.
 
 ## Running the integration tests
 
-`run-tests.sh` is the entry point used both locally and in CI:
+`run-tests.sh` is the entry point for a complete native-Linux DevNet run:
 
 ```bash
 ./run-tests.sh                              # dingo mode (default): bring up, run devnet tests, tear down
@@ -505,8 +508,8 @@ runs).
 All scenarios live in `internal/test/devnet/scenarios/` and use the harness
 in `internal/test/devnet/`.
 
-Generic scenarios (`//go:build devnet`) run in both dingo and conformance
-mode:
+Generic scenarios (`//go:build linux && devnet`) run in both dingo and
+conformance mode:
 
 | Test | What it verifies |
 |------|-------------------|
@@ -518,16 +521,17 @@ mode:
 | `TestEpochBoundaryConsensus` | All nodes remain in consensus across at least one epoch boundary (exercises candidate-nonce freeze, lab nonce roll, and new-epoch VRF verification) |
 | `TestAcceleratedScenarioTimeline` | The accelerated scenario timeline: readiness, block and transaction propagation, chain agreement, an epoch transition, a peer interruption with recovery, and a relay restart — all on one shared clock, driven by streamed ChainSync events. Skipped unless `DEVNET_ACCELERATED=1`; see Accelerated scenario timeline above. |
 
-Reference-conformance scenario (`//go:build devnet && devnet_conformance`),
-runs only with `--conformance`:
+Reference-conformance scenario
+(`//go:build linux && devnet && devnet_conformance`) runs only with
+`--conformance`:
 
 | Test | What it verifies |
 |------|-------------------|
 | `TestCardanoProducerChainAdvances` | `cardano-producer`'s tip advances (sanity check on the reference node) |
 
-Dingo-only feature scenario (`//go:build devnet && !devnet_conformance`),
-runs only in the default dingo mode — no `cardano-node` reference exists for
-this feature:
+Dingo-only feature scenario
+(`//go:build linux && devnet && !devnet_conformance`) runs only in the default
+dingo mode — no `cardano-node` reference exists for this feature:
 
 | Test | What it verifies |
 |------|-------------------|
@@ -589,22 +593,22 @@ harness and the compose port mappings always agree.
 | `.env`                       | Sets the default `COMPOSE_PROFILES=dingo` |
 | `compose-project.sh`         | Derives a stable, worktree-specific Compose project name, a collision-checked bridge subnet and host port block, and a rendered topology directory; wraps `docker compose up` with a retry on subnet collision |
 | `start.sh` / `stop.sh`       | Convenience wrappers around `docker compose up -d` / `down -v`; accept `--conformance` |
-| `run-tests.sh`               | Full bring-up → test → tear-down cycle used by CI; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
+| `run-tests.sh`               | Full native-Linux bring-up → test → tear-down runner; accepts `--conformance`, `--keep-up`, and forwards other flags to `go test` |
 | `../antithesis/Dockerfile.txpump`, `../antithesis/cmd/txpump/` | Source for the `txpump` load generator image |
-| `harness.go`                 | Go test harness: Ouroboros NtN client, tip queries, consensus checks, the `WaitForChainStart` genesis gate, and per-scenario failure capture (build tag `devnet`) |
-| `config.go`                  | `testnet*.yaml` loader, derived timings, and spec validation (**no build tag** — its tests run in the ordinary `go test ./...`) |
-| `chainstate.go`              | Observed-chain state machine: applies RollForward/RollBackward, tracks tip and retained headers, and exposes cross-node agreement helpers and bounded-context conditions (**no build tag**) |
-| `timeline.go`                | `ScenarioPlan`: derives the accelerated scenario's phases, deadlines, outage length, and hard timeout from the network spec (**no build tag**) |
-| `observer.go`                | Persistent per-node ChainSync sessions feeding `chainstate.go`, with automatic reconnect across container restarts (build tag `devnet`) |
-| `nodectl.go`                 | Stops/starts compose services for the disruption phases and supplies the Docker side of failure capture (build tag `devnet`) |
-| `artifacts.go`               | What a failed scenario preserves and where: capture planning and artifact writing (**no build tag** — its tests run in the ordinary `go test ./...`) |
-| `endpoints.go`               | The `NodeEndpoint` description shared by the harness, observers, and failure capture (**no build tag**) |
-| `endpoints_dingo.go`         | Dingo-mode node endpoints and NtC addresses (`//go:build devnet && !devnet_conformance`) |
-| `endpoints_conformance.go`   | Conformance-mode node endpoints (`//go:build devnet && devnet_conformance`) |
-| `lsq.go`                     | `RewardAccountsByNtc` / `RewardAccountsByNtcForCreds`: LocalStateQuery over NtC TCP (build tag `devnet`) |
-| `credentials.go`             | Loads genesis stake credentials for the CIP-50 scenario (build tag `devnet`) |
-| `harness_test.go`, `credentials_test.go` | Tests for the harness/credential helpers themselves (build tag `devnet`) |
-| `scenarios/`                 | Devnet test scenarios (one or more `Test*` per file, gated per the Test scenarios table above) |
+| `harness.go`                 | Go test harness: Ouroboros NtN client, tip queries, consensus checks, the `WaitForChainStart` genesis gate, and per-scenario failure capture (`linux && devnet`) |
+| `config.go`                  | `testnet*.yaml` loader, derived timings, and spec validation (`linux`; its tests run in the ordinary Linux `go test ./...`) |
+| `chainstate.go`              | Observed-chain state machine: applies RollForward/RollBackward, tracks tip and retained headers, and exposes cross-node agreement helpers and bounded-context conditions (`linux`) |
+| `timeline.go`                | `ScenarioPlan`: derives the accelerated scenario's phases, deadlines, outage length, and hard timeout from the network spec (`linux`) |
+| `observer.go`                | Persistent per-node ChainSync sessions feeding `chainstate.go`, with automatic reconnect across container restarts (`linux && devnet`) |
+| `nodectl.go`                 | Stops/starts compose services for the disruption phases and supplies the Docker side of failure capture (`linux && devnet`) |
+| `artifacts.go`               | What a failed scenario preserves and where: capture planning and artifact writing (`linux`; its tests run in the ordinary Linux `go test ./...`) |
+| `endpoints.go`               | The `NodeEndpoint` description shared by the harness, observers, and failure capture (`linux`) |
+| `endpoints_dingo.go`         | Dingo-mode node endpoints and NtC addresses (`linux && devnet && !devnet_conformance`) |
+| `endpoints_conformance.go`   | Conformance-mode node endpoints (`linux && devnet && devnet_conformance`) |
+| `lsq.go`                     | `RewardAccountsByNtc` / `RewardAccountsByNtcForCreds`: LocalStateQuery over NtC TCP (`linux && devnet`) |
+| `credentials.go`             | Loads genesis stake credentials for the CIP-50 scenario (`linux && devnet`) |
+| `harness_test.go`, `credentials_test.go` | Tests for the harness/credential helpers themselves (`linux && devnet`) |
+| `scenarios/`                 | DevNet test scenarios (`linux` plus the scenario-specific constraints in the Test scenarios table above) |
 
 ## Cleanup
 

--- a/internal/test/devnet/artifacts.go
+++ b/internal/test/devnet/artifacts.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +24,10 @@ import (
 	"strings"
 )
 
-// This file carries no build tag on purpose. What a failed scenario
-// preserves, and where, is decided here so it is covered by an ordinary
-// `go test ./...` run; only the Docker calls that supply the evidence
-// need the devnet tag and a live network.
+// This file carries the package-wide Linux constraint but does not require
+// the devnet tag. What a failed scenario preserves, and where, is therefore
+// covered by an ordinary Linux `go test ./...` run; only the Docker calls
+// that supply the evidence need the devnet tag and a live network.
 
 // ArtifactDir returns the directory failure evidence is written to, and
 // whether one is configured. run-tests.sh creates it and preserves it on

--- a/internal/test/devnet/artifacts_test.go
+++ b/internal/test/devnet/artifacts_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,15 +59,9 @@ func (f *fakeArtifactSource) Logs(
 }
 
 // requireSinglePathSegment asserts that name addresses exactly one entry
-// directly inside root, and does so without depending on the platform's
-// separator. A literal would: filepath.Join normalizes through Clean,
-// whose documented last step replaces every slash with filepath.Separator,
-// so on Windows filepath.Dir(filepath.Join("/root", name)) is `\root` and
-// never equals a "/root" literal. This file carries no build tag, so it
-// runs under the untagged `go test ./...` that release validation runs on
-// windows-latest; an assertion that only holds on one separator fails
-// there and blocks the release. Both sides are built with filepath here,
-// so they normalize identically on every platform.
+// directly inside root without hard-coding a path separator. Both sides use
+// filepath so this Linux-only harness still emits paths that portable
+// artifact tooling can consume safely.
 func requireSinglePathSegment(
 	t *testing.T,
 	root, name string,
@@ -318,10 +314,9 @@ func TestWriteFailureArtifactsBoundsCapturedLogs(t *testing.T) {
 // arrive that way, but ArtifactName is exported and NodeControl's
 // caller passes a name of its own, so it is covered too; ':' '*' '?' '"'
 // '<' '>' '|' and a trailing dot all survive t.Run untouched. They are
-// here to hold the encoding to its contract on every platform the
-// untagged tests run on: distinct names stay distinct, each one stays a
-// single path segment, and each one names a directory the filesystem
-// will actually create.
+// here to hold the portable encoding contract in the Linux unit suite:
+// distinct names stay distinct, each one stays a single path segment, and
+// each one names a directory the filesystem will actually create.
 var artifactNameCorpus = []string{
 	"TestSustainedConsensus",
 	"accelerated-timeline",
@@ -388,13 +383,11 @@ func TestArtifactNameLeavesPlainScenarioNamesAlone(t *testing.T) {
 }
 
 // TestArtifactNamesCreateDistinctDirectories checks that every name in
-// artifactNameCorpus creates a directory of its own on the filesystem
-// under test, rather than checking that the encodings differ as
-// strings. Lexical injectivity is not the same guarantee: a filesystem
-// that rewrites a name stores two distinct encodings in one directory,
-// and a filesystem that rejects one stores neither. Windows does both,
-// so this is where that shows up rather than in
-// TestArtifactNameIsInjective.
+// artifactNameCorpus creates a directory of its own on the supported Linux
+// filesystem rather than checking only that the encodings differ as strings.
+// Lexical injectivity is not the same guarantee: a filesystem that rewrites a
+// name stores two distinct encodings in one directory, and a filesystem that
+// rejects one stores neither.
 //
 // The corpus is the scope of the claim. It leaves out names differing
 // only in case, which do share a directory where the filesystem folds
@@ -446,8 +439,8 @@ func TestArtifactNamesCreateDistinctDirectories(t *testing.T) {
 // and trailing-space escapes directly. Windows removes both from the end
 // of a name, so an encoding that ended in either would be stored under a
 // shorter name -- and two encodings that differ only there would become
-// one directory. The filesystem test above only catches this when it runs
-// on Windows; this one holds everywhere.
+// one directory. The explicit lexical assertion keeps that property covered
+// even though the DevNet package is not built on Windows.
 func TestArtifactNameNeverEndsInAStrippedCharacter(t *testing.T) {
 	for _, name := range artifactNameCorpus {
 		got := ArtifactName(name)

--- a/internal/test/devnet/chainstate.go
+++ b/internal/test/devnet/chainstate.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +18,10 @@
 // against a private Cardano DevNet consisting of Dingo and cardano-node
 // instances connected via Docker Compose.
 //
-// The chain-observation types in this file carry no build tag so the
-// state machine driving the DevNet scenarios is unit-tested on every
-// ordinary `go test ./...` run, without Docker. The pieces that dial real
-// nodes are gated behind the `devnet` tag.
+// The chain-observation types in this file carry only the package-wide Linux
+// constraint, so the state machine driving the DevNet scenarios is covered by
+// an ordinary Linux `go test ./...` run without Docker. The pieces that dial
+// real nodes additionally require the `devnet` tag.
 package devnet
 
 import (

--- a/internal/test/devnet/chainstate_test.go
+++ b/internal/test/devnet/chainstate_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/config.go
+++ b/internal/test/devnet/config.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/config_test.go
+++ b/internal/test/devnet/config_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/credentials.go
+++ b/internal/test/devnet/credentials.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/credentials_test.go
+++ b/internal/test/devnet/credentials_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/endpoints.go
+++ b/internal/test/devnet/endpoints.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +19,10 @@ package devnet
 // NodeEndpoint describes a node that the test harness can connect to
 // using the Ouroboros Node-to-Node mini-protocol over TCP.
 //
-// This is plain data and carries no build tag, so the failure-capture
-// planning in artifacts.go stays testable without a running DevNet. The
-// code that dials an endpoint lives in the devnet-tagged files.
+// This is plain data and carries only the package-wide Linux constraint, so
+// the failure-capture planning in artifacts.go stays testable without a
+// running DevNet. The code that dials an endpoint additionally requires the
+// devnet tag.
 type NodeEndpoint struct {
 	Name        string
 	Address     string // host:port

--- a/internal/test/devnet/endpoints_conformance.go
+++ b/internal/test/devnet/endpoints_conformance.go
@@ -1,4 +1,4 @@
-//go:build devnet && devnet_conformance
+//go:build linux && devnet && devnet_conformance
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/endpoints_dingo.go
+++ b/internal/test/devnet/endpoints_dingo.go
@@ -1,4 +1,4 @@
-//go:build devnet && !devnet_conformance
+//go:build linux && devnet && !devnet_conformance
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/harness.go
+++ b/internal/test/devnet/harness.go
@@ -1,3 +1,5 @@
+//go:build linux && devnet
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build devnet
 
 package devnet
 

--- a/internal/test/devnet/harness_test.go
+++ b/internal/test/devnet/harness_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/isolation_test.go
+++ b/internal/test/devnet/isolation_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/lsq.go
+++ b/internal/test/devnet/lsq.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/nodectl.go
+++ b/internal/test/devnet/nodectl.go
@@ -1,3 +1,5 @@
+//go:build linux && devnet
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build devnet
 
 package devnet
 
@@ -178,9 +178,9 @@ func (n *NodeControl) containerID(
 // be diagnosable after the network is gone: what every node's chain
 // actually did, which containers were up, and each service's logs.
 //
-// The writing itself lives in artifacts.go, untagged, so what a failure
-// preserves is covered by an ordinary test run. This method supplies the
-// Docker side of it.
+// The writing itself lives in artifacts.go without the optional devnet tag,
+// so what a failure preserves is covered by an ordinary Linux test run. This
+// method supplies the Docker side of it.
 func (n *NodeControl) CaptureFailureArtifacts(
 	ctx context.Context,
 	name string,

--- a/internal/test/devnet/observer.go
+++ b/internal/test/devnet/observer.go
@@ -1,3 +1,5 @@
+//go:build linux && devnet
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-//go:build devnet
 
 package devnet
 

--- a/internal/test/devnet/run-tests.sh
+++ b/internal/test/devnet/run-tests.sh
@@ -19,7 +19,7 @@
 # This script:
 #   1. Starts the DevNet (configurator + all nodes)
 #   2. Waits for all nodes to become healthy
-#   3. Runs the Go integration tests tagged with //go:build devnet
+#   3. Runs the Go integration tests tagged with //go:build linux && devnet
 #   4. Tears down the DevNet and reports results
 #
 # Usage:

--- a/internal/test/devnet/run_tests_script_test.go
+++ b/internal/test/devnet/run_tests_script_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/scenarios/accelerated_timeline_test.go
+++ b/internal/test/devnet/scenarios/accelerated_timeline_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/basic_forging_test.go
+++ b/internal/test/devnet/scenarios/basic_forging_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/chain_growth_test.go
+++ b/internal/test/devnet/scenarios/chain_growth_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/cip50_pledge_leverage_test.go
+++ b/internal/test/devnet/scenarios/cip50_pledge_leverage_test.go
@@ -1,4 +1,4 @@
-//go:build devnet && !devnet_conformance
+//go:build linux && devnet && !devnet_conformance
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/conformance_reference_test.go
+++ b/internal/test/devnet/scenarios/conformance_reference_test.go
@@ -1,4 +1,4 @@
-//go:build devnet && devnet_conformance
+//go:build linux && devnet && devnet_conformance
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/epoch_boundary_test.go
+++ b/internal/test/devnet/scenarios/epoch_boundary_test.go
@@ -1,4 +1,4 @@
-//go:build devnet
+//go:build linux && devnet
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/scenarios/stake_address_info_test.go
+++ b/internal/test/devnet/scenarios/stake_address_info_test.go
@@ -1,4 +1,4 @@
-//go:build devnet && !devnet_conformance
+//go:build linux && devnet && !devnet_conformance
 
 // Copyright 2026 Blink Labs Software
 //

--- a/internal/test/devnet/timeline.go
+++ b/internal/test/devnet/timeline.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/timeline_test.go
+++ b/internal/test/devnet/timeline_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/test/devnet/uid_parity_test.go
+++ b/internal/test/devnet/uid_parity_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary

- constrain the Docker-backed DevNet harness to native Linux
- preserve the existing DevNet and conformance scenario predicates
- enforce the directory-wide platform boundary for newly added Go files
- document the supported platform and update the Windows workflow rationale

## Validation

- `go test -race ./internal/architecture -count=1`
- `go test -run '^$' -tags 'devnet devnet_conformance' ./internal/test/devnet/...`
- Windows and Darwin cross-builds of `./...`
- `make docs-parity`
- `actionlint .github/workflows/go-test.yml`
- `bash -n internal/test/devnet/run-tests.sh`
- `git diff --check`

Fixes #3728


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrains the Docker-backed DevNet harness in `internal/test/devnet/` to native Linux by adding a `linux` build constraint to every Go file, so `go test ./...` no longer builds or runs it on macOS or Windows where it cannot work.

- Adds `TestDevnetFilesStayLinuxOnly` to reject new files in that tree that lack a `linux`-requiring constraint.
- Preserves the existing `devnet` and `devnet_conformance` scenario tags by combining them with `linux`.
- Updates the DevNet README, `ARCHITECTURE.md`, and the Windows CI job comment to document the Linux-only boundary.

Fixes #3728.

<sup>Written for commit 8209ff92c5385de8dc6df7c3a997e533172da128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

