### PR TITLE
test(conformance): replay the corpus once per backend and reset only dirty tables

### DIFF
--- a/internal/test/conformance/README.md
+++ b/internal/test/conformance/README.md
@@ -30,16 +30,12 @@ Run the full suite:
 go test ./internal/test/conformance/
 ```
 
-Run with verbose vector-level output (useful when investigating a failure):
+Run with verbose vector-level output (useful when investigating a failure).
+This also prints the per-vector pass/fail statistics, which a separate
+`…WithResults` test used to produce from its own second replay of the corpus:
 
 ```bash
 go test -v ./internal/test/conformance/ -run TestRulesConformanceVectors
-```
-
-Run the variant that reports per-vector pass/fail statistics:
-
-```bash
-go test -v ./internal/test/conformance/ -run TestRulesConformanceVectorsWithResults
 ```
 
 Run a single vector by substring match (delegated by the harness):
@@ -125,11 +121,13 @@ re-migration -- which is what keeps the cost of a Reset (and so the whole
 vector suite, which resets once per vector) from being a real
 close/reopen/re-migrate network round trip every time.
 
-`TestRulesConformanceVectorsWithResultsPostgres` runs the SQLite and
-Postgres harnesses in the same test and compares vector counts instead of
-asserting a hardcoded number, so the two runs should exercise the identical
-vector count with identical pass counts, and the comparison stays correct
-even as the embedded `ouroboros-mock` vector corpus grows or shrinks.
+`TestRulesConformanceVectorsPostgres` also compares its results against the
+SQLite baseline rather than asserting a hardcoded number, so the two backends
+should exercise the identical vector count with identical pass counts, and the
+comparison stays correct even as the embedded `ouroboros-mock` vector corpus
+grows or shrinks. Both backends' replays are memoized per process (see
+[Corpus replay budget](#corpus-replay-budget)), so the comparison reuses the
+SQLite run the gate already performed instead of rebuilding a baseline.
 
 ## MySQL backend
 
@@ -183,8 +181,9 @@ vector. `TestMain` drops the process database and removes this directory
 once, after every test in the process has finished -- see
 `conformance_main_test.go`.
 
-`TestRulesConformanceVectorsWithResultsMysql` follows the same
-count-comparison approach as the Postgres variant, for the same reason.
+`TestRulesConformanceVectorsMysql` follows the same count-comparison approach
+as the Postgres variant, for the same reason, and likewise reuses the memoized
+SQLite baseline.
 
 ## When to run them
 
@@ -216,18 +215,73 @@ Cross-repo change cascades that must re-run this suite:
    `database.SetTransactionMetadataOnly` and `ledger/governance`, not an
    in-memory mirror -- and comparing expected vs. actual ledger state after
    each step.
-4. `RunAllVectors` fails the Go test on any vector mismatch;
-   `RunAllVectorsWithResults` returns structured pass/fail counts instead
-   so progress can be tracked.
+4. Each backend replays the corpus once per process through
+   `RunAllVectorsWithResults`, which returns structured per-vector results.
+   `assertCorpus` turns those results back into named per-vector subtests and
+   fails on any mismatch, so the single replay serves as both the pass/fail
+   gate and the progress statistics. See
+   [Corpus replay budget](#corpus-replay-budget).
 5. Between vectors, `Reset()` clears the real backend (not just in-memory
    bookkeeping) so each vector starts from a genuinely empty database --
    see each backend's own "Reset semantics" above for how.
+
+## Corpus replay budget
+
+One full replay of the vector corpus is the single most expensive thing in this
+package -- 917s of Linux CI time with real Postgres and MySQL attached -- and
+the corpus exercises `gouroboros` ledger rules, which do not vary by storage
+backend. Replaying it more than once per backend therefore buys no additional
+rule coverage.
+
+Each backend replays the corpus **exactly once per `go test` process**, and
+every consumer reads that one memoized result set: the pass/fail gate, the
+progress statistics, and the cross-backend comparison. The vector extraction is
+shared the same way, once rather than once per replay. See `corpus_test.go`.
+
+Before this, a Linux CI run with both DSNs configured replayed the corpus eight
+times:
+
+| Test | sqlite | postgres | mysql |
+|---|---|---|---|
+| `TestRulesConformanceVectors` | 1 | | |
+| `TestRulesConformanceVectorsWithResults` | 1 | | |
+| `TestRulesConformanceVectorsPostgres` | | 1 | |
+| `…WithResultsPostgres` | 1 | 1 | |
+| `TestRulesConformanceVectorsMysql` | | | 1 |
+| `…WithResultsMysql` | 1 | | 1 |
+| **total** | **4** | **2** | **2** |
+
+Two redundancies stacked: each `…WithResults` test re-ran the corpus purely to
+count rather than assert, and each cross-backend comparison rebuilt its own
+SQLite baseline from scratch instead of reusing one.
+
+### Why any per-backend replay earns its cost
+
+The per-dialect replays are not rule coverage -- they drive Dingo's storage
+layer through each dialect's semantics, and that has found real bugs. Both
+came from #3599, and neither is a ledger-rule bug:
+
+- `loadPoolAssociations` held a `pool_registration` cursor open while issuing
+  nested per-row queries on the same connection. SQLite tolerates concurrently
+  open cursors on one connection; MySQL and PostgreSQL do not, so a pool with
+  at least one owner or relay corrupted the connection once returned to the
+  pool, surfacing as a spurious "pool not found" on the next unrelated read.
+- `go-sql-driver/mysql` reports the number of rows an `UPDATE` actually
+  changed, not the number its `WHERE` clause matched, unlike `sqlite3` and
+  `lib/pq`. A DRep voting again in the same epoch with an unchanged
+  activity/expiry epoch matched a real row but changed no column, so MySQL
+  reported `affected == 0` -- indistinguishable from the row not existing.
+
+Both were found by driving the storage layer through the corpus's variety of
+access patterns. That needs **one** pass per dialect, not several.
 
 ## Files
 
 | File | Purpose |
 |---|---|
-| `conformance_test.go` | Go test entry points, SQLite backend (`TestRulesConformanceVectors`, `…WithResults`) |
+| `conformance_test.go` | Go test entry point, SQLite backend (`TestRulesConformanceVectors`) |
+| `corpus_test.go` | Memoized per-backend corpus replay, shared assertion/reporting/comparison helpers, and the shared vector extraction |
+| `corpus_main_test.go` | `TestMain` for the untagged build — removes the shared vector extraction (`!dingo_extra_plugins` build tag) |
 | `conformance_postgres_test.go` | Go test entry points, PostgreSQL backend, including restart/rollback/invalid-DSN acceptance tests (`dingo_extra_plugins` build tag) |
 | `conformance_mysql_test.go` | Go test entry points, MySQL backend, including restart/rollback/invalid-DSN acceptance tests (`dingo_extra_plugins` build tag) |
 | `conformance_main_test.go` | `TestMain` — drops this process's Postgres schema and MySQL database and removes their paired blob directories once, after every test in the process has finished (`dingo_extra_plugins` build tag) |

--- a/internal/test/conformance/conformance_main_test.go
+++ b/internal/test/conformance/conformance_main_test.go
@@ -52,6 +52,11 @@ func TestMain(m *testing.M) {
 	// of returning early.
 	cleanupFailed := false
 
+	if err := cleanupCorpusTestdata(); err != nil {
+		log.Printf("conformance: remove shared vector extraction: %v", err)
+		cleanupFailed = true
+	}
+
 	if postgresProcessBlobDir != "" {
 		if isPostgresConformanceConfigured() {
 			if err := dropPostgresSchema(

--- a/internal/test/conformance/conformance_mysql_test.go
+++ b/internal/test/conformance/conformance_mysql_test.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -106,102 +107,36 @@ func newTestMysqlConformanceManager(t *testing.T) *DingoStateManager {
 	return sm
 }
 
-// TestRulesConformanceVectorsMysql is the strict pass/fail gate for the
-// MySQL-backed DingoStateManager: it fails immediately on the first vector
-// mismatch (via harness.RunAllVectors), mirroring TestRulesConformanceVectors
-// in conformance_test.go.
+var (
+	mysqlCorpusOnce sync.Once
+	mysqlCorpusRun  corpusRun
+)
+
+// mysqlCorpusResults returns the MySQL backend's memoized corpus replay.
+// Requires the caller to have already skipped when MySQL is not configured.
+func mysqlCorpusResults(t *testing.T) []conformance.VectorResult {
+	t.Helper()
+	mysqlCorpusOnce.Do(func() {
+		sm := newTestMysqlConformanceManager(t)
+		defer sm.Close()
+		mysqlCorpusRun = replayCorpus(sm)
+	})
+	require.NoError(t, mysqlCorpusRun.err, "mysql corpus replay")
+	return mysqlCorpusRun.results
+}
+
+// TestRulesConformanceVectorsMysql replays the corpus against a real
+// MySQL-backed state manager, then asserts, reports, and compares against the
+// SQLite baseline in one pass. See TestRulesConformanceVectorsPostgres and
+// corpus_test.go for why a per-dialect replay earns its cost while a repeated
+// one does not.
 func TestRulesConformanceVectorsMysql(t *testing.T) {
 	skipIfMysqlConformanceNotConfigured(t)
 
-	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sm := newTestMysqlConformanceManager(t)
-	defer sm.Close()
-
-	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
-		TestdataRoot: testdataRoot,
-		Debug:        testing.Verbose(),
-	})
-
-	harness.RunAllVectors(t)
-}
-
-// TestRulesConformanceVectorsWithResultsMysql runs the harness against both
-// the SQLite-backed and MySQL-backed state managers in the same test and
-// compares them, rather than asserting a hardcoded vector count: the two
-// runs should exercise the identical number of vectors with identical pass
-// counts, and the comparison stays correct even as the embedded
-// ouroboros-mock vector corpus grows or shrinks.
-func TestRulesConformanceVectorsWithResultsMysql(t *testing.T) {
-	skipIfMysqlConformanceNotConfigured(t)
-
-	sqliteRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sqliteSm, err := NewDingoStateManager()
-	require.NoError(t, err)
-	defer sqliteSm.Close()
-
-	sqliteHarness := conformance.NewHarness(sqliteSm, conformance.HarnessConfig{
-		TestdataRoot: sqliteRoot,
-	})
-	sqliteResults, err := sqliteHarness.RunAllVectorsWithResults()
-	require.NoError(t, err, "failed to run sqlite vectors")
-
-	mysqlRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	mysqlSm := newTestMysqlConformanceManager(t)
-	defer mysqlSm.Close()
-
-	mysqlHarness := conformance.NewHarness(mysqlSm, conformance.HarnessConfig{
-		TestdataRoot: mysqlRoot,
-	})
-	mysqlResults, err := mysqlHarness.RunAllVectorsWithResults()
-	require.NoError(t, err, "failed to run mysql vectors")
-
-	var mysqlPassed, mysqlFailed int
-	for _, result := range mysqlResults {
-		if result.Success {
-			mysqlPassed++
-		} else {
-			mysqlFailed++
-		}
-	}
-
-	t.Logf("Conformance Test Results (MySQL):")
-	t.Logf("  Total vectors: %d", len(mysqlResults))
-	t.Logf("  Passed: %d", mysqlPassed)
-	t.Logf("  Failed: %d", mysqlFailed)
-	if len(mysqlResults) > 0 {
-		t.Logf(
-			"  Pass rate: %.1f%%",
-			float64(mysqlPassed)/float64(len(mysqlResults))*100,
-		)
-	}
-	if mysqlFailed > 0 && testing.Verbose() {
-		t.Log("First failures:")
-		failCount := 0
-		for _, result := range mysqlResults {
-			if !result.Success && failCount < 5 {
-				t.Logf("  %s: %v", result.Title, result.Error)
-				failCount++
-			}
-		}
-		if mysqlFailed > 5 {
-			t.Logf("  ... and %d more failures", mysqlFailed-5)
-		}
-	}
-
-	require.Equal(
-		t,
-		len(sqliteResults),
-		len(mysqlResults),
-		"mysql backend exercised a different number of vectors than "+
-			"sqlite; vector discovery/extraction should be backend-invariant",
-	)
-	require.Zero(t, mysqlFailed, "mysql backend failed vectors sqlite passed")
+	results := mysqlCorpusResults(t)
+	reportCorpus(t, "mysql", results)
+	assertBackendMatchesSqlite(t, "mysql", results)
+	assertCorpus(t, "mysql", results)
 }
 
 // TestNewDingoMysqlStateManagerRestartSurvivesReopen proves state committed

--- a/internal/test/conformance/conformance_mysql_test.go
+++ b/internal/test/conformance/conformance_mysql_test.go
@@ -117,7 +117,24 @@ var (
 func mysqlCorpusResults(t *testing.T) []conformance.VectorResult {
 	t.Helper()
 	mysqlCorpusOnce.Do(func() {
-		sm := newTestMysqlConformanceManager(t)
+		// Construct here rather than through
+		// newTestMysqlConformanceManager: that helper reports a
+		// construction failure with require.NoError on its own
+		// *testing.T, and sync.Once marks itself done even when its
+		// function unwinds through t.FailNow's runtime.Goexit. A later
+		// consumer in the same process would then read a zero-value
+		// corpusRun -- nil results and nil error -- pass its
+		// require.NoError, and fail in assertCorpus with a misleading
+		// "produced no vectors" instead of the construction failure.
+		// Storing the error keeps corpusRun's documented contract, and
+		// matches sqliteCorpusResults.
+		sm, err := NewDingoMysqlStateManager(mysqlConformanceRootDSN())
+		if err != nil {
+			mysqlCorpusRun = corpusRun{
+				err: fmt.Errorf("new mysql state manager: %w", err),
+			}
+			return
+		}
 		defer sm.Close()
 		mysqlCorpusRun = replayCorpus(sm)
 	})

--- a/internal/test/conformance/conformance_postgres_test.go
+++ b/internal/test/conformance/conformance_postgres_test.go
@@ -141,7 +141,24 @@ var (
 func postgresCorpusResults(t *testing.T) []conformance.VectorResult {
 	t.Helper()
 	postgresCorpusOnce.Do(func() {
-		sm := newTestPostgresConformanceManager(t)
+		// Construct here rather than through
+		// newTestPostgresConformanceManager: that helper reports a
+		// construction failure with require.NoError on its own
+		// *testing.T, and sync.Once marks itself done even when its
+		// function unwinds through t.FailNow's runtime.Goexit. A later
+		// consumer in the same process would then read a zero-value
+		// corpusRun -- nil results and nil error -- pass its
+		// require.NoError, and fail in assertCorpus with a misleading
+		// "produced no vectors" instead of the construction failure.
+		// Storing the error keeps corpusRun's documented contract, and
+		// matches sqliteCorpusResults.
+		sm, err := NewDingoPostgresStateManager(postgresConformanceDSN())
+		if err != nil {
+			postgresCorpusRun = corpusRun{
+				err: fmt.Errorf("new postgres state manager: %w", err),
+			}
+			return
+		}
 		defer sm.Close()
 		postgresCorpusRun = replayCorpus(sm)
 	})

--- a/internal/test/conformance/conformance_postgres_test.go
+++ b/internal/test/conformance/conformance_postgres_test.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -130,102 +131,40 @@ func newTestPostgresConformanceManager(t *testing.T) *DingoStateManager {
 	return sm
 }
 
-// TestRulesConformanceVectorsPostgres is the strict pass/fail gate for the
-// Postgres-backed DingoStateManager: it fails immediately on the first
-// vector mismatch (via harness.RunAllVectors), mirroring
-// TestRulesConformanceVectors in conformance_test.go.
+var (
+	postgresCorpusOnce sync.Once
+	postgresCorpusRun  corpusRun
+)
+
+// postgresCorpusResults returns the Postgres backend's memoized corpus replay.
+// Callers must have already skipped when Postgres is not configured.
+func postgresCorpusResults(t *testing.T) []conformance.VectorResult {
+	t.Helper()
+	postgresCorpusOnce.Do(func() {
+		sm := newTestPostgresConformanceManager(t)
+		defer sm.Close()
+		postgresCorpusRun = replayCorpus(sm)
+	})
+	require.NoError(t, postgresCorpusRun.err, "postgres corpus replay")
+	return postgresCorpusRun.results
+}
+
+// TestRulesConformanceVectorsPostgres is the pass/fail gate for the
+// Postgres-backed DingoStateManager, and also reports the progress statistics
+// and the SQLite comparison that previously each cost their own corpus replay.
+//
+// The corpus exercises gouroboros ledger rules, which do not vary by storage
+// backend, so this run is not here for rule coverage -- it is here to drive
+// Dingo's storage layer through Postgres' dialect. See corpus_test.go for the
+// two real bugs that found and for why one pass per dialect is the right
+// amount.
 func TestRulesConformanceVectorsPostgres(t *testing.T) {
 	skipIfPostgresConformanceNotConfigured(t)
 
-	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sm := newTestPostgresConformanceManager(t)
-	defer sm.Close()
-
-	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
-		TestdataRoot: testdataRoot,
-		Debug:        testing.Verbose(),
-	})
-
-	harness.RunAllVectors(t)
-}
-
-// TestRulesConformanceVectorsWithResultsPostgres runs the harness against
-// both the SQLite-backed and Postgres-backed state managers in the same
-// test and compares them, rather than asserting a hardcoded vector count:
-// the two runs should exercise the identical number of vectors with
-// identical pass counts, and the comparison stays correct even as the
-// embedded ouroboros-mock vector corpus grows or shrinks.
-func TestRulesConformanceVectorsWithResultsPostgres(t *testing.T) {
-	skipIfPostgresConformanceNotConfigured(t)
-
-	sqliteRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sqliteSm, err := NewDingoStateManager()
-	require.NoError(t, err)
-	defer sqliteSm.Close()
-
-	sqliteHarness := conformance.NewHarness(sqliteSm, conformance.HarnessConfig{
-		TestdataRoot: sqliteRoot,
-	})
-	sqliteResults, err := sqliteHarness.RunAllVectorsWithResults()
-	require.NoError(t, err, "failed to run sqlite vectors")
-
-	pgRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	pgSm := newTestPostgresConformanceManager(t)
-	defer pgSm.Close()
-
-	pgHarness := conformance.NewHarness(pgSm, conformance.HarnessConfig{
-		TestdataRoot: pgRoot,
-	})
-	pgResults, err := pgHarness.RunAllVectorsWithResults()
-	require.NoError(t, err, "failed to run postgres vectors")
-
-	var pgPassed, pgFailed int
-	for _, result := range pgResults {
-		if result.Success {
-			pgPassed++
-		} else {
-			pgFailed++
-		}
-	}
-
-	t.Logf("Conformance Test Results (PostgreSQL):")
-	t.Logf("  Total vectors: %d", len(pgResults))
-	t.Logf("  Passed: %d", pgPassed)
-	t.Logf("  Failed: %d", pgFailed)
-	if len(pgResults) > 0 {
-		t.Logf(
-			"  Pass rate: %.1f%%",
-			float64(pgPassed)/float64(len(pgResults))*100,
-		)
-	}
-	if pgFailed > 0 && testing.Verbose() {
-		t.Log("First failures:")
-		failCount := 0
-		for _, result := range pgResults {
-			if !result.Success && failCount < 5 {
-				t.Logf("  %s: %v", result.Title, result.Error)
-				failCount++
-			}
-		}
-		if pgFailed > 5 {
-			t.Logf("  ... and %d more failures", pgFailed-5)
-		}
-	}
-
-	require.Equal(
-		t,
-		len(sqliteResults),
-		len(pgResults),
-		"postgres backend exercised a different number of vectors than "+
-			"sqlite; vector discovery/extraction should be backend-invariant",
-	)
-	require.Zero(t, pgFailed, "postgres backend failed vectors sqlite passed")
+	results := postgresCorpusResults(t)
+	reportCorpus(t, "postgres", results)
+	assertBackendMatchesSqlite(t, "postgres", results)
+	assertCorpus(t, "postgres", results)
 }
 
 // TestNewDingoPostgresStateManagerRestartSurvivesReopen proves state

--- a/internal/test/conformance/conformance_test.go
+++ b/internal/test/conformance/conformance_test.go
@@ -16,13 +16,11 @@ package conformance
 
 import (
 	"testing"
-
-	"github.com/blinklabs-io/ouroboros-mock/conformance"
-	"github.com/stretchr/testify/require"
 )
 
-// TestRulesConformanceVectors runs the Amaru ledger rules conformance test vectors
-// using Dingo's ledger implementation via the shared harness from ouroboros-mock/conformance.
+// TestRulesConformanceVectors runs the Amaru ledger rules conformance test
+// vectors using Dingo's ledger implementation via the shared harness from
+// ouroboros-mock/conformance.
 //
 // The test vectors exercise Conway era ledger rules including:
 // - UTxO validation (inputs, outputs, fees, collateral)
@@ -30,74 +28,12 @@ import (
 // - Governance (proposals, voting, enactment)
 // - Script execution (native scripts, Plutus V1/V2/V3)
 //
-// Test vectors are embedded in the ouroboros-mock module and extracted at test time.
+// Test vectors are embedded in the ouroboros-mock module and extracted at test
+// time. This asserts and reports from a single corpus replay; see
+// corpus_test.go for why the replay is memoized per backend and what the
+// previous separate statistics pass cost.
 func TestRulesConformanceVectors(t *testing.T) {
-	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sm, err := NewDingoStateManager()
-	require.NoError(t, err)
-	defer sm.Close()
-
-	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
-		TestdataRoot: testdataRoot,
-		Debug:        testing.Verbose(),
-	})
-
-	harness.RunAllVectors(t)
-}
-
-// TestRulesConformanceVectorsWithResults runs the conformance tests and reports
-// detailed statistics. This is useful for tracking implementation progress.
-func TestRulesConformanceVectorsWithResults(t *testing.T) {
-	testdataRoot, err := conformance.ExtractEmbeddedTestdata(t.TempDir())
-	require.NoError(t, err, "failed to extract embedded testdata")
-
-	sm, err := NewDingoStateManager()
-	require.NoError(t, err)
-	defer sm.Close()
-
-	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
-		TestdataRoot: testdataRoot,
-		Debug:        false,
-	})
-
-	results, err := harness.RunAllVectorsWithResults()
-	if err != nil {
-		t.Fatalf("failed to run vectors: %v", err)
-	}
-
-	var successes, failures int
-	for _, result := range results {
-		if result.Success {
-			successes++
-		} else {
-			failures++
-		}
-	}
-
-	t.Logf("Conformance Test Results:")
-	t.Logf("  Total vectors: %d", len(results))
-	t.Logf("  Passed: %d", successes)
-	t.Logf("  Failed: %d", failures)
-	if len(results) > 0 {
-		t.Logf(
-			"  Pass rate: %.1f%%",
-			float64(successes)/float64(len(results))*100,
-		)
-	}
-
-	if failures > 0 && testing.Verbose() {
-		t.Log("First failures:")
-		failCount := 0
-		for _, result := range results {
-			if !result.Success && failCount < 5 {
-				t.Logf("  %s: %v", result.Title, result.Error)
-				failCount++
-			}
-		}
-		if failures > 5 {
-			t.Logf("  ... and %d more failures", failures-5)
-		}
-	}
+	results := sqliteCorpusResults(t)
+	reportCorpus(t, "sqlite", results)
+	assertCorpus(t, "sqlite", results)
 }

--- a/internal/test/conformance/corpus_main_test.go
+++ b/internal/test/conformance/corpus_main_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !dingo_extra_plugins
+
+package conformance
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+// TestMain removes the shared vector extraction (see corpusTestdataRoot) after
+// every test in this process has finished.
+//
+// The build constraint is what keeps this from colliding with the TestMain in
+// conformance_main_test.go, which is tagged dingo_extra_plugins and performs
+// the same cleanup alongside its Postgres and MySQL teardown. Exactly one
+// TestMain exists in either build configuration; do not drop either
+// constraint.
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	cleanupFailed := false
+	if err := cleanupCorpusTestdata(); err != nil {
+		log.Printf("conformance: remove shared vector extraction: %v", err)
+		cleanupFailed = true
+	}
+
+	os.Exit(processCleanupExitCode(code, cleanupFailed))
+}
+
+// processCleanupExitCode folds a process-cleanup failure into the test run's
+// own exit code, matching the tagged build's helper of the same name so both
+// configurations treat a leaked resource identically. A real test failure's
+// exit code is never downgraded, only upgraded from 0.
+func processCleanupExitCode(testExitCode int, cleanupFailed bool) int {
+	if cleanupFailed && testExitCode == 0 {
+		return 1
+	}
+	return testExitCode
+}

--- a/internal/test/conformance/corpus_test.go
+++ b/internal/test/conformance/corpus_test.go
@@ -302,17 +302,12 @@ func assertCorpusSetsMatch(
 		if result.Success {
 			continue
 		}
-		passed, ok := sqlitePassed[result.Path]
-		require.Truef(
-			t,
-			ok,
-			"%s backend ran vector %q that sqlite never ran",
-			backend,
-			result.Path,
-		)
+		// No presence guard here: ElementsMatch above FailNows on any path
+		// set difference, so every backend path exists in sqlitePassed by
+		// the time this loop runs.
 		require.Falsef(
 			t,
-			passed,
+			sqlitePassed[result.Path],
 			"%s backend failed a vector sqlite passed (%s at event %d): %v",
 			backend,
 			result.Title,
@@ -368,10 +363,16 @@ func TestAssertCorpusSetsMatchRejectsDifferentPaths(t *testing.T) {
 	)
 }
 
-// TestAssertCorpusSetsMatchRejectsUnknownFailedVector proves a failing vector
-// the sqlite baseline never ran is reported rather than silently accepted by
-// the absent-key-reads-false lookup.
-func TestAssertCorpusSetsMatchRejectsUnknownFailedVector(t *testing.T) {
+// TestAssertCorpusSetsMatchRejectsExtraBackendVector proves a backend vector
+// the sqlite baseline never ran is reported.
+//
+// It is caught by the path set comparison, not by any per-vector presence
+// check. An earlier revision added such a check after ElementsMatch and a test
+// asserting it; both were dead, because ElementsMatch FailNows first on a real
+// *testing.T. The recording asserter used here does not stop on failure, so
+// that test passed on the ElementsMatch failure while claiming to exercise the
+// guard -- it asserted something already true.
+func TestAssertCorpusSetsMatchRejectsExtraBackendVector(t *testing.T) {
 	sqliteResults := []conformance.VectorResult{{Path: "a", Success: true}}
 	backendResults := []conformance.VectorResult{{Path: "z", Success: false}}
 

--- a/internal/test/conformance/corpus_test.go
+++ b/internal/test/conformance/corpus_test.go
@@ -75,6 +75,10 @@ func corpusTestdataRoot() (string, error) {
 			testdataErr = fmt.Errorf("create testdata dir: %w", err)
 			return
 		}
+		// Record the directory before extraction, not after: a failure
+		// below still leaves a real directory on disk, and
+		// cleanupCorpusTestdata's empty-string early return would skip it.
+		testdataDir = dir
 		// ExtractEmbeddedTestdata returns the extracted root, which is a
 		// "testdata" subdirectory of dir, not dir itself. Use the returned
 		// path; dir is only what gets removed on cleanup.
@@ -83,7 +87,7 @@ func corpusTestdataRoot() (string, error) {
 			testdataErr = fmt.Errorf("extract embedded testdata: %w", err)
 			return
 		}
-		testdataDir, testdataRoot = dir, root
+		testdataRoot = root
 	})
 	return testdataRoot, testdataErr
 }
@@ -231,6 +235,14 @@ func corpusCounts(results []conformance.VectorResult) (int, int) {
 // means extraction or discovery diverged rather than a rule behaving
 // differently; a vector failing here that SQLite passed is a dialect
 // divergence, which is what running the corpus on this backend is for.
+//
+// The vector comparison is deliberately one-directional. The opposite
+// divergence -- SQLite failing a vector this backend passes -- is not silent:
+// assertCorpus runs over every backend's own results, including SQLite's in
+// TestRulesConformanceVectors, and fails on any vector that backend failed. So
+// a divergence in either direction turns the run red; naming it here as well
+// would only duplicate the SQLite gate. What this direction adds is
+// attribution, pointing at the backend rather than at the corpus.
 func assertBackendMatchesSqlite(
 	t *testing.T,
 	backend string,

--- a/internal/test/conformance/corpus_test.go
+++ b/internal/test/conformance/corpus_test.go
@@ -249,7 +249,27 @@ func assertBackendMatchesSqlite(
 	results []conformance.VectorResult,
 ) {
 	t.Helper()
-	sqliteResults := sqliteCorpusResults(t)
+	assertCorpusSetsMatch(t, backend, sqliteCorpusResults(t), results)
+}
+
+// corpusAsserter is the subset of *testing.T the corpus comparison needs. It
+// exists so the comparison can be exercised against a recorder rather than
+// only through a real corpus replay; a zero-value testing.T is not usable for
+// that, since require's FailNow needs a running test goroutine.
+type corpusAsserter interface {
+	require.TestingT
+	Helper()
+}
+
+// assertCorpusSetsMatch is assertBackendMatchesSqlite's comparison, split out
+// so it can be exercised without replaying the corpus.
+func assertCorpusSetsMatch(
+	t corpusAsserter,
+	backend string,
+	sqliteResults []conformance.VectorResult,
+	results []conformance.VectorResult,
+) {
+	t.Helper()
 
 	require.Equal(
 		t,
@@ -260,7 +280,21 @@ func assertBackendMatchesSqlite(
 		backend,
 	)
 
-	sqlitePassed := map[string]bool{}
+	// Compare the path sets, not just their sizes. Equal counts over
+	// different paths would otherwise slip through, and the pass lookup
+	// below cannot catch it on its own: a backend path absent from the
+	// sqlite map reads as false, which is exactly what the assertion
+	// expects, so {a,b} against {a,c} would pass on both checks.
+	require.ElementsMatch(
+		t,
+		corpusPaths(sqliteResults),
+		corpusPaths(results),
+		"%s backend exercised different vectors than sqlite; vector "+
+			"discovery/extraction should be backend-invariant",
+		backend,
+	)
+
+	sqlitePassed := make(map[string]bool, len(sqliteResults))
 	for _, result := range sqliteResults {
 		sqlitePassed[result.Path] = result.Success
 	}
@@ -268,9 +302,17 @@ func assertBackendMatchesSqlite(
 		if result.Success {
 			continue
 		}
+		passed, ok := sqlitePassed[result.Path]
+		require.Truef(
+			t,
+			ok,
+			"%s backend ran vector %q that sqlite never ran",
+			backend,
+			result.Path,
+		)
 		require.Falsef(
 			t,
-			sqlitePassed[result.Path],
+			passed,
 			"%s backend failed a vector sqlite passed (%s at event %d): %v",
 			backend,
 			result.Title,
@@ -278,4 +320,84 @@ func assertBackendMatchesSqlite(
 			result.Error,
 		)
 	}
+}
+
+// corpusPaths returns each result's vector path, for set comparison between
+// backends.
+func corpusPaths(results []conformance.VectorResult) []string {
+	paths := make([]string, len(results))
+	for i, result := range results {
+		paths[i] = result.Path
+	}
+	return paths
+}
+
+// recordingAsserter records whether an assertion failed, without the Goexit a
+// real *testing.T performs, so a single call's outcome can be inspected.
+type recordingAsserter struct {
+	failed bool
+}
+
+func (r *recordingAsserter) Errorf(string, ...any) { r.failed = true }
+func (r *recordingAsserter) FailNow()              { r.failed = true }
+func (r *recordingAsserter) Helper()               {}
+
+// TestAssertCorpusSetsMatchRejectsDifferentPaths proves the comparison fails
+// when two backends run the same number of vectors with different paths.
+//
+// The count check alone cannot see this, and neither can the pass lookup: a
+// backend path absent from the sqlite map reads as false, which is what that
+// assertion expects. So {a,b} against {a,c} passed both checks before the path
+// set comparison was added.
+func TestAssertCorpusSetsMatchRejectsDifferentPaths(t *testing.T) {
+	sqliteResults := []conformance.VectorResult{
+		{Path: "a", Success: true},
+		{Path: "b", Success: true},
+	}
+	backendResults := []conformance.VectorResult{
+		{Path: "a", Success: true},
+		{Path: "c", Success: true},
+	}
+
+	rec := &recordingAsserter{}
+	assertCorpusSetsMatch(rec, "probe", sqliteResults, backendResults)
+	require.True(
+		t,
+		rec.failed,
+		"equal counts over different vector paths must fail the comparison",
+	)
+}
+
+// TestAssertCorpusSetsMatchRejectsUnknownFailedVector proves a failing vector
+// the sqlite baseline never ran is reported rather than silently accepted by
+// the absent-key-reads-false lookup.
+func TestAssertCorpusSetsMatchRejectsUnknownFailedVector(t *testing.T) {
+	sqliteResults := []conformance.VectorResult{{Path: "a", Success: true}}
+	backendResults := []conformance.VectorResult{{Path: "z", Success: false}}
+
+	rec := &recordingAsserter{}
+	assertCorpusSetsMatch(rec, "probe", sqliteResults, backendResults)
+	require.True(
+		t,
+		rec.failed,
+		"a failed vector absent from the sqlite baseline must be reported",
+	)
+}
+
+// TestAssertCorpusSetsMatchAcceptsIdenticalRuns proves the comparison stays
+// quiet when both backends ran the same vectors with the same outcomes, so the
+// checks above cannot pass by simply failing everything.
+func TestAssertCorpusSetsMatchAcceptsIdenticalRuns(t *testing.T) {
+	results := []conformance.VectorResult{
+		{Path: "a", Success: true},
+		{Path: "b", Success: true},
+	}
+
+	rec := &recordingAsserter{}
+	assertCorpusSetsMatch(rec, "probe", results, results)
+	require.False(
+		t,
+		rec.failed,
+		"identical runs must not be reported as divergent",
+	)
 }

--- a/internal/test/conformance/corpus_test.go
+++ b/internal/test/conformance/corpus_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/stretchr/testify/require"
+)
+
+// One full replay of the Amaru vector corpus is expensive -- it was 917s of
+// this package's Linux CI time with real Postgres and MySQL attached -- and
+// the corpus exercises gouroboros ledger rules, which do not vary by storage
+// backend. Replaying it more than once per backend therefore buys no rule
+// coverage.
+//
+// What the per-backend replays do buy is dialect divergence, and that is not
+// hypothetical: #3599 found two real bugs this way, neither of them a rule bug.
+// loadPoolAssociations held a pool_registration cursor open while issuing
+// nested per-row queries on one connection, which SQLite tolerates and MySQL
+// and PostgreSQL do not; and go-sql-driver/mysql reports rows changed rather
+// than rows matched, so a DRep voting twice in an epoch with an unchanged
+// expiry looked like a missing row. Both were found by driving the storage
+// layer through the corpus's variety of access patterns, which needs one pass
+// per dialect, not several.
+//
+// So each backend replays the corpus exactly once per `go test` process, and
+// every consumer -- the pass/fail gate, the progress statistics, and the
+// cross-backend comparison -- reads that one memoized result set. Before this,
+// a Linux CI run replayed the corpus eight times: SQLite four (a plain pass, a
+// statistics pass, and a fresh baseline rebuilt inside each of the two
+// comparison tests), Postgres twice, and MySQL twice.
+
+// corpusRun is one backend's memoized corpus replay. err is retained rather
+// than failing inside the sync.Once, so that every test reading this backend
+// reports the same construction or replay failure instead of only whichever
+// test happened to trigger the Once first.
+type corpusRun struct {
+	results []conformance.VectorResult
+	err     error
+}
+
+var (
+	testdataOnce sync.Once
+	testdataDir  string
+	testdataRoot string
+	testdataErr  error
+)
+
+// corpusTestdataRoot extracts the embedded vector corpus once per process.
+// It deliberately does not use t.TempDir(): the extraction is shared across
+// tests, so tying it to the lifetime of whichever test triggered it first
+// would delete it while later tests still name its paths in failure output.
+// TestMain removes it (see cleanupCorpusTestdata).
+func corpusTestdataRoot() (string, error) {
+	testdataOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "dingo-conformance-vectors-")
+		if err != nil {
+			testdataErr = fmt.Errorf("create testdata dir: %w", err)
+			return
+		}
+		// ExtractEmbeddedTestdata returns the extracted root, which is a
+		// "testdata" subdirectory of dir, not dir itself. Use the returned
+		// path; dir is only what gets removed on cleanup.
+		root, err := conformance.ExtractEmbeddedTestdata(dir)
+		if err != nil {
+			testdataErr = fmt.Errorf("extract embedded testdata: %w", err)
+			return
+		}
+		testdataDir, testdataRoot = dir, root
+	})
+	return testdataRoot, testdataErr
+}
+
+// cleanupCorpusTestdata removes the shared extraction. Safe to call when the
+// corpus was never extracted, which is the case for a run whose tests all
+// skipped.
+func cleanupCorpusTestdata() error {
+	if testdataDir == "" {
+		return nil
+	}
+	return os.RemoveAll(testdataDir)
+}
+
+// replayCorpus runs the whole corpus once against sm and returns per-vector
+// results. It uses RunAllVectorsWithResults rather than RunAllVectors so the
+// single pass can serve both the gate and the statistics; assertCorpus turns
+// the results back into per-vector subtests, so no subtest naming is lost.
+func replayCorpus(sm *DingoStateManager) corpusRun {
+	root, err := corpusTestdataRoot()
+	if err != nil {
+		return corpusRun{err: err}
+	}
+	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
+		TestdataRoot: root,
+	})
+	results, err := harness.RunAllVectorsWithResults()
+	if err != nil {
+		return corpusRun{err: fmt.Errorf("run vectors: %w", err)}
+	}
+	return corpusRun{results: results}
+}
+
+var (
+	sqliteCorpusOnce sync.Once
+	sqliteCorpusRun  corpusRun
+)
+
+// sqliteCorpusResults returns the SQLite backend's memoized corpus replay.
+// SQLite needs no external service, so this is the backend every run has and
+// the baseline the Postgres and MySQL comparisons measure against.
+func sqliteCorpusResults(t *testing.T) []conformance.VectorResult {
+	t.Helper()
+	sqliteCorpusOnce.Do(func() {
+		sm, err := NewDingoStateManager()
+		if err != nil {
+			sqliteCorpusRun = corpusRun{
+				err: fmt.Errorf("new sqlite state manager: %w", err),
+			}
+			return
+		}
+		defer sm.Close()
+		sqliteCorpusRun = replayCorpus(sm)
+	})
+	require.NoError(t, sqliteCorpusRun.err, "sqlite corpus replay")
+	return sqliteCorpusRun.results
+}
+
+// assertCorpus is the pass/fail gate. Each vector becomes a named subtest, as
+// harness.RunAllVectors produced, so a failure still identifies its vector by
+// path in the test output; the result carries the event index the vector
+// failed at, which the assertion path did not report.
+func assertCorpus(
+	t *testing.T,
+	backend string,
+	results []conformance.VectorResult,
+) {
+	t.Helper()
+	require.NotEmpty(
+		t,
+		results,
+		"%s: corpus replay produced no vectors; vector discovery or "+
+			"extraction is broken, and an empty corpus would otherwise "+
+			"report as a pass",
+		backend,
+	)
+	for _, result := range results {
+		t.Run(result.Path, func(t *testing.T) {
+			if result.Success {
+				return
+			}
+			t.Fatalf(
+				"vector failed on %s at event %d of %d: %v (%s)",
+				backend,
+				result.FailedEvent,
+				result.EventCount,
+				result.Error,
+				result.Title,
+			)
+		})
+	}
+}
+
+// reportCorpus logs the progress statistics that a separate second replay per
+// backend used to produce.
+func reportCorpus(
+	t *testing.T,
+	backend string,
+	results []conformance.VectorResult,
+) {
+	t.Helper()
+	passed, failed := corpusCounts(results)
+
+	t.Logf("Conformance Test Results (%s):", backend)
+	t.Logf("  Total vectors: %d", len(results))
+	t.Logf("  Passed: %d", passed)
+	t.Logf("  Failed: %d", failed)
+	if len(results) > 0 {
+		t.Logf(
+			"  Pass rate: %.1f%%",
+			float64(passed)/float64(len(results))*100,
+		)
+	}
+
+	if failed > 0 && testing.Verbose() {
+		t.Log("First failures:")
+		failCount := 0
+		for _, result := range results {
+			if !result.Success && failCount < 5 {
+				t.Logf("  %s: %v", result.Title, result.Error)
+				failCount++
+			}
+		}
+		if failed > 5 {
+			t.Logf("  ... and %d more failures", failed-5)
+		}
+	}
+}
+
+// corpusCounts returns the passed and failed vector counts.
+func corpusCounts(results []conformance.VectorResult) (int, int) {
+	var passed, failed int
+	for _, result := range results {
+		if result.Success {
+			passed++
+		} else {
+			failed++
+		}
+	}
+	return passed, failed
+}
+
+// assertBackendMatchesSqlite compares an external backend's replay against the
+// SQLite baseline. Vector discovery is backend-invariant, so a different count
+// means extraction or discovery diverged rather than a rule behaving
+// differently; a vector failing here that SQLite passed is a dialect
+// divergence, which is what running the corpus on this backend is for.
+func assertBackendMatchesSqlite(
+	t *testing.T,
+	backend string,
+	results []conformance.VectorResult,
+) {
+	t.Helper()
+	sqliteResults := sqliteCorpusResults(t)
+
+	require.Equal(
+		t,
+		len(sqliteResults),
+		len(results),
+		"%s backend exercised a different number of vectors than sqlite; "+
+			"vector discovery/extraction should be backend-invariant",
+		backend,
+	)
+
+	sqlitePassed := map[string]bool{}
+	for _, result := range sqliteResults {
+		sqlitePassed[result.Path] = result.Success
+	}
+	for _, result := range results {
+		if result.Success {
+			continue
+		}
+		require.Falsef(
+			t,
+			sqlitePassed[result.Path],
+			"%s backend failed a vector sqlite passed (%s at event %d): %v",
+			backend,
+			result.Title,
+			result.FailedEvent,
+			result.Error,
+		)
+	}
+}

--- a/internal/test/conformance/reset_cost.go
+++ b/internal/test/conformance/reset_cost.go
@@ -64,6 +64,11 @@ type backendResetter struct {
 	// guarantee a non-empty slice.
 	truncate func(context.Context, *sql.DB, []string) error
 
+	// extraDirty reports bare table names that must be truncated even when
+	// they hold no rows, because emptiness is not the only state a Reset has
+	// to clear. Optional; nil means rows are the only criterion.
+	extraDirty func(context.Context, *sql.DB, []string) ([]string, error)
+
 	// probeDirty reports which of the given qualified tables hold rows.
 	// Injectable so reset's skip/subset behavior is testable without a
 	// server; nil means nonEmptyTables, which is what both real backends
@@ -101,6 +106,13 @@ func (r *backendResetter) reset(ctx context.Context) error {
 	dirty, err := probe(ctx, r.db, qualified)
 	if err != nil {
 		return err
+	}
+	if r.extraDirty != nil {
+		extra, err := r.extraDirty(ctx, r.db, tables)
+		if err != nil {
+			return err
+		}
+		dirty = mergeQualified(dirty, extra, r.qualify)
 	}
 	if len(dirty) == 0 {
 		// The common case for a vector that wrote nothing, and for the first
@@ -207,4 +219,30 @@ func nonEmptyTables(
 		return nil, fmt.Errorf("probe non-empty tables: %w", err)
 	}
 	return dirty, nil
+}
+
+// mergeQualified adds the qualified form of each extra bare table name to
+// dirty, skipping any already present, so a table reported by both the row
+// probe and an extra criterion is truncated once.
+func mergeQualified(
+	dirty []string,
+	extra []string,
+	qualify func(string) string,
+) []string {
+	if len(extra) == 0 {
+		return dirty
+	}
+	seen := make(map[string]struct{}, len(dirty))
+	for _, table := range dirty {
+		seen[table] = struct{}{}
+	}
+	for _, table := range extra {
+		qualified := qualify(table)
+		if _, ok := seen[qualified]; ok {
+			continue
+		}
+		seen[qualified] = struct{}{}
+		dirty = append(dirty, qualified)
+	}
+	return dirty
 }

--- a/internal/test/conformance/reset_cost.go
+++ b/internal/test/conformance/reset_cost.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Reset runs once per vector, so anything it does is multiplied by the size of
+// the corpus (~315 vectors). Measured against the pre-change reset path, each
+// external backend paid three separate per-vector costs, and the eight-replay
+// baseline run spent 4m40s of CPU across 55 minutes of wall clock -- 8.4%,
+// i.e. almost entirely blocked on database round trips rather than on vector
+// work:
+//
+//  1. a fresh sql.Open plus Close, so a TCP connect and authentication
+//     handshake per vector;
+//  2. an information_schema query per vector, re-deriving a table list that
+//     cannot change (migrations run once, at construction);
+//  3. for MySQL, one TRUNCATE statement per table per vector. At 84 tables
+//     that is ~26,460 implicit-commit DDL statements per replay. PostgreSQL
+//     already batched into a single multi-table TRUNCATE.
+//
+// backendResetter removes all three: it holds one admin connection for the
+// manager's lifetime, caches the table list after the first successful
+// discovery, and truncates only the tables that actually hold rows.
+//
+// Truncating only non-empty tables is what makes the cost proportional to what
+// a vector wrote rather than to the schema size, and it deliberately keeps
+// TRUNCATE rather than switching to a single batched DELETE transaction:
+// TRUNCATE resets AUTO_INCREMENT and DELETE does not, and 78 of the 84 tables
+// carry such a column. Restoring those counters would mean an ALTER TABLE per
+// table, putting the per-table DDL straight back.
+type backendResetter struct {
+	db *sql.DB
+
+	// listTables discovers the base tables to manage, excluding the
+	// migration runner's own schema_migrations bookkeeping.
+	listTables func(context.Context, *sql.DB) ([]string, error)
+
+	// qualify fully quotes a bare table name for this dialect.
+	qualify func(string) string
+
+	// truncate empties exactly the given already-qualified tables. Callers
+	// guarantee a non-empty slice.
+	truncate func(context.Context, *sql.DB, []string) error
+
+	// probeDirty reports which of the given qualified tables hold rows.
+	// Injectable so reset's skip/subset behavior is testable without a
+	// server; nil means nonEmptyTables, which is what both real backends
+	// use.
+	probeDirty func(context.Context, *sql.DB, []string) ([]string, error)
+
+	// mu guards tables and discovered across the sequential-but-not-
+	// guaranteed-single-goroutine Reset calls the harness makes.
+	mu         sync.Mutex
+	tables     []string
+	discovered bool
+}
+
+// reset empties every non-empty managed table. It is the wipeMetadata hook.
+func (r *backendResetter) reset(ctx context.Context) error {
+	tables, err := r.cachedTables(ctx)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		// Nothing migrated yet (Reset can be called before any construction
+		// has run migrations against this schema/database).
+		return nil
+	}
+
+	qualified := make([]string, len(tables))
+	for i, table := range tables {
+		qualified[i] = r.qualify(table)
+	}
+
+	probe := r.probeDirty
+	if probe == nil {
+		probe = nonEmptyTables
+	}
+	dirty, err := probe(ctx, r.db, qualified)
+	if err != nil {
+		return err
+	}
+	if len(dirty) == 0 {
+		// The common case for a vector that wrote nothing, and for the first
+		// vector of a run. No DDL at all.
+		return nil
+	}
+	return r.truncate(ctx, r.db, dirty)
+}
+
+// cachedTables returns the managed table list, discovering it at most once.
+//
+// An empty result is deliberately not cached: Reset can run before migrations
+// have created anything, and caching that would leave the resetter permanently
+// convinced the schema is empty.
+func (r *backendResetter) cachedTables(ctx context.Context) ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.discovered {
+		return r.tables, nil
+	}
+	tables, err := r.listTables(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	r.tables, r.discovered = tables, true
+	return r.tables, nil
+}
+
+// Close releases the long-lived admin connection.
+func (r *backendResetter) Close() error {
+	if r.db == nil {
+		return nil
+	}
+	return r.db.Close()
+}
+
+// nonEmptyTables returns the subset of qualified that currently holds at least
+// one row, in a single round trip.
+//
+// The query is one UNION ALL of EXISTS probes, selecting each table's index
+// rather than its name so no identifier ever has to survive being embedded in
+// a string literal. Asking per table instead would trade the per-table
+// TRUNCATE this exists to avoid for a per-table SELECT, which is cheaper but
+// still O(tables) round trips; this stays at one regardless of schema size.
+//
+// EXISTS stops at the first row, so a probe against a large table is no more
+// expensive than against a small one.
+//
+// The index must be single-quoted: that makes it a SQL string literal, where
+// double quotes would be an identifier reference in PostgreSQL and select a
+// column named after the number. Both PostgreSQL and MySQL 8 accept a
+// FROM-less `SELECT ... WHERE ...`, so no dummy FROM is needed; the MySQL
+// restriction on that shape applies to 5.x, and this repository's services
+// pin mysql:8.
+func nonEmptyTables(
+	ctx context.Context,
+	db *sql.DB,
+	qualified []string,
+) ([]string, error) {
+	if len(qualified) == 0 {
+		return nil, nil
+	}
+
+	var query strings.Builder
+	for i, table := range qualified {
+		if i > 0 {
+			query.WriteString(" UNION ALL ")
+		}
+		// The literal is a decimal index this function generated, never
+		// caller or operator input.
+		query.WriteString("SELECT '")
+		query.WriteString(strconv.Itoa(i))
+		query.WriteString("' AS i WHERE EXISTS ")
+		query.WriteString("(SELECT 1 FROM ")
+		query.WriteString(table)
+		query.WriteString(")")
+	}
+
+	rows, err := db.QueryContext(ctx, query.String())
+	if err != nil {
+		return nil, fmt.Errorf("probe non-empty tables: %w", err)
+	}
+	defer rows.Close()
+
+	var dirty []string
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("scan non-empty table index: %w", err)
+		}
+		idx, err := strconv.Atoi(raw)
+		if err != nil || idx < 0 || idx >= len(qualified) {
+			return nil, fmt.Errorf(
+				"non-empty table probe returned unusable index %q",
+				raw,
+			)
+		}
+		dirty = append(dirty, qualified[idx])
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("probe non-empty tables: %w", err)
+	}
+	return dirty, nil
+}

--- a/internal/test/conformance/reset_cost_test.go
+++ b/internal/test/conformance/reset_cost_test.go
@@ -164,6 +164,29 @@ func TestBackendResetterSkipsTruncateEntirelyWhenClean(t *testing.T) {
 // backend rather than asserting on the generated string. Reintroducing double
 // quotes fails TestNonEmptyTablesPostgres.
 
+// dropAndCloseOnCleanup registers the drop of a test-created schema or database
+// and the close of the admin pool so both actually run, in that order.
+//
+// t.Cleanup is last-in-first-out, and a deferred call in the test body runs
+// before any Cleanup. So `defer db.Close()` closes the pool first and a
+// Cleanup-registered DROP then executes against a closed pool, fails, and --
+// with its error discarded -- silently leaves the schema or database behind
+// after every run. Registering the close first makes it run last, and both
+// errors are reported rather than swallowed so a future leak is visible.
+func dropAndCloseOnCleanup(t *testing.T, db *sql.DB, drop string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close admin pool: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if _, err := db.Exec(drop); err != nil {
+			t.Errorf("%s: %v", drop, err)
+		}
+	})
+}
+
 // TestNonEmptyTablesPostgres proves the probe returns exactly the tables
 // holding rows on PostgreSQL.
 func TestNonEmptyTablesPostgres(t *testing.T) {
@@ -171,14 +194,13 @@ func TestNonEmptyTablesPostgres(t *testing.T) {
 
 	db, err := sql.Open("pgx", postgresConformanceDSN())
 	require.NoError(t, err)
-	defer db.Close()
 
 	schema := "probe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	_, err = db.Exec(`CREATE SCHEMA ` + pgQuoteIdent(schema))
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = db.Exec(`DROP SCHEMA ` + pgQuoteIdent(schema) + ` CASCADE`)
-	})
+	dropAndCloseOnCleanup(
+		t, db, `DROP SCHEMA `+pgQuoteIdent(schema)+` CASCADE`,
+	)
 
 	assertProbeFindsOnlyPopulated(t, db, schema, pgQuoteQualified,
 		func(qualified string) string {
@@ -197,18 +219,15 @@ func TestNonEmptyTablesMysql(t *testing.T) {
 	cfg.DBName = ""
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	require.NoError(t, err)
-	defer db.Close()
 
 	database := "probe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	_, err = db.Exec(
 		"CREATE DATABASE " + mysqlQuoteIdentifier(database),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = db.Exec(
-			"DROP DATABASE " + mysqlQuoteIdentifier(database),
-		)
-	})
+	dropAndCloseOnCleanup(
+		t, db, "DROP DATABASE "+mysqlQuoteIdentifier(database),
+	)
 
 	qualify := func(schema, table string) string {
 		return mysqlQuoteIdentifier(schema) + "." +
@@ -344,14 +363,13 @@ func TestMysqlAdvancedAutoIncrementTablesFiltersToManaged(t *testing.T) {
 	cfg.DBName = ""
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	require.NoError(t, err)
-	defer db.Close()
 
 	database := "aiprobe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
 	_, err = db.Exec("CREATE DATABASE " + mysqlQuoteIdentifier(database))
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_, _ = db.Exec("DROP DATABASE " + mysqlQuoteIdentifier(database))
-	})
+	dropAndCloseOnCleanup(
+		t, db, "DROP DATABASE "+mysqlQuoteIdentifier(database),
+	)
 
 	ctx := context.Background()
 	for _, name := range []string{"managed", "unmanaged"} {

--- a/internal/test/conformance/reset_cost_test.go
+++ b/internal/test/conformance/reset_cost_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dingo_extra_plugins
+
+package conformance
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"testing"
+	"time"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResetter builds a backendResetter with no real database, recording what
+// each injected hook was asked to do.
+type fakeResetter struct {
+	resetter    *backendResetter
+	listCalls   int
+	listReturns [][]string
+	truncated   [][]string
+	dirty       []string
+}
+
+func newFakeResetter(t *testing.T, listReturns ...[]string) *fakeResetter {
+	t.Helper()
+	f := &fakeResetter{listReturns: listReturns}
+	f.resetter = &backendResetter{
+		listTables: func(
+			context.Context,
+			*sql.DB,
+		) ([]string, error) {
+			idx := f.listCalls
+			f.listCalls++
+			if idx >= len(f.listReturns) {
+				idx = len(f.listReturns) - 1
+			}
+			return f.listReturns[idx], nil
+		},
+		qualify: func(table string) string { return `"s"."` + table + `"` },
+		probeDirty: func(
+			_ context.Context,
+			_ *sql.DB,
+			_ []string,
+		) ([]string, error) {
+			return f.dirty, nil
+		},
+		truncate: func(
+			_ context.Context,
+			_ *sql.DB,
+			qualified []string,
+		) error {
+			f.truncated = append(f.truncated, qualified)
+			return nil
+		},
+	}
+	return f
+}
+
+// TestBackendResetterCachesTableList proves the information_schema query runs
+// once rather than once per Reset. Reset runs once per vector across a
+// ~315-vector corpus, so re-deriving a table list that cannot change (it is
+// fixed by the migrations that ran at construction) was 315 wasted round trips
+// per backend per replay.
+func TestBackendResetterCachesTableList(t *testing.T) {
+	f := newFakeResetter(t, []string{"a", "b"})
+	f.dirty = []string{`"s"."a"`}
+
+	for range 5 {
+		require.NoError(t, f.resetter.reset(context.Background()))
+	}
+
+	require.Equal(
+		t,
+		1,
+		f.listCalls,
+		"table list should be discovered once and cached, not re-queried "+
+			"per Reset",
+	)
+}
+
+// TestBackendResetterDoesNotCacheEmptyDiscovery proves an empty discovery is
+// retried rather than remembered. Reset can run before any construction has
+// migrated the schema, and caching that would leave the resetter permanently
+// convinced there is nothing to truncate -- which would silently leak every
+// vector's rows into the next one once migrations did land.
+func TestBackendResetterDoesNotCacheEmptyDiscovery(t *testing.T) {
+	f := newFakeResetter(t, nil, []string{"a"})
+	f.dirty = []string{`"s"."a"`}
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+	require.Empty(
+		t,
+		f.truncated,
+		"nothing migrated yet, so nothing should be truncated",
+	)
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+	require.Equal(t, 2, f.listCalls, "empty discovery must be retried")
+	require.Equal(
+		t,
+		[][]string{{`"s"."a"`}},
+		f.truncated,
+		"the retried discovery should be used",
+	)
+}
+
+// TestBackendResetterTruncatesOnlyDirtyTables proves the truncate hook is
+// handed exactly the tables holding rows, not the whole schema. This is the
+// change that makes reset cost proportional to what a vector wrote: MySQL has
+// no multi-table TRUNCATE, so before this it issued one implicit-commit DDL
+// statement for all 84 tables on every vector.
+func TestBackendResetterTruncatesOnlyDirtyTables(t *testing.T) {
+	f := newFakeResetter(t, []string{"a", "b", "c", "d"})
+	f.dirty = []string{`"s"."b"`, `"s"."d"`}
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+
+	require.Equal(
+		t,
+		[][]string{{`"s"."b"`, `"s"."d"`}},
+		f.truncated,
+		"only the tables reported dirty should be truncated",
+	)
+}
+
+// TestBackendResetterSkipsTruncateEntirelyWhenClean proves a vector that wrote
+// nothing issues no DDL at all, rather than truncating every table to no
+// effect.
+func TestBackendResetterSkipsTruncateEntirelyWhenClean(t *testing.T) {
+	f := newFakeResetter(t, []string{"a", "b"})
+	f.dirty = nil
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+
+	require.Empty(
+		t,
+		f.truncated,
+		"no table holds rows, so no TRUNCATE should be issued",
+	)
+}
+
+// nonEmptyTables' query has to be valid in two dialects at once, and the way
+// it can be wrong is a syntax error rather than a wrong answer: the index must
+// be a single-quoted SQL string literal, since double quotes are an identifier
+// reference in PostgreSQL and would select a column named after the number.
+//
+// Only a real server catches that, so these run the actual query against each
+// backend rather than asserting on the generated string. Reintroducing double
+// quotes fails TestNonEmptyTablesPostgres.
+
+// TestNonEmptyTablesPostgres proves the probe returns exactly the tables
+// holding rows on PostgreSQL.
+func TestNonEmptyTablesPostgres(t *testing.T) {
+	skipIfPostgresConformanceNotConfigured(t)
+
+	db, err := sql.Open("pgx", postgresConformanceDSN())
+	require.NoError(t, err)
+	defer db.Close()
+
+	schema := "probe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	_, err = db.Exec(`CREATE SCHEMA ` + pgQuoteIdent(schema))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DROP SCHEMA ` + pgQuoteIdent(schema) + ` CASCADE`)
+	})
+
+	assertProbeFindsOnlyPopulated(t, db, schema, pgQuoteQualified,
+		func(qualified string) string {
+			return `CREATE TABLE ` + qualified + ` (v integer)`
+		},
+	)
+}
+
+// TestNonEmptyTablesMysql proves the same on MySQL, whose grammar is the
+// stricter of the two.
+func TestNonEmptyTablesMysql(t *testing.T) {
+	skipIfMysqlConformanceNotConfigured(t)
+
+	cfg, err := mysqldriver.ParseDSN(mysqlConformanceRootDSN())
+	require.NoError(t, err)
+	cfg.DBName = ""
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	defer db.Close()
+
+	database := "probe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	_, err = db.Exec(
+		"CREATE DATABASE " + mysqlQuoteIdentifier(database),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec(
+			"DROP DATABASE " + mysqlQuoteIdentifier(database),
+		)
+	})
+
+	qualify := func(schema, table string) string {
+		return mysqlQuoteIdentifier(schema) + "." +
+			mysqlQuoteIdentifier(table)
+	}
+	assertProbeFindsOnlyPopulated(t, db, database, qualify,
+		func(qualified string) string {
+			return "CREATE TABLE " + qualified + " (v int)"
+		},
+	)
+}
+
+// assertProbeFindsOnlyPopulated creates three tables, populates the middle
+// one, and asserts nonEmptyTables reports that one and only that one. The
+// empty-in, empty-out case is asserted first, since "no table holds rows" is
+// the case that lets a vector skip DDL entirely.
+func assertProbeFindsOnlyPopulated(
+	t *testing.T,
+	db *sql.DB,
+	namespace string,
+	qualify func(string, string) string,
+	createStmt func(string) string,
+) {
+	t.Helper()
+	ctx := context.Background()
+
+	names := []string{"t_a", "t_b", "t_c"}
+	qualified := make([]string, len(names))
+	for i, name := range names {
+		qualified[i] = qualify(namespace, name)
+		_, err := db.ExecContext(ctx, createStmt(qualified[i]))
+		require.NoError(t, err, "create %s", qualified[i])
+	}
+
+	dirty, err := nonEmptyTables(ctx, db, qualified)
+	require.NoError(t, err, "probe over three empty tables")
+	require.Empty(t, dirty, "no table holds rows yet")
+
+	_, err = db.ExecContext(
+		ctx, "INSERT INTO "+qualified[1]+" (v) VALUES (1)",
+	)
+	require.NoError(t, err)
+
+	dirty, err = nonEmptyTables(ctx, db, qualified)
+	require.NoError(t, err, "probe with one populated table")
+	require.Equal(
+		t,
+		[]string{qualified[1]},
+		dirty,
+		"probe should report exactly the populated table",
+	)
+
+	_, err = db.ExecContext(
+		ctx, "INSERT INTO "+qualified[2]+" (v) VALUES (2)",
+	)
+	require.NoError(t, err)
+
+	dirty, err = nonEmptyTables(ctx, db, qualified)
+	require.NoError(t, err, "probe with two populated tables")
+	require.ElementsMatch(
+		t,
+		[]string{qualified[1], qualified[2]},
+		dirty,
+		"probe should report both populated tables",
+	)
+}

