### PR TITLE
test(dbtest): cover metadata seeding and artifact isolation

### DIFF
--- a/internal/test/dbtest/database_test.go
+++ b/internal/test/dbtest/database_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbtest
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+)
+
+// metadataFilesUnderTempRoot lists every metadata file below the root that
+// testing.TB.TempDir allocates for a single test. NewDatabaseWithOptions calls
+// tb.TempDir() with the test's own tb when it points the provider at a
+// directory of its own, so anything it writes lands under that same root and
+// its presence or absence distinguishes a file-backed metadata store from an
+// in-memory one.
+func metadataFilesUnderTempRoot(tb testing.TB, root string) []string {
+	tb.Helper()
+	var found []string
+	err := filepath.WalkDir(
+		root,
+		func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !entry.IsDir() && entry.Name() == metadataTemplateFile {
+				found = append(found, path)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		tb.Fatalf("walk %s: %v", root, err)
+	}
+	return found
+}
+
+// TestNewDatabaseWithOptionsSeedsCallerDataDir pins the routing that keeps
+// RawSQLiteMetadata working: a caller that supplies a DataDir gets the
+// template seeded into that directory, with the provider left to resolve its
+// own path, so the metadata file is the one at db.DataDir().
+func TestNewDatabaseWithOptionsSeedsCallerDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	db, err := NewDatabaseWithOptions(t, Options{
+		Config: &database.Config{DataDir: dataDir},
+	})
+	if err != nil {
+		t.Fatalf("NewDatabaseWithOptions: %v", err)
+	}
+	if db.DataDir() != dataDir {
+		t.Fatalf("DataDir() = %q, want %q", db.DataDir(), dataDir)
+	}
+	if _, err := os.Stat(
+		filepath.Join(dataDir, metadataTemplateFile),
+	); err != nil {
+		t.Fatalf("metadata file in caller data dir: %v", err)
+	}
+
+	// The raw fixture opens db.DataDir()/metadata.sqlite unconditionally and
+	// SQLite creates that file empty rather than failing, so a provider
+	// pointed somewhere else surfaces here as a missing table rather than an
+	// open error.
+	raw, err := RawSQLiteMetadata(t, db)
+	if err != nil {
+		t.Fatalf("RawSQLiteMetadata: %v", err)
+	}
+	var completed int
+	if err := raw.QueryRow(
+		`SELECT count(*) FROM schema_migrations
+		 WHERE completed_at IS NOT NULL`,
+	).Scan(&completed); err != nil {
+		t.Fatalf("read schema_migrations through raw fixture: %v", err)
+	}
+	if completed == 0 {
+		t.Error("raw fixture sees no completed migration")
+	}
+}
+
+// TestNewDatabaseWithOptionsWithoutDataDir covers the other branch: with no
+// DataDir the provider is pointed at a directory of the fixture's own, which
+// is still a file-backed database rather than the in-memory store the
+// provider would build from an empty data directory.
+func TestNewDatabaseWithOptionsWithoutDataDir(t *testing.T) {
+	root := filepath.Dir(t.TempDir())
+	db, err := NewDatabaseWithOptions(t, Options{
+		Config: &database.Config{DataDir: ""},
+	})
+	if err != nil {
+		t.Fatalf("NewDatabaseWithOptions: %v", err)
+	}
+	if db.DataDir() != "" {
+		t.Errorf("DataDir() = %q, want empty", db.DataDir())
+	}
+	files := metadataFilesUnderTempRoot(t, root)
+	if len(files) != 1 {
+		t.Fatalf(
+			"metadata files under the test temp root = %v, want exactly one",
+			files,
+		)
+	}
+	assertMigratedSchema(t, files[0])
+}
+
+// TestNewDatabaseWithOptionsInMemoryMetadata pins the opt-out: the template is
+// not written anywhere and the provider falls back to the in-memory
+// shared-cache store it builds from an empty data directory.
+func TestNewDatabaseWithOptionsInMemoryMetadata(t *testing.T) {
+	root := filepath.Dir(t.TempDir())
+	db, err := NewDatabaseWithOptions(t, Options{
+		Config:           &database.Config{DataDir: ""},
+		InMemoryMetadata: true,
+	})
+	if err != nil {
+		t.Fatalf("NewDatabaseWithOptions: %v", err)
+	}
+	if db.Metadata() == nil {
+		t.Fatal("no metadata store")
+	}
+	if files := metadataFilesUnderTempRoot(t, root); len(files) != 0 {
+		t.Errorf("in-memory metadata store wrote %v", files)
+	}
+	// The in-memory store is migrated in place, so it answers a settings
+	// query that an unmigrated database could not.
+	if _, err := db.Metadata().GetCommitTimestamp(); err != nil {
+		t.Errorf("GetCommitTimestamp on in-memory store: %v", err)
+	}
+}

