### PR TITLE
test(database): isolate integration migration locks

### DIFF
--- a/database/plugin/metadata/sqlstore/account_baseline_integration_test.go
+++ b/database/plugin/metadata/sqlstore/account_baseline_integration_test.go
@@ -56,6 +56,7 @@ func TestPostgresAccountBaselineBackfill(t *testing.T) {
 		postgresDSNWithSearchPath(t, dsn, schema),
 		"postgres",
 		registry,
+		schema,
 	)
 }
 
@@ -82,6 +83,7 @@ func TestMySQLAccountBaselineBackfill(t *testing.T) {
 		mysqlDSNWithDatabase(t, dsn, database),
 		"mysql",
 		registry,
+		database,
 	)
 }
 
@@ -91,6 +93,7 @@ func testAccountBaselineBackfill(
 	dsn string,
 	dialectName string,
 	registry []migrations.Migration,
+	lockNamespace string,
 ) {
 	t.Helper()
 	ctx := context.Background()
@@ -102,11 +105,7 @@ func testAccountBaselineBackfill(
 			DB:       db,
 			Dialect:  dialectName,
 			Registry: versions,
-			Locker: migrations.NewAdvisoryLocker(
-				dialectName,
-				0x64696e676f6261,
-				time.Second,
-			),
+			Locker:   integrationMigrationLocker(dialectName, lockNamespace),
 		}
 		require.NoError(t, runner.Run(ctx))
 	}

--- a/database/plugin/metadata/sqlstore/dialect_integration_test.go
+++ b/database/plugin/metadata/sqlstore/dialect_integration_test.go
@@ -40,6 +40,7 @@ func TestPostgresSQLStoreIntegration(t *testing.T) {
 		"pgx",
 		postgresDSNWithSearchPath(t, dsn, schema),
 		"postgres",
+		schema,
 	)
 }
 
@@ -63,6 +64,7 @@ func TestMySQLSQLStoreIntegration(t *testing.T) {
 		"mysql",
 		mysqlDSNWithDatabase(t, dsn, database),
 		"mysql",
+		database,
 	)
 }
 
@@ -84,7 +86,10 @@ func mysqlDSNWithDatabase(t *testing.T, dsn, database string) string {
 	return parsed.FormatDSN()
 }
 