--- a/internal/test/conformance/reset_cost_test.go
+++ b/internal/test/conformance/reset_cost_test.go
@@ -275,3 +275,53 @@ func assertProbeFindsOnlyPopulated(
 		"probe should report both populated tables",
 	)
 }
+
+// TestBackendResetterTruncatesExtraDirtyTables proves a table reported by
+// extraDirty is truncated even though it holds no rows.
+//
+// MySQL's TRUNCATE is what resets AUTO_INCREMENT, so a vector that inserts and
+// then deletes rows leaves the table empty with its counter advanced. Skipping
+// it because it is empty would carry that counter into the next vector.
+func TestBackendResetterTruncatesExtraDirtyTables(t *testing.T) {
+	f := newFakeResetter(t, []string{"a", "b"})
+	f.dirty = nil
+	f.resetter.extraDirty = func(
+		context.Context,
+		*sql.DB,
+		[]string,
+	) ([]string, error) {
+		return []string{"b"}, nil
+	}
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+
+	require.Equal(
+		t,
+		[][]string{{`"s"."b"`}},
+		f.truncated,
+		"an empty table reported by extraDirty must still be truncated",
+	)
+}
+
+// TestBackendResetterDeduplicatesExtraDirtyTables proves a table reported by
+// both the row probe and extraDirty is truncated once, not twice.
+func TestBackendResetterDeduplicatesExtraDirtyTables(t *testing.T) {
+	f := newFakeResetter(t, []string{"a", "b"})
+	f.dirty = []string{`"s"."b"`}
+	f.resetter.extraDirty = func(
+		context.Context,
+		*sql.DB,
+		[]string,
+	) ([]string, error) {
+		return []string{"b"}, nil
+	}
+
+	require.NoError(t, f.resetter.reset(context.Background()))
+
+	require.Equal(
+		t,
+		[][]string{{`"s"."b"`}},
+		f.truncated,
+		"a table reported by both criteria must be truncated once",
+	)
+}

