### PR TITLE
fix(chainselection): surface handler panics instead of dropping them

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1225,6 +1225,8 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `chainselection.genesis_corroboration_failed` | ChainSelector | Densest Genesis fast source lacked corroboration and was denied selection |
 | `chainselection.genesis_mode_exited` | ChainSelector | Left Genesis mode for Praos after catching up to the best known tip |
 | `chainselection.selected_none` | ChainSelector | Best-peer selection transitioned to none (selection stalled) |
+| `chainselection.peer_rollback_handler_panic` | ChainSelector | The PeerRollbackEvent handler panicked; its subscription was torn down |
+| `chainselection.evaluation_panic` | ChainSelector | A background evaluation tick or triggered evaluation panicked; the transition it would have produced was dropped |
 | `chainsync.client_added` | ChainsyncState | Client tracking added |
 | `chainsync.client_removed` | ChainsyncState | Client tracking removed |
 | `chainsync.client_synced` | ChainsyncState | Client caught up |
@@ -1366,6 +1368,22 @@ All event types follow the `subsystem.snake_case_name` convention.
   closure reads without its own synchronization (see the live restore/
   truncate section below for the concrete case this exists for). Never call
   it from within the subscriber's own handler.
+- `SubscribeFuncStrict` is `SubscribeFuncWithBuffer` for handlers implementing
+  state-machine logic where continuing past a failed event is unsafe (e.g. a
+  handler mutating state derived from a monotonic chain-event stream). A
+  handler panic is still recovered and logged so it cannot crash the node,
+  but unlike a plain `SubscribeFunc` handler it is not silently followed by
+  continued delivery: the caller's `onPanic` hook (if any) runs with the
+  failing event and the recovered value, and the subscription is torn down
+  immediately afterward. `chainselection.NewChainSelector` uses this for its
+  `chainselection.peer_rollback` subscription, publishing
+  `chainselection.peer_rollback_handler_panic` from its `onPanic` hook so a
+  lost subscription has a durable signal beyond a log line. Plain
+  `SubscribeFunc`/`SubscribeFuncWithBuffer` remain the right choice for
+  handlers that are safe to keep retrying on the next event —
+  `internal/dblifecycle.Manager`'s automatic-snapshot handler is the
+  concrete case this distinction exists for: a panic in one epoch's snapshot
+  attempt must not stop automatic snapshots for every later epoch.
 
 ## Storage Architecture
 

--- a/chainselection/event.go
+++ b/chainselection/event.go
@@ -50,6 +50,22 @@ const (
 	// application from uncorroborated peers is separately gated via
 	// ShouldApplyIngress; this event is for observability of the stall.
 	ChainSelectedNoneEventType event.EventType = "chainselection.selected_none"
+
+	// PeerRollbackHandlerPanicEventType is published when the
+	// PeerRollbackEvent handler registered in NewChainSelector panics. The
+	// EventBus subscription that delivers PeerRollbackEvent is torn down
+	// immediately afterward (see event.EventBus.SubscribeFuncStrict), so
+	// this is the durable signal that rollback handling for this selector
+	// has stopped rather than a swallowed panic followed by business as
+	// usual.
+	PeerRollbackHandlerPanicEventType event.EventType = "chainselection.peer_rollback_handler_panic"
+
+	// EvaluationPanicEventType is published when a background evaluation
+	// tick or triggered evaluation panics. The evaluation loop itself keeps
+	// running (see ChainSelector.recoverEvaluationPanic), but the specific
+	// best-peer transition that evaluation would have produced is dropped;
+	// this event is the only remaining signal that it happened.
+	EvaluationPanicEventType event.EventType = "chainselection.evaluation_panic"
 )
 
 // PeerTipUpdateEvent is published when a peer's chain tip is updated via
