### PR TITLE
build(deps): gouroboros 0.202.4

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2330,7 +2330,11 @@ delegation view, validates the signing delegate, and charges the resolved
 genesis issuer against the rolling `k`-signature PBFT window. Each main block's
 delegation payload is signature-checked and scheduled for activation after
 `2k` slots; activation replaces the issuer's delegate, while self-delegation
-revokes the prior delegate. The in-memory delegation and issuer-window states
+revokes the prior delegate. The payload is passed to the delegation state as
+the CBOR it arrived in rather than as decoded certificates, because a
+certificate's signature covers the wire encoding of its epoch field and
+re-encoding a decoded value cannot reproduce a non-canonical encoding the
+issuer signed. The in-memory delegation and issuer-window states
 are updated only after the block transaction commits. On startup or after a
 rollback, the delegation view is reconstructed from the canonical Byron chain
 through the applied tip, while the issuer window retains only its last `k`

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.3-0.20260830105016-55a204470e9f
+	github.com/blinklabs-io/gouroboros v0.202.4
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
 	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.202.3-0.20260830105016-55a204470e9f h1:KXZwp6eDAW04EXRSDTobW5xyeYj9oDh6UJZrEgoN3/U=
-github.com/blinklabs-io/gouroboros v0.202.3-0.20260830105016-55a204470e9f/go.mod h1:y+bzoTL4JC1qu5m2NTERWuFl+fz6JPKBq22lQDIpjWs=
+github.com/blinklabs-io/gouroboros v0.202.4 h1:Cn4bNUQIlAPnT68HVbrCXqxSJA+UckiYtVufIpVD/5w=
+github.com/blinklabs-io/gouroboros v0.202.4/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=

--- a/ledger/byron_pbft.go
+++ b/ledger/byron_pbft.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	byronconsensus "github.com/blinklabs-io/gouroboros/consensus/byron"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -414,10 +415,18 @@ func (ls *LedgerState) advanceByronPBFTState(
 			block,
 		)
 	}
-	state.delegationState, err = state.delegationState.ApplyPayload(
+	dlgPayload, err := byronDelegationPayload(mainBlock)
+	if err != nil {
+		return byronPBFTState{}, fmt.Errorf(
+			"apply Byron PBFT delegation payload at slot %d: %w",
+			block.SlotNumber(),
+			err,
+		)
+	}
+	state.delegationState, err = state.delegationState.ApplyPayloadCbor(
 		epoch,
 		block.SlotNumber(),
-		mainBlock.Body.DlgPayload,
+		dlgPayload,
 	)
 	if err != nil {
 		return byronPBFTState{}, fmt.Errorf(
@@ -427,6 +436,34 @@ func (ls *LedgerState) advanceByronPBFTState(
 		)
 	}
 	return state, nil
+}
+
+// byronDelegationPayload returns the block's delegation certificates as the
+// CBOR they arrived in. A certificate's signature covers the wire encoding of
+// its epoch field, so re-encoding a decoded certificate can produce bytes the
+// issuer never signed; the preserved payload is what PBFTDelegationState needs
+// to verify them.
+func byronDelegationPayload(
+	block *ledgerbyron.ByronMainBlock,
+) ([]cbor.RawMessage, error) {
+	raw := block.Body.DlgPayloadCbor()
+	if len(raw) == 0 {
+		// A body that never round-tripped through the CBOR decoder has no
+		// preserved payload. That is only consistent with an empty payload;
+		// anything else would mean silently dropping delegation certificates.
+		if len(block.Body.DlgPayload) > 0 {
+			return nil, fmt.Errorf(
+				"block body has %d delegation certificate(s) but no preserved CBOR",
+				len(block.Body.DlgPayload),
+			)
+		}
+		return nil, nil
+	}
+	var payload []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode delegation payload: %w", err)
+	}
+	return payload, nil
 }
 
 func byronBlockEpoch(block ledger.Block) (uint64, error) {

--- a/ledger/eras/plutus_validity_outcome_test.go
+++ b/ledger/eras/plutus_validity_outcome_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// uplcProgramVersion110 is UPLC program version 1.1.0, the version Plutus V3
+// and V4 scripts are encoded with.
+var uplcProgramVersion110 = lang.LanguageVersion{1, 1, 0}
+
 type declaredValidityConwayTx struct {
 	*mockConwayFeeTx
 	valid bool
@@ -44,7 +48,11 @@ func newDijkstraGuardingValidityOutcomeTx(
 ) *gdijkstra.DijkstraTransaction {
 	t.Helper()
 	program := &syn.Program[syn.DeBruijn]{
-		Version: version,
+		// The UPLC program version is not the ledger language version. Plutus
+		// V3 and V4 scripts carry UPLC 1.1.0; lang.LanguageVersionV3/V4
+		// ({1,2,0} and {1,3,0}) select the cost model and are not valid
+		// program versions.
+		Version: uplcProgramVersion110,
 		Term: &syn.Lambda[syn.DeBruijn]{
 			Body: &syn.Constant{Con: &syn.Unit{}},
 		},

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -108,21 +108,21 @@ type utxoValidationRuleSkip struct {
 const (
 	noUtxoValidationRuleIndex = -1
 
-	// Positions in gouroboros v0.201.1
+	// Positions in gouroboros v0.202.4
 	// UtxoValidationRules. Function
 	// values are not directly comparable in Go, so setup guards compare
 	// their runtime function names before filtering by index.
 	shelleyUtxoValidateFeeTooSmallRuleIndex    = 6
-	shelleyUtxoValidateMaxTxSizeRuleIndex      = 13
+	shelleyUtxoValidateMaxTxSizeRuleIndex      = 15
 	allegraUtxoValidateFeeTooSmallRuleIndex    = 6
-	allegraUtxoValidateMaxTxSizeRuleIndex      = 13
+	allegraUtxoValidateMaxTxSizeRuleIndex      = 14
 	alonzoUtxoValidatePlutusScriptsRuleIndex   = 27
-	babbageUtxoValidatePlutusScriptsRuleIndex  = 31
+	babbageUtxoValidatePlutusScriptsRuleIndex  = 32
 	conwayUtxoValidateConwayFeaturesRuleIndex  = 19
 	conwayUtxoValidateFeeTooSmallRuleIndex     = 24
 	conwayUtxoValidateExUnitsTooBigRuleIndex   = 39
-	conwayUtxoValidatePlutusScriptsRuleIndex   = 43
-	dijkstraUtxoValidatePlutusScriptsRuleIndex = 43
+	conwayUtxoValidatePlutusScriptsRuleIndex   = 44
+	dijkstraUtxoValidatePlutusScriptsRuleIndex = 44
 
 	conwayRefScriptCostStride = 25_600
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `gouroboros` to `v0.202.4` and adapts the ledger to its API and validation changes so the dependency update is correct and clean.

- Byron PBFT delegation now applies the preserved payload CBOR via `ApplyPayloadCbor` instead of re-encoding decoded certificates, because a certificate's signature covers the wire encoding of its epoch field.
- Updated five hardcoded UTxO validation rule skip indices that no longer matched the reordered upstream rule slices; the stale indices panicked during package init for every importer of `ledger/eras`.
- Fixed the Dijkstra guarding script fixture to use UPLC program version 1.1.0, which `gouroboros` now validates.

<sup>Written for commit c026b170d3ba2cb9c9e174177076af85e33c9d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying library to a stable tagged release.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->