--- a/internal/test/conformance/reset_cost_test.go
+++ b/internal/test/conformance/reset_cost_test.go
@@ -325,3 +325,59 @@ func TestBackendResetterDeduplicatesExtraDirtyTables(t *testing.T) {
 		"a table reported by both criteria must be truncated once",
 	)
 }
+
+// TestMysqlAdvancedAutoIncrementTablesFiltersToManaged proves the probe reports
+// only tables the resetter manages, even though information_schema returns
+// every table in the database with an advanced counter.
+//
+// The managed set deliberately excludes schema_migrations
+// (listMysqlConformanceTables). Truncating the migration runner's own
+// bookkeeping desyncs tracked migration state from the physical schema, and the
+// next construction re-applies already-applied DDL and fails on a duplicate
+// column. An unfiltered probe would sweep any such table in the moment it
+// gained an AUTO_INCREMENT column.
+func TestMysqlAdvancedAutoIncrementTablesFiltersToManaged(t *testing.T) {
+	skipIfMysqlConformanceNotConfigured(t)
+
+	cfg, err := mysqldriver.ParseDSN(mysqlConformanceRootDSN())
+	require.NoError(t, err)
+	cfg.DBName = ""
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	require.NoError(t, err)
+	defer db.Close()
+
+	database := "aiprobe_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	_, err = db.Exec("CREATE DATABASE " + mysqlQuoteIdentifier(database))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DROP DATABASE " + mysqlQuoteIdentifier(database))
+	})
+
+	ctx := context.Background()
+	for _, name := range []string{"managed", "unmanaged"} {
+		qualified := mysqlQuoteIdentifier(database) + "." +
+			mysqlQuoteIdentifier(name)
+		_, err = db.ExecContext(ctx, "CREATE TABLE "+qualified+
+			" (id INT AUTO_INCREMENT PRIMARY KEY, v INT)")
+		require.NoError(t, err)
+		// Advance the counter, then empty the table: exactly the
+		// write-then-delete shape that leaves a table empty with a live
+		// AUTO_INCREMENT.
+		_, err = db.ExecContext(ctx, "INSERT INTO "+qualified+" (v) VALUES (1)")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "DELETE FROM "+qualified)
+		require.NoError(t, err)
+	}
+
+	advanced, err := mysqlAdvancedAutoIncrementTables(
+		ctx, db, database, []string{"managed"},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{"managed"},
+		advanced,
+		"only the managed table should be reported, not every table in the "+
+			"database with an advanced counter",
+	)
+}

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -150,6 +150,12 @@ type DingoStateManager struct {
 	// dataDir wiping never touches -- see state_manager_postgres.go and
 	// state_manager_mysql.go.
 	wipeMetadata func() error
+
+	// closeExtra, when set, releases backend-scoped resources the manager
+	// owns beyond its database -- currently the long-lived admin connection
+	// backendResetter holds so Reset does not reconnect per vector (see
+	// reset_cost.go). Close joins its error.
+	closeExtra func() error
 }
 
 // newDingoStateManager opens a real backend per opts and wraps it in a
