### PR TITLE
fix(koiosparity): prove pool departure from retained state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5683,9 +5683,22 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   equality leaves membership unproven and keeps the stricter classification:
   a read error, an empty set (which cannot distinguish "captured, no pools"
   from "not captured"), no ready summary, a zero count, or a disagreeing
-  count. Because `pool_stake_snapshot` is windowed while `reward_pool_input`
-  is retained for the life of the database, an epoch older than that window
-  has no membership evidence and keeps the stricter classification too.
+  count.
+
+  `pool_stake_snapshot` is windowed — `cleanupOldSnapshots` prunes it to
+  `currentEpoch - 3` — while `epoch_summary` and `reward_pool_input` are
+  retained for the life of the database, so an epoch older than that window
+  used to have no membership evidence at all and every departed pool in it
+  became a `dingo_db_missing`, which in strict mode stops the node. A Preview
+  genesis replay closes an epoch about every 25 seconds, so an observer only
+  has to run roughly 75 seconds behind the node to fall outside the window
+  permanently. `checkEpoch` therefore falls back to the same completeness
+  argument on the retained tables: a K+1 reward-input set whose size equals
+  the K+1 `epoch_summary.TotalPoolCount` accounts for every pool in that pool
+  set, so absence from it is departure. The fallback fails closed exactly like
+  the primary path — a degraded pool omitted from `reward_pool_input` while it
+  stays in the pool set leaves the counts unequal, so membership is unproven
+  and the stricter classification stands (issue #3795).
 
   The same split applies a third time to `reward_pool_input`'s stake-epoch
   fields (`delegated_stake`/`delegator_count`/`fixed_cost`/`margin`, reported

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -537,6 +537,22 @@ func checkEpoch(
 	// disagrees -- leaves membership unproven and keeps the stricter
 	// dingo_db_missing classification (dingo #3485).
 	var paramEpochPools map[string]struct{}
+	var declaredParamPools uint64
+	paramSummary, sErr := dingo.GetEpochData(ctx, paramEpoch)
+	switch {
+	case sErr != nil:
+		logger.Debug(
+			"koiosparity: could not resolve param-epoch pool count",
+			"network", network,
+			"epoch", epoch,
+			"param_epoch", paramEpoch,
+			"error", sErr,
+		)
+	case paramSummary == nil:
+		// No ready summary, so no declared count to verify against.
+	default:
+		declaredParamPools = paramSummary.TotalPoolCount
+	}
 	members, membersErr := dingo.GetPoolStakeSnapshotMembers(ctx, paramEpoch)
 	switch {
 	case membersErr != nil:
@@ -548,31 +564,54 @@ func checkEpoch(
 			"error", membersErr,
 		)
 	case len(members) == 0:
-		// Cannot distinguish "captured, no pools" from "not captured".
+		// Cannot distinguish "captured, no pools" from "not captured", and
+		// retention deletes the rows outright — see the reward-input fallback
+		// below.
+	case declaredParamPools == 0:
+		// No ready summary, or no declared count to verify against.
+	case uint64(len(members)) != declaredParamPools:
+		logger.Debug(
+			"koiosparity: param-epoch pool set is incomplete",
+			"network", network,
+			"epoch", epoch,
+			"param_epoch", paramEpoch,
+			"members", len(members),
+			"declared", declaredParamPools,
+		)
 	default:
-		paramSummary, sErr := dingo.GetEpochData(ctx, paramEpoch)
-		switch {
-		case sErr != nil:
+		paramEpochPools = members
+	}
+	// pool_stake_snapshot is pruned to currentEpoch-3 by
+	// Manager.cleanupOldSnapshots (ledger/snapshot/rotation.go), so an observer
+	// running behind the node loses that evidence for every epoch it checks
+	// and every departed pool becomes a strict-mode halt. epoch_summary and
+	// reward_pool_input are both retained for the life of the database, and
+	// the same completeness argument applies to them: a K+1 reward-input set
+	// whose size equals the K+1 summary's declared pool count accounts for
+	// every pool in that pool set, so absence from it is departure. Anything
+	// short of an exact match — a degraded pool omitted from reward_pool_input
+	// while it stays in the pool set, a skipped bundle, an unread pool map —
+	// leaves membership unproven and keeps the stricter classification
+	// (dingo #3795, preserving #3485's direction).
+	if paramEpochPools == nil && declaredParamPools > 0 && dingoPoolErr == nil {
+		paramInputs := make(map[string]struct{}, len(dingoPoolMap))
+		for keyHex, dingoPool := range dingoPoolMap {
+			if dingoPool != nil && dingoPool.ParamsPresent {
+				paramInputs[keyHex] = struct{}{}
+			}
+		}
+		if uint64(len(paramInputs)) == declaredParamPools {
+			paramEpochPools = paramInputs
+		} else {
 			logger.Debug(
-				"koiosparity: could not resolve param-epoch pool count",
+				"koiosparity: param-epoch reward-input set does not account "+
+					"for the declared pool set",
 				"network", network,
 				"epoch", epoch,
 				"param_epoch", paramEpoch,
-				"error", sErr,
+				"reward_inputs", len(paramInputs),
+				"declared", declaredParamPools,
 			)
-		case paramSummary == nil || paramSummary.TotalPoolCount == 0:
-			// No ready summary, or no declared count to verify against.
-		case uint64(len(members)) != paramSummary.TotalPoolCount:
-			logger.Debug(
-				"koiosparity: param-epoch pool set is incomplete",
-				"network", network,
-				"epoch", epoch,
-				"param_epoch", paramEpoch,
-				"members", len(members),
-				"declared", paramSummary.TotalPoolCount,
-			)
-		default:
-			paramEpochPools = members
 		}
 	}
 	if dingoPoolErr != nil {

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1560,4 +1560,22 @@ INSERT INTO reward_pool_input (
 		100,
 	)
 	require.NoError(t, err)
+	// The remaining reward_pool_input columns are NOT NULL with defaults, so
+	// the partial insert above is a complete row. Asserted rather than assumed
+	// — a fixture that silently wrote nothing would make the departure tests
+	// pass for the wrong reason.
+	var rows, params int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*), COUNT(blocks_produced) FROM reward_pool_input
+		 WHERE epoch = ?`,
+		paramEpoch,
+	).Scan(&rows, &params))
+	require.Equal(t, 1, rows, "the param-epoch reward input must exist")
+	require.Equal(t, 1, params, "with its block count populated")
+	var snapshots int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM pool_stake_snapshot WHERE epoch = ?`,
+		paramEpoch,
+	).Scan(&snapshots))
+	require.Zero(t, snapshots, "the mark rows must be gone")
 }

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -16,6 +16,7 @@ package koiosparity
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"log/slog"
 	"math/big"
@@ -1452,4 +1453,111 @@ func TestCheckIncompleteParamEpochPoolSetStillErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, mismatches, 1)
 	require.Equal(t, CategoryDBMissing, mismatches[0].Category)
