### PR TITLE
chore(deps): bump gouroboros to v0.202.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.4
+	github.com/blinklabs-io/gouroboros v0.202.5
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
 	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.202.4 h1:Cn4bNUQIlAPnT68HVbrCXqxSJA+UckiYtVufIpVD/5w=
-github.com/blinklabs-io/gouroboros v0.202.4/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.5 h1:2NGWnwil3266QVc16IDbA0MIrEK6TlVB81TlDzpFUzk=
+github.com/blinklabs-io/gouroboros v0.202.5/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=

--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -6,8 +6,8 @@ toolchain go1.26.7
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
-	github.com/blinklabs-io/gouroboros v0.202.2
-	github.com/blinklabs-io/plutigo v0.4.0
+	github.com/blinklabs-io/gouroboros v0.202.5
+	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/test/antithesis/go.sum
+++ b/internal/test/antithesis/go.sum
@@ -4,12 +4,12 @@ github.com/antithesishq/antithesis-sdk-go v0.7.0 h1:uWDG8BqLD1lI2ps38WDz2vXflrTX
 github.com/antithesishq/antithesis-sdk-go v0.7.0/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8SbHbDQQkZ4=
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/gouroboros v0.202.2 h1:rb21cE7YJwpbh/fEWxC5IpSig+zdDsuZUF/T5NrjGYw=
-github.com/blinklabs-io/gouroboros v0.202.2/go.mod h1:y+bzoTL4JC1qu5m2NTERWuFl+fz6JPKBq22lQDIpjWs=
+github.com/blinklabs-io/gouroboros v0.202.5 h1:2NGWnwil3266QVc16IDbA0MIrEK6TlVB81TlDzpFUzk=
+github.com/blinklabs-io/gouroboros v0.202.5/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
-github.com/blinklabs-io/plutigo v0.4.0 h1:DVh4LtCq4Hc7Rfc5jSGD2cLK7610y8ai9F7vwW9r620=
-github.com/blinklabs-io/plutigo v0.4.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
+github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=
+github.com/blinklabs-io/plutigo v0.5.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0/go.mod h1:+K/MYXcLBtHEQjRbjHuJChuybk4LCgjdjgRwil+e+Kk=
 github.com/btcsuite/btcd/btcutil v1.2.0 h1:p3+S2g3Q+7G5NOh4Ji+2UrBOrg5Z0Q4ykzShWG1Dhgs=

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -263,6 +263,7 @@ func ValidateTxAlonzo(
 			ls,
 			tx,
 			slices.Concat(resolvedInputs, resolvedRefInputs),
+			script.StrictValidityUpperBoundForTransaction(tx),
 		)
 		if err != nil {
 			return err
@@ -414,6 +415,7 @@ func EvaluateTxAlonzo(
 			ls,
 			tx,
 			slices.Concat(resolvedInputs, resolvedRefInputs),
+			script.StrictValidityUpperBoundForTransaction(tx),
 		)
 		if err != nil {
 			return 0, lcommon.ExUnits{}, nil, err

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -281,6 +281,7 @@ func ValidateTxBabbage(
 			ls,
 			tx,
 			slices.Concat(resolvedInputs, resolvedRefInputs),
+			script.StrictValidityUpperBoundForTransaction(tx),
 		)
 		if err != nil {
 			return err
@@ -306,6 +307,7 @@ func ValidateTxBabbage(
 				ls,
 				tx,
 				slices.Concat(resolvedInputs, resolvedRefInputs),
+				script.StrictValidityUpperBoundForTransaction(tx),
 			)
 			if err != nil {
 				return err
@@ -368,6 +370,7 @@ func ValidateTxBabbage(
 				ls,
 				tx,
 				slices.Concat(resolvedInputs, resolvedRefInputs),
+				script.StrictValidityUpperBoundForTransaction(tx),
 			)
 			if err != nil {
 				return err
@@ -506,6 +509,7 @@ func EvaluateTxBabbage(
 			ls,
 			tx,
 			slices.Concat(resolvedInputs, resolvedRefInputs),
+			script.StrictValidityUpperBoundForTransaction(tx),
 		)
 		if err != nil {
 			return 0, lcommon.ExUnits{}, nil, err
@@ -532,6 +536,7 @@ func EvaluateTxBabbage(
 				ls,
 				tx,
 				slices.Concat(resolvedInputs, resolvedRefInputs),
+				script.StrictValidityUpperBoundForTransaction(tx),
 			)
 			if err != nil {
 				return 0, lcommon.ExUnits{}, nil, err
@@ -574,6 +579,7 @@ func EvaluateTxBabbage(
 				ls,
 				tx,
 				slices.Concat(resolvedInputs, resolvedRefInputs),
+				script.StrictValidityUpperBoundForTransaction(tx),
 			)
 			if err != nil {
 				return 0, lcommon.ExUnits{}, nil, err

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -1017,6 +1017,7 @@ func (c *conwayTxInfoCache) v1() (script.TxInfoV1, error) {
 			c.ls,
 			c.tx,
 			c.resolvedInputs,
+			script.StrictValidityUpperBoundForTransaction(c.tx),
 		)
 		if err != nil {
 			return script.TxInfoV1{}, conway.ScriptContextConstructionError{
@@ -1035,6 +1036,7 @@ func (c *conwayTxInfoCache) v2() (script.TxInfoV2, error) {
 			c.ls,
 			c.tx,
 			c.resolvedInputs,
+			script.StrictValidityUpperBoundForTransaction(c.tx),
 		)
 		if err != nil {
 			return script.TxInfoV2{}, conway.ScriptContextConstructionError{

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -1396,7 +1396,12 @@ func TestTxInfoV2ContextSortsInputs(t *testing.T) {
 		{Id: bodySecond, Output: newTestOutput(1_000_000)},
 	}
 
-	txInfo, err := script.NewTxInfoV2FromTransaction(ls, tx, resolved)
+	txInfo, err := script.NewTxInfoV2FromTransaction(
+		ls,
+		tx,
+		resolved,
+		script.StrictValidityUpperBoundForTransaction(tx),
+	)
 
 	require.NoError(t, err)
 	require.Len(t, txInfo.Inputs, 2)


### PR DESCRIPTION
Adopts gouroboros `v0.202.5`, which #3745 unblocked: `*LedgerView` now satisfies `common.CommitteeCredentialState`, so the fail-closed committee rule in `df65301` has a provider.

`b24cbc7` added a `strictValidityUpperBound` argument to `NewTxInfoV1FromTransaction` and `NewTxInfoV2FromTransaction`. All ten call sites in `ledger/eras/` pass `script.StrictValidityUpperBoundForTransaction(tx)`, matching gouroboros' own call sites, so the Plutus script context uses the exclusive upper bound from Conway and the closed bound before it.

`internal/test/antithesis` was pinned at `v0.202.2` and moves to `v0.202.5`, taking plutigo `v0.5.0` transitively — the root module already pins `v0.5.0`.

Pinned to `v0.202.5` deliberately, not to gouroboros `main`: `main` carries #2155, whose consumer side is #3687 and whose rule fails closed on `LedgerView.TreasuryValue()` returning `ErrNotImplemented`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `gouroboros` to v0.202.5 and adapts to its new `strictValidityUpperBound` parameter for Plutus script context construction.

- Passes `script.StrictValidityUpperBoundForTransaction(tx)` at all ten call sites in `ledger/eras/`, matching gouroboros' own usage.
- Keeps the exclusive validity upper bound for Conway transactions and the closed bound for earlier eras.
- Moves `internal/test/antithesis` from v0.202.2 to v0.202.5, which brings `plutigo` v0.5.0 transitively.
- Pins to v0.202.5 deliberately rather than gouroboros `main`, since `main` carries a fail-closed rule on `LedgerView.TreasuryValue()` that returns `ErrNotImplemented`.

<sup>Written for commit 9ffb302d867f7065a1901312e5a7d8410b25825a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

