### PR TITLE
build(make): exclude .claude worktrees from module discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO_FILES=$(shell find $(ROOT_DIR) -path '$(ROOT_DIR)/.worktrees' -prune -o -name
 
 # Gather every Go module directory. Nested modules have their own go.mod and
 # are therefore outside the root module's ./..., so they need their own run.
-GO_MODULE_DIRS=$(shell find $(ROOT_DIR) -path '$(ROOT_DIR)/.worktrees' -prune -o -path '$(ROOT_DIR)/.tools' -prune -o -name go.mod -print | xargs -n1 dirname)
+GO_MODULE_DIRS=$(shell find $(ROOT_DIR) -path '$(ROOT_DIR)/.worktrees' -prune -o -path '$(ROOT_DIR)/.claude' -prune -o -path '$(ROOT_DIR)/.tools' -prune -o -name go.mod -print | xargs -n1 dirname)
 
 # Gather list of expected binaries
 BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)


### PR DESCRIPTION
GO_MODULE_DIRS prunes .worktrees and .tools but not .claude, so git worktrees created under .claude/worktrees are discovered as Go modules and linted alongside the real ones. make lint then reports golangci-lint findings from whatever branches happen to be checked out there, which fail the target for reasons unrelated to the tree being linted.

Prune .claude the same way .worktrees already is. Module discovery now returns only the root module, examples/dingo-gov-lens, and internal/test/antithesis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `make lint` discovering Go modules inside `.claude/worktrees`, so lint results no longer include findings from unrelated checked-out branches. Module discovery now prunes `.claude` alongside `.worktrees` and `.tools`.

<sup>Written for commit ae435699b44a0e2f57c0e8c55138f41969ee83e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded internal configuration directories from module-wide development tasks such as linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->