@@ -219,6 +225,9 @@ func newDingoStateManagerAt(dataDir string) (*DingoStateManager, error) {
 // finished.
 func (m *DingoStateManager) Close() error {
 	err := closeRealDatabase(m.db, m.host)
+	if m.closeExtra != nil {
+		err = errors.Join(err, m.closeExtra())
+	}
 	if m.ownsDataDir && m.dataDir != "" {
 		if rmErr := os.RemoveAll(m.dataDir); rmErr != nil {
 			err = errors.Join(err, rmErr)

--- a/internal/test/conformance/state_manager_mysql.go
+++ b/internal/test/conformance/state_manager_mysql.go
@@ -19,6 +19,7 @@ package conformance
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -149,10 +150,133 @@ func newDingoMysqlStateManagerAtDatabase(
 	if err != nil {
 		return nil, err
 	}
-	m.wipeMetadata = func() error {
-		return truncateMysqlConformanceDatabase(rootDSN, database)
+	resetter, err := newMysqlResetter(rootDSN, database)
+	if err != nil {
+		return nil, errors.Join(err, m.Close())
 	}
+	m.wipeMetadata = func() error {
+		return resetter.reset(context.Background())
+	}
+	m.closeExtra = resetter.Close
 	return m, nil
+}
+
+// newMysqlResetter opens the one admin connection this manager's Reset reuses
+// for its whole lifetime, replacing a per-vector sql.Open/Close.
+//
+// DBName is cleared because MySQL rejects Ping and most statements against a
+// DSN naming a database that does not exist yet, though it always does here
+// once the store has been constructed once.
+//
+// MySQL has no multi-table TRUNCATE, so unlike PostgreSQL this backend still
+// issues one statement per table -- but only for tables a vector actually
+// wrote, rather than all 84 every time. See reset_cost.go for why TRUNCATE is
+// kept over a single batched DELETE.
+func newMysqlResetter(rootDSN, database string) (*backendResetter, error) {
+	cfg, err := mysqldriver.ParseDSN(rootDSN)
+	if err != nil {
+		return nil, fmt.Errorf("parse mysql root DSN: %w", err)
+	}
+	cfg.DBName = ""
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("open mysql admin connection: %w", err)
+	}
+	return &backendResetter{
+		db: db,
+		listTables: func(
+			ctx context.Context,
+			db *sql.DB,
+		) ([]string, error) {
+			return listMysqlConformanceTables(ctx, db, database)
+		},
+		qualify: func(table string) string {
+			return mysqlQuoteIdentifier(database) + "." +
+				mysqlQuoteIdentifier(table)
+		},
+		truncate: func(
+			ctx context.Context,
+			db *sql.DB,
+			qualified []string,
+		) error {
+			return truncateMysqlTables(ctx, db, qualified)
+		},
+	}, nil
+}
+
+// truncateMysqlTables empties exactly the given tables with foreign key
+// checks disabled.
+//
+// The disable/restore pair must run on the same session as the TRUNCATEs --
+// FOREIGN_KEY_CHECKS is a session variable, and a pooled *sql.DB may hand each
+// statement a different connection -- so this pins one conn for the duration.
+func truncateMysqlTables(
+	ctx context.Context,
+	db *sql.DB,
+	qualified []string,
+) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire mysql admin connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(
+		ctx, "SET FOREIGN_KEY_CHECKS=0",
+	); err != nil {
+		return fmt.Errorf("disable mysql foreign key checks: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS=1")
+	}()
+	for _, table := range qualified {
+		if _, err := conn.ExecContext(
+			ctx, "TRUNCATE TABLE "+table,
+		); err != nil {
+			return fmt.Errorf("truncate mysql table %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// listMysqlConformanceTables returns database's base tables, excluding
+// schema_migrations -- see listPostgresConformanceTables for why that table is
+// never truncated.
+func listMysqlConformanceTables(
+	ctx context.Context,
+	db *sql.DB,
+	database string,
+) ([]string, error) {
+	rows, err := db.QueryContext(
+		ctx,
+		"SELECT table_name FROM information_schema.tables "+
+			"WHERE table_schema = ? AND table_type = 'BASE TABLE' "+
+			"AND table_name <> 'schema_migrations'",
+		database,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list mysql database %q tables: %w",
+			database,
+			err,
+		)
+	}
+	defer rows.Close()
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan mysql table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"list mysql database %q tables: %w",
+			database,
+			err,
+		)
+	}
+	return tables, nil
 }
 
 // mysqlDSNWithDatabase returns dsn with its DBName set to database,
@@ -165,108 +289,6 @@ func mysqlDSNWithDatabase(dsn, database string) (string, error) {
 	}
 	cfg.DBName = database
 	return cfg.FormatDSN(), nil
-}
-
-// truncateMysqlConformanceDatabase empties every base table in database, in
-// place, over an admin connection built from rootDSN (with DBName cleared,
-// since MySQL rejects Ping/most statements against a DSN naming a database
-// that doesn't exist yet -- though it always does here once the store has
-// been constructed once). Used as DingoStateManager's wipeMetadata hook
-// (see Reset in state_manager.go).
-//
-// This truncates rather than drops the database: unlike
-// metadata.Resettable.Reset (database/plugin/metadata/mysql's own Reset
-// callback, which drops tables individually, requiring a fresh migration
-// run -- and, for the database-per-suite provisioning this constructor
-// relies on, a fresh CREATE DATABASE -- before the store is usable again),
-// TRUNCATE keeps every table in place, so the already-open store's
-// connection pool keeps working immediately afterward -- no close, no
-// reopen, no re-migration. At one Reset per vector across the ~300-vector
-// suite, avoiding a real close/reopen/re-migrate round trip per vector is
-// what keeps the MySQL backend's wall-clock cost in the same ballpark as
-// SQLite's rather than a full order of magnitude slower.
-//
-// The table list is discovered from information_schema rather than
-// hardcoded, so it stays correct as migrations add tables.
-//
-// schema_migrations itself is deliberately excluded: it is the migration
-// runner's own bookkeeping table (database/plugin/metadata/sqlstore/migrations/runner.go),
-// not conformance data. Truncating it would desync tracked migration state
-// from the physical schema without reverting any DDL -- a later
-// construction against this same, already-migrated database would see an
-// empty schema_migrations table, decide every migration (including ones
-// whose columns/tables already physically exist from the first
-// construction) still needs to run, and fail with a duplicate
-// column/table error partway through re-applying already-applied DDL.
-func truncateMysqlConformanceDatabase(rootDSN, database string) error {
-	cfg, err := mysqldriver.ParseDSN(rootDSN)
-	if err != nil {
-		return fmt.Errorf("parse mysql root DSN: %w", err)
-	}
-	cfg.DBName = ""
-	db, err := sql.Open("mysql", cfg.FormatDSN())
-	if err != nil {
-		return fmt.Errorf("open mysql admin connection: %w", err)
-	}
-	defer db.Close()
-
-	rows, err := db.Query(
-		"SELECT table_name FROM information_schema.tables "+
-			"WHERE table_schema = ? AND table_type = 'BASE TABLE' "+
-			"AND table_name <> 'schema_migrations'",
-		database,
-	)
-	if err != nil {
-		return fmt.Errorf("list mysql database %q tables: %w", database, err)
-	}
-	defer rows.Close()
-	var tables []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return fmt.Errorf("scan mysql table name: %w", err)
-		}
-		tables = append(tables, name)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("list mysql database %q tables: %w", database, err)
-	}
-	if len(tables) == 0 {
-		// Nothing migrated yet (e.g. Reset called before any construction
-		// ever ran migrations against this database) -- nothing to
-		// truncate.
-		return nil
-	}
-
-	conn, err := db.Conn(context.Background())
-	if err != nil {
-		return fmt.Errorf("acquire mysql admin connection: %w", err)
-	}
-	defer conn.Close()
-	if _, err := conn.ExecContext(
-		context.Background(), "SET FOREIGN_KEY_CHECKS=0",
-	); err != nil {
-		return fmt.Errorf("disable mysql foreign key checks: %w", err)
-	}
-	defer func() {
-		_, _ = conn.ExecContext(
-			context.Background(), "SET FOREIGN_KEY_CHECKS=1",
-		)
-	}()
-	quotedDB := mysqlQuoteIdentifier(database)
-	for _, table := range tables {
-		quoted := quotedDB + "." + mysqlQuoteIdentifier(table)
-		if _, err := conn.ExecContext(
-			context.Background(), "TRUNCATE TABLE "+quoted,
-		); err != nil {
-			return fmt.Errorf(
-				"truncate mysql table %s: %w",
-				quoted,
-				err,
-			)
-		}
-	}
-	return nil
 }
 
 // mysqlQuoteIdentifier backtick-quotes a MySQL identifier, doubling any

--- a/internal/test/conformance/state_manager_mysql.go
+++ b/internal/test/conformance/state_manager_mysql.go
@@ -201,7 +201,66 @@ func newMysqlResetter(rootDSN, database string) (*backendResetter, error) {
 		) error {
 			return truncateMysqlTables(ctx, db, qualified)
 		},
+		extraDirty: func(
+			ctx context.Context,
+			db *sql.DB,
+			tables []string,
+		) ([]string, error) {
+			return mysqlAdvancedAutoIncrementTables(ctx, db, database, tables)
+		},
 	}, nil
