### PR TITLE
fix(koiosparity): compare member_rewards on the rewards the ledger credits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5491,7 +5491,7 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   | `/pool_history` | derived-match | `block_cnt` | Exact value against `reward_pool_input` at parameter epoch K+1. |
   | `/pool_history` | derived-match | `fixed_cost` | Exact value against `reward_pool_input` at stake epoch K-1: a mark snapshot records the pool parameters in force for the epoch it is the basis for. |
   | `/pool_history` | derived-match | `margin` | K-1 values compared as equivalent rational numbers. |
-  | `/pool_history` | derived-match | `member_rewards` | Exact lovelace equality with aggregated `reward_pool_output.member_reward_total` at K-1. |
+  | `/pool_history` | derived-match | `member_rewards` | Exact lovelace equality with the sum of K-1 `reward_account_output` member rows the ledger credits (`spendable`, not `guarded`), falling back to `reward_pool_output.member_reward_total` only when that row's `unspendable` is zero. |
   | `/pool_history` | intentionally-incomparable | `pool_fees`, `deleg_rewards` | Koios derives these from an approximation that omits the pledge/owner-stake bonus and rounds components. |
   | `/pool_history` | unsupported | `active_stake_pct`, `saturation_pct`, `epoch_ros` | Dingo has no matching persisted pool aggregate. |
   | `/account_reward_history` | exact-match | `stake_address`, `earned_epoch` | Identifies the `(stake_address, type)` row `CompareAccountEpoch` matches on; response identity must equal the requested epoch. |
@@ -5635,13 +5635,31 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   `pool_fees` from `fixed_cost`+`margin` alone, omitting the pledge/owner-stake
   bonus the Shelley ledger spec folds into the true leader reward, so it
   systematically diverges from Dingo's exact value for any pool with owner
