### PR TITLE
test(ledger): cover Leios closure double-consume tolerance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2307,13 +2307,19 @@ the ranking block's point so a rollback removes them — but without validation 
 consumed-input recovery (`Database.SetTransactionWithOpts` with
 `SkipConsumedInputRecovery`): the endorser block was admitted by its Leios
 certificate, so its transactions are trusted, and a consumed input not yet
-present is left as a no-op rather than driving blob recovery. Replayed endorser
-transaction hashes are skipped so effects are not applied twice. Applying the
-produced outputs keeps the UTxO set — and the stake distribution derived from it
-— complete, matching the reference; recording metadata only (the prior behavior)
-left endorser-resident outputs missing, which diverged the UTxO and made
-downstream transactions and the leader-election stake snapshot treat inputs the
-endorser block should have produced as absent. Every other network takes the
+present is left as a no-op rather than driving blob recovery. An input that is
+present but already spent by a *different* certified endorser transaction is
+also a no-op (`TransactionStore.SetTransactionLeiosClosure`), matching
+`ValidateNone`'s `Map.delete` on a missing key: two certified endorser blocks
+may legitimately name the same input across blocks, and failing there wedged
+block application (issue #3643). Ranking-block application keeps the hard
+`ErrUtxoConflict` check. Replayed endorser transaction hashes are skipped so
+effects are not applied twice. Applying the produced outputs keeps the UTxO set
+— and the stake distribution derived from it — complete, matching the
+reference; recording metadata only (the prior behavior) left endorser-resident
+outputs missing, which diverged the UTxO and made downstream transactions and
+the leader-election stake snapshot treat inputs the endorser block should have
+produced as absent. Every other network takes the
 CIP-conformant path, where the endorser transactions are applied to the UTxO with
 dingo's normal per-tx validation and consumed-input recovery, as a side delta
 recorded under the ranking block's point (so a rollback removes them). dingo no longer carries the

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1265,12 +1265,22 @@ matching the reference ledger's `applyLeiosClosure` (prototype-2026w29,
 `ruleApplyTxValidation` `ValidateNone`): produced outputs and input spends are
 written, and a consumed input absent from the store is left as a no-op instead
 of driving blob recovery (`Database.SetTransactionWithOpts` with
-`SkipConsumedInputRecovery`). Applying the outputs keeps the UTxO set — and the
-stake distribution derived from it — complete, matching the reference; the prior
-metadata-only behavior omitted the produced outputs, which diverged the UTxO and
-made downstream transactions and the leader-election stake snapshot treat inputs
-the endorser block should have produced as missing (the `utxo not found` repair
-loop and the `pool has no stake in epoch snapshot` header rejection). Positive
+`SkipConsumedInputRecovery`). A consumed input that is present but already
+spent by a *different* certified endorser transaction is likewise a no-op:
+`SkipConsumedInputRecovery` routes the metadata write through
+`TransactionStore.SetTransactionLeiosClosure`, which skips only that input and
+still writes the transaction's produced outputs and its remaining spends. Two
+certified endorser blocks can name the same input across blocks, and
+`ValidateNone` treats the second consume as `Map.delete` on a missing key;
+returning `ErrUtxoConflict` there wedged block application instead (issue
+#3643). Ranking-block application and the CIP-conformant endorser apply keep
+the hard `ErrUtxoConflict` check, so a real double-spend is still rejected.
+Applying the outputs keeps the UTxO set — and the stake distribution derived
+from it — complete, matching the reference; the prior metadata-only behavior
+omitted the produced outputs, which diverged the UTxO and made downstream
+transactions and the leader-election stake snapshot treat inputs the endorser
+block should have produced as missing (the `utxo not found` repair loop and the
+`pool has no stake in epoch snapshot` header rejection). Positive
 donations from valid endorser transactions are accumulated in `network_donation`
 under the ranking block's slot/epoch so the treasury update at the epoch boundary
 matches the CIP path. Replayed endorser transactions (hashes already present) are

--- a/ledger/leios_apply_double_consume_test.go
+++ b/ledger/leios_apply_double_consume_test.go
@@ -1,0 +1,383 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"database/sql"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// leiosApplyTestProducerTx builds a Dijkstra endorser transaction with no
+// inputs that produces two enterprise (payment-only) outputs, so later
+// transactions have live UTxOs to consume.
+func leiosApplyTestProducerTx(
+	t *testing.T,
+	seed byte,
+) (cbor.RawMessage, lcommon.Transaction) {
+	t.Helper()
+	addr := append([]byte{0x60}, bytes.Repeat([]byte{seed}, 28)...)
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		1: []any{
+			map[uint]any{0: addr, 1: uint64(1_000_000)},
+			map[uint]any{0: addr, 1: uint64(2_000_000)},
+		},
+		2: uint64(200_000),
+	})
+	require.NoError(t, err)
+	return leiosApplyTestTxFromBody(t, bodyCbor)
+}
+
+// leiosApplyTestSpendingTx builds a Dijkstra endorser transaction consuming
+// inTxId#inIdx and producing a single output.
+func leiosApplyTestSpendingTx(
+	t *testing.T,
+	seed byte,
+	inTxId []byte,
+	inIdx uint64,
+) (cbor.RawMessage, lcommon.Transaction) {
+	t.Helper()
+	addr := append([]byte{0x60}, bytes.Repeat([]byte{seed}, 28)...)
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		0: []any{[]any{inTxId, inIdx}},
+		1: []any{map[uint]any{0: addr, 1: uint64(500_000)}},
+		// A distinct fee per seed keeps the transaction hashes distinct.
+		2: uint64(200_000) + uint64(seed),
+	})
+	require.NoError(t, err)
+	return leiosApplyTestTxFromBody(t, bodyCbor)
+}
+
+func leiosApplyTestTxFromBody(
+	t *testing.T,
+	bodyCbor []byte,
+) (cbor.RawMessage, lcommon.Transaction) {
+	t.Helper()
+	txCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		map[uint]any{},
+		true,
+		nil,
+	})
+	require.NoError(t, err)
+	tx, err := gledger.NewTransactionFromCbor(gledger.TxTypeDijkstra, txCbor)
+	require.NoError(t, err)
+	return cbor.RawMessage(txCbor), tx
+}
+
+// leiosApplyTestApplyEndorserBlock applies one endorser block in its own
+// database transaction, mirroring how ledgerProcessBlock applies the certified
+// closure ahead of the ranking block's own transactions.
+func leiosApplyTestApplyEndorserBlock(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	rbPoint ocommon.Point,
+	rbBlockNumber uint64,
+	ebSlot uint64,
+	ebHash []byte,
+	rawTxs ...cbor.RawMessage,
+) (int, error) {
+	t.Helper()
+	applied := -1
+	txn := db.Transaction(true)
+	err := txn.Do(func(txn *database.Txn) error {
+		var err error
+		applied, _, err = ls.applyEndorserBlock(
+			txn,
+			rbPoint,
+			rbBlockNumber,
+			ebSlot,
+			ebHash,
+			rawTxs,
+		)
+		return err
+	})
+	return applied, err
+}
+
+// leiosApplyTestUtxoState returns a produced UTxO's spender and deletion slot.
+func leiosApplyTestUtxoState(
+	t *testing.T,
+	raw *sql.DB,
+	txId []byte,
+	outputIdx uint32,
+) (spentBy []byte, deletedSlot uint64) {
+	t.Helper()
+	var spender []byte
+	require.NoError(t, raw.QueryRow(`
+SELECT spent_at_tx_id, deleted_slot FROM utxo
+WHERE tx_id = ? AND output_idx = ?`,
+		txId,
+		outputIdx,
+	).Scan(&spender, &deletedSlot))
+	return spender, deletedSlot
+}
+
+// The Musashi/Haskell-conformant closure apply folds a certified endorser
+// block's transactions onto the ledger without validation, mirroring the
+// reference ledger's applyLeiosClosure (ruleApplyTxValidation ValidateNone in
+// Ouroboros.Consensus.Shelley.Ledger.Leios). Two certified endorser blocks may
+// therefore name the same input across blocks: for the reference the second
+// consume is Map.delete on a missing key -- a no-op -- and the transaction's
+// produced outputs are still added.
+//
+// This is the wedge reported as issue #3643 ("UTxO already spent" while
+// applying the certified endorser block at ranking-block slot 1864040): the
+// failing apply is the endorser block's, and the conflict is between two
+// *different* certified transactions, so no transaction-hash dedup can address
+// it. The tolerance lives in the metadata store (SetTransactionLeiosClosure)
+// and is selected by BatchedTxIngestOpts.SkipConsumedInputRecovery; this test
+// covers the ledger-side wiring that reaches it (applyEndorserBlock ->
+// LedgerDelta.skipConsumedInputRecovery -> Database.SetTransactionWithOpts),
+// which the store-level test in database/plugin/metadata/sqlite cannot reach.
+func TestApplyEndorserBlockHaskellPathToleratesCrossEndorserDoubleConsume(
+	t *testing.T,
+) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	// LeiosApplyEndorserBlockTxs defaults to false (Haskell-conformant).
+	rawProducer, producerTx := leiosApplyTestProducerTx(t, 0xa1)
+	require.Len(t, producerTx.Produced(), 2)
+	producerHash := producerTx.Hash().Bytes()
+	rawFirst, firstTx := leiosApplyTestSpendingTx(t, 0xb1, producerHash, 0)
+	rawSecond, secondTx := leiosApplyTestSpendingTx(t, 0xb2, producerHash, 0)
+	require.NotEqual(
+		t,
+		firstTx.Hash(),
+		secondTx.Hash(),
+		"the double-consume must come from two distinct transactions",
+	)
+
+	producerPoint := leiosApplyTestRankingPoint(0x11)
+	firstPoint := leiosApplyTestRankingPoint(0x12)
+	secondPoint := leiosApplyTestRankingPoint(0x13)
+
+	applied, err := leiosApplyTestApplyEndorserBlock(
+		t, ls, db, producerPoint, 1, 900, leiosApplyTestEbHash(0xa2),
+		rawProducer,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
+
+	applied, err = leiosApplyTestApplyEndorserBlock(
+		t, ls, db, firstPoint, 2, 901, leiosApplyTestEbHash(0xb3),
+		rawFirst,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
+	spentBy, deletedSlot := leiosApplyTestUtxoState(t, gdb, producerHash, 0)
+	require.Equal(t, firstTx.Hash().Bytes(), spentBy)
+	require.Equal(t, firstPoint.Slot, deletedSlot)
+
+	// The second certified endorser block re-consumes the same input. The
+	// closure apply must fold it on instead of failing with ErrUtxoConflict.
+	applied, err = leiosApplyTestApplyEndorserBlock(
+		t, ls, db, secondPoint, 3, 902, leiosApplyTestEbHash(0xb4),
+		rawSecond,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, applied)
+
+	// The contested input stays consumed by the first certified transaction,
+	// at the ranking-block slot that applied it.
+	spentBy, deletedSlot = leiosApplyTestUtxoState(t, gdb, producerHash, 0)
+	require.Equal(t, firstTx.Hash().Bytes(), spentBy)
+	require.Equal(t, firstPoint.Slot, deletedSlot)
+
+	// Absence case: the second transaction is present in the endorser block
+	// and in no ranking block, so it must still be applied -- its row is
+	// recorded and its produced output is live at its ranking block's slot.
+	var storedSlot uint64
+	require.NoError(t, gdb.QueryRow(`
+SELECT slot FROM "transaction" WHERE hash = ?`,
+		secondTx.Hash().Bytes(),
+	).Scan(&storedSlot))
+	require.Equal(t, secondPoint.Slot, storedSlot)
+	spentBy, deletedSlot = leiosApplyTestUtxoState(
+		t, gdb, secondTx.Hash().Bytes(), 0,
+	)
+	require.Empty(t, spentBy)
+	require.Equal(t, uint64(0), deletedSlot)
+	var addedSlot uint64
+	require.NoError(t, gdb.QueryRow(`
+SELECT added_slot FROM utxo WHERE tx_id = ? AND output_idx = 0`,
+		secondTx.Hash().Bytes(),
+	).Scan(&addedSlot))
+	require.Equal(t, secondPoint.Slot, addedSlot)
+}
+
+// The tolerance is scoped to the Musashi closure apply. On the CIP-conformant
+// path (LeiosApplyEndorserBlockTxs true) endorser transactions are applied with
+// ranking-block semantics -- consumed-input recovery stays on and a conflicting
+// consume is a hard error -- so a real double-spend still fails and the
+// endorser block is refused.
+func TestApplyEndorserBlockCIPPathRejectsCrossEndorserDoubleConsume(
+	t *testing.T,
+) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	ls.config.LeiosApplyEndorserBlockTxs = true // CIP-conformant path
+	rawProducer, producerTx := leiosApplyTestProducerTx(t, 0xc1)
+	producerHash := producerTx.Hash().Bytes()
+	rawFirst, firstTx := leiosApplyTestSpendingTx(t, 0xd1, producerHash, 0)
+	rawSecond, secondTx := leiosApplyTestSpendingTx(t, 0xd2, producerHash, 0)
+
+	firstPoint := leiosApplyTestRankingPoint(0x22)
+	_, err := leiosApplyTestApplyEndorserBlock(
+		t, ls, db, leiosApplyTestRankingPoint(0x21), 1, 910,
+		leiosApplyTestEbHash(0xc2), rawProducer,
+	)
+	require.NoError(t, err)
+	_, err = leiosApplyTestApplyEndorserBlock(
+		t, ls, db, firstPoint, 2, 911, leiosApplyTestEbHash(0xd3), rawFirst,
+	)
+	require.NoError(t, err)
+
+	_, err = leiosApplyTestApplyEndorserBlock(
+		t, ls, db, leiosApplyTestRankingPoint(0x23), 3, 912,
+		leiosApplyTestEbHash(0xd4), rawSecond,
+	)
+	require.ErrorIs(t, err, types.ErrUtxoConflict)
+	var storageErr *leiosEndorserBlockStorageError
+	require.ErrorAs(
+		t,
+		err,
+		&storageErr,
+		"a failure after storage mutation must abort the outer transaction",
+	)
+
+	// The aborted endorser block left no effects: the contested input is still
+	// consumed by the first transaction and the rejected one has no row.
+	spentBy, deletedSlot := leiosApplyTestUtxoState(t, gdb, producerHash, 0)
+	require.Equal(t, firstTx.Hash().Bytes(), spentBy)
+	require.Equal(t, firstPoint.Slot, deletedSlot)
+	var rows int64
+	require.NoError(t, gdb.QueryRow(`
+SELECT COUNT(*) FROM "transaction" WHERE hash = ?`,
+		secondTx.Hash().Bytes(),
+	).Scan(&rows))
+	require.Equal(t, int64(0), rows)
+}
+
+// A ranking block's own transactions are applied by a delta with the closure
+// options off (ledger/state.go). Absence case for the closure tolerance: a
+// transaction present only in the ranking block is applied normally and
+// consumes its input, and a ranking-block transaction that re-consumes an
+// input an earlier certified endorser-block transaction already spent is still
+// rejected as a double-spend.
+func TestRankingBlockDeltaKeepsHardConsumedInputConflict(t *testing.T) {
+	ls, db, gdb := newLeiosApplyTestLedger(t)
+	// LeiosApplyEndorserBlockTxs defaults to false (Haskell-conformant).
+	rawProducer, producerTx := leiosApplyTestProducerTx(t, 0xe1)
+	producerHash := producerTx.Hash().Bytes()
+	rawClosure, closureTx := leiosApplyTestSpendingTx(t, 0xf1, producerHash, 0)
+	// Spends the producer's second (still live) output.
+	rawRankingOnly, rankingOnlyTx := leiosApplyTestSpendingTx(
+		t, 0xf2, producerHash, 1,
+	)
+	// Re-spends the output the certified closure already consumed.
+	rawConflict, conflictTx := leiosApplyTestSpendingTx(
+		t, 0xf3, producerHash, 0,
+	)
+
+	closurePoint := leiosApplyTestRankingPoint(0x31)
+	_, err := leiosApplyTestApplyEndorserBlock(
+		t, ls, db, leiosApplyTestRankingPoint(0x30), 1, 920,
+		leiosApplyTestEbHash(0xe2), rawProducer,
+	)
+	require.NoError(t, err)
+	_, err = leiosApplyTestApplyEndorserBlock(
+		t, ls, db, closurePoint, 2, 921, leiosApplyTestEbHash(0xf4),
+		rawClosure,
+	)
+	require.NoError(t, err)
+
+	// A transaction present only in the ranking block still applies.
+	rankingPoint := leiosApplyTestRankingPoint(0x32)
+	require.NoError(t, leiosApplyTestApplyRankingDelta(
+		t, ls, db, rankingPoint, 3, rawRankingOnly, rankingOnlyTx,
+	))
+	spentBy, deletedSlot := leiosApplyTestUtxoState(t, gdb, producerHash, 1)
+	require.Equal(t, rankingOnlyTx.Hash().Bytes(), spentBy)
+	require.Equal(t, rankingPoint.Slot, deletedSlot)
+
+	// A ranking-block transaction re-consuming the closure's input is a
+	// double-spend and must be rejected.
+	err = leiosApplyTestApplyRankingDelta(
+		t, ls, db, leiosApplyTestRankingPoint(0x33), 4, rawConflict,
+		conflictTx,
+	)
+	require.ErrorIs(t, err, types.ErrUtxoConflict)
+	spentBy, deletedSlot = leiosApplyTestUtxoState(t, gdb, producerHash, 0)
+	require.Equal(t, closureTx.Hash().Bytes(), spentBy)
+	require.Equal(t, closurePoint.Slot, deletedSlot)
+	var rows int64
+	require.NoError(t, gdb.QueryRow(`
+SELECT COUNT(*) FROM "transaction" WHERE hash = ?`,
+		conflictTx.Hash().Bytes(),
+	).Scan(&rows))
+	require.Equal(t, int64(0), rows)
+}
+
+// leiosApplyTestApplyRankingDelta applies one transaction as a ranking-block
+// delta, the way ledgerProcessBlock applies a block's own transactions: the
+// closure options (skipConsumedInputRecovery) stay off. Ranking-block deltas
+// normally take their offsets from database.BlockIndexer.ComputeOffsets over
+// the block CBOR; the endorser-blob builder is reused here because the
+// consumed-input path only requires that an offset exists for the transaction
+// and each produced output.
+func leiosApplyTestApplyRankingDelta(
+	t *testing.T,
+	ls *LedgerState,
+	db *database.Database,
+	rbPoint ocommon.Point,
+	rbBlockNumber uint64,
+	rawTx cbor.RawMessage,
+	tx lcommon.Transaction,
+) error {
+	t.Helper()
+	var elems []cbor.RawMessage
+	_, err := cbor.Decode([]byte(rawTx), &elems)
+	require.NoError(t, err)
+	var ebHash [lcommon.Blake2b256Size]byte
+	copy(ebHash[:], leiosApplyTestEbHash(0x00))
+	_, offsets, err := buildEndorserBlockBlob(
+		[]lcommon.Transaction{tx},
+		[][]byte{[]byte(elems[0])},
+		rbPoint.Slot,
+		ebHash,
+	)
+	require.NoError(t, err)
+	txn := db.Transaction(true)
+	return txn.Do(func(txn *database.Txn) error {
+		delta := NewLedgerDelta(
+			rbPoint,
+			uint(dijkstra.EraIdDijkstra),
+			rbBlockNumber,
+		)
+		defer delta.Release()
+		delta.Offsets = offsets
+		delta.addTransaction(tx, 0)
+		return delta.applyWithoutRecordingDonations(ls, txn)
+	})
+}