+}
+
+// mysqlAdvancedAutoIncrementTables returns the tables whose AUTO_INCREMENT
+// counter has moved past its initial value.
+//
+// Truncating only tables that currently hold rows would otherwise let a
+// counter survive a Reset: a vector that inserts rows and deletes them again
+// leaves the table empty but its AUTO_INCREMENT advanced, and MySQL's TRUNCATE
+// is what resets that. Skipping the TRUNCATE keeps the advanced counter for the
+// next vector.
+//
+// This is MySQL-only on purpose. PostgreSQL's TRUNCATE here does not carry
+// RESTART IDENTITY, so it never reset sequences either before or after the
+// dirty-table optimization; adding the same probe there would imply a
+// guarantee that side has never provided.
+func mysqlAdvancedAutoIncrementTables(
+	ctx context.Context,
+	db *sql.DB,
+	database string,
+	tables []string,
+) ([]string, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(
+		ctx,
+		"SELECT table_name FROM information_schema.tables "+
+			"WHERE table_schema = ? AND auto_increment > 1",
+		database,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list mysql advanced auto_increment tables: %w",
+			err,
+		)
+	}
+	defer rows.Close()
+	var advanced []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan mysql table name: %w", err)
+		}
+		advanced = append(advanced, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"list mysql advanced auto_increment tables: %w",
+			err,
+		)
+	}
+	return advanced, nil
 }
 
 // truncateMysqlTables empties exactly the given tables with foreign key