+}
+
+// TestCheckDepartedPoolSurvivesSnapshotRetentionPrune covers a departure
+// checked after `pool_stake_snapshot` retention has already removed the K+1
+// mark rows. `Manager.cleanupOldSnapshots` (ledger/snapshot/rotation.go) prunes
+// that table to `currentEpoch - 3`, and a Preview genesis replay closes an
+// epoch roughly every 25 seconds, so an observer only has to run about 75
+// seconds behind the node to lose the evidence for every epoch it checks.
+//
+// Absence of the mark rows is not evidence of anything, so departure has to be
+// established from state that outlives them: `epoch_summary` and
+// `reward_pool_input` are both retained for the life of the database, and a K+1
+// reward-input set whose size matches the K+1 summary's declared pool count
+// accounts for every pool in that pool set. A pool missing from a complete set
+// left it (dingo #3795).
+func TestCheckDepartedPoolSurvivesSnapshotRetentionPrune(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	dingoDir, cachePath, _ := seedDepartureFixture(
+		t, network, koiosEpoch, false,
+	)
+	pruneParamEpochSnapshots(t, dingoDir, koiosEpoch+1)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		result.ErrorEpochs,
+		"pruned snapshots must not turn a departure into an ERROR",
+	)
+	require.Empty(t, result.FailEpochs)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryPoolDeparted, mismatches[0].Category)
+}
+
+// TestCheckIncompleteRewardInputSetStillErrorsAfterPrune is the fail-closed
+// half. With the mark rows pruned and the K+1 reward-input set short of the
+// declared pool count, some pool in that pool set has no reward-input row, so
+// absence proves nothing and the strict classification has to stand.
+func TestCheckIncompleteRewardInputSetStillErrorsAfterPrune(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	// Two pools declared at K+1, but only the one reward-input row the prune
+	// helper writes, so the set is incomplete.
+	dingoDir, cachePath, _ := seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, false, 2,
+	)
+	pruneParamEpochSnapshots(t, dingoDir, koiosEpoch+1)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Contains(t, result.ErrorEpochs, koiosEpoch)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryDBMissing, mismatches[0].Category)
+}
+
+// pruneParamEpochSnapshots reproduces what snapshot retention leaves behind at
+// paramEpoch: the mark pool_stake_snapshot rows are gone, and the durable
+// reward_pool_input row for the pool that stayed in the set remains. The
+// subject pool of the departure fixture deliberately gets no row.
+func pruneParamEpochSnapshots(
+	t *testing.T,
+	dingoDir string,
+	paramEpoch uint64,
+) {
+	t.Helper()
+	path := filepath.Join(dingoDir, "metadata.sqlite")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=journal_mode(WAL)")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+	_, err = db.Exec(
+		`DELETE FROM pool_stake_snapshot WHERE epoch = ?`,
+		paramEpoch,
+	)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+INSERT INTO reward_pool_input (
+    pool_key_hash, epoch, blocks_produced, total_blocks_in_epoch
+) VALUES (?, ?, ?, ?)`,
+		testPoolKeyHash(t, 0x0a),
+		paramEpoch,
+		3,
+		100,
+	)
+	require.NoError(t, err)
 }

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1560,10 +1560,13 @@ INSERT INTO reward_pool_input (
 		100,
 	)
 	require.NoError(t, err)
-	// The remaining reward_pool_input columns are NOT NULL with defaults, so
-	// the partial insert above is a complete row. Asserted rather than assumed
-	// — a fixture that silently wrote nothing would make the departure tests
-	// pass for the wrong reason.
+	// The omitted columns are either nullable (margin, reward_account),
+	// auto-generated (id), or NOT NULL with a default (pledge,
+	// delegated_stake, owner_stake, cost, delegator_count,
+	// reward_account_credential_tag, captured_slot, boundary_slot), so the
+	// partial insert above is a complete row. Asserted rather than assumed — a
+	// fixture that silently wrote nothing would make the departure tests pass
+	// for the wrong reason.
 	var rows, params int
 	require.NoError(t, db.QueryRow(
 		`SELECT COUNT(*), COUNT(blocks_produced) FROM reward_pool_input