### PR DESCRIPTION
No production change. `f8f4414c` fixed #3643 but left the ledger-side wiring uncovered: `applyEndorserBlock` -> `LedgerDelta.skipConsumedInputRecovery` -> `SetTransactionWithOpts` -> `SetTransactionLeiosClosure`. Its own test calls the store method directly and cannot see the wiring.

Three cases, all through production paths:
- Musashi path tolerates a cross-EB double-consume; the input stays spent by the first tx, the second tx and its output still land.
- CIP path still rejects it with `types.ErrUtxoConflict` and leaves no effects.
- Ranking-block delta still rejects a double-spend.

Reverting `f8f4414c`'s routing hunk in `database/transaction.go:289-302`:
```
--- FAIL: TestApplyEndorserBlockHaskellPathToleratesCrossEndorserDoubleConsume
    UTxO already spent: f56c80c8...:0 (already spent_by=f04319b7... this_tx=506fb9a0...)
--- PASS: TestApplyEndorserBlockCIPPathRejectsCrossEndorserDoubleConsume
--- PASS: TestRankingBlockDeltaKeepsHardConsumedInputConflict
```
Compiled; only the tolerance case failed. Every pre-existing EB test passed on that reverted tree.

`DATABASE.md`/`ARCHITECTURE.md` document the already-spent no-op and its `ValidateNone` basis, which `f8f4414c` did not.

Refs #3643

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests covering the ledger-side wiring for the Leios closure double-consume tolerance that fixed #3643, which the existing store-level test couldn't reach. No production change. Updates `DATABASE.md` and `ARCHITECTURE.md` to document the already-spent no-op behavior.

**Test cases**
- Musashi path: a second certified endorser block re-consuming the same input applies cleanly; the input stays spent by the first transaction.
- CIP path: the double-consume is rejected with `types.ErrUtxoConflict` and leaves no effects.
- Ranking-block delta: re-consuming an endorser-block input is still rejected as a double-spend.

<sup>Written for commit 895f3a7bc035c27a28fd32b92dbdb5e4600ef487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