-func testSQLStoreIntegration(t *testing.T, driver, dsn, dialectName string) {
+func testSQLStoreIntegration(
+	t *testing.T,
+	driver, dsn, dialectName, lockNamespace string,
+) {
 	t.Helper()
 	db, err := OpenDB(driver, dsn, dialectName)
 	require.NoError(t, err)
@@ -96,19 +101,11 @@ func testSQLStoreIntegration(t *testing.T, driver, dsn, dialectName string) {
 	case "postgres":
 		dialect = PostgresDialect()
 		registry, err = migrations.PostgresRegistry()
-		locker = migrations.NewAdvisoryLocker(
-			"postgres",
-			0x64696e676f6d6574,
-			time.Second,
-		)
+		locker = integrationMigrationLocker("postgres", lockNamespace)
 	case "mysql":
 		dialect = MySQLDialect()
 		registry, err = migrations.MySQLRegistry()
-		locker = migrations.NewAdvisoryLocker(
-			"mysql",
-			0x64696e676f6d6574,
-			time.Second,
-		)
+		locker = integrationMigrationLocker("mysql", lockNamespace)
 	}
 	require.NoError(t, err)
 	store, err := New(Config{

--- a/database/plugin/metadata/sqlstore/integration_lock_test.go
+++ b/database/plugin/metadata/sqlstore/integration_lock_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore/migrations"
+	"github.com/stretchr/testify/require"
+)
+
+func integrationMigrationLocker(
+	dialect string,
+	namespace string,
+) migrations.Locker {
+	// PostgreSQL and MySQL advisory locks are server-scoped. These tests use
+	// isolated schemas or databases, so their locks must be isolated too.
+	return migrations.NewAdvisoryLocker(
+		dialect,
+		integrationMigrationLockKey(namespace),
+		time.Second,
+	)
+}
+
+func integrationMigrationLockKey(namespace string) int64 {
+	digest := sha256.Sum256([]byte(namespace))
+	return int64(binary.BigEndian.Uint64(digest[:8]))
+}
+
+func TestIntegrationMigrationLockKey(t *testing.T) {
+	t.Parallel()
+
+	first := integrationMigrationLockKey("sqlstore_pool_1")
+	require.Equal(
+		t,
+		first,
+		integrationMigrationLockKey("sqlstore_pool_1"),
+	)
+	require.NotEqual(
+		t,
+		first,
+		integrationMigrationLockKey("sqlstore_pool_2"),
+	)
+}

--- a/database/plugin/metadata/sqlstore/pool_associations_integration_test.go
+++ b/database/plugin/metadata/sqlstore/pool_associations_integration_test.go
@@ -69,6 +69,7 @@ func TestPostgresGetPoolDoesNotCorruptConnection(t *testing.T) {
 		"pgx",
 		postgresDSNWithSearchPath(t, dsn, schema),
 		"postgres",
+		schema,
 	)
 }
 
@@ -92,12 +93,13 @@ func TestMySQLGetPoolDoesNotCorruptConnection(t *testing.T) {
 		"mysql",
 		mysqlDSNWithDatabase(t, dsn, database),
 		"mysql",
+		database,
 	)
 }
 
 func testGetPoolDoesNotCorruptConnection(
 	t *testing.T,
-	driver, dsn, dialectName string,
+	driver, dsn, dialectName, lockNamespace string,
 ) {
 	t.Helper()
 	db, err := OpenDB(driver, dsn, dialectName)
@@ -110,19 +112,11 @@ func testGetPoolDoesNotCorruptConnection(
 	case "postgres":
 		dialect = PostgresDialect()
 		registry, err = migrations.PostgresRegistry()
-		locker = migrations.NewAdvisoryLocker(
-			"postgres",
-			0x64696e676f6d6574,
-			time.Second,
-		)
+		locker = integrationMigrationLocker("postgres", lockNamespace)
 	case "mysql":
 		dialect = MySQLDialect()
 		registry, err = migrations.MySQLRegistry()
-		locker = migrations.NewAdvisoryLocker(
-			"mysql",
-			0x64696e676f6d6574,
-			time.Second,
-		)
+		locker = integrationMigrationLocker("mysql", lockNamespace)
 	}
 	require.NoError(t, err)
 	store, err := New(Config{


### PR DESCRIPTION
## Summary

- derive test-only migration advisory keys from each isolated schema or database
- prevent concurrently running metadata backend packages from sharing unrelated test locks
- preserve production provider lock keys and timeouts
- cover deterministic and distinct test namespace keys

## Validation

- reproduced both MySQL migration-lock timeouts with the pre-fix three-package command
- repeated focused PostgreSQL/MySQL three-package suite three times
- `go test -race ./database/plugin/metadata/sqlstore -run '^TestIntegrationMigrationLockKey$' -count=1`
- tagged `go vet`
- NilAway
- modernize
- GolangCI (0 issues)
- `make docs-parity import-boundaries`
- `git diff --check`

Fixes #3731


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes migration lock timeouts in integration tests by isolating test-only advisory lock keys per schema or database, so concurrently running metadata packages no longer share unrelated test locks. Fixes #3731.

- Derives each test lock key from the isolated schema or database namespace.
- Preserves production provider lock keys and timeouts.
- Adds a focused test covering deterministic and distinct namespace keys.

<sup>Written for commit f692434e8c908a3e4f36d42a8a228775fdf56f10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database integration-test isolation by using unique migration-lock namespaces for each PostgreSQL schema and MySQL database.
  * Reduced the risk of lock collisions when tests run concurrently.
  * Added coverage confirming lock keys remain stable and distinct across namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->