### PR DESCRIPTION
Closes blinklabs-io/dingo#3795

`poolDepartedAtParamEpoch` decides whether a missing `reward_pool_input` row is
a benign departure or a real Dingo gap by looking the pool up in the K+1 mark
`pool_stake_snapshot` set. `Manager.cleanupOldSnapshots` prunes that table to
`currentEpoch - 3`, so an observer running behind the node gets an empty set,
keeps the strict classification, and reports every departed pool as
`dingo_db_missing`. In strict mode that stops the node on a divergence that is
not one.

A Preview genesis replay closes an epoch about every 25 seconds, so roughly 75
seconds of lag is enough to fall outside the window permanently.

## Observed

Preview, from genesis, `--koios-parity-strict`, observer at epoch 14 with the
node at epoch 20:

```
level=ERROR msg="koiosparity observer: epoch validation failed"
  network=preview epoch=14 error="parity ERROR at epoch 14 (1 mismatch(es))" strict=true
level=ERROR msg="fatal koios parity validation failure, initiating shutdown"

epoch 14  pool1nk3uj4fdd6d42tx26y537xaejd76u6xyrn0ql8sr4r9tullk84y
          reward_pool_input_params  dingo="" koios=present  dingo_db_missing
```

The pool sets matched exactly (44/44) and `pool_stake_snapshot` held only epochs
17-20. That pool carries a retirement certificate for epoch 14, so it left the
pool set at the K+1 boundary and its epoch-14 block count is stamped on a row
that is correctly never written — the `pool_departed` case #3485 introduced.

A second replay whose observer stayed within the retention window classified the
same pool in the same epoch as `pool_departed` and passed, which is the
mechanism confirmed from both sides.

## The fix

`epoch_summary` and `reward_pool_input` are both retained for the life of the
database and carry the same completeness argument the mark rows do: a K+1
reward-input set whose size equals the K+1 `epoch_summary.TotalPoolCount`
accounts for every pool in that pool set, so absence from it is departure.

Used only as a fallback when the snapshot path cannot establish membership, and
it fails closed the same way: a degraded active pool omitted from
`reward_pool_input` while it stays in the pool set leaves the counts unequal, so
membership is unproven and the stricter classification stands. #3485's direction
is preserved, not relaxed.

## Tests

- `TestCheckDepartedPoolSurvivesSnapshotRetentionPrune` — fails on `main`:
  with the K+1 mark rows deleted, epoch 14 goes to ERROR instead of recording
  `pool_departed`.
- `TestCheckIncompleteRewardInputSetStillErrorsAfterPrune` — the fail-closed
  half, with the reward-input set short of the declared count.
- The existing `TestCheckDegradedActivePoolStillErrors`,
  `TestCheckIncompleteParamEpochPoolSetStillErrors` and
  `TestCheckMissingRewardBundleStillErrors` still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes departed pools being reported as `dingo_db_missing` when the observer runs behind the node and `pool_stake_snapshot` retention has already pruned the K+1 membership evidence. In strict mode this stopped the node on a divergence that isn't one.

- Falls back to the same completeness argument on the retained `epoch_summary` and `reward_pool_input` tables: a K+1 reward-input set whose size equals the declared pool count accounts for every pool in that set, so absence is departure.
- Fails closed exactly like the primary path: an incomplete reward-input set leaves membership unproven and keeps the stricter classification, preserving the #3485 direction.
- Tests cover the departure-with-pruned-snapshots and fail-closed cases, and the retention fixture now asserts it wrote exactly one reward input with no mark rows.

<sup>Written for commit 3a92f49d673c4fd390502ed688db79b4c090f41f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