@@ -165,4 +181,28 @@ type GenesisModeExitedEvent struct {
 	LocalSlot          uint64
 	BestKnownSlot      uint64
 	GenesisWindowSlots uint64
+}
+
+// PeerRollbackHandlerPanicEvent is published when HandlePeerRollbackEvent
+// panics. Panic carries the recovered panic value for diagnostics.
+type PeerRollbackHandlerPanicEvent struct {
+	Panic any
+}
+
+// EvaluationPanicEvent is published when a background evaluation tick or
+// triggered evaluation panics.
+//
+// Fields:
+//   - Panic: the recovered panic value, for diagnostics.
+//   - Triggered: true when the panic occurred in runTriggeredEvaluation (the
+//     evaluationLoop select case draining evaluationTrigger, fed by
+//     SetConnectionEligible/SetConnectionPriority's triggerEvaluation calls);
+//     false for the periodic ticker tick (runEvaluationTick), which also
+//     runs cleanupStalePeers first. Panics from EvaluateAndSwitch called
+//     directly outside evaluationLoop (e.g. from UpdatePeerTip, RemovePeer,
+//     SetLocalTip, or an event handler) are not covered by this event --
+//     only the two evaluationLoop paths recover and surface panics here.
+type EvaluationPanicEvent struct {
+	Panic     any
+	Triggered bool
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -221,9 +221,19 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 		// not be absorbed and silently followed by the next rollback as if
 		// this one had actually been applied -- see onPeerRollbackPanic and
 		// event.EventBus.SubscribeFuncStrict.
+		//
+		// SubscriberBackpressureBlock, not the default Detach: this stream is
+		// ordering-critical, since a dropped rollback leaves a peer's tracked
+		// tip stale relative to its actual (rolled-back) chain, feeding
+		// selection from data the peer itself has already disavowed. Nothing
+		// here re-subscribes, so Detach would let ordinary backpressure alone
+		// (with no panic at all) silently and permanently stop rollback
+		// processing -- the same durable loss a panic causes, but far easier
+		// to trigger.
 		cfg.EventBus.SubscribeFuncStrict(
 			PeerRollbackEventType,
 			event.DefaultSubscriberBuffer,
+			event.SubscriberBackpressureBlock,
 			cs.HandlePeerRollbackEvent,
 			cs.onPeerRollbackPanic,
 		)
@@ -1798,17 +1808,56 @@ func (cs *ChainSelector) runTriggeredEvaluation() {
 // evaluation panicked would be a worse outcome than the missed transition:
 // the periodic ticker is itself the recovery path, giving the selector
 // another chance on fresh peer/local-tip state a moment later.
+//
+// The logging and publish calls below run after this function's own
+// recover() has already consumed the evaluation panic, so nothing further up
+// the stack can catch a second one. Each is wrapped in its own nested
+// recovery: a misbehaving Logger or EventBus.Publish panicking here would
+// otherwise propagate out of this deferred call as a fresh, unrecovered
+// panic, which would stop runEvaluationTick/runTriggeredEvaluation from
+// returning at all and crash the entire process once it unwinds past
+// evaluationLoop's for/select with nothing left to catch it -- taking down
+// chain selection (and the node) over what should have been one dropped
+// transition.
 func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
 	r := recover()
 	if r == nil {
 		return
 	}
-	cs.config.Logger.Error(
-		"panic in chain selection evaluation; transition dropped",
-		"panic", r,
-		"triggered", triggered,
-	)
-	if cs.config.EventBus != nil {
+	func() {
+		defer func() {
+			if r2 := recover(); r2 != nil {
+				// The configured Logger just proved unusable; fall back to
+				// the stdlib default rather than risk calling it again.
+				slog.Default().Error(
+					"panic while logging a chain selection evaluation panic",
+					"triggered", triggered,
+					"original_panic", r,
+					"logging_panic", r2,
+				)
+			}
+		}()
+		cs.config.Logger.Error(
+			"panic in chain selection evaluation; transition dropped",
+			"panic", r,
+			"triggered", triggered,
+		)
+	}()
+	if cs.config.EventBus == nil {
+		return
+	}
+	func() {
+		defer func() {
+			if r2 := recover(); r2 != nil {
+				slog.Default().Error(
+					"panic while publishing a chain selection evaluation "+
+						"panic event",
+					"triggered", triggered,
+					"original_panic", r,
+					"publish_panic", r2,
+				)
+			}
+		}()
 		cs.config.EventBus.Publish(
 			EvaluationPanicEventType,
 			event.NewEvent(
@@ -1816,7 +1865,7 @@ func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
 				EvaluationPanicEvent{Panic: r, Triggered: triggered},
 			),
 		)
-	}
+	}()
 }
 
 func (cs *ChainSelector) cleanupStalePeers() {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -215,9 +215,17 @@ func NewChainSelector(cfg ChainSelectorConfig) *ChainSelector {
 		cs.mode = SelectionModeGenesis
 	}
 	if cfg.EventBus != nil && !cfg.DisableEventSubscriptions {
-		cfg.EventBus.SubscribeFunc(
+		// SubscribeFuncStrict, not SubscribeFunc: HandlePeerRollbackEvent
+		// mutates chain-selection state machine state (per-peer observed
+		// history) from a monotonic rollback stream. A handler panic must
+		// not be absorbed and silently followed by the next rollback as if
+		// this one had actually been applied -- see onPeerRollbackPanic and
+		// event.EventBus.SubscribeFuncStrict.
+		cfg.EventBus.SubscribeFuncStrict(
 			PeerRollbackEventType,
+			event.DefaultSubscriberBuffer,
 			cs.HandlePeerRollbackEvent,
+			cs.onPeerRollbackPanic,
 		)
 	}
 	return cs
@@ -801,14 +809,16 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 // not an all-time high-water mark.
 func (cs *ChainSelector) SetLocalTip(tip ochainsync.Tip) {
 	shouldEvaluate := false
-	cs.mutex.Lock()
-	if tip.BlockNumber > cs.localTipProgressBlock {
-		cs.localTipProgressAt = cs.now()
-	}
-	cs.localTipProgressBlock = tip.BlockNumber
-	cs.localTip = tip
-	shouldEvaluate = cs.advanceSelectionModeLocked()
-	cs.mutex.Unlock()
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+		if tip.BlockNumber > cs.localTipProgressBlock {
+			cs.localTipProgressAt = cs.now()
+		}
+		cs.localTipProgressBlock = tip.BlockNumber
+		cs.localTip = tip
+		shouldEvaluate = cs.advanceSelectionModeLocked()
+	}()
 	if shouldEvaluate {
 		cs.EvaluateAndSwitch()
 	}
@@ -829,10 +839,12 @@ func (cs *ChainSelector) now() time.Time {
 // comparison.
 func (cs *ChainSelector) SetSecurityParam(k uint64) {
 	shouldEvaluate := false
-	cs.mutex.Lock()
-	cs.securityParam = k
-	shouldEvaluate = cs.advanceSelectionModeLocked()
-	cs.mutex.Unlock()
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+		cs.securityParam = k
+		shouldEvaluate = cs.advanceSelectionModeLocked()
+	}()
 	if shouldEvaluate {
 		cs.EvaluateAndSwitch()
 	}
@@ -1705,15 +1717,44 @@ func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 	}
 
 	var shouldEvaluate bool
-	cs.mutex.Lock()
-	if peerTip, exists := cs.peerTips[e.ConnectionId]; exists {
-		peerTip.ApplyRollback(e.Point, e.Tip)
-		shouldEvaluate = true
-	}
-	cs.mutex.Unlock()
+	func() {
+		cs.mutex.Lock()
+		defer cs.mutex.Unlock()
+		if peerTip, exists := cs.peerTips[e.ConnectionId]; exists {
+			peerTip.ApplyRollback(e.Point, e.Tip)
+			shouldEvaluate = true
+		}
+	}()
 
 	if shouldEvaluate {
 		cs.EvaluateAndSwitch()
+	}
+}
+
+// onPeerRollbackPanic is the SubscribeFuncStrict onPanic hook for the
+// PeerRollbackEventType subscription registered in NewChainSelector. The
+// EventBus has already recovered and logged the panic and torn down the
+// subscription by the time this runs; it adds chain-selection-specific
+// context to the log and publishes PeerRollbackHandlerPanicEventType so an
+// operator or automated watcher has a durable signal that rollback handling
+// for this selector has stopped, rather than silently missing every
+// subsequent peer rollback with no trace beyond a generic log line.
+func (cs *ChainSelector) onPeerRollbackPanic(evt event.Event, r any) {
+	cs.config.Logger.Error(
+		"chain selector rollback handler panicked; rollback subscription stopped",
+		"event_type",
+		evt.Type,
+		"panic",
+		r,
+	)
+	if cs.config.EventBus != nil {
+		cs.config.EventBus.Publish(
+			PeerRollbackHandlerPanicEventType,
+			event.NewEvent(
+				PeerRollbackHandlerPanicEventType,
+				PeerRollbackHandlerPanicEvent{Panic: r},
+			),
+		)
 	}
 }
 
@@ -1733,31 +1774,49 @@ func (cs *ChainSelector) evaluationLoop() {
 	}
 }
 
-// runEvaluationTick runs one evaluation tick with panic recovery.
-// If a panic occurs, it's logged and the loop continues.
+// runEvaluationTick runs one evaluation tick with panic recovery. If a panic
+// occurs, recoverEvaluationPanic surfaces it and the ticker loop continues on
+// the next tick.
 func (cs *ChainSelector) runEvaluationTick() {
-	defer func() {
-		if r := recover(); r != nil {
-			cs.config.Logger.Error(
-				"panic in evaluation tick, continuing",
-				"panic", r,
-			)
-		}
-	}()
+	defer cs.recoverEvaluationPanic(false)
 	cs.cleanupStalePeers()
 	cs.EvaluateAndSwitch()
 }
 
 func (cs *ChainSelector) runTriggeredEvaluation() {
-	defer func() {
-		if r := recover(); r != nil {
-			cs.config.Logger.Error(
-				"panic in triggered evaluation, continuing",
-				"panic", r,
-			)
-		}
-	}()
+	defer cs.recoverEvaluationPanic(true)
 	cs.EvaluateAndSwitch()
+}
+
+// recoverEvaluationPanic recovers a panic from one evaluation tick or
+// triggered evaluation, logs it, and publishes EvaluationPanicEventType so
+// the dropped transition is surfaced to subscribers instead of vanishing
+// silently. The evaluation loop itself keeps running afterward -- both
+// runEvaluationTick and runTriggeredEvaluation return normally once this
+// defer completes, so evaluationLoop's for/select goes on to the next tick or
+// trigger. Stopping chain selection entirely for the whole node because one
+// evaluation panicked would be a worse outcome than the missed transition:
+// the periodic ticker is itself the recovery path, giving the selector
+// another chance on fresh peer/local-tip state a moment later.
+func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	cs.config.Logger.Error(
+		"panic in chain selection evaluation; transition dropped",
+		"panic", r,
+		"triggered", triggered,
+	)
+	if cs.config.EventBus != nil {
+		cs.config.EventBus.Publish(
+			EvaluationPanicEventType,
+			event.NewEvent(
+				EvaluationPanicEventType,
+				EvaluationPanicEvent{Panic: r, Triggered: triggered},
+			),
+		)
+	}
 }
 
 func (cs *ChainSelector) cleanupStalePeers() {

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1829,7 +1829,10 @@ func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
 			if r2 := recover(); r2 != nil {
 				// The configured Logger just proved unusable; fall back to
 				// the stdlib default rather than risk calling it again.
-				slog.Default().Error(
+				// safeLog, not a direct call: the fallback itself must not
+				// be the thing that finally lets a panic escape.
+				safeLog(
+					slog.Default(),
 					"panic while logging a chain selection evaluation panic",
 					"triggered", triggered,
 					"original_panic", r,
@@ -1849,7 +1852,8 @@ func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
 	func() {
 		defer func() {
 			if r2 := recover(); r2 != nil {
-				slog.Default().Error(
+				safeLog(
+					slog.Default(),
 					"panic while publishing a chain selection evaluation "+
 						"panic event",
 					"triggered", triggered,
@@ -1866,6 +1870,18 @@ func (cs *ChainSelector) recoverEvaluationPanic(triggered bool) {
 			),
 		)
 	}()
+}
+
+// safeLog calls logger.Error, discarding any panic instead of letting it
+// propagate. Used only as the last-resort step inside a panic-recovery path
+// that has nothing left above it to catch a further panic -- e.g. reporting
+// that the configured Logger itself panicked, via slog.Default() instead.
+// Even that fallback must not be the thing that finally lets a panic escape,
+// so this is the floor: it stops here, silently, rather than one level
+// deeper.
+func safeLog(logger *slog.Logger, msg string, args ...any) {
+	defer func() { _ = recover() }()
+	logger.Error(msg, args...)
 }
 
 func (cs *ChainSelector) cleanupStalePeers() {

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -16,9 +16,13 @@ package chainselection
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"math"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2519,4 +2523,203 @@ func TestOmittedObservedFrontierIsNotPromotedToAdvertisedTip(t *testing.T) {
 		*bestPeer,
 		"a peer that delivered no headers must not hold selection on its advertised tip",
 	)
+}
+
+// panicLogHandler is an slog.Handler that panics on every Handle call, used
+// to inject a deterministic panic into a locked section that logs. It
+// otherwise delegates to inner, including WithAttrs/WithGroup, so a wrapped
+// child logger (e.g. from Logger.With) still panics on Handle.
+type panicLogHandler struct {
+	inner slog.Handler
+}
+
+func (h *panicLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *panicLogHandler) Handle(context.Context, slog.Record) error {
+	panic("intentional logger panic")
+}
+
+func (h *panicLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &panicLogHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *panicLogHandler) WithGroup(name string) slog.Handler {
+	return &panicLogHandler{inner: h.inner.WithGroup(name)}
+}
+
+// TestChainSelectorSetLocalTipUnlocksOnPanic is a regression test for a bug
+// where SetLocalTip (and SetSecurityParam, HandlePeerRollbackEvent) took
+// cs.mutex.Lock() and called cs.mutex.Unlock() as a bare statement after the
+// locked work instead of via defer. advanceSelectionModeLocked logs on a
+// Genesis-mode exit while the lock is held; if that log call panics (a
+// misbehaving Logger, but the same failure mode as any other panic in code
+// reachable from inside the lock), the bare Unlock() was skipped and
+// cs.mutex stayed locked forever -- deadlocking every future ChainSelector
+// call, not just dropping the one event. This test drives a real Genesis
+// exit with a Logger that panics on every Handle call and then verifies
+// cs.mutex is still acquirable afterward.
+func TestChainSelectorSetLocalTipUnlocksOnPanic(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		GenesisMode:   true,
+		SecurityParam: 10,
+	})
+
+	connId := newTestConnectionId(1)
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("peer-100")},
+		BlockNumber: 100,
+	}, nil)
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	// Installed under cs.mutex, after the setup UpdatePeerTip call above
+	// (which itself logs), matching how every production read of
+	// cs.config.Logger is itself guarded by cs.mutex.
+	cs.mutex.Lock()
+	cs.config.Logger = slog.New(
+		&panicLogHandler{inner: slog.NewTextHandler(io.Discard, nil)},
+	)
+	cs.mutex.Unlock()
+
+	func() {
+		defer func() {
+			require.NotNil(
+				t,
+				recover(),
+				"expected the Genesis-exit log call to panic",
+			)
+		}()
+		// Drives the local tip to within the Genesis window of the peer's
+		// advertised tip (100), triggering advanceSelectionModeLocked's
+		// Genesis-exit log call while cs.mutex is held.
+		cs.SetLocalTip(ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 75, Hash: []byte("local-75")},
+			BlockNumber: 75,
+		})
+	}()
+
+	// If SetLocalTip's locked section left cs.mutex locked, this blocks
+	// forever instead of closing unlocked.
+	unlocked := make(chan struct{})
+	go func() {
+		cs.mutex.Lock()
+		cs.mutex.Unlock()
+		close(unlocked)
+	}()
+	select {
+	case <-unlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"cs.mutex is still locked after the panic; " +
+				"SetLocalTip must unlock via defer",
+		)
+	}
+}
+
+// TestChainSelectorOnPeerRollbackPanicPublishesEvent verifies onPeerRollbackPanic,
+// the SubscribeFuncStrict onPanic hook NewChainSelector registers for
+// PeerRollbackEventType: it must publish PeerRollbackHandlerPanicEventType
+// carrying the recovered panic value, so a component that lost its rollback
+// subscription to a handler panic (event.EventBus.SubscribeFuncStrict tears
+// the subscription down) has a durable, observable signal instead of a
+// generic log line.
+func TestChainSelectorOnPeerRollbackPanicPublishesEvent(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:                  bus,
+		DisableEventSubscriptions: true,
+	})
+
+	var received atomic.Value
+	bus.SubscribeFunc(
+		PeerRollbackHandlerPanicEventType,
+		func(evt event.Event) {
+			received.Store(evt.Data)
+		},
+	)
+
+	cs.onPeerRollbackPanic(
+		event.NewEvent(PeerRollbackEventType, PeerRollbackEvent{
+			ConnectionId: newTestConnectionId(1),
+		}),
+		"intentional rollback handler panic",
+	)
+
+	require.Eventually(
+		t,
+		func() bool {
+			return received.Load() != nil
+		},
+		2*time.Second,
+		10*time.Millisecond,
+		"a rollback handler panic must publish PeerRollbackHandlerPanicEventType",
+	)
+	got, ok := received.Load().(PeerRollbackHandlerPanicEvent)
+	require.True(t, ok)
+	assert.Equal(t, "intentional rollback handler panic", got.Panic)
+}
+
+// TestChainSelectorEvaluationPanicSurfacedAndLoopContinues verifies that a
+// panic during a triggered evaluation is surfaced via
+// EvaluationPanicEventType instead of silently dropping the failed
+// transition, and that the evaluation loop remains usable for the next
+// evaluation afterward -- runTriggeredEvaluation is the same panic-recovery
+// wrapper the background evaluationLoop's triggered path uses, called
+// directly here to keep the test deterministic instead of racing a
+// ticker/channel.
+func TestChainSelectorEvaluationPanicSurfacedAndLoopContinues(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	var received atomic.Value
+	bus.SubscribeFunc(EvaluationPanicEventType, func(evt event.Event) {
+		received.Store(evt.Data)
+	})
+
+	cs := NewChainSelector(ChainSelectorConfig{EventBus: bus})
+
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 10, Hash: []byte("slot-10")},
+		BlockNumber: 10,
+	}
+	connA := newTestConnectionId(1)
+	connB := newTestConnectionId(2)
+	cs.UpdatePeerTip(connA, tip, nil)
+	cs.UpdatePeerTip(connB, tip, nil)
+
+	// Installed under cs.mutex, matching comparePeerTipsPraos's locked read
+	// of cs.config.BlockfetchLatency. Reached only once both peers compare
+	// as the same chain (equal tip and priority), which the two identical
+	// UpdatePeerTip calls above set up.
+	cs.mutex.Lock()
+	cs.config.BlockfetchLatency = func(ouroboros.ConnectionId) (time.Duration, bool) {
+		panic("blockfetch latency boom")
+	}
+	cs.mutex.Unlock()
+
+	cs.runTriggeredEvaluation()
+
+	require.Eventually(t, func() bool {
+		return received.Load() != nil
+	}, 2*time.Second, 10*time.Millisecond,
+		"a panic during evaluation must publish EvaluationPanicEventType",
+	)
+	got, ok := received.Load().(EvaluationPanicEvent)
+	require.True(t, ok)
+	assert.Equal(t, "blockfetch latency boom", got.Panic)
+	assert.True(t, got.Triggered)
+
+	// The evaluation loop keeps running after a panic: clearing the
+	// panicking latency func and evaluating again must succeed normally
+	// rather than the earlier panic having wedged the selector.
+	cs.mutex.Lock()
+	cs.config.BlockfetchLatency = nil
+	cs.mutex.Unlock()
+	require.NotPanics(t, func() {
+		cs.runTriggeredEvaluation()
+	})
+	require.NotNil(t, cs.GetBestPeer())
 }

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -2723,3 +2723,33 @@ func TestChainSelectorEvaluationPanicSurfacedAndLoopContinues(t *testing.T) {
 	})
 	require.NotNil(t, cs.GetBestPeer())
 }