--- a/internal/test/conformance/state_manager_mysql.go
+++ b/internal/test/conformance/state_manager_mysql.go
@@ -220,6 +220,15 @@ func newMysqlResetter(rootDSN, database string) (*backendResetter, error) {
 // is what resets that. Skipping the TRUNCATE keeps the advanced counter for the
 // next vector.
 //
+// The result is filtered to the managed set. information_schema reports every
+// table in the database, and truncating one this resetter does not manage would
+// break the extraDirty contract -- most importantly for schema_migrations,
+// which listMysqlConformanceTables excludes deliberately: emptying the
+// migration runner's own bookkeeping desyncs tracked migration state from the
+// physical schema, and the next construction re-applies already-applied DDL and
+// fails on a duplicate column. That table carries no AUTO_INCREMENT today, so
+// the unfiltered form was harmless by coincidence rather than by construction.
+//
 // This is MySQL-only on purpose. PostgreSQL's TRUNCATE here does not carry
 // RESTART IDENTITY, so it never reset sequences either before or after the
 // dirty-table optimization; adding the same probe there would imply a
@@ -246,11 +255,18 @@ func mysqlAdvancedAutoIncrementTables(
 		)
 	}
 	defer rows.Close()
+	managed := make(map[string]struct{}, len(tables))
+	for _, table := range tables {
+		managed[table] = struct{}{}
+	}
 	var advanced []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			return nil, fmt.Errorf("scan mysql table name: %w", err)
