### PR TITLE
fix(database): fail fast on a closed badger store

### DIFF
--- a/database/plugin/blob/badger/closed_store_test.go
+++ b/database/plugin/blob/badger/closed_store_test.go
@@ -1,0 +1,57 @@
+package badger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTransactionOnClosedStoreFailsFast pins that a closed store hands back
+// an unusable transaction instead of calling into a closed Badger.
+//
+// Regression test for #3609. badger.DB.NewTransaction takes a read timestamp
+// via oracle.readTs, which waits on the commit watermark with
+// context.Background(). Closing the DB stops the watermark's process
+// goroutine, and a Done mark still queued in markCh at that moment is dropped
+// (y/watermark.go selects randomly between the close signal and the mark), so
+// doneUntil can stay behind nextTxnTs-1 permanently. A read transaction taken
+// afterwards then blocks forever with no context to cancel it.
+func TestNewTransactionOnClosedStoreFailsFast(t *testing.T) {
+	store, err := New()
+	require.NoError(t, err)
+
+	// Issue at least one commit timestamp, so the watermark has a mark to
+	// drop; this is the state the hang needs.
+	txn := store.NewTransaction(true)
+	require.NoError(t, store.Set(txn, []byte("key"), []byte("value")))
+	require.NoError(t, txn.Commit())
+
+	require.NoError(t, store.Close())
+
+	got := make(chan types.Txn, 1)
+	go func() { got <- store.NewTransaction(false) }()
+
+	var closedTxn types.Txn
+	select {
+	case closedTxn = <-got:
+	case <-time.After(30 * time.Second):
+		t.Fatal(
+			"NewTransaction blocked on a closed store (see #3609)",
+		)
+	}
+	require.NotNil(t, closedTxn)
+
+	_, err = store.Get(closedTxn, []byte("key"))
+	require.ErrorIs(t, err, types.ErrBlobStoreUnavailable)
+	require.ErrorIs(
+		t,
+		store.Set(closedTxn, []byte("key"), []byte("value")),
+		types.ErrBlobStoreUnavailable,
+	)
+
+	// Commit and Rollback stay nil-safe so deferred cleanup cannot panic.
+	require.NoError(t, closedTxn.Rollback())
+	require.NoError(t, closedTxn.Commit())
+}

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -535,9 +535,28 @@ func (d *BlobStoreBadger) Sync() error {
 	return nil
 }
 
-// NewTransaction creates a new badger transaction
+// NewTransaction creates a new badger transaction. A store that is closed or
+// not yet open yields a transaction reporting types.ErrBlobStoreUnavailable
+// from every operation, rather than one built from a closed *badger.DB.
+//
+// Building one from a closed DB can hang forever. badger.DB.NewTransaction
+// takes a read timestamp through oracle.readTs, which waits on the commit
+// watermark with context.Background(). Close stops that watermark's process
+// goroutine, and a Done mark still queued when the close signal arrives can
+// be dropped, because y/watermark.go selects between the mark channel and the
+// close signal and Go picks randomly when both are ready. doneUntil then
+// stays behind nextTxnTs-1 permanently and the wait has no context to cancel
+// it. See #3609.
+//
+// IsClosed narrows this window rather than eliminating it. A store closed
+// concurrently with this call already breaks the database.New contract, which
+// requires the stores to outlive Database.Close.
 func (d *BlobStoreBadger) NewTransaction(update bool) types.Txn {
-	return newBadgerTxn(d, d.DB().NewTransaction(update))
+	db := d.DB()
+	if db == nil || db.IsClosed() {
+		return newBadgerTxn(d, nil)
+	}
+	return newBadgerTxn(d, db.NewTransaction(update))
 }
 
 // Get retrieves a value from badger within a transaction


### PR DESCRIPTION
BlobStoreBadger.NewTransaction called badger.DB.NewTransaction without checking whether the store was open. On a closed DB that call can block forever: oracle.readTs waits on the commit watermark with context.Background(), and Close has already stopped the watermark process goroutine, so a Done mark still queued when the close signal arrives can be dropped (y/watermark.go selects between the mark channel and the close signal). doneUntil then stays behind nextTxnTs-1 with no context to cancel the wait.

The goroutine dump in the linked run shows exactly that state: `WaitForMark(..., 0x1)` with no badger goroutine alive, so doneUntil was 0 and nextTxnTs 2.

Guarded with `db == nil || db.IsClosed()`, returning a transaction that reports `types.ErrBlobStoreUnavailable`. Backup and Restore already use this guard; NewTransaction was the only `*badger.DB` entry point without it. Commit and Rollback on that transaction stay nil-safe.

Without the fix the new test fails deterministically:

```
expected: "blob store unavailable"
in chain: "DB::Get key: \"key\" err: DB Closed"
```

`IsClosed` narrows rather than eliminates the window; a store closed concurrently with the call already breaks the database.New contract.

Fixes #3609

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang when calling `NewTransaction` on a closed badger store by returning a transaction that reports `ErrBlobStoreUnavailable` instead of blocking forever.

- Guards with `db == nil || db.IsClosed()`, matching the existing guard in Backup and Restore.
- Adds a regression test that would hang without the fix.
- Commit and Rollback on the returned transaction stay nil-safe.

<sup>Written for commit 2adf63311cb7582e0b47a09d67ca1b61131d342e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Operations on unopened or closed Badger stores now fail promptly with a clear unavailability error instead of potentially blocking indefinitely.
  - Transactions returned after store closure safely reject reads and writes, while cleanup operations remain safe to call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->