+
+// TestChainSelectorRecoverEvaluationPanicToleratesPanickingLogger is a
+// regression test for a bug where recoverEvaluationPanic's own logging call
+// was not panic-safe: it runs after this function's own recover() has
+// already consumed the evaluation panic, so nothing further up the stack
+// could catch a second one. A misbehaving Logger panicking there would
+// propagate out of the deferred call as a fresh, unrecovered panic --
+// runTriggeredEvaluation/runEvaluationTick would never return, crashing the
+// whole process once it unwound past evaluationLoop's for/select with
+// nothing left to catch it, over what should have been one dropped
+// transition. This drives a real evaluation panic with a Logger that panics
+// on every Handle call and verifies the panic is fully contained.
+func TestChainSelectorRecoverEvaluationPanicToleratesPanickingLogger(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	defer bus.Close()
+
+	cs := NewChainSelector(ChainSelectorConfig{EventBus: bus})
+	cs.mutex.Lock()
+	cs.config.Logger = slog.New(
+		&panicLogHandler{inner: slog.NewTextHandler(io.Discard, nil)},
+	)
+	cs.mutex.Unlock()
+
+	require.NotPanics(t, func() {
+		func() {
+			defer cs.recoverEvaluationPanic(true)
+			panic("evaluation boom")
+		}()
+	}, "a panicking Logger must not escape recoverEvaluationPanic")
+}

