### PR TITLE
docs: record optimized preview API bootstrap timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,14 +599,15 @@ Mainnet's total includes its index rebuild; subsequent restarts reused the
 completed database rather than repeating the bootstrap.
 
 The Preview API path was also measured in a profiled run on 2026-08-31/09-01
-using the SQLite bulk-load pragmas and a retained Mithril artifact cache. It
+using the SQLite bulk-load pragmas and a temporary Mithril artifact cache. It
 completed in **7h 36m 07s** end-to-end, including the historical metadata
 backfill (24,547s) and deferred index rebuild (16m). The earlier Preview API
 baseline was approximately 20h 53m, so this run used 63.6% less elapsed time.
-The approximately 30 GB Mithril cache is optional after the snapshot has been
-downloaded; peak space was approximately 76 GB when it was retained (46 GB
-database plus 30 GB cache), while steady state after removing it was
-approximately 46 GB.
+The approximately 30 GB Mithril cache is temporary and can be removed after
+the snapshot is imported. Peak bootstrap space was approximately 76 GB while
+the cache was present (46 GB database plus 30 GB cache); after cleanup, the
+database requires approximately 46 GB and a fresh bootstrap needs approximately
+61 GB for the database plus the 15 GB snapshot.
 
 ### Disk Space Requirements
 
@@ -617,7 +618,7 @@ Bootstrapping requires temporary disk space for both the downloaded snapshot and
 | mainnet |      ~180 GB | ~200+ GB |      ~400 GB |
 | preprod |       ~60 GB |   ~80 GB |      ~150 GB |
 | preview |       ~15 GB |   ~25 GB |       ~50 GB |
-| preview (API mode) | ~15 GB | ~46 GB | ~61 GB (or ~76 GB with retained cache) |
+| preview (API mode) | ~15 GB | ~46 GB | ~61 GB minimum (~76 GB peak during bootstrap) |
 
 These are approximate values that grow over time. The snapshot can be deleted after import, but you need sufficient space for both during the load process.
 

--- a/README.md
+++ b/README.md
@@ -598,6 +598,14 @@ runs on 2026-08-26 and 2026-08-28, from bootstrap start through completion:
 Mainnet's total includes its index rebuild; subsequent restarts reused the
 completed database rather than repeating the bootstrap.
 
+The Preview API path was also measured in a profiled run on 2026-08-31/09-01
+using the SQLite bulk-load pragmas and a retained Mithril artifact cache. It
+completed in **7h 36m 07s** end-to-end, including the historical metadata
+backfill (24,547s) and deferred index rebuild (16m). The earlier Preview API
+baseline was approximately 20h 53m, so this run was 63.6% faster. Peak space
+was approximately 76 GB (46 GB database plus 30 GB Mithril cache); steady
+state after removing the cache was approximately 46 GB.
+
 ### Disk Space Requirements
 
 Bootstrapping requires temporary disk space for both the downloaded snapshot and the Dingo database:

--- a/README.md
+++ b/README.md
@@ -602,9 +602,11 @@ The Preview API path was also measured in a profiled run on 2026-08-31/09-01
 using the SQLite bulk-load pragmas and a retained Mithril artifact cache. It
 completed in **7h 36m 07s** end-to-end, including the historical metadata
 backfill (24,547s) and deferred index rebuild (16m). The earlier Preview API
-baseline was approximately 20h 53m, so this run was 63.6% faster. Peak space
-was approximately 76 GB (46 GB database plus 30 GB Mithril cache); steady
-state after removing the cache was approximately 46 GB.
+baseline was approximately 20h 53m, so this run used 63.6% less elapsed time.
+The approximately 30 GB Mithril cache is optional after the snapshot has been
+downloaded; peak space was approximately 76 GB when it was retained (46 GB
+database plus 30 GB cache), while steady state after removing it was
+approximately 46 GB.
 
 ### Disk Space Requirements
 
@@ -615,6 +617,7 @@ Bootstrapping requires temporary disk space for both the downloaded snapshot and
 | mainnet |      ~180 GB | ~200+ GB |      ~400 GB |
 | preprod |       ~60 GB |   ~80 GB |      ~150 GB |
 | preview |       ~15 GB |   ~25 GB |       ~50 GB |
+| preview (API mode) | ~15 GB | ~46 GB | ~61 GB (or ~76 GB with retained cache) |
 
 These are approximate values that grow over time. The snapshot can be deleted after import, but you need sufficient space for both during the load process.
 


### PR DESCRIPTION
## Summary
- record the profiled Preview API Mithril bootstrap timing after the bulk-load optimization
- document observed peak and steady-state disk usage

## Validation
- `git diff --check`
- benchmark completed successfully on lv5: 7h36m07s end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the profiled Preview API bootstrap timing in the README after the SQLite bulk-load optimization. The end-to-end run took 7h 36m 07s, down from the ~20h 53m baseline (63.6% faster), and the docs now specify peak (~76 GB) and steady-state (~46 GB) disk usage plus the temporary ~30 GB Mithril cache and a fresh-bootstrap need of ~61 GB for the database with the 15 GB snapshot.

<sup>Written for commit 58f0e21b1bcd915e0fc5e336be37bb4b37a581cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Preview API Mithril bootstrap timing data from a recent performance run.
  * Documented end-to-end duration, backfill and index-rebuild times, performance gains over the previous baseline, and peak and steady-state disk usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->