--- a/internal/test/dbtest/database_test.go
+++ b/internal/test/dbtest/database_test.go
@@ -18,17 +18,50 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
 )
 
-// metadataFilesUnderTempRoot lists every metadata file below the root that
-// testing.TB.TempDir allocates for a single test. NewDatabaseWithOptions calls
-// tb.TempDir() with the test's own tb when it points the provider at a
-// directory of its own, so anything it writes lands under that same root and
-// its presence or absence distinguishes a file-backed metadata store from an
-// in-memory one.
+// tempDirTB hands NewDatabaseWithOptions a scratch root the test owns, so what
+// the fixture writes through tb.TempDir() can be observed exactly.
+//
+// Deriving that root from filepath.Dir(t.TempDir()) would instead depend on
+// where testing.TB.TempDir happens to place a test's directories: today it
+// allocates one parent per test and numbers the calls beneath it, so the
+// parent is per-test, but that layout is not part of TempDir's contract. One
+// MkdirTemp per call would make the parent os.TempDir() itself and silently
+// widen every walk below to the shared temp directory, where a stray
+// metadata.sqlite -- a crashed run's leftover, or another package's file under
+// `go test ./...` -- would decide the assertions.
+//
+// Everything else, including Cleanup and Errorf, reaches the embedded TB, so
+// the database is still closed by the real test's cleanup.
+type tempDirTB struct {
+	testing.TB
+	root string
+	seq  int
+}
+
+// TempDir allocates a numbered directory under the root, matching
+// testing.TB.TempDir's guarantee that separate calls get separate
+// directories. Removal comes with the root, which the real test owns.
+func (tb *tempDirTB) TempDir() string {
+	tb.Helper()
+	tb.seq++
+	dir := filepath.Join(tb.root, strconv.Itoa(tb.seq))
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		tb.Fatalf("allocate temp dir under %s: %v", tb.root, err)
+	}
+	return dir
+}
+
+// metadataFilesUnderTempRoot lists every metadata file below root.
+// NewDatabaseWithOptions calls tb.TempDir() when it points the provider at a
+// directory of its own, so with a tempDirTB anything it writes lands under
+// that root and its presence or absence distinguishes a file-backed metadata
+// store from an in-memory one.
 func metadataFilesUnderTempRoot(tb testing.TB, root string) []string {
 	tb.Helper()
 	var found []string
@@ -96,8 +129,8 @@ func TestNewDatabaseWithOptionsSeedsCallerDataDir(t *testing.T) {
 // is still a file-backed database rather than the in-memory store the
 // provider would build from an empty data directory.
 func TestNewDatabaseWithOptionsWithoutDataDir(t *testing.T) {
-	root := filepath.Dir(t.TempDir())
-	db, err := NewDatabaseWithOptions(t, Options{
+	root := t.TempDir()
+	db, err := NewDatabaseWithOptions(&tempDirTB{TB: t, root: root}, Options{
 		Config: &database.Config{DataDir: ""},
 	})
 	if err != nil {
@@ -120,8 +153,8 @@ func TestNewDatabaseWithOptionsWithoutDataDir(t *testing.T) {
 // not written anywhere and the provider falls back to the in-memory
 // shared-cache store it builds from an empty data directory.
 func TestNewDatabaseWithOptionsInMemoryMetadata(t *testing.T) {
-	root := filepath.Dir(t.TempDir())
-	db, err := NewDatabaseWithOptions(t, Options{
+	root := t.TempDir()
+	db, err := NewDatabaseWithOptions(&tempDirTB{TB: t, root: root}, Options{
 		Config:           &database.Config{DataDir: ""},
 		InMemoryMetadata: true,
 	})

--- a/internal/test/dbtest/template.go
+++ b/internal/test/dbtest/template.go
@@ -67,6 +67,19 @@ var (
 // inside its data directory.
 const metadataTemplateFile = "metadata.sqlite"
 
+// metadataTemplateDirPrefix is the os.MkdirTemp prefix for the scratch
+// directory a template build owns.
+//
+// The process ID scopes it. os.MkdirTemp places the directory directly in the
+// shared temp directory, which every test binary that imports this package
+// builds into, so an unscoped prefix leaves a leaked directory unattributable
+// and makes the shared directory's contents useless as evidence about any one
+// build: a sibling binary's build in flight under `go test ./...` is
+// indistinguishable from this binary's leak.
+func metadataTemplateDirPrefix() string {
+	return fmt.Sprintf("dingo-dbtest-metadata-template-%d-", os.Getpid())
+}
+
 // migratedMetadataTemplate returns the bytes of a fully migrated SQLite
 // metadata database, running the migration exactly once per process.
 func migratedMetadataTemplate() ([]byte, error) {
@@ -104,7 +117,7 @@ func templateCleanupError(err error, dir string, removeErr error) error {
 // closes cleanly; reading a live database would capture a torn page or leave
 // the content in a companion -wal file this template does not carry.
 func buildMetadataTemplate() (_ []byte, err error) {
-	dir, err := os.MkdirTemp("", "dingo-dbtest-metadata-template-")
+	dir, err := os.MkdirTemp("", metadataTemplateDirPrefix())
 	if err != nil {
 		return nil, fmt.Errorf("create metadata template dir: %w", err)
 	}

--- a/internal/test/dbtest/template_test.go
+++ b/internal/test/dbtest/template_test.go
@@ -15,7 +15,10 @@
 package dbtest
 
 import (
+	"database/sql"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -79,4 +82,250 @@ func TestTemplateCleanupError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// minTemplateTables is a floor on the tables a fully migrated metadata
+// database carries. The schema had 84 when the template was introduced; the
+// floor exists to separate a complete copy from a truncated or empty one, not
+// to pin the schema's size, so it sits well below the real count.
+const minTemplateTables = 50
+
+// openMetadataFile opens a database/sql handle directly on a materialized
+// template file. The sqlite driver is registered by this package's own blank
+// import in database.go.
+func openMetadataFile(tb testing.TB, path string) *sql.DB {
+	tb.Helper()
+	raw, err := sql.Open(
+		"sqlite",
+		"file:"+path+"?_pragma=busy_timeout(30000)",
+	)
+	if err != nil {
+		tb.Fatalf("open %s: %v", path, err)
+	}
+	tb.Cleanup(func() {
+		if err := raw.Close(); err != nil {
+			tb.Errorf("close %s: %v", path, err)
+		}
+	})
+	if err := raw.Ping(); err != nil {
+		tb.Fatalf("ping %s: %v", path, err)
+	}
+	return raw
+}
+
+// assertMigratedSchema fails unless path holds a complete migrated schema.
+//
+// A copy taken from a still-open database would carry the header and whatever
+// pages had already been written back, with the rest of the schema stranded in
+// a companion -wal file the template does not include, so an opened copy is
+// not evidence on its own: only reading the tables out of it is.
+func assertMigratedSchema(tb testing.TB, path string) {
+	tb.Helper()
+	raw := openMetadataFile(tb, path)
+	var tables int
+	if err := raw.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table'`,
+	).Scan(&tables); err != nil {
+		tb.Fatalf("count tables in %s: %v", path, err)
+	}
+	if tables < minTemplateTables {
+		tb.Errorf(
+			"%s has %d tables, want at least %d",
+			path,
+			tables,
+			minTemplateTables,
+		)
+	}
+	var completed int
+	if err := raw.QueryRow(
+		`SELECT count(*) FROM schema_migrations
+		 WHERE completed_at IS NOT NULL`,
+	).Scan(&completed); err != nil {
+		tb.Fatalf("read schema_migrations in %s: %v", path, err)
+	}
+	if completed == 0 {
+		tb.Errorf("%s records no completed migration", path)
+	}
+}
+
+// materializeTemplate writes raw into a fresh directory and returns the path
+// it wrote, so the bytes can be inspected as a database.
+func materializeTemplate(tb testing.TB, raw []byte) string {
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), metadataTemplateFile)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		tb.Fatalf("write template copy: %v", err)
+	}
+	return path
+}
+
+// scratchTemplateDirs lists the scratch directories buildMetadataTemplate
+// creates, by the prefix it passes to os.MkdirTemp.
+func scratchTemplateDirs(tb testing.TB) []string {
+	tb.Helper()
+	dirs, err := filepath.Glob(
+		filepath.Join(os.TempDir(), "dingo-dbtest-metadata-template-*"),
+	)
+	if err != nil {
+		tb.Fatalf("glob scratch template dirs: %v", err)
+	}
+	return dirs
+}
+
+// TestBuildMetadataTemplate covers the build directly rather than through the
+// consuming packages: it must hand back the bytes of a fully migrated
+// database and keep nothing on disk afterwards.
+func TestBuildMetadataTemplate(t *testing.T) {
+	// Drive the process-wide template to completion first. sync.Once returns
+	// only after its function has, so once this call returns no build started
+	// by another test can still be holding a scratch directory while this one
+	// samples the temp directory.
+	if _, err := migratedMetadataTemplate(); err != nil {
+		t.Fatalf("prime metadata template: %v", err)
+	}
+	before := make(map[string]struct{})
+	for _, dir := range scratchTemplateDirs(t) {
+		before[dir] = struct{}{}
+	}
+
+	raw, err := buildMetadataTemplate()
+	if err != nil {
+		t.Fatalf("buildMetadataTemplate: %v", err)
+	}
+	if len(raw) == 0 {
+		t.Fatal("buildMetadataTemplate returned no bytes")
+	}
+
+	t.Run("removes its scratch directory", func(t *testing.T) {
+		var leaked []string
+		for _, dir := range scratchTemplateDirs(t) {
+			if _, ok := before[dir]; !ok {
+				leaked = append(leaked, dir)
+			}
+		}
+		if len(leaked) > 0 {
+			t.Errorf("build left scratch directories behind: %v", leaked)
+		}
+	})
+
+	t.Run("bytes carry the migrated schema", func(t *testing.T) {
+		assertMigratedSchema(t, materializeTemplate(t, raw))
+	})
+}
+
+// TestMigratedMetadataTemplateMemoizes pins the memoization that the whole
+// fixture exists for: the migration runs once per process. Identical contents
+// would not show that -- two separate builds produce identical bytes -- so
+// this compares the backing arrays, which only match when the second call
+// returned the cached slice instead of building again.
+func TestMigratedMetadataTemplateMemoizes(t *testing.T) {
+	first, err := migratedMetadataTemplate()
+	if err != nil {
+		t.Fatalf("first migratedMetadataTemplate: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("migratedMetadataTemplate returned no bytes")
+	}
+	second, err := migratedMetadataTemplate()
+	if err != nil {
+		t.Fatalf("second migratedMetadataTemplate: %v", err)
+	}
+	if len(second) != len(first) {
+		t.Fatalf(
+			"template length changed between calls: %d then %d",
+			len(first),
+			len(second),
+		)
+	}
+	if &second[0] != &first[0] {
+		t.Error("second call rebuilt the template instead of caching it")
+	}
+}
+
+// TestSeedMetadataTemplateCreatesDir covers seeding into a directory that does
+// not exist yet, which is what a caller-supplied DataDir usually is.
+func TestSeedMetadataTemplateCreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "missing", "data")
+	if err := seedMetadataTemplate(dir); err != nil {
+		t.Fatalf("seedMetadataTemplate: %v", err)
+	}
+	assertMigratedSchema(t, filepath.Join(dir, metadataTemplateFile))
+}
+
+// writeSentinel records a row in the seeded database that a rewrite of the
+// file would destroy, and closes the handle so SQLite checkpoints the row into
+// the database file itself.
+//
+// The close is what makes the sentinel evidence. SQLite writes to a companion
+// -wal file first, and that log is valid against the template bytes it was
+// written over, so a reseed that overwrote the database file would leave the
+// log in place and a reader would replay the sentinel back over the fresh
+// copy -- the test would pass whether or not the no-op branch exists.
+func writeSentinel(tb testing.TB, path string) {
+	tb.Helper()
+	raw, err := sql.Open(
+		"sqlite",
+		"file:"+path+"?_pragma=busy_timeout(30000)",
+	)
+	if err != nil {
+		tb.Fatalf("open %s: %v", path, err)
+	}
+	defer func() {
+		if err := raw.Close(); err != nil {
+			tb.Errorf("close %s: %v", path, err)
+		}
+		// A surviving log would put the sentinel back after an overwrite.
+		if _, err := os.Stat(path + "-wal"); !errors.Is(
+			err,
+			os.ErrNotExist,
+		) {
+			tb.Errorf(
+				"write-ahead log still present after close: %v",
+				err,
+			)
+		}
+	}()
+	if _, err := raw.Exec(
+		`CREATE TABLE dbtest_sentinel (id INTEGER PRIMARY KEY)`,
+	); err != nil {
+		tb.Fatalf("create sentinel table: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO dbtest_sentinel (id) VALUES (1)`,
+	); err != nil {
+		tb.Fatalf("insert sentinel row: %v", err)
+	}
+}
+
+// TestSeedMetadataTemplateKeepsExistingData pins the no-op branch with data a
+// rewrite would destroy. Comparing bytes would not do it: the template is
+// byte-identical to itself, so an unconditional rewrite would still compare
+// equal. A row written into the seeded file after the first call survives only
+// if the second call left the file alone.
+func TestSeedMetadataTemplateKeepsExistingData(t *testing.T) {
+	dir := t.TempDir()
+	if err := seedMetadataTemplate(dir); err != nil {
+		t.Fatalf("first seedMetadataTemplate: %v", err)
+	}
+	path := filepath.Join(dir, metadataTemplateFile)
+	writeSentinel(t, path)
+
+	if err := seedMetadataTemplate(dir); err != nil {
+		t.Fatalf("second seedMetadataTemplate: %v", err)
+	}
+
+	raw := openMetadataFile(t, path)
+	var sentinel int
+	if err := raw.QueryRow(
+		`SELECT count(*) FROM dbtest_sentinel`,
+	).Scan(&sentinel); err != nil {
+		t.Fatalf("read sentinel table after reseed: %v", err)
+	}
+	if sentinel != 1 {
+		t.Errorf("sentinel rows after reseed = %d, want 1", sentinel)
+	}
+	// The file must still be the migrated template as well, so a second call
+	// that wiped it back to an empty database cannot pass by leaving nothing
+	// for the sentinel query to contradict.
+	assertMigratedSchema(t, path)
 }

--- a/internal/test/dbtest/template_test.go
+++ b/internal/test/dbtest/template_test.go
@@ -161,10 +161,16 @@ func materializeTemplate(tb testing.TB, raw []byte) string {
 
 // scratchTemplateDirs lists the scratch directories buildMetadataTemplate
 // creates, by the prefix it passes to os.MkdirTemp.
+//
+// That prefix carries the process ID, which is what keeps this bounded to the
+// build under test. The directories live in the shared temp directory, so an
+// unscoped pattern would also match every other test binary that imports
+// dbtest -- under `go test ./...` a sibling's build in flight would read as a
+// directory this build leaked.
 func scratchTemplateDirs(tb testing.TB) []string {
 	tb.Helper()
 	dirs, err := filepath.Glob(
-		filepath.Join(os.TempDir(), "dingo-dbtest-metadata-template-*"),
+		filepath.Join(os.TempDir(), metadataTemplateDirPrefix()+"*"),
 	)
 	if err != nil {
 		tb.Fatalf("glob scratch template dirs: %v", err)
@@ -275,14 +281,14 @@ func writeSentinel(tb testing.TB, path string) {
 			tb.Errorf("close %s: %v", path, err)
 		}
 		// A surviving log would put the sentinel back after an overwrite.
-		if _, err := os.Stat(path + "-wal"); !errors.Is(
-			err,
-			os.ErrNotExist,
-		) {
-			tb.Errorf(
-				"write-ahead log still present after close: %v",
-				err,
-			)
+		// A present log is a nil stat error, so the file's presence is
+		// what gets reported; only an unexpected stat failure carries one.
+		wal := path + "-wal"
+		switch _, err := os.Stat(wal); {
+		case err == nil:
+			tb.Errorf("write-ahead log %s still present after close", wal)
+		case !errors.Is(err, os.ErrNotExist):
+			tb.Errorf("stat write-ahead log %s: %v", wal, err)
 		}
 	}()
 	if _, err := raw.Exec(


### PR DESCRIPTION
Follow-up to the non-blocking note on #3752: `buildMetadataTemplate` and
`seedMetadataTemplate` were covered only transitively through consuming
packages. This adds direct tests in `internal/test/dbtest`.

Properties pinned:

- `buildMetadataTemplate` returns non-empty bytes and leaves no
  `dingo-dbtest-metadata-template-*` scratch directory behind.
- Those bytes are a checkpointed database: a copy written to a fresh
  directory reports the migrated table count and completed `schema_migrations`
  rows. Reading the file before the host is stopped leaves those rows in the
  companion `-wal` file and fails this assertion.
- `migratedMetadataTemplate` returns the cached slice on the second call
  rather than rebuilding. Compared by backing array, since two builds produce
  identical bytes.
- `seedMetadataTemplate` creates a missing data directory, and is a no-op when
  a metadata file is present. The sentinel row is checkpointed into the
  database file before the second call, because a row left in the `-wal` file
  replays over an overwritten copy of the same template bytes and would pass
  either way.
- `NewDatabaseWithOptions` with a caller `DataDir` seeds that directory and
  leaves the provider's own path resolution alone, so `RawSQLiteMetadata`
  opens the migrated file; with no `DataDir` it points the provider at a
  file-backed directory of its own; `Options.InMemoryMetadata` writes no file
  and restores the in-memory store.

Each test was checked red against the regression it guards by reverting the
corresponding behavior in `template.go` or `database.go`.

Validation:

- `go build ./...`
- `go test -race ./internal/test/dbtest/...`, untagged and
  `-tags dingo_extra_plugins`
- `go vet ./internal/test/dbtest/...`, both configurations
- `golangci-lint run ./internal/test/dbtest/...`
- `nilaway ./internal/test/dbtest/...`, both configurations
- `modernize ./internal/test/dbtest/...`, both configurations
- `golines --ignore-generated --chain-split-dots --max-len=80 --reformat-tags`
- `go test ./internal/architecture`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct tests in `internal/test/dbtest` for the metadata template seeding contract, which was previously only covered transitively through consuming packages.

- Pins that `buildMetadataTemplate` returns a fully migrated database's bytes and removes its scratch directory.
- Pins that `migratedMetadataTemplate` caches its result across calls instead of rebuilding.
- Pins that `seedMetadataTemplate` creates missing directories and preserves existing data when a metadata file is present.
- Covers all three `NewDatabaseWithOptions` metadata routes: caller-supplied `DataDir`, no `DataDir`, and `InMemoryMetadata`.
- Scopes the scratch directory prefix to the process ID and routes temp dirs through a test-owned root so checks can't match sibling test binaries' in-flight artifacts.
- Each test was verified to fail against the regression it guards.

<sup>Written for commit e0398c1d81d0401bef76ef16c74e41ea79b7f67e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