--- a/event/event.go
+++ b/event/event.go
@@ -908,7 +908,10 @@ func (e *EventBus) reportHandlerPanic(
 			if r2 := recover(); r2 != nil {
 				// The configured Logger just proved unusable; fall back to
 				// the stdlib default rather than risk calling it again.
-				slog.Default().Error(
+				// safeLog, not a direct call: the fallback itself must not
+				// be the thing that finally lets a panic escape.
+				safeLog(
+					slog.Default(),
 					"panic while logging a SubscribeFunc handler panic",
 					"event_type", evt.Type,
 					"original_panic", r,
@@ -932,7 +935,8 @@ func (e *EventBus) reportHandlerPanic(
 	func() {
 		defer func() {
 			if r2 := recover(); r2 != nil {
-				slog.Default().Error(
+				safeLog(
+					slog.Default(),
 					"panic in SubscribeFuncStrict onPanic hook",
 					"event_type", evt.Type,
 					"original_panic", r,
@@ -942,6 +946,18 @@ func (e *EventBus) reportHandlerPanic(
 		}()
 		onPanic(evt, r)
 	}()
+}
+
+// safeLog calls logger.Error, discarding any panic instead of letting it
+// propagate. Used only as the last-resort step inside a panic-recovery path
+// that has nothing left above it to catch a further panic -- e.g. reporting
+// that the configured Logger itself panicked, via slog.Default() instead.
+// Even that fallback must not be the thing that finally lets a panic escape,
+// so this is the floor: it stops here, silently, rather than one level
+// deeper.
+func safeLog(logger *slog.Logger, msg string, args ...any) {
+	defer func() { _ = recover() }()
+	logger.Error(msg, args...)
 }
 
 // Unsubscribe stops delivery of events for a particular type for an existing subscriber

--- a/event/event.go
+++ b/event/event.go
@@ -780,8 +780,8 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 	return subId
 }
 
-// SubscribeFuncStrict is like SubscribeFuncWithBuffer, but for handlers that
-// implement state-machine logic where silently continuing past a failed
+// SubscribeFuncStrict is like SubscribeFuncWithBufferPolicy, but for handlers
+// that implement state-machine logic where silently continuing past a failed
 // event is unsafe -- e.g. a handler that mutates state derived from a
 // monotonic stream of chain events, where the next event's correctness
 // depends on the previous one having actually been applied. A handler panic
@@ -796,6 +796,15 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 //     so no further event is delivered into (and silently dropped by) a
 //     handler that just proved its state may be inconsistent.
 //
+// backpressurePolicy is independent of the panic behavior above and must be
+// chosen deliberately: SubscriberBackpressureDetach can silently drop this
+// subscription on ordinary backpressure alone, with the same permanent loss
+// of future events as a panic would cause, since nothing here re-subscribes.
+// Use SubscriberBackpressureBlock for an ordering-critical stream whose
+// omission would leave the owning component's state stale in a way it cannot
+// safely recover from -- chainselection.NewChainSelector's PeerRollbackEvent
+// subscription is the concrete example.
+//
 // Use SubscribeFunc/SubscribeFuncWithBuffer instead for handlers that are
 // safe to keep retrying on the next event -- internal/dblifecycle.Manager is
 // the concrete example this distinction exists for: a panic in one epoch's
@@ -804,6 +813,7 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 func (e *EventBus) SubscribeFuncStrict(
 	eventType EventType,
 	buffer int,
+	backpressurePolicy SubscriberBackpressurePolicy,
 	handlerFunc EventHandlerFunc,
 	onPanic EventPanicHandler,
 ) EventSubscriberId {
@@ -812,15 +822,11 @@ func (e *EventBus) SubscribeFuncStrict(
 		e.stopMu.RUnlock()
 		return 0
 	}
-	// Backpressure policy is fixed at Detach, matching SubscribeFuncWithBuffer's
-	// default: this variant's own axis is panic behavior, not backpressure, and
-	// a handler strict enough to need its subscription torn down on panic has
-	// no business blocking a publisher indefinitely on a full buffer either.
 	subId, chSub := e.subscribeInternal(
 		eventType,
 		buffer,
 		true,
-		SubscriberBackpressureDetach,
+		backpressurePolicy,
 	)
 	e.subscriberWg.Add(1)
 	e.stopMu.RUnlock()
@@ -874,22 +880,68 @@ func (e *EventBus) safeHandlerCall(
 	defer func() {
 		if r := recover(); r != nil {
 			panicked = true
-			logger := e.Logger
-			if logger == nil {
-				logger = slog.Default()
-			}
-			logger.Error(
-				"SubscribeFunc handler panicked",
-				"event_type", evt.Type,
-				"panic", r,
-			)
-			if onPanic != nil {
-				onPanic(evt, r)
-			}
+			e.reportHandlerPanic(evt, r, onPanic)
 		}
 	}()
 	handlerFunc(evt)
 	return false
+}
+
+// reportHandlerPanic logs a recovered SubscribeFunc handler panic and invokes
+// onPanic, each under its own nested recovery. It always runs from inside
+// safeHandlerCall's deferred recover, which has already consumed the
+// handler's own panic -- nothing further up the call stack can catch a
+// second one. Without containing it here, a misbehaving Logger or onPanic
+// hook panicking would propagate out of safeHandlerCall as a brand new,
+// unrecovered panic: safeHandlerCall would never return at all (so
+// SubscribeFuncStrict never observes panicked=true and never tears the
+// subscription down), and the panic would keep unwinding past the dispatch
+// goroutine's remaining defers with nothing left to catch it, crashing the
+// entire process over what should have been a single bad event.
+func (e *EventBus) reportHandlerPanic(
+	evt Event,
+	r any,
+	onPanic EventPanicHandler,
+) {
+	func() {
+		defer func() {
+			if r2 := recover(); r2 != nil {
+				// The configured Logger just proved unusable; fall back to
+				// the stdlib default rather than risk calling it again.
+				slog.Default().Error(
+					"panic while logging a SubscribeFunc handler panic",
+					"event_type", evt.Type,
+					"original_panic", r,
+					"logging_panic", r2,
+				)
+			}
+		}()
+		logger := e.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Error(
+			"SubscribeFunc handler panicked",
+			"event_type", evt.Type,
+			"panic", r,
+		)
+	}()
+	if onPanic == nil {
+		return
+	}
+	func() {
+		defer func() {
+			if r2 := recover(); r2 != nil {
+				slog.Default().Error(
+					"panic in SubscribeFuncStrict onPanic hook",
+					"event_type", evt.Type,
+					"original_panic", r,
+					"hook_panic", r2,
+				)
+			}
+		}()
+		onPanic(evt, r)
+	}()
 }
 
 // Unsubscribe stops delivery of events for a particular type for an existing subscriber

--- a/event/event.go
+++ b/event/event.go
@@ -94,6 +94,12 @@ const (
 	SubscriberBackpressureBlock
 )
 
+// EventPanicHandler is invoked by SubscribeFuncStrict, on the subscription's
+// own dispatch goroutine, after a handler panic has been recovered and
+// logged. It receives the event that was being processed and the recovered
+// panic value.
+type EventPanicHandler func(Event, any)
+
 type Event struct {
 	Timestamp time.Time
 	Data      any
@@ -764,7 +770,89 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 			if e.terminalClosing.Load() {
 				return
 			}
-			e.safeHandlerCall(handlerFunc, evt)
+			e.safeHandlerCall(handlerFunc, evt, nil)
+		}
+	}(
+		chSub.ch,
+		handlerFunc,
+		chSub.done,
+	)
+	return subId
+}
+
+// SubscribeFuncStrict is like SubscribeFuncWithBuffer, but for handlers that
+// implement state-machine logic where silently continuing past a failed
+// event is unsafe -- e.g. a handler that mutates state derived from a
+// monotonic stream of chain events, where the next event's correctness
+// depends on the previous one having actually been applied. A handler panic
+// is never absorbed the way it is for a plain SubscribeFunc handler:
+//
+//   - it is still recovered and logged, so it cannot crash the node;
+//   - onPanic (if non-nil) is invoked with the event and the recovered panic
+//     value, on the subscription's own dispatch goroutine, so the owning
+//     component can react (log with its own context, alert, mark itself
+//     degraded);
+//   - the subscription is then torn down and its dispatch goroutine exits,
+//     so no further event is delivered into (and silently dropped by) a
+//     handler that just proved its state may be inconsistent.
+//
+// Use SubscribeFunc/SubscribeFuncWithBuffer instead for handlers that are
+// safe to keep retrying on the next event -- internal/dblifecycle.Manager is
+// the concrete example this distinction exists for: a panic in one epoch's
+// snapshot attempt must not stop automatic snapshots for every later epoch,
+// so it deliberately relies on the plain SubscribeFunc behavior instead.
+func (e *EventBus) SubscribeFuncStrict(
+	eventType EventType,
+	buffer int,
+	handlerFunc EventHandlerFunc,
+	onPanic EventPanicHandler,
+) EventSubscriberId {
+	e.stopMu.RLock()
+	if e.stopped || e.closed {
+		e.stopMu.RUnlock()
+		return 0
+	}
+	// Backpressure policy is fixed at Detach, matching SubscribeFuncWithBuffer's
+	// default: this variant's own axis is panic behavior, not backpressure, and
+	// a handler strict enough to need its subscription torn down on panic has
+	// no business blocking a publisher indefinitely on a full buffer either.
+	subId, chSub := e.subscribeInternal(
+		eventType,
+		buffer,
+		true,
+		SubscriberBackpressureDetach,
+	)
+	e.subscriberWg.Add(1)
+	e.stopMu.RUnlock()
+
+	go func(evtCh <-chan Event, handlerFunc EventHandlerFunc, done chan struct{}) {
+		defer close(done)
+		defer e.subscriberWg.Done()
+		// Self-cleans its own channelSubsById entry for the same reason
+		// SubscribeFuncWithBufferPolicy's dispatch goroutine does -- see its
+		// matching comment above. The panic path below additionally calls
+		// Unsubscribe itself, which removes the e.subscribers/snapshot
+		// entries immediately; this defer only ever needs to cover the
+		// channelSubsById bookkeeping unsubscribe() defers to it.
+		defer func() {
+			e.mu.Lock()
+			delete(e.channelSubsById, subId)
+			e.mu.Unlock()
+		}()
+		for {
+			evt, ok := <-evtCh
+			if !ok {
+				return
+			}
+			if e.terminalClosing.Load() {
+				return
+			}
+			if e.safeHandlerCall(handlerFunc, evt, onPanic) {
+				// The handler panicked: stop delivering events to it rather
+				// than looping back for the next one as if nothing failed.
+				e.Unsubscribe(eventType, subId)
+				return
+			}
 		}
 	}(
 		chSub.ch,
@@ -775,13 +863,17 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 }
 
 // safeHandlerCall invokes a SubscribeFunc handler with panic recovery so that
-// a misbehaving handler cannot crash the node.
+// a misbehaving handler cannot crash the node. Returns true if the handler
+// panicked. onPanic, when non-nil, runs after the panic is recovered and
+// logged.
 func (e *EventBus) safeHandlerCall(
 	handlerFunc EventHandlerFunc,
 	evt Event,
-) {
+	onPanic EventPanicHandler,
+) (panicked bool) {
 	defer func() {
 		if r := recover(); r != nil {
+			panicked = true
 			logger := e.Logger
 			if logger == nil {
 				logger = slog.Default()
@@ -791,9 +883,13 @@ func (e *EventBus) safeHandlerCall(
 				"event_type", evt.Type,
 				"panic", r,
 			)
+			if onPanic != nil {
+				onPanic(evt, r)
+			}
 		}
 	}()
 	handlerFunc(evt)
+	return false
 }
 
 // Unsubscribe stops delivery of events for a particular type for an existing subscriber

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -510,6 +510,7 @@ func TestSubscribeFuncStrictPanicRecovery(t *testing.T) {
 	subId := eb.SubscribeFuncStrict(
 		testEvtType,
 		0,
+		event.SubscriberBackpressureDetach,
 		func(evt event.Event) {
 			received.Add(1)
 			panic("intentional strict test panic")
@@ -543,13 +544,69 @@ func TestSubscribeFuncStrictPanicRecovery(t *testing.T) {
 	)
 
 	// A later publish must not reach the (now unsubscribed) handler.
+	// Never, not Eventually: received is already 1 from the panicking
+	// delivery, so an Eventually would pass on its first poll without ever
+	// observing whether the post-panic publish got delivered.
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, "after-panic"))
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(
+	require.Never(
 		t,
-		int32(1),
-		received.Load(),
+		func() bool { return received.Load() != 1 },
+		time.Second,
+		10*time.Millisecond,
 		"no further event should be delivered after the handler panicked",
+	)
+}
+
+// TestSubscribeFuncStrictOnPanicHookPanicIsContained is a regression test for
+// a bug where a panicking onPanic hook was not itself panic-safe: it runs
+// from inside safeHandlerCall's own deferred recover, which has already
+// consumed the handler's panic, so nothing further up the stack could catch
+// a second one from onPanic. That let a misbehaving onPanic hook (or Logger)
+// propagate out of safeHandlerCall as a fresh, unrecovered panic --
+// safeHandlerCall never returned at all, so SubscribeFuncStrict never
+// observed panicked=true and never tore the subscription down, and the
+// panic crashed the whole process once it unwound past the dispatch
+// goroutine's remaining defers with nothing left to catch it. This verifies
+// the subscription is still torn down, and the EventBus itself remains
+// usable, even when onPanic panics.
+func TestSubscribeFuncStrictOnPanicHookPanicIsContained(t *testing.T) {
+	var testEvtType event.EventType = "test.strict.onpanic.panic"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	eb.SubscribeFuncStrict(
+		testEvtType,
+		0,
+		event.SubscriberBackpressureDetach,
+		func(evt event.Event) {
+			panic("intentional handler panic")
+		},
+		func(evt event.Event, r any) {
+			panic("intentional onPanic hook panic")
+		},
+	)
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "boom"))
+
+	require.Eventually(t, func() bool {
+		return !eb.HasSubscribers(testEvtType)
+	}, 10*time.Second, 10*time.Millisecond,
+		"the subscription must still be torn down even when onPanic itself panics",
+	)
+
+	// The EventBus itself must still be usable: an unrelated subscription
+	// must still receive its own events normally, proving the dispatch
+	// goroutine's panic did not crash the process or corrupt the bus.
+	var otherType event.EventType = "test.strict.onpanic.panic.other"
+	var received atomic.Bool
+	eb.SubscribeFunc(otherType, func(event.Event) {
+		received.Store(true)
+	})
+	eb.Publish(otherType, event.NewEvent(otherType, "ok"))
+	require.Eventually(t, func() bool {
+		return received.Load()
+	}, 10*time.Second, 10*time.Millisecond,
+		"the EventBus must remain usable after a panicking onPanic hook",
 	)
 }
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -574,6 +574,8 @@ func TestSubscribeFuncStrictOnPanicHookPanicIsContained(t *testing.T) {
 	eb := event.NewEventBus(nil, nil)
 	defer eb.Stop()
 
+	var onPanicCalled atomic.Bool
+
 	eb.SubscribeFuncStrict(
 		testEvtType,
 		0,
@@ -582,12 +584,22 @@ func TestSubscribeFuncStrictOnPanicHookPanicIsContained(t *testing.T) {
 			panic("intentional handler panic")
 		},
 		func(evt event.Event, r any) {
+			// Set before panicking: this is what proves the panic below
+			// actually happened inside onPanic (the path under test) rather
+			// than the test passing on handler-panic teardown alone with
+			// onPanic silently never having run at all.
+			onPanicCalled.Store(true)
 			panic("intentional onPanic hook panic")
 		},
 	)
 
 	eb.Publish(testEvtType, event.NewEvent(testEvtType, "boom"))
 
+	require.Eventually(t, func() bool {
+		return onPanicCalled.Load()
+	}, 10*time.Second, 10*time.Millisecond,
+		"onPanic must have been invoked",
+	)
 	require.Eventually(t, func() bool {
 		return !eb.HasSubscribers(testEvtType)
 	}, 10*time.Second, 10*time.Millisecond,

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -493,6 +493,66 @@ func TestSubscribeFuncPanicRecovery(t *testing.T) {
 	)
 }
 
+// TestSubscribeFuncStrictPanicRecovery verifies that, unlike SubscribeFunc,
+// a SubscribeFuncStrict handler panic is recovered but not silently followed
+// by continued delivery: onPanic is invoked with the failing event and the
+// recovered value, and the subscription is torn down so a later publish is
+// not delivered to it.
+func TestSubscribeFuncStrictPanicRecovery(t *testing.T) {
+	var testEvtType event.EventType = "test.strict.panic"
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+
+	var received atomic.Int32
+	var panicEvt atomic.Value
+	var panicVal atomic.Value
+
+	subId := eb.SubscribeFuncStrict(
+		testEvtType,
+		0,
+		func(evt event.Event) {
+			received.Add(1)
+			panic("intentional strict test panic")
+		},
+		func(evt event.Event, r any) {
+			panicEvt.Store(evt)
+			panicVal.Store(r)
+		},
+	)
+	require.NotZero(t, subId)
+
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "boom"))
+
+	require.Eventually(t, func() bool {
+		return panicVal.Load() != nil
+	}, 10*time.Second, 10*time.Millisecond,
+		"onPanic should be invoked after the handler panics",
+	)
+	require.Equal(t, "intentional strict test panic", panicVal.Load())
+	require.Equal(
+		t,
+		testEvtType,
+		panicEvt.Load().(event.Event).Type,
+		"onPanic should receive the event that was being processed",
+	)
+
+	require.Eventually(t, func() bool {
+		return !eb.HasSubscribers(testEvtType)
+	}, 10*time.Second, 10*time.Millisecond,
+		"the subscription must be torn down after the handler panics",
+	)
+
+	// A later publish must not reach the (now unsubscribed) handler.
+	eb.Publish(testEvtType, event.NewEvent(testEvtType, "after-panic"))
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(
+		t,
+		int32(1),
+		received.Load(),
+		"no further event should be delivered after the handler panicked",
+	)
+}
+
 // TestPublishNoGoroutineLeak verifies that publishing far more events than a
 // subscriber's buffer can hold does not leak goroutines. This is a regression
 // test for MEM-06 where publishWithTimeout spawned goroutines that could never


### PR DESCRIPTION
## Summary

Fixes #3396. State-machine event handlers in the chain selector were recovering panics and silently continuing as if the event had been processed successfully — and in three places, a panic while holding `ChainSelector.mutex` skipped the unlock entirely, deadlocking the selector permanently.

## Changes by file

**`event/event.go`**
- Why: `SubscribeFunc`'s panic recovery logs and moves on to the next event with no way for the owning component to know delivery failed, and no way to stop feeding events to a handler that just proved it may be in a bad state.
- What: Added `EventPanicHandler` and `EventBus.SubscribeFuncStrict` — a handler panic is still recovered and logged (never crashes the node), but also invokes a caller-supplied `onPanic` hook and tears the subscription down instead of continuing. `SubscribeFunc`/`SubscribeFuncWithBuffer` are untouched, since `internal/dblifecycle.Manager` relies on today's forgiving behavior (a panic in one epoch's snapshot must not stop snapshots for later epochs).
- Tests: `TestSubscribeFuncStrictPanicRecovery` — asserts the `onPanic` hook fires with the failing event/value, and that a publish after the panic is never delivered.

**`chainselection/selector.go`**
- Why (bug): `SetLocalTip`, `SetSecurityParam`, and `HandlePeerRollbackEvent` called `cs.mutex.Lock()` and then `cs.mutex.Unlock()` as a bare statement after the locked work. A panic in between (e.g. `advanceSelectionModeLocked`'s Genesis-exit log call) skipped the unlock, deadlocking every future `ChainSelector` call — not just dropping one event.
- What (bug fix): Wrapped each in `func() { Lock(); defer Unlock(); ... }()`, matching the pattern already used elsewhere in this file.
- Why (surfacing): The issue's two named locations.
- What (surfacing): `NewChainSelector`'s `PeerRollbackEvent` subscription now uses `SubscribeFuncStrict`, with a new `onPeerRollbackPanic` hook that logs with chain-selection context and publishes `PeerRollbackHandlerPanicEventType`. `runEvaluationTick`/`runTriggeredEvaluation` (the two background evaluation-loop panic-recovery paths) now publish `EvaluationPanicEventType` via a new `recoverEvaluationPanic` helper instead of only logging — the loop itself keeps running, since stopping chain selection node-wide over one bad tick would be worse than the missed transition.
- Tests:
  - `TestChainSelectorSetLocalTipUnlocksOnPanic` — regression test for the deadlock bug, using a logger that panics on every `Handle` call to drive a real Genesis-exit panic while the lock is held, then verifies the mutex is still acquirable. Verified this fails (hangs 2s) against the pre-fix code and passes against the fix.
  - `TestChainSelectorOnPeerRollbackPanicPublishesEvent` — verifies the rollback-panic hook publishes `PeerRollbackHandlerPanicEventType`.
  - `TestChainSelectorEvaluationPanicSurfacedAndLoopContinues` — verifies a panic during evaluation (injected via a panicking `BlockfetchLatency` config callback) publishes `EvaluationPanicEventType`, and that the evaluation loop keeps working afterward.

**`chainselection/event.go`**
- Why: New event types need definitions in the same place as the package's other event types/payloads.
- What: Added `PeerRollbackHandlerPanicEventType`/`PeerRollbackHandlerPanicEvent` and `EvaluationPanicEventType`/`EvaluationPanicEvent`.

**`ARCHITECTURE.md`**
- Why: Project convention requires architecture docs to stay in sync with EventBus topic and lifecycle/concurrency changes.
- What: Documented the two new event types in the Key Event Types table, and added a bullet explaining `SubscribeFuncStrict` vs. plain `SubscribeFunc`/`SubscribeFuncWithBuffer`, including why `internal/dblifecycle.Manager` deliberately keeps using the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3396 by stopping `chainselection` handler panics from deadlocking the selector and from disappearing without a trace.

**Bug Fixes**
- `SetLocalTip`, `SetSecurityParam`, and `HandlePeerRollbackEvent` now unlock via `defer`, so a panic can't leave the selector permanently locked.
- The rollback subscription now blocks on backpressure, so an ordinary backlog can't silently stop rollback processing.
- Panic reporting is itself panic-safe: a panicking logger, `onPanic` hook, or fallback logger can't crash the node or prevent subscription teardown.

**New Features**
- `SubscribeFuncStrict` recovers and logs handler panics, runs an `onPanic` hook, and stops delivering further events; plain `SubscribeFunc`/`SubscribeFuncWithBuffer` behavior is unchanged.
- New `PeerRollbackHandlerPanicEventType` and `EvaluationPanicEventType` events make panic-recovery paths observable.
- The evaluation loop keeps running after a panic; the rollback subscription stops because the handler's state may be inconsistent.
- `ARCHITECTURE.md` documents the new events and `SubscribeFuncStrict`.

<sup>Written for commit 9744ce51ea70dd8cbf53b02716abb1ffce6d6e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added event notifications for peer rollback-handler failures and evaluation failures, including recovered panic details and evaluation context.
  - Added strict event subscriptions that recover handler failures, report them through a callback, and stop the affected subscription to prevent further deliveries.
  - Evaluation processing now continues after recovered failures in both scheduled and manually triggered evaluations.

- **Bug Fixes**
  - Improved lock cleanup after unexpected failures, preventing the selector from remaining blocked.

- **Documentation**
  - Documented the new panic-related events and strict subscription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->