### PR TITLE
ci: stop main pushes from cancelling each other's runs

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -25,10 +25,22 @@ permissions:
   contents: read
 
 concurrency:
-  # A superseding push or force-push must not accumulate runners, on a branch
-  # or on main. A cancelled main run still leaves the newest commit validated,
-  # which costs bisect precision on a burst of merges but never coverage.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Pull-request runs still supersede themselves: a new push to the branch
+  # cancels the run for the commit it replaced, so a force-push or a rapid
+  # series of pushes cannot accumulate runners.
+  #
+  # Main pushes must not supersede each other. The previous fallback to
+  # github.ref put every main push in one group, and merges land faster than
+  # this suite finishes, so each merge cancelled the run in flight: 8 of the
+  # 10 main runs before this change ended cancelled. cancel-in-progress: false
+  # would not have fixed it, because GitHub keeps at most one pending run per
+  # group and cancels the earlier pending one, so intermediate commits would
+  # have been skipped by superseding instead of by cancellation. github.run_id
+  # is unique per run and defined on every event, so each main push and each
+  # workflow_dispatch gets a group of its own and runs to completion. That is
+  # what makes the main run a backstop for every merged commit rather than
+  # only for whichever commit happens to be last in a burst.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Same grouping as go-test.yml, for the same reason: the github.ref fallback
+  # put every main push in one group, so a merge cancelled the lint run for
+  # the commit before it and that commit went unlinted. Tag pushes were never
+  # affected, since each tag is a distinct ref. Pull-request runs keep
+  # superseding themselves. See the longer explanation in go-test.yml.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

`go-test.yml` and `golangci-lint.yml` both grouped concurrency on:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: true
```

`github.event.pull_request.number` is empty on a `push` event, so every main
push fell back to `github.ref` = `refs/heads/main` and shared one group. With
`cancel-in-progress: true`, each merge cancelled the run still in flight.
Merges arrive faster than the suite finishes: the one main `go-test` run in
the last ten that completed took 37 minutes (20:14:27Z to 20:51:13Z in run
33554142075), while main pushes arrived roughly ten minutes apart.

Last 10 main `go-test` runs: 8 cancelled, 1 failure, 1 queued.

| Run | Conclusion |
| --- | --- |
| 33561668417 | cancelled |
| 33560112018 | cancelled |
| 33554142075 | failure |
| 33554112549 | cancelled |
| 33553121942 | cancelled |
| 33549617638 | cancelled |
| 33545824345 | cancelled |
| 33544843149 | cancelled |
| 33541292691 | cancelled |

`golangci-lint` on main shows the same pattern: 5 of the last 15 main runs
cancelled (33561668385, 33560112040, 33554112575, 33535388112, 33535317059).

The comment previously in `go-test.yml` claimed a cancelled main run "costs
bisect precision on a burst of merges but never coverage". That holds only if
the newest run survives. Under this merge rate the newest run is cancelled
too, so main CI was producing no coverage at all.

## Change

The fallback becomes `github.run_id`:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
cancel-in-progress: true
```

Reasoning, per the documented behavior of `concurrency.group` and
`cancel-in-progress`:

- On `pull_request`, `github.event.pull_request.number` is set and constant
  across pushes to the branch, so pushes to a PR keep superseding each other.
  That is the behavior worth keeping, and it is unchanged.
- On `push` and `workflow_dispatch` the pull-request context is empty, so the
  group falls through to `github.run_id`, which the Actions documentation
  describes as "guaranteed to be both unique and defined for the run". A
  unique group has nothing to cancel and nothing to queue behind, so every
  main push and every manual dispatch runs to completion regardless of the
  value of `cancel-in-progress`.
- `cancel-in-progress: false` with the group still keyed on `github.ref` would
  not fix this. The documentation states that "any existing pending job or
  workflow in the same concurrency group will be canceled and the new queued
  job or workflow will take its place", so at most one pending run per group
  survives. Intermediate commits would still be skipped, by superseding
  instead of by cancellation. Validating every merged commit requires the main
  group to be unique per run.