-  stake. `member_rewards` has no such approximation (it's a direct sum of
-  per-delegator reward amounts) and is compared 1:1 against
-  `reward_pool_output.member_reward_total` — but only once
-  `DingoPoolEpochData.MemberRewardPresent` is true. An absent
-  `reward_pool_output` row is never treated as "nothing to compare": within
-  `--grace-hours` of the epoch closing it is `reference_lag` (reward
-  calculation may simply not have finished yet); past that window it is
+  stake. `member_rewards` has no such approximation — it is a direct sum of
+  per-delegator reward amounts — but the Dingo side of it is deliberately not
+  `reward_pool_output.member_reward_total`. `Result.addReward`
+  (`ledger/rewards/rewards.go`) accumulates that column from every member
+  reward the calculation produced, spendable or not, while Koios reports what
+  members actually received, so the two differ by exactly the pool's
+  unspendable member rewards and any pool holding one failed against a node
+  that was right (issue #3797). The row's own `unspendable` column is not a
+  usable correction, since it accumulates unspendable *leader* rewards too.
+
+  The comparable quantity is the sum over the stake epoch's
+  `reward_account_output` member rows that the ledger credits — `spendable`
+  set and `guarded` clear, the same pair `applyStakeRewards` tests before
+  calling `AddAccountRewardByCredential`. `cleanupOldSnapshots` retains
+  `reward_account_output` without bound only in `api` storage mode, so those
+  rows can be absent; the comparison then falls back to
+  `member_reward_total`, but only when `unspendable` is zero, where nothing was
+  withheld and the pool's member total is its spendable member total by
+  construction. With rows absent and something withheld the quantities provably
+  differ, and the field is reported as missing rather than compared on the wrong
+  basis.
+
+  An absent `reward_pool_output` row is never treated as "nothing to compare"
+  either: within `--grace-hours` of the epoch closing it is `reference_lag`
+  (reward calculation may simply not have finished yet); past that window it is
   `dingo_db_missing` (a genuine gap in Dingo's own computation). Both are
   `ERROR`, never a silent `PASS`. `ComparePoolEpoch` applies the identical
   presence/grace split to `reward_pool_input`'s param-epoch field

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -510,10 +510,20 @@ func ComparePoolEpoch(
 		}
 	}
 
-	// member_rewards — reward_pool_output.member_reward_total vs Koios
-	// pool_history.member_rewards. Both are a direct sum of per-delegator
-	// reward amounts (excluding the pool operator's own leader/margin cut),
-	// so, unlike pool_fees/deleg_rewards below, this is safe to compare 1:1.
+	// member_rewards — Dingo's spendable member reward sum vs Koios
+	// pool_history.member_rewards. Both are a direct sum of the per-delegator
+	// reward amounts actually credited (excluding the pool operator's own
+	// leader/margin cut), so, unlike pool_fees/deleg_rewards below, this is
+	// safe to compare 1:1.
+	//
+	// reward_pool_output.member_reward_total is deliberately not the Dingo
+	// side of this comparison. It sums every member reward the calculation
+	// produced, spendable or not, so it exceeds Koios's figure by exactly the
+	// pool's unspendable member rewards — amounts computed for a credential
+	// the ledger correctly never credits. Comparing it reported a
+	// value_mismatch for any pool holding one, against a node that was right
+	// (dingo #3797). The row's own unspendable column is not a usable
+	// correction either, since it accumulates unspendable leader rewards too.
 	//
 	// pool_fees and deleg_rewards are intentionally NOT compared against
 	// Dingo's LeaderReward/TotalReward: Koios's grest.get_pool_history_data_bulk
@@ -535,7 +545,18 @@ func ComparePoolEpoch(
 	// (dingo_db_missing, ERROR). Neither case can produce a PASS.
 	if koiosPool.MemberRewards != "" {
 		switch {
-		case !dingoPool.MemberRewardPresent:
+		case !dingoPool.MemberRewardPresent,
+			!dingoPool.SpendableMemberRewardPresent &&
+				dingoPool.PoolUnspendable > 0:
+			// Either the reward calculation has not produced a
+			// reward_pool_output row for this pool/epoch, or it has and the
+			// per-account rows the comparable sum is formed from are gone
+			// while the row says something was withheld — so the two
+			// quantities provably differ and the comparison cannot be formed.
+			// Neither may read as a pass: within the grace window it may
+			// simply not be computed yet (reference_lag, ERROR); past it, it
+			// is a genuine gap in what Dingo can answer (dingo_db_missing,
+			// ERROR).
 			cat := CategoryDBMissing
 			if graceHours > 0 && !epochEndTime.IsZero() &&
 				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour {
@@ -551,17 +572,27 @@ func ComparePoolEpoch(
 				Category:   cat,
 				CheckedAt:  now,
 			})
-		case dingoPool.MemberRewardTotal != koiosPool.MemberRewards:
-			out = append(out, CheckMismatch{
-				Network:    network,
-				Epoch:      epoch,
-				PoolBech32: koiosPool.PoolBech32,
-				Field:      "member_rewards",
-				DingoValue: dingoPool.MemberRewardTotal,
-				KoiosValue: koiosPool.MemberRewards,
-				Category:   CategoryValueMismatch,
-				CheckedAt:  now,
-			})
+		default:
+			// Prefer the per-account sum. Falling back to the pool total is
+			// only sound because PoolUnspendable is zero on this branch:
+			// nothing was withheld, so the pool's member total is its
+			// spendable member total by construction.
+			dingoValue := dingoPool.SpendableMemberRewardTotal
+			if !dingoPool.SpendableMemberRewardPresent {
+				dingoValue = dingoPool.MemberRewardTotal
+			}
+			if dingoValue != koiosPool.MemberRewards {
+				out = append(out, CheckMismatch{
+					Network:    network,
+					Epoch:      epoch,
+					PoolBech32: koiosPool.PoolBech32,
+					Field:      "member_rewards",
+					DingoValue: dingoValue,
+					KoiosValue: koiosPool.MemberRewards,
+					Category:   CategoryValueMismatch,
+					CheckedAt:  now,
+				})
+			}
 		}
 	}
 

--- a/internal/koiosparity/compare_test.go
+++ b/internal/koiosparity/compare_test.go
@@ -895,3 +895,103 @@ func TestComparePoolEpochDepartedRequiresStakeEpochRow(t *testing.T) {
 	}
 	require.Equal(t, StatusError, DetermineStatus(ms))
 }
+
+// TestComparePoolEpochMemberRewardsExcludesUnspendable pins the quantity
+// member_rewards is compared on. Koios reports the rewards members actually
+// received; reward_pool_output.member_reward_total sums every member reward the
+// calculation produced, spendable or not. A pool with an unspendable member
+// reward — one computed for a credential the ledger correctly never credits —
+// used to fail against a node that was right (dingo #3797).
+func TestComparePoolEpochMemberRewardsExcludesUnspendable(t *testing.T) {
+	now := time.Now()
+	koios := &KoiosPoolEpoch{
+		PoolBech32:    "pool1test",
+		ActiveStake:   "1000",
+		BlockCnt:      2,
+		Delegators:    3,
+		FixedCost:     "340000000",
+		Margin:        "0.1",
+		MemberRewards: "327005332",
+	}
+	// The shape observed on Preview epoch 18: six spendable member rewards
+	// summing to Koios's figure, plus one unspendable 71328 the pool total
+	// still carries.
+	dingo := &DingoPoolEpochData{
+		StakePresent:                 true,
+		DelegatedStake:               "1000",
+		ParamsPresent:                true,
+		BlocksProduced:               2,
+		DelegatorCount:               3,
+		FixedCost:                    "340000000",
+		Margin:                       "1/10",
+		MemberRewardPresent:          true,
+		MemberRewardTotal:            "327076660",
+		SpendableMemberRewardPresent: true,
+		SpendableMemberRewardTotal:   "327005332",
+	}
+	require.Empty(t, ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, false,
+	), "an unspendable member reward is not a divergence")
+
+	// A real disagreement in the spendable sum still fails, and reports the
+	// spendable figure rather than the pool total.
+	dingo.SpendableMemberRewardTotal = "327005333"
+	ms := ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, false,
+	)
+	require.Len(t, ms, 1)
+	require.Equal(t, "member_rewards", ms[0].Field)
+	require.Equal(t, CategoryValueMismatch, ms[0].Category)
+	require.Equal(t, "327005333", ms[0].DingoValue)
+}
+
+// TestComparePoolEpochMemberRewardsWithoutAccountOutputs covers a node whose
+// reward_account_output rows for the epoch are gone — cleanupOldSnapshots
+// retains them without bound only in api storage mode.
+//
+// Falling back to reward_pool_output.member_reward_total is sound exactly when
+// the row says nothing was withheld, because the pool's member total is then
+// its spendable member total by construction. When something was withheld the
+// two provably differ, so the field is reported as a missing row rather than
+// compared on a basis that would fail a correct ledger.
+func TestComparePoolEpochMemberRewardsWithoutAccountOutputs(t *testing.T) {
+	now := time.Now()
+	koios := &KoiosPoolEpoch{
+		PoolBech32:    "pool1test",
+		ActiveStake:   "1000",
+		BlockCnt:      2,
+		Delegators:    3,
+		FixedCost:     "340000000",
+		Margin:        "0.1",
+		MemberRewards: "327005332",
+	}
+	dingo := &DingoPoolEpochData{
+		StakePresent:                 true,
+		DelegatedStake:               "1000",
+		ParamsPresent:                true,
+		BlocksProduced:               2,
+		DelegatorCount:               3,
+		FixedCost:                    "340000000",
+		Margin:                       "1/10",
+		MemberRewardPresent:          true,
+		MemberRewardTotal:            "327005332",
+		SpendableMemberRewardPresent: false,
+		PoolUnspendable:              0,
+	}
+	require.Empty(t, ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, false,
+	), "with nothing withheld the pool total is the spendable total")
+
+	// The same missing rows, but the pool withheld something, so the pool
+	// total is known to overstate what members received.
+	dingo.PoolUnspendable = 71328
+	dingo.MemberRewardTotal = "327076660"
+	ms := ComparePoolEpoch(
+		"preview", 5, koios, dingo, now, 0, time.Time{}, false,
+	)
+	require.Len(t, ms, 1,
+		"an unformable comparison must not read as a pass")
+	require.Equal(t, "member_rewards", ms[0].Field)
+	require.Equal(t, CategoryDBMissing, ms[0].Category)
+	require.Equal(t, StatusError, DetermineStatus(ms))
+}

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -516,7 +516,8 @@ func (d *DingoDB) GetPoolEpochDataMap(
 // The predicate matches what the ledger actually credits: applyStakeRewards
 // (ledger/reward_calculation.go) skips a reward that is not spendable and one
 // whose reward account is guarded by CIP-0163 expiry, so both are excluded
-// here.
+// from the sum — but not from the presence test, which asks only whether the
+// epoch's rows survive at all.
 //
 // The rows are summed in Go rather than by the database: amount is a decimal
 // TEXT column, and the cast a portable SUM would need differs across the three
@@ -533,12 +534,17 @@ func (d *DingoDB) addSpendableMemberRewards(
 	m map[string]*DingoPoolEpochData,
 	stakeEpoch uint64,
 ) error {
+	// Every row for the epoch is read and filtered here rather than in the
+	// WHERE clause, so presence means "the epoch's per-account rows exist"
+	// exactly as it does in DatabaseSource.GetPoolEpochDataMap. Filtering in
+	// SQL would make an epoch holding only leader or only withheld rows look
+	// like a pruned epoch in one implementation and a populated one in the
+	// other, and the two must not be able to disagree.
 	rows, err := d.query(
 		ctx,
-		`SELECT pool_key_hash, amount FROM reward_account_output
-WHERE epoch = ? AND reward_type = ? AND spendable = TRUE AND guarded = FALSE`,
+		`SELECT pool_key_hash, reward_type, amount, spendable, guarded
+FROM reward_account_output WHERE epoch = ?`,
 		stakeEpoch,
-		rewardTypeMember,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -552,11 +558,18 @@ WHERE epoch = ? AND reward_type = ? AND spendable = TRUE AND guarded = FALSE`,
 	any := false
 	for rows.Next() {
 		var poolHash []byte
+		var rewardType string
 		var amount types.Uint64
-		if err := rows.Scan(&poolHash, &amount); err != nil {
+		var spendable, guarded bool
+		if err := rows.Scan(
+			&poolHash, &rewardType, &amount, &spendable, &guarded,
+		); err != nil {
 			return err
 		}
 		any = true
+		if rewardType != rewardTypeMember || !spendable || guarded {
+			continue
+		}
 		totals[hex.EncodeToString(poolHash)] += uint64(amount)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -144,7 +144,45 @@ type DingoPoolEpochData struct {
 	// stakeRewardEpochsForNewEpoch: both are read/written at
 	// epochs.snapshot).
 	MemberRewardTotal string
+	// PoolUnspendable is reward_pool_output.unspendable at the stake epoch:
+	// every reward the calculation attributed to this pool and the ledger
+	// then withheld, member and leader alike. Zero is the case that makes
+	// MemberRewardTotal usable as the comparable quantity on its own — with
+	// nothing withheld, the pool's member total is its spendable member total
+	// by construction.
+	PoolUnspendable uint64
+
+	// SpendableMemberRewardPresent reports that reward_account_output rows
+	// exist for the stake epoch at all, which is what makes a per-pool
+	// spendable sum meaningful: a pool with no rows then genuinely earned no
+	// spendable member reward, rather than the table having been pruned out
+	// from under the read (cleanupOldSnapshots retains reward_account_output
+	// without bound only in api storage mode).
+	SpendableMemberRewardPresent bool
+	// SpendableMemberRewardTotal is the sum of reward_account_output.amount
+	// over the stake epoch's member rows the ledger actually credits —
+	// spendable and not guarded by CIP-0163 expiry, the same pair
+	// applyStakeRewards tests before crediting — which is the quantity Koios
+	// pool_history.member_rewards reports.
+	//
+	// reward_pool_output.member_reward_total is deliberately not that
+	// quantity: Result.addReward (ledger/rewards/rewards.go) accumulates it
+	// from every member reward the calculation produced, spendable or not, so
+	// the two differ by exactly the pool's unspendable member rewards — a
+	// reward computed for a credential the ledger correctly never credits.
+	// Comparing it against Koios reported a value_mismatch for any pool
+	// holding one, against a ledger that was right (dingo #3797).
+	//
+	// Subtracting reward_pool_output.unspendable from member_reward_total
+	// would not be equivalent: that column accumulates unspendable leader
+	// rewards too.
+	SpendableMemberRewardTotal string
 }
+
+// rewardTypeMember is the reward_account_output.reward_type value Dingo writes
+// for a delegator's share of a pool reward, as opposed to the operator's
+// "leader" row. Matches Koios /account_reward_history's own "member" type.
+const rewardTypeMember = "member"
 
 // DingoDB reads reward state directly from Dingo's metadata database.
 // It supports all three backends Dingo supports: SQLite, PostgreSQL, MySQL.
@@ -432,7 +470,7 @@ func (d *DingoDB) GetPoolEpochDataMap(
 
 	rows, err = d.query(
 		ctx,
-		`SELECT pool_key_hash, member_reward_total FROM reward_pool_output WHERE epoch = ?`,
+		`SELECT pool_key_hash, member_reward_total, unspendable FROM reward_pool_output WHERE epoch = ?`,
 		stakeEpoch,
 	)
 	if err != nil {
@@ -446,7 +484,8 @@ func (d *DingoDB) GetPoolEpochDataMap(
 	for rows.Next() {
 		var poolHash []byte
 		var reward types.Uint64
-		if err := rows.Scan(&poolHash, &reward); err != nil {
+		var unspendable types.Uint64
+		if err := rows.Scan(&poolHash, &reward, &unspendable); err != nil {
 			return nil, err
 		}
 		key := hex.EncodeToString(poolHash)
@@ -457,8 +496,90 @@ func (d *DingoDB) GetPoolEpochDataMap(
 		}
 		data.MemberRewardPresent = true
 		data.MemberRewardTotal = strconv.FormatUint(uint64(reward), 10)
+		data.PoolUnspendable = uint64(unspendable)
 	}
-	return m, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := d.addSpendableMemberRewards(ctx, m, stakeEpoch); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// addSpendableMemberRewards fills SpendableMemberRewardTotal/Present from the
+// stake epoch's reward_account_output rows — the sum Koios
+// pool_history.member_rewards reports, which reward_pool_output's own
+// member_reward_total is not (see DingoPoolEpochData).
+//
+// The predicate matches what the ledger actually credits: applyStakeRewards
+// (ledger/reward_calculation.go) skips a reward that is not spendable and one
+// whose reward account is guarded by CIP-0163 expiry, so both are excluded
+// here.
+//
+// The rows are summed in Go rather than by the database: amount is a decimal
+// TEXT column, and the cast a portable SUM would need differs across the three
+// backends DingoDB supports. Preview and preprod produce on the order of a
+// hundred rows per epoch, and the observer only runs on those two networks.
+//
+// Presence is epoch-level. A pool with no spendable member row legitimately
+// earned nothing, but only if the table holds the epoch at all —
+// cleanupOldSnapshots retains reward_account_output without bound in api
+// storage mode and prunes it in core, so an empty read must not be reported as
+// a pool-wide zero.
+func (d *DingoDB) addSpendableMemberRewards(
+	ctx context.Context,
+	m map[string]*DingoPoolEpochData,
+	stakeEpoch uint64,
+) error {
+	rows, err := d.query(
+		ctx,
+		`SELECT pool_key_hash, amount FROM reward_account_output
+WHERE epoch = ? AND reward_type = ? AND spendable = TRUE AND guarded = FALSE`,
+		stakeEpoch,
+		rewardTypeMember,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"reward_account_output epoch %d: %w",
+			stakeEpoch,
+			err,
+		)
+	}
+	defer rows.Close()
+	totals := make(map[string]uint64)
+	any := false
+	for rows.Next() {
+		var poolHash []byte
+		var amount types.Uint64
+		if err := rows.Scan(&poolHash, &amount); err != nil {
+			return err
+		}
+		any = true
+		totals[hex.EncodeToString(poolHash)] += uint64(amount)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if !any {
+		return nil
+	}
+	for key, total := range totals {
+		data, ok := m[key]
+		if !ok {
+			data = &DingoPoolEpochData{}
+			m[key] = data
+		}
+		data.SpendableMemberRewardTotal = strconv.FormatUint(total, 10)
+	}
+	for _, data := range m {
+		data.SpendableMemberRewardPresent = true
+		if data.SpendableMemberRewardTotal == "" {
+			data.SpendableMemberRewardTotal = "0"
+		}
+	}
+	return nil
 }
 
 func (d *DingoDB) query(

--- a/internal/koiosparity/dingo_db_test.go
+++ b/internal/koiosparity/dingo_db_test.go
@@ -466,6 +466,23 @@ func TestGetPoolEpochDataMapSpendableMemberPresenceIsEpochWide(t *testing.T) {
 		Spendable:   false,
 	}).Error)
 
+	// A second pool in the same epoch with no reward_account_output rows of
+	// its own. "Epoch-wide" means it is answerable too, at zero — a per-pool
+	// presence rule would report it as pruned and turn a correct zero into a
+	// dingo_db_missing ERROR.
+	quiet := testPoolKeyHash(t, 0x04)
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    quiet,
+		DelegatedStake: types.Uint64(1_000),
+		DelegatorCount: 1,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
+		Epoch:             stakeEpoch,
+		PoolKeyHash:       quiet,
+		MemberRewardTotal: types.Uint64(0),
+	}).Error)
+
 	m, err := db.GetPoolEpochDataMap(
 		context.Background(), stakeEpoch, paramEpoch,
 	)
@@ -477,6 +494,12 @@ func TestGetPoolEpochDataMapSpendableMemberPresenceIsEpochWide(t *testing.T) {
 	assert.Equal(t, "0", data.SpendableMemberRewardTotal,
 		"nothing was credited to a member")
 	assert.Equal(t, uint64(77), data.PoolUnspendable)
+
+	quietData := m[hex.EncodeToString(quiet)]
+	require.NotNil(t, quietData)
+	assert.True(t, quietData.SpendableMemberRewardPresent,
+		"presence is a property of the epoch, not of the pool")
+	assert.Equal(t, "0", quietData.SpendableMemberRewardTotal)
 }
 
 // TestGetPoolEpochDataMapSpendableMemberAbsentWhenEpochPruned is the other

--- a/internal/koiosparity/dingo_db_test.go
+++ b/internal/koiosparity/dingo_db_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -418,4 +419,93 @@ func TestGetPoolEpochDataMapTracksChangingPoolParams(t *testing.T) {
 		data.BlocksProduced,
 		"blocks_produced still comes from the param epoch",
 	)
+}
+
+// TestGetPoolEpochDataMapSpendableMemberPresenceIsEpochWide pins what
+// SpendableMemberRewardPresent means, which the two RewardParitySource
+// implementations must not be able to disagree about. It reports whether the
+// epoch's reward_account_output rows survive at all — cleanupOldSnapshots
+// retains them without bound only in api storage mode — not whether any of
+// them is a credited member reward. An epoch holding only a leader reward and a
+// withheld member reward is a populated epoch whose spendable member total is
+// genuinely zero, and reporting that as a pruned epoch would turn a correct
+// zero into a dingo_db_missing ERROR.
+func TestGetPoolEpochDataMapSpendableMemberPresenceIsEpochWide(t *testing.T) {
+	const stakeEpoch, paramEpoch = uint64(9), uint64(11)
+	db, gdb := openTestDingoDB(t)
+	pool := testPoolKeyHash(t, 0x01)
+
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    pool,
+		DelegatedStake: types.Uint64(1_000),
+		DelegatorCount: 1,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
+		Epoch:             stakeEpoch,
+		PoolKeyHash:       pool,
+		MemberRewardTotal: types.Uint64(77),
+		Unspendable:       types.Uint64(77),
+	}).Error)
+	// A leader reward and a withheld member reward: rows exist, nothing was
+	// credited to a member.
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch:       stakeEpoch,
+		PoolKeyHash: pool,
+		StakingKey:  testPoolKeyHash(t, 0x02),
+		RewardType:  "leader",
+		Amount:      types.Uint64(500),
+		Spendable:   true,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardAccountOutput{
+		Epoch:       stakeEpoch,
+		PoolKeyHash: pool,
+		StakingKey:  testPoolKeyHash(t, 0x03),
+		RewardType:  "member",
+		Amount:      types.Uint64(77),
+		Spendable:   false,
+	}).Error)
+
+	m, err := db.GetPoolEpochDataMap(
+		context.Background(), stakeEpoch, paramEpoch,
+	)
+	require.NoError(t, err)
+	data := m[hex.EncodeToString(pool)]
+	require.NotNil(t, data)
+	assert.True(t, data.SpendableMemberRewardPresent,
+		"rows exist for the epoch, so the sum is answerable")
+	assert.Equal(t, "0", data.SpendableMemberRewardTotal,
+		"nothing was credited to a member")
+	assert.Equal(t, uint64(77), data.PoolUnspendable)
+}
+
+// TestGetPoolEpochDataMapSpendableMemberAbsentWhenEpochPruned is the other
+// side: with no reward_account_output rows for the epoch at all, the sum cannot
+// be formed and presence must stay false so ComparePoolEpoch falls back to the
+// pool total only where that is provably equal.
+func TestGetPoolEpochDataMapSpendableMemberAbsentWhenEpochPruned(t *testing.T) {
+	const stakeEpoch, paramEpoch = uint64(9), uint64(11)
+	db, gdb := openTestDingoDB(t)
+	pool := testPoolKeyHash(t, 0x01)
+
+	require.NoError(t, gdb.Create(&models.RewardPoolInput{
+		Epoch:          stakeEpoch,
+		PoolKeyHash:    pool,
+		DelegatedStake: types.Uint64(1_000),
+		DelegatorCount: 1,
+	}).Error)
+	require.NoError(t, gdb.Create(&models.RewardPoolOutput{
+		Epoch:             stakeEpoch,
+		PoolKeyHash:       pool,
+		MemberRewardTotal: types.Uint64(500),
+	}).Error)
+
+	m, err := db.GetPoolEpochDataMap(
+		context.Background(), stakeEpoch, paramEpoch,
+	)
+	require.NoError(t, err)
+	data := m[hex.EncodeToString(pool)]
+	require.NotNil(t, data)
+	assert.False(t, data.SpendableMemberRewardPresent)
+	assert.Equal(t, "500", data.MemberRewardTotal)
 }

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -331,6 +331,52 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 			uint64(out.MemberRewardTotal),
 			10,
 		)
+		data.PoolUnspendable = uint64(out.Unspendable)
+	}
+
+	// The comparable member-reward quantity, formed the same way DingoDB
+	// forms it — see DingoDB.addSpendableMemberRewards for why
+	// reward_pool_output.member_reward_total is not it, and why presence is
+	// established epoch-wide rather than per pool.
+	accountOutputs, err := meta.GetRewardAccountOutputs(
+		stakeEpoch,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reward_account_output epoch %d: %w",
+			stakeEpoch,
+			err,
+		)
+	}
+	if len(accountOutputs) > 0 {
+		totals := make(map[string]uint64, len(m))
+		for _, out := range accountOutputs {
+			if out == nil || out.RewardType != rewardTypeMember {
+				continue
+			}
+			// applyStakeRewards credits a reward only when it is spendable
+			// and not guarded by CIP-0163 expiry; anything else was computed
+			// and withheld, and Koios never reports it.
+			if !out.Spendable || out.Guarded {
+				continue
+			}
+			totals[hex.EncodeToString(out.PoolKeyHash)] += uint64(out.Amount)
+		}
+		for key, total := range totals {
+			data, ok := m[key]
+			if !ok {
+				data = &DingoPoolEpochData{}
+				m[key] = data
+			}
+			data.SpendableMemberRewardTotal = strconv.FormatUint(total, 10)
+		}
+		for _, data := range m {
+			data.SpendableMemberRewardPresent = true
+			if data.SpendableMemberRewardTotal == "" {
+				data.SpendableMemberRewardTotal = "0"
+			}
+		}
 	}
 	return m, nil
 }


### PR DESCRIPTION
Closes blinklabs-io/dingo#3797

`ComparePoolEpoch` compared Koios `pool_history.member_rewards` against
`reward_pool_output.member_reward_total`. Koios reports what members actually
received; that column sums every member reward the calculation produced,
spendable or not. The two differ by exactly the pool's unspendable member
rewards, so any pool holding one reported a `value_mismatch` against a node that
was right.

## How it was found

A Preview genesis replay with the parity observer, epoch 18:

```
pool18pn6p9ef58u4ga3wagp44qhzm8f6zncl57g6qgh0pk3yytwz54h
member_rewards   dingo 327076660   koios 327005332   value_mismatch
```

Dingo's own per-account rows account for the difference exactly:

```
leader | spendable | 1 |   407574413
member | withheld  | 1 |       71328
member | spendable | 6 |   327005332
```

The withheld row belongs to
`stake_test17zhxa3demmvdm0sapsd2aa5g20jza78tyu93dhutujr5wvgtfxxtv`, a script
stake credential whose account is `active = 0`. Dingo withheld it correctly —
`reward = 0`, no `account_reward_delta` row — which is what cardano-ledger does.

## The fix

The comparable quantity is the sum over the stake epoch's
`reward_account_output` member rows the ledger actually credits: `spendable` set
and `guarded` clear, the same pair `applyStakeRewards` tests before calling
`AddAccountRewardByCredential`.

`cleanupOldSnapshots` retains `reward_account_output` without bound only in
`api` storage mode, so those rows can be absent. The comparison then falls back
to `member_reward_total`, but only when `reward_pool_output.unspendable` is
zero — nothing was withheld, so the pool's member total is its spendable member
total by construction. With the rows absent and something withheld the two
provably differ, and the field is reported as a missing row rather than compared
on a basis that fails a correct ledger.

Subtracting `unspendable` from `member_reward_total` is not a substitute:
`Result.addReward` accumulates that column from unspendable *leader* rewards
too, so it over-corrects for any pool whose own reward account is unspendable.

## Tests

- `TestComparePoolEpochMemberRewardsExcludesUnspendable` — fails on `main`,
  using the epoch-18 shape: an unspendable member reward is not a divergence,
  and a real disagreement in the spendable sum still fails and reports the
  spendable figure.
- `TestComparePoolEpochMemberRewardsWithoutAccountOutputs` — both halves of the
  fallback, with and without something withheld.
- Every existing comparison and check test passes unchanged, which is the
  point of scoping the fallback to the provably-equal case rather than
  requiring per-account rows everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `koios-parity`'s `member_rewards` comparison to check the rewards the ledger actually credits instead of `reward_pool_output.member_reward_total`, which includes unspendable member rewards. Pools with such rewards no longer report `value_mismatch` against a correct node (closes #3797).

**Behavior**
- Compares the sum of `reward_account_output` member rows that are `spendable` and not `guarded`, matching `applyStakeRewards`.
- Falls back to the pool total only when `unspendable` is zero; if those rows are absent and something was withheld, the field is reported as missing instead.
- Does not subtract `unspendable` from the pool total, since that column also includes unspendable leader rewards.
- Both data sources treat presence as epoch-wide: if any row exists, every pool in the epoch is answerable, so a pool with no rows reads as a genuine zero rather than a pruned table.

**Tests and docs**
- Adds tests for the Preview epoch-18 case, missing rows, and epoch-wide presence with a pool that has no rows.
- Updates `ARCHITECTURE.md` with the new comparison basis and fallback rule.

<sup>Written for commit 10c232f382448ab6e4b8659563115ef473161d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