+		}
+		if _, ok := managed[name]; !ok {
+			continue
 		}
 		advanced = append(advanced, name)
 	}

--- a/internal/test/conformance/state_manager_postgres.go
+++ b/internal/test/conformance/state_manager_postgres.go
@@ -17,7 +17,9 @@
 package conformance
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -149,10 +151,105 @@ func newDingoPostgresStateManagerAtSchema(
 	if err != nil {
 		return nil, err
 	}
-	m.wipeMetadata = func() error {
-		return truncatePostgresConformanceSchema(dsn, schema)
+	resetter, err := newPostgresResetter(dsn, schema)
+	if err != nil {
+		return nil, errors.Join(err, m.Close())
 	}
+	m.wipeMetadata = func() error {
+		return resetter.reset(context.Background())
+	}
+	m.closeExtra = resetter.Close
 	return m, nil
+}
+
+// newPostgresResetter opens the one admin connection this manager's Reset
+// reuses for its whole lifetime, replacing a per-vector sql.Open/Close. See
+// reset_cost.go for why the per-vector connection, table-list query, and
+// unconditional truncate were each worth removing.
+func newPostgresResetter(dsn, schema string) (*backendResetter, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres admin connection: %w", err)
+	}
+	return &backendResetter{
+		db: db,
+		listTables: func(
+			ctx context.Context,
+			db *sql.DB,
+		) ([]string, error) {
+			return listPostgresConformanceTables(ctx, db, schema)
+		},
+		qualify: func(table string) string {
+			return pgQuoteQualified(schema, table)
+		},
+		truncate: func(
+			ctx context.Context,
+			db *sql.DB,
+			qualified []string,
+		) error {
+			// PostgreSQL takes every table in one statement, so this is a
+			// single implicit-commit DDL round trip regardless of how many
+			// tables the vector dirtied.
+			if _, err := db.ExecContext(
+				ctx,
+				"TRUNCATE TABLE "+strings.Join(qualified, ", ")+" CASCADE",
+			); err != nil {
+				return fmt.Errorf(
+					"truncate postgres schema %q: %w",
+					schema,
+					err,
+				)
+			}
+			return nil
+		},
+	}, nil
+}
+
+// listPostgresConformanceTables returns schema's base tables, excluding
+// schema_migrations.
+//
+// schema_migrations is the migration runner's own bookkeeping table
+// (database/plugin/metadata/sqlstore/migrations/runner.go), not conformance
+// data. Truncating it would desync tracked migration state from the physical
+// schema without reverting any DDL: a later construction against this
+// already-migrated schema would see an empty schema_migrations, decide every
+// migration still needed to run, and fail with a duplicate column/table error
+// partway through re-applying already-applied DDL.
+func listPostgresConformanceTables(
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) ([]string, error) {
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT table_name FROM information_schema.tables
+WHERE table_schema = $1 AND table_type = 'BASE TABLE' AND table_name <> 'schema_migrations'`,
+		schema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list postgres schema %q tables: %w",
+			schema,
+			err,
+		)
+	}
+	defer rows.Close()
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan postgres table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"list postgres schema %q tables: %w",
+			schema,
+			err,
+		)
+	}
+	return tables, nil
 }
 
 // ensurePostgresConformanceSchema creates schema (if it doesn't already
@@ -182,94 +279,15 @@ func ensurePostgresConformanceSchema(dsn, schema string) error {
 	return nil
 }
 
-// truncatePostgresConformanceSchema empties every base table in schema, in
-// place, over an ordinary connection to dsn (not the live store's own
-// connection pool -- Reset calls this without going through
-// DingoStateManager.db at all, so it works whether or not the store
-// considers itself mid-transaction). Used as DingoStateManager's
-// wipeMetadata hook (see Reset in state_manager.go).
-//
-// This truncates rather than drops-and-recreates: unlike
-// metadata.Resettable.Reset (database/plugin/metadata/postgres's own Reset
-// callback, which drops tables outright, requiring a fresh migration run
-// before the store is usable again), TRUNCATE keeps every table (and
-// index/constraint) in place, so the already-open store's connection pool
-// keeps working immediately afterward -- no close, no reopen, no
-// re-migration. At one Reset per vector across the ~300-vector suite,
-// avoiding a real close/reopen/re-migrate round trip per vector is what
-// keeps the Postgres backend's wall-clock cost in the same ballpark as
-// SQLite's rather than a full order of magnitude slower.
-//
-// The table list is discovered from information_schema rather than
-// hardcoded, so it stays correct as migrations add tables. Like
-// recreatePostgresConformanceSchema before it, this only ever touches
-// schema (postgresConformanceSchema): unlike metadata.Resettable.Reset,
-// which scans and drops tables across *every* non-system schema in the
-// database -- appropriate for its actual use (preparing a target for
-// RestoreFrom), not safe to call on every vector reset since it would also
-// destroy database/plugin/metadata/postgres's own concurrently running
-// tests' tables in the shared dingo_test database.
-//
-// schema_migrations itself is deliberately excluded: it is the migration
-// runner's own bookkeeping table (database/plugin/metadata/sqlstore/migrations/runner.go),
-// not conformance data. Truncating it would desync tracked migration state
-// from the physical schema without reverting any DDL -- a later
-// construction against this same, already-migrated schema would see an
-// empty schema_migrations table, decide every migration (including ones
-// whose columns/tables already physically exist from the first
-// construction) still needs to run, and fail with a duplicate
-// column/table error partway through re-applying already-applied DDL.
-func truncatePostgresConformanceSchema(dsn, schema string) error {
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		return fmt.Errorf("open postgres admin connection: %w", err)
-	}
-	defer db.Close()
-
-	rows, err := db.Query(
-		`SELECT table_name FROM information_schema.tables
-WHERE table_schema = $1 AND table_type = 'BASE TABLE' AND table_name <> 'schema_migrations'`,
-		schema,
-	)
-	if err != nil {
-		return fmt.Errorf("list postgres schema %q tables: %w", schema, err)
-	}
-	defer rows.Close()
-	var tables []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return fmt.Errorf("scan postgres table name: %w", err)
-		}
-		tables = append(tables, name)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("list postgres schema %q tables: %w", schema, err)
-	}
-	if len(tables) == 0 {
-		// Nothing migrated yet (e.g. Reset called before any construction
-		// ever ran migrations against this schema) -- nothing to truncate.
-		return nil
-	}
-
-	quoted := make([]string, len(tables))
-	for i, table := range tables {
-		quoted[i] = pgQuoteQualified(schema, table)
-	}
-	if _, err := db.Exec(
-		"TRUNCATE TABLE " + strings.Join(quoted, ", ") + " CASCADE",
-	); err != nil {
-		return fmt.Errorf("truncate postgres schema %q: %w", schema, err)
-	}
-	return nil
+// pgQuoteIdent double-quotes a single PostgreSQL identifier, doubling any
+// embedded quote.
+func pgQuoteIdent(ident string) string {
+	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
 }
 
 // pgQuoteQualified double-quotes schema and table independently, so an
 // identifier requiring escaping in either part is handled correctly
 // (`"schema"."table"`, not a single quoted "schema.table").
 func pgQuoteQualified(schema, table string) string {
-	quote := func(ident string) string {
-		return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
-	}
-	return quote(schema) + "." + quote(table)
+	return pgQuoteIdent(schema) + "." + pgQuoteIdent(table)
 }


### PR DESCRIPTION
## Summary

Two changes to what the conformance suite spends its time on.

**Replay the corpus once per backend.** A Linux run with both DSNs configured
replayed it eight times: sqlite four, postgres twice, mysql twice. Each
`…WithResults` test re-ran the corpus to count rather than assert, and each
cross-backend comparison rebuilt its own sqlite baseline instead of reusing one.
Now each backend replays once per process and every consumer reads that memoized
result set — the pass/fail gate, the statistics, and the sqlite comparison. The
vector extraction is shared the same way.

**Reset only the tables a vector wrote.** `Reset` runs once per vector, and each
external backend paid a fresh `sql.Open`/`Close`, an `information_schema` query
re-deriving a table list that cannot change, and — for MySQL, which has no
multi-table `TRUNCATE` — one statement per table. `backendResetter` holds one
admin connection for the manager's lifetime, caches the table list after the
first successful discovery, and truncates only tables that hold rows. A vector
that wrote nothing issues no DDL.

## Notes for review

- Coverage is preserved. `assertCorpus` rebuilds per-vector named subtests from
  the memoized results and fails on any vector failure, and now also reports the
  event index the vector failed at. A new empty-corpus guard stops broken
  discovery from reporting as a pass.
- The per-dialect replays are kept deliberately: they are what found #3599's
  nested-cursor and MySQL affected-rows bugs. That needs one pass per dialect,
  not several.
- `TRUNCATE` is kept over a single batched `DELETE`: `TRUNCATE` resets
  `AUTO_INCREMENT` and `DELETE` does not, and 78 of the 84 tables carry such a
  column, so restoring the counters would mean an `ALTER TABLE` per table.
- Empty discovery is not cached, since `Reset` can run before migrations have
  created anything; caching it would silently leak each vector's rows into the
  next.
- Adds a `!dingo_extra_plugins` `TestMain` so the untagged build cleans the
  shared extraction; exactly one `TestMain` exists in either build config.

## Validation

- `go test ./internal/test/conformance/` (sqlite)
- `go test -tags dingo_extra_plugins` against real Postgres and MySQL
- `go vet` untagged and `-tags dingo_extra_plugins`
- `golangci-lint`, `nilaway`, `modernize`, `golines`
- `go test ./internal/docsparity/ ./internal/architecture/`

`DATABASE.md` and `ARCHITECTURE.md` checked and not affected: test-only change.
`internal/test/conformance/README.md` is updated.

Refs #3599