- `workflow_dispatch` needs no separate treatment. It reaches the same
  `run_id` fallback, which also stops a dispatch on `refs/heads/main` from
  colliding with a main push.

`golangci-lint.yml` gets the same expression. Its tag pushes were never
affected, since each tag is a distinct ref.

## publish.yml: not changed

`publish.yml` uses `group: ${{ github.workflow }}-${{ github.ref }}` with
`cancel-in-progress: ${{ github.ref_type != 'tag' }}`. This is not the same
defect. Its main-branch job publishes a moving `main` image tag rather than a
per-commit validation result, so superseding an in-flight build with a newer
commit is correct and avoids an older build overwriting the tag after a newer
one. Tag releases are already exempted from cancellation by `ref_type`. Left
exactly as-is.

Other workflows were checked and are not defective: `ci-docker.yml` and
`conventional-commits.yml` run only on `pull_request`; `benchmark.yml` and
`antithesis.yml` use fixed group names with deliberate serialization and do
not run on main pushes.

## Cost

Main runs no longer cancel each other, so a burst of merges will hold several
concurrent runs. dingo is a public repository, so Actions minutes are not
metered; the cost is concurrent runner slots. This is acceptable: the runs are
the only thing that validates a merged commit, the burst is bounded by the
merge rate, and the previous behavior spent those same runner slots on runs
that were destroyed before producing a result.

## Verification

- `actionlint .github/workflows/*.yml` passes.
- Both changed files parsed with a YAML parser; the resulting `on:` triggers
  and `concurrency` blocks match the intent, and `publish.yml` parses
  unchanged.
- `go test ./internal/docsparity/` passes (`lint_coverage_test.go` is pinned to
  `.github/workflows/golangci-lint.yml`).

GitHub Actions cannot be executed locally, so the behavior change is verified
by reasoning against the documented semantics plus `actionlint`, not by a run.
What would prove it after merge: consecutive main merges each producing a
completed `go-test` run rather than a cancelled one.

## Separate pre-existing failure, not addressed here

Run 33554142075 is the one main `go-test` run in that window that completed,
and it failed. The failing job is `go-test (Windows) (1.26.x)`; the failing
test is `TestManagerRedeliveredEventIsNotFatal` in
`internal/dblifecycle` at `manager_test.go:357`, with `Condition never
satisfied`. All other jobs in that run, including `go-test (Linux, race)`,
passed.

This looks like a too-tight timeout on a slow Windows runner rather than a
functional regression. The assertion is a `require.Eventually` with a 5s
deadline waiting for the epoch-8 snapshot manifest. The job log shows the
epoch-7 snapshot captured at 20:30:02 and the epoch-8 snapshot captured at
20:30:15 — the behavior under test (a redelivered event is not fatal and a
later epoch is still captured) did hold, roughly 13s after the deadline. The
test as a whole took 31.48s.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops main-branch pushes from cancelling each other's CI runs in `go-test.yml` and `golangci-lint.yml`. Main pushes previously shared one concurrency group keyed on `github.ref`, so each merge cancelled the run still in flight—8 of the last 10 main `go-test` runs ended cancelled. The group now falls back to `github.run_id`, which is unique per run, so each main push runs to completion while pull-request runs still supersede each other.

**Key details**
- `cancel-in-progress: false` alone would not fix this: GitHub keeps at most one pending run per group and cancels the earlier one, so intermediate commits would still be skipped.
- `publish.yml` is intentionally unchanged: it publishes a moving `main` image tag, where superseding an older in-flight build is correct, and tag releases are already exempted from cancellation.
- `workflow_dispatch` also hits the `run_id` fallback, so manual dispatches no longer collide with a main push.

<sup>Written for commit 6a4c0f54456404370622ff908b4335453eaea5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

