### PR TITLE
feat(koiosparity): cache the Koios account universe across epochs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6003,10 +6003,12 @@ never the reverse.
   account that earned a reward in a closed epoch registered before that epoch
   ended, so a later crawl is complete for it, while an earlier one may be
   missing an account and a short universe silently skips accounts. An epoch
-  carrying no end time falls back to `accountUniverseMaxAge`. Whether a crawl is
-  cached at all is recorded in `koios_account_universe_state` rather than
-  inferred from the address rows, so a network whose `/account_list` is
-  legitimately empty still has a reusable crawl. A refresh that
+  carrying no end time is not reused against at all — there is no bound to
+  measure the crawl by, and a universe short one account skips it silently — so
+  it re-crawls. Whether a crawl is cached at all is recorded in
+  `koios_account_universe_state` rather than inferred from the address rows, so
+  a network whose `/account_list` is legitimately empty still has a reusable
+  crawl. A refresh that
   fails is an error rather than a fallback to the stale set, for the same
   reason. `GetAllAccountAddressesWithProgress` logs a line every 50 pages so a
   long crawl is distinguishable from a stalled one; the logger is a parameter

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5991,6 +5991,24 @@ never the reverse.
   `nil` (the standalone CLI's `fetch` invoked without `--metadata-*`
   configured for accounts) — the universe then falls back to Koios's list
   alone.
+
+  The Koios half is cached in `koios_account_universe`, keyed by network, and
+  reused across epochs by `ResolveKoiosAccountUniverseCached`. The crawl is 304
+  sequential `/account_list` requests for Preview's 303k accounts, and the
+  in-process observer resolves the universe once per epoch rather than once per
+  run, so paying it every epoch left the observer falling monotonically behind
+  a node that closes a Preview epoch about every 25 seconds — never recovering,
+  and silent while it happened (issue #3796). A cached crawl is reused only
+  when it was taken no earlier than the end of the epoch being checked: an
+  account that earned a reward in a closed epoch registered before that epoch
+  ended, so a later crawl is complete for it, while an earlier one may be
+  missing an account and a short universe silently skips accounts. An epoch
+  carrying no end time falls back to `accountUniverseMaxAge`. A refresh that
+  fails is an error rather than a fallback to the stale set, for the same
+  reason. `GetAllAccountAddressesWithProgress` logs a line every 50 pages so a
+  long crawl is distinguishable from a stalled one; the logger is a parameter
+  rather than a client field because the same client serves the concurrent
+  chunk fetchers.
 - **Koios endpoint.** `/account_rewards` is deprecated; `/account_reward_
   history` is the replacement (`KoiosClient.GetAccountRewardHistory`), taking
   the same `stake_addresses_with_epoch_no` POST body shape via a new `post()`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6003,7 +6003,10 @@ never the reverse.
   account that earned a reward in a closed epoch registered before that epoch
   ended, so a later crawl is complete for it, while an earlier one may be
   missing an account and a short universe silently skips accounts. An epoch
-  carrying no end time falls back to `accountUniverseMaxAge`. A refresh that
+  carrying no end time falls back to `accountUniverseMaxAge`. Whether a crawl is
+  cached at all is recorded in `koios_account_universe_state` rather than
+  inferred from the address rows, so a network whose `/account_list` is
+  legitimately empty still has a reusable crawl. A refresh that
   fails is an error rather than a fallback to the stale set, for the same
   reason. `GetAllAccountAddressesWithProgress` logs a line every 50 pages so a
   long crawl is distinguishable from a stalled one; the logger is a parameter

--- a/internal/koiosparity/account_universe_cache_test.go
+++ b/internal/koiosparity/account_universe_cache_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAccountListServer serves a one-page /account_list and counts the requests
+// it answers, so a test can assert how many times the universe was crawled.
+func newAccountListServer(
+	t *testing.T,
+	calls *atomic.Int32,
+	addrs ...string,
+) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/account_list" {
+				http.NotFound(w, r)
+				return
+			}
+			calls.Add(1)
+			var sb strings.Builder
+			sb.WriteByte('[')
+			for i, addr := range addrs {
+				if i > 0 {
+					sb.WriteByte(',')
+				}
+				fmt.Fprintf(&sb, `{"stake_address":%q}`, addr)
+			}
+			sb.WriteByte(']')
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(sb.String()))
+		}),
+	)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newUniverseTestClient(srv *httptest.Server) *KoiosClient {
+	return &KoiosClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+		limiter: newBurstLimiter(0, koiosBurstWindow),
+	}
+}
+
+// TestResolveKoiosAccountUniverseCachedReusesCrawlAcrossEpochs is the point of
+// the cache. The crawl is 304 sequential /account_list requests on Preview, and
+// paying it once per epoch is why the in-process observer could not keep pace
+// with a syncing node (dingo #3796). A second epoch whose end time the cached
+// crawl already covers must not touch Koios again.
+func TestResolveKoiosAccountUniverseCachedReusesCrawlAcrossEpochs(t *testing.T) {
+	var calls atomic.Int32
+	srv := newAccountListServer(t, &calls, "stake_test1a", "stake_test1b")
+	koios := newUniverseTestClient(srv)
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	epochEnd := time.Now().Add(-time.Hour)
+	logger := slog.New(slog.DiscardHandler)
+
+	first, err := ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview", epochEnd, logger,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stake_test1a", "stake_test1b"}, first)
+	require.Equal(t, int32(1), calls.Load())
+
+	// A later epoch that also ended before the crawl is fully covered by it.
+	second, err := ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview",
+		epochEnd.Add(30*time.Minute), logger,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, int32(1), calls.Load(),
+		"a cached crawl covering the epoch must not be re-fetched")
+
+	// Control: the uncached resolver the observer used to call directly does
+	// crawl again, so the counter above is measuring what it claims to.
+	_, err = ResolveKoiosAccountUniverse(context.Background(), koios)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+// TestResolveKoiosAccountUniverseCachedRefreshesForNewerEpoch is the other
+// half. An account that earned a reward in an epoch registered before that
+// epoch ended, so a crawl taken before the epoch closed may be missing one and
+// cannot be reused — a short universe silently skips accounts, which reads as
+// a pass.
+func TestResolveKoiosAccountUniverseCachedRefreshesForNewerEpoch(t *testing.T) {
+	var calls atomic.Int32
+	srv := newAccountListServer(t, &calls, "stake_test1a")
+	koios := newUniverseTestClient(srv)
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	logger := slog.New(slog.DiscardHandler)
+	_, err = ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview",
+		time.Now().Add(-time.Hour), logger,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), calls.Load())
+
+	// An epoch that closed after the crawl was taken.
+	_, err = ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview",
+		time.Now().Add(time.Hour), logger,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load(),
+		"a crawl older than the epoch's close must be refreshed")
+}
+
+// TestAccountUniverseCacheRoundTrip pins the storage contract the resolver
+// relies on: a save replaces the previous set wholesale rather than merging
+// into it, so a shrinking universe cannot leave a stale address behind.
+func TestAccountUniverseCacheRoundTrip(t *testing.T) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	addrs, fetchedAt, err := cache.GetAccountUniverse("preview")
+	require.NoError(t, err)
+	assert.Empty(t, addrs)
+	assert.True(t, fetchedAt.IsZero(), "nothing cached yet")
+
+	first := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	require.NoError(t, cache.SaveAccountUniverse(
+		"preview", []string{"stake_test1a", "stake_test1b"}, first,
+	))
+	require.NoError(t, cache.SaveAccountUniverse(
+		"preprod", []string{"stake_test1z"}, first,
+	))
+
+	addrs, fetchedAt, err = cache.GetAccountUniverse("preview")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stake_test1a", "stake_test1b"}, addrs)
+	assert.WithinDuration(t, first, fetchedAt, time.Second)
+
+	second := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, cache.SaveAccountUniverse(
+		"preview", []string{"stake_test1b"}, second,
+	))
+	addrs, fetchedAt, err = cache.GetAccountUniverse("preview")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stake_test1b"}, addrs,
+		"a save replaces the set rather than merging into it")
+	assert.WithinDuration(t, second, fetchedAt, time.Second)
+
+	other, _, err := cache.GetAccountUniverse("preprod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stake_test1z"}, other,
+		"networks are stored independently")
+}
+
+// TestAccountUniverseFreshFallsBackToMaxAge covers an epoch whose end time the
+// cache does not carry — old rows predate the column — where the only
+// available bound is the crawl's own age.
+func TestAccountUniverseFreshFallsBackToMaxAge(t *testing.T) {
+	assert.False(t, accountUniverseFresh(time.Time{}, time.Time{}),
+		"no crawl is never fresh")
+	assert.True(t, accountUniverseFresh(
+		time.Now().Add(-time.Minute), time.Time{},
+	))
+	assert.False(t, accountUniverseFresh(
+		time.Now().Add(-2*accountUniverseMaxAge), time.Time{},
+	))
+}

--- a/internal/koiosparity/account_universe_cache_test.go
+++ b/internal/koiosparity/account_universe_cache_test.go
@@ -149,10 +149,11 @@ func TestAccountUniverseCacheRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	defer cache.Close() //nolint:errcheck
 
-	addrs, fetchedAt, err := cache.GetAccountUniverse("preview")
+	addrs, fetchedAt, cached, err := cache.GetAccountUniverse("preview")
 	require.NoError(t, err)
 	assert.Empty(t, addrs)
-	assert.True(t, fetchedAt.IsZero(), "nothing cached yet")
+	assert.False(t, cached, "nothing cached yet")
+	assert.True(t, fetchedAt.IsZero())
 
 	first := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
 	require.NoError(t, cache.SaveAccountUniverse(
@@ -162,8 +163,9 @@ func TestAccountUniverseCacheRoundTrip(t *testing.T) {
 		"preprod", []string{"stake_test1z"}, first,
 	))
 
-	addrs, fetchedAt, err = cache.GetAccountUniverse("preview")
+	addrs, fetchedAt, cached, err = cache.GetAccountUniverse("preview")
 	require.NoError(t, err)
+	assert.True(t, cached)
 	assert.Equal(t, []string{"stake_test1a", "stake_test1b"}, addrs)
 	assert.WithinDuration(t, first, fetchedAt, time.Second)
 
@@ -171,14 +173,16 @@ func TestAccountUniverseCacheRoundTrip(t *testing.T) {
 	require.NoError(t, cache.SaveAccountUniverse(
 		"preview", []string{"stake_test1b"}, second,
 	))
-	addrs, fetchedAt, err = cache.GetAccountUniverse("preview")
+	addrs, fetchedAt, cached, err = cache.GetAccountUniverse("preview")
 	require.NoError(t, err)
+	assert.True(t, cached)
 	assert.Equal(t, []string{"stake_test1b"}, addrs,
 		"a save replaces the set rather than merging into it")
 	assert.WithinDuration(t, second, fetchedAt, time.Second)
 
-	other, _, err := cache.GetAccountUniverse("preprod")
+	other, _, cached, err := cache.GetAccountUniverse("preprod")
 	require.NoError(t, err)
+	assert.True(t, cached)
 	assert.Equal(t, []string{"stake_test1z"}, other,
 		"networks are stored independently")
 }
@@ -195,4 +199,68 @@ func TestAccountUniverseFreshFallsBackToMaxAge(t *testing.T) {
 	assert.False(t, accountUniverseFresh(
 		time.Now().Add(-2*accountUniverseMaxAge), time.Time{},
 	))
+}
+
+// TestResolveKoiosAccountUniverseCachedWithEmptyCrawl covers a network whose
+// /account_list is legitimately empty. Presence is recorded separately from the
+// address rows, so an empty crawl is still a cached crawl and a later epoch it
+// covers does not pay for it again.
+func TestResolveKoiosAccountUniverseCachedWithEmptyCrawl(t *testing.T) {
+	var calls atomic.Int32
+	srv := newAccountListServer(t, &calls)
+	koios := newUniverseTestClient(srv)
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	epochEnd := time.Now().Add(-time.Hour)
+	logger := slog.New(slog.DiscardHandler)
+	for range 2 {
+		addrs, err := ResolveKoiosAccountUniverseCached(
+			context.Background(), koios, cache, "preview", epochEnd, logger,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, addrs)
+	}
+	assert.Equal(t, int32(1), calls.Load(),
+		"an empty crawl is still a cached crawl")
+}
+
+// TestResolveKoiosAccountUniverseCachedMaxAgeFallback exercises the resolver
+// end to end for an epoch carrying no end time, where the crawl's own age is
+// the only available bound.
+func TestResolveKoiosAccountUniverseCachedMaxAgeFallback(t *testing.T) {
+	var calls atomic.Int32
+	srv := newAccountListServer(t, &calls, "stake_test1a")
+	koios := newUniverseTestClient(srv)
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	logger := slog.New(slog.DiscardHandler)
+
+	_, err = ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview", time.Time{}, logger,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), calls.Load())
+
+	// A fresh crawl inside the window is reused.
+	_, err = ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview", time.Time{}, logger,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+
+	// Age it past the window and the resolver crawls again.
+	require.NoError(t, cache.SaveAccountUniverse(
+		"preview",
+		[]string{"stake_test1a"},
+		time.Now().Add(-2*accountUniverseMaxAge),
+	))
+	_, err = ResolveKoiosAccountUniverseCached(
+		context.Background(), koios, cache, "preview", time.Time{}, logger,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load(),
+		"a crawl older than the max age must be refreshed")
 }

--- a/internal/koiosparity/account_universe_cache_test.go
+++ b/internal/koiosparity/account_universe_cache_test.go
@@ -242,3 +242,33 @@ func TestResolveKoiosAccountUniverseCachedRefusesUnboundedReuse(t *testing.T) {
 		time.Now(), time.Now().Add(-time.Minute),
 	))
 }
+
+// TestAccountUniverseStateBackfilledOnUpgrade covers a cache written before
+// koios_account_universe_state existed: the crawl's rows are there but the
+// state row is not, which would read as "never crawled" and pay for a full
+// /account_list walk on first use. The schema migration backfills it.
+func TestAccountUniverseStateBackfilledOnUpgrade(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.db")
+	cache, err := OpenCache(path, nil)
+	require.NoError(t, err)
+
+	fetchedAt := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	require.NoError(t, cache.SaveAccountUniverse(
+		"preview", []string{"stake_test1a", "stake_test1b"}, fetchedAt,
+	))
+	// Drop the state row to reproduce the older layout, then reopen so the
+	// schema pass runs against it.
+	_, err = cache.db.Exec(`DELETE FROM koios_account_universe_state`)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	reopened, err := OpenCache(path, nil)
+	require.NoError(t, err)
+	defer reopened.Close() //nolint:errcheck
+
+	addrs, got, cached, err := reopened.GetAccountUniverse("preview")
+	require.NoError(t, err)
+	assert.True(t, cached, "the existing crawl must survive the upgrade")
+	assert.Equal(t, []string{"stake_test1a", "stake_test1b"}, addrs)
+	assert.WithinDuration(t, fetchedAt, got, time.Second)
+}

--- a/internal/koiosparity/account_universe_cache_test.go
+++ b/internal/koiosparity/account_universe_cache_test.go
@@ -187,20 +187,6 @@ func TestAccountUniverseCacheRoundTrip(t *testing.T) {
 		"networks are stored independently")
 }
 
-// TestAccountUniverseFreshFallsBackToMaxAge covers an epoch whose end time the
-// cache does not carry — old rows predate the column — where the only
-// available bound is the crawl's own age.
-func TestAccountUniverseFreshFallsBackToMaxAge(t *testing.T) {
-	assert.False(t, accountUniverseFresh(time.Time{}, time.Time{}),
-		"no crawl is never fresh")
-	assert.True(t, accountUniverseFresh(
-		time.Now().Add(-time.Minute), time.Time{},
-	))
-	assert.False(t, accountUniverseFresh(
-		time.Now().Add(-2*accountUniverseMaxAge), time.Time{},
-	))
-}
-
 // TestResolveKoiosAccountUniverseCachedWithEmptyCrawl covers a network whose
 // /account_list is legitimately empty. Presence is recorded separately from the
 // address rows, so an empty crawl is still a cached crawl and a later epoch it
@@ -226,10 +212,11 @@ func TestResolveKoiosAccountUniverseCachedWithEmptyCrawl(t *testing.T) {
 		"an empty crawl is still a cached crawl")
 }
 
-// TestResolveKoiosAccountUniverseCachedMaxAgeFallback exercises the resolver
-// end to end for an epoch carrying no end time, where the crawl's own age is
-// the only available bound.
-func TestResolveKoiosAccountUniverseCachedMaxAgeFallback(t *testing.T) {
+// TestResolveKoiosAccountUniverseCachedRefusesUnboundedReuse covers an epoch
+// whose end time the cache does not carry. There is then nothing to measure the
+// crawl against, and reusing it anyway could skip an account that registered
+// between the crawl and the epoch's close — a short universe reads as a pass.
+func TestResolveKoiosAccountUniverseCachedRefusesUnboundedReuse(t *testing.T) {
 	var calls atomic.Int32
 	srv := newAccountListServer(t, &calls, "stake_test1a")
 	koios := newUniverseTestClient(srv)
@@ -238,29 +225,20 @@ func TestResolveKoiosAccountUniverseCachedMaxAgeFallback(t *testing.T) {
 	defer cache.Close() //nolint:errcheck
 	logger := slog.New(slog.DiscardHandler)
 
-	_, err = ResolveKoiosAccountUniverseCached(
-		context.Background(), koios, cache, "preview", time.Time{}, logger,
-	)
-	require.NoError(t, err)
-	require.Equal(t, int32(1), calls.Load())
-
-	// A fresh crawl inside the window is reused.
-	_, err = ResolveKoiosAccountUniverseCached(
-		context.Background(), koios, cache, "preview", time.Time{}, logger,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), calls.Load())
-
-	// Age it past the window and the resolver crawls again.
-	require.NoError(t, cache.SaveAccountUniverse(
-		"preview",
-		[]string{"stake_test1a"},
-		time.Now().Add(-2*accountUniverseMaxAge),
-	))
-	_, err = ResolveKoiosAccountUniverseCached(
-		context.Background(), koios, cache, "preview", time.Time{}, logger,
-	)
-	require.NoError(t, err)
+	for range 2 {
+		_, err = ResolveKoiosAccountUniverseCached(
+			context.Background(), koios, cache, "preview", time.Time{}, logger,
+		)
+		require.NoError(t, err)
+	}
 	assert.Equal(t, int32(2), calls.Load(),
-		"a crawl older than the max age must be refreshed")
+		"with no bound to measure against, the crawl is not reused")
+
+	assert.False(t, accountUniverseFresh(time.Time{}, time.Now()),
+		"no crawl is never fresh")
+	assert.False(t, accountUniverseFresh(time.Now(), time.Time{}),
+		"no bound is never fresh")
+	assert.True(t, accountUniverseFresh(
+		time.Now(), time.Now().Add(-time.Minute),
+	))
 }

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1506,6 +1506,19 @@ func createCacheSchema(db *sql.DB) error {
 		}
 	}
 
+	// A cache written before koios_account_universe_state existed carries the
+	// crawl's rows but no state row, which reads as "never crawled" and pays
+	// for a full /account_list walk on first use. Backfill the state from the
+	// rows already there instead.
+	if _, err := db.Exec(`
+INSERT INTO koios_account_universe_state (network, fetched_at, address_count)
+SELECT network, MAX(fetched_at), COUNT(*)
+FROM koios_account_universe
+WHERE network NOT IN (SELECT network FROM koios_account_universe_state)
+GROUP BY network`); err != nil {
+		return fmt.Errorf("migrate koios_account_universe_state: %w", err)
+	}
+
 	// Older cache files created before #3097 have a koios_account_rewards
 	// table missing reward_type/spendable_epoch/pool_id_bech32 (schema-only
 	// era, #1875) — add each column additively rather than dropping and

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1269,6 +1269,84 @@ func (c *Cache) GetStatusSummary(network string) ([]CheckEpochStatus, error) {
 	return ret, rows.Err()
 }
 
+// SaveAccountUniverse replaces the cached Koios /account_list crawl for
+// network with addrs, stamped fetchedAt. Written in one transaction so a
+// failure part-way cannot leave a half-replaced set that a later read would
+// treat as a complete universe.
+func (c *Cache) SaveAccountUniverse(
+	network string,
+	addrs []string,
+	fetchedAt time.Time,
+) error {
+	tx, err := c.db.Begin()
+	if err != nil {
+		return fmt.Errorf("save account universe: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(
+		`DELETE FROM koios_account_universe WHERE network = ?`,
+		network,
+	); err != nil {
+		return fmt.Errorf("save account universe: clear: %w", err)
+	}
+	stmt, err := tx.Prepare(`
+INSERT INTO koios_account_universe (network, stake_address, fetched_at)
+VALUES (?, ?, ?)
+ON CONFLICT (network, stake_address) DO UPDATE SET fetched_at = excluded.fetched_at`)
+	if err != nil {
+		return fmt.Errorf("save account universe: prepare: %w", err)
+	}
+	defer stmt.Close() //nolint:errcheck
+	for _, addr := range addrs {
+		if addr == "" {
+			continue
+		}
+		if _, err := stmt.Exec(network, addr, fetchedAt.UTC()); err != nil {
+			return fmt.Errorf("save account universe: insert: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("save account universe: commit: %w", err)
+	}
+	return nil
+}
+
+// GetAccountUniverse returns the cached crawl for network and the time it was
+// taken. A zero time with no addresses means nothing is cached; the caller
+// decides whether what is cached is fresh enough for the epoch it is checking.
+func (c *Cache) GetAccountUniverse(
+	network string,
+) ([]string, time.Time, error) {
+	rows, err := c.db.Query(
+		`SELECT stake_address, fetched_at FROM koios_account_universe
+		WHERE network = ? ORDER BY stake_address`,
+		network,
+	)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("get account universe: %w", err)
+	}
+	defer rows.Close()
+	var addrs []string
+	var newest time.Time
+	for rows.Next() {
+		var addr string
+		var fetchedAt time.Time
+		if err := rows.Scan(&addr, &fetchedAt); err != nil {
+			return nil, time.Time{}, fmt.Errorf(
+				"get account universe: %w", err,
+			)
+		}
+		addrs = append(addrs, addr)
+		if fetchedAt.After(newest) {
+			newest = fetchedAt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, time.Time{}, fmt.Errorf("get account universe: %w", err)
+	}
+	return addrs, newest, nil
+}
+
 func createCacheSchema(db *sql.DB) error {
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS koios_epoch_info (
@@ -1359,6 +1437,16 @@ func createCacheSchema(db *sql.DB) error {
 			pool_bech32 TEXT NOT NULL, stake_address TEXT NOT NULL, field TEXT NOT NULL, dingo_value TEXT NOT NULL,
 			koios_value TEXT NOT NULL, category TEXT NOT NULL, checked_at DATETIME NOT NULL)`,
 		`CREATE INDEX IF NOT EXISTS idx_cm_net_epoch ON check_mismatches(network, epoch)`,
+		// The Koios /account_list crawl, cached across epochs. Without it the
+		// per-account fetch re-walked the whole list once per epoch — 304
+		// sequential requests for Preview's 303k accounts — which is why the
+		// in-process observer could not keep pace with a syncing node
+		// (dingo #3796). fetched_at is per row so a refresh can replace the set
+		// wholesale and the newest value still dates the crawl.
+		`CREATE TABLE IF NOT EXISTS koios_account_universe (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL,
+			stake_address TEXT NOT NULL, fetched_at DATETIME NOT NULL)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_kau_net_addr ON koios_account_universe(network, stake_address)`,
 	}
 	for _, stmt := range statements {
 		if _, err := db.Exec(stmt); err != nil {

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -17,6 +17,7 @@ package koiosparity
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1297,6 +1298,7 @@ ON CONFLICT (network, stake_address) DO UPDATE SET fetched_at = excluded.fetched
 		return fmt.Errorf("save account universe: prepare: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
+	saved := 0
 	for _, addr := range addrs {
 		if addr == "" {
 			continue
@@ -1304,6 +1306,17 @@ ON CONFLICT (network, stake_address) DO UPDATE SET fetched_at = excluded.fetched
 		if _, err := stmt.Exec(network, addr, fetchedAt.UTC()); err != nil {
 			return fmt.Errorf("save account universe: insert: %w", err)
 		}
+		saved++
+	}
+	if _, err := tx.Exec(`
+INSERT INTO koios_account_universe_state (network, fetched_at, address_count)
+VALUES (?, ?, ?)
+ON CONFLICT (network) DO UPDATE SET
+    fetched_at = excluded.fetched_at,
+    address_count = excluded.address_count`,
+		network, fetchedAt.UTC(), saved,
+	); err != nil {
+		return fmt.Errorf("save account universe: state: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("save account universe: commit: %w", err)
@@ -1311,40 +1324,54 @@ ON CONFLICT (network, stake_address) DO UPDATE SET fetched_at = excluded.fetched
 	return nil
 }
 
-// GetAccountUniverse returns the cached crawl for network and the time it was
-// taken. A zero time with no addresses means nothing is cached; the caller
-// decides whether what is cached is fresh enough for the epoch it is checking.
+// GetAccountUniverse returns the cached crawl for network, the time it was
+// taken, and whether a crawl is cached at all. The last is read from
+// koios_account_universe_state rather than inferred from the address count, so
+// a crawl that returned nothing is still a crawl; the caller decides whether
+// what is cached is fresh enough for the epoch it is checking.
 func (c *Cache) GetAccountUniverse(
 	network string,
-) ([]string, time.Time, error) {
+) ([]string, time.Time, bool, error) {
+	var fetchedAt time.Time
+	err := c.db.QueryRow(
+		`SELECT fetched_at FROM koios_account_universe_state WHERE network = ?`,
+		network,
+	).Scan(&fetchedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, time.Time{}, false, nil
+	}
+	if err != nil {
+		return nil, time.Time{}, false, fmt.Errorf(
+			"get account universe state: %w", err,
+		)
+	}
 	rows, err := c.db.Query(
-		`SELECT stake_address, fetched_at FROM koios_account_universe
+		`SELECT stake_address FROM koios_account_universe
 		WHERE network = ? ORDER BY stake_address`,
 		network,
 	)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("get account universe: %w", err)
+		return nil, time.Time{}, false, fmt.Errorf(
+			"get account universe: %w", err,
+		)
 	}
 	defer rows.Close()
 	var addrs []string
-	var newest time.Time
 	for rows.Next() {
 		var addr string
-		var fetchedAt time.Time
-		if err := rows.Scan(&addr, &fetchedAt); err != nil {
-			return nil, time.Time{}, fmt.Errorf(
+		if err := rows.Scan(&addr); err != nil {
+			return nil, time.Time{}, false, fmt.Errorf(
 				"get account universe: %w", err,
 			)
 		}
 		addrs = append(addrs, addr)
-		if fetchedAt.After(newest) {
-			newest = fetchedAt
-		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, time.Time{}, fmt.Errorf("get account universe: %w", err)
+		return nil, time.Time{}, false, fmt.Errorf(
+			"get account universe: %w", err,
+		)
 	}
-	return addrs, newest, nil
+	return addrs, fetchedAt, true, nil
 }
 
 func createCacheSchema(db *sql.DB) error {
@@ -1447,6 +1474,12 @@ func createCacheSchema(db *sql.DB) error {
 			id INTEGER PRIMARY KEY AUTOINCREMENT, network TEXT NOT NULL,
 			stake_address TEXT NOT NULL, fetched_at DATETIME NOT NULL)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_kau_net_addr ON koios_account_universe(network, stake_address)`,
+		// Presence of a crawl is recorded separately from its rows, so a crawl
+		// that legitimately returned no addresses is still a cached crawl
+		// rather than indistinguishable from never having run.
+		`CREATE TABLE IF NOT EXISTS koios_account_universe_state (
+			network TEXT PRIMARY KEY, fetched_at DATETIME NOT NULL,
+			address_count INTEGER NOT NULL)`,
 	}
 	for _, stmt := range statements {
 		if _, err := db.Exec(stmt); err != nil {

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -68,11 +68,14 @@ func ResolveKoiosAccountUniverse(
 // registered before that epoch ended, so a crawl taken after it is complete
 // for that epoch no matter how much later the check runs. A crawl taken before
 // it may be missing an account that registered in between, so it is refused
-// and re-crawled. A zero notBefore (an epoch whose end time the cache does not
-// carry) falls back to accountUniverseMaxAge.
+// and re-crawled.
 //
-// A refresh that fails does not fall back to the stale set: an incomplete
-// universe silently skips accounts, which reads as a pass.
+// A zero notBefore — an epoch whose end time the cache does not carry, which
+// old cache rows do not — is not a licence to reuse whatever is cached. There
+// is then no bound to measure the crawl against, so it re-crawls: a universe
+// short by one account silently skips it, and a skipped account reads as a
+// pass. For the same reason a refresh that fails is an error rather than a
+// fallback to the stale set.
 func ResolveKoiosAccountUniverseCached(
 	ctx context.Context,
 	koios *KoiosClient,
@@ -124,18 +127,11 @@ func ResolveKoiosAccountUniverseCached(
 	return addrs, nil
 }
 
-// accountUniverseMaxAge bounds how stale a cached crawl may be when the epoch
-// being checked carries no end time to measure against.
-const accountUniverseMaxAge = time.Hour
-
 // accountUniverseFresh reports whether a crawl taken at fetchedAt covers an
 // epoch that ended at notBefore. See ResolveKoiosAccountUniverseCached.
 func accountUniverseFresh(fetchedAt, notBefore time.Time) bool {
-	if fetchedAt.IsZero() {
+	if fetchedAt.IsZero() || notBefore.IsZero() {
 		return false
-	}
-	if notBefore.IsZero() {
-		return time.Since(fetchedAt) < accountUniverseMaxAge
 	}
 	return !fetchedAt.Before(notBefore)
 }

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -57,6 +57,89 @@ func ResolveKoiosAccountUniverse(
 	return addrs, nil
 }
 
+// ResolveKoiosAccountUniverseCached is ResolveKoiosAccountUniverse backed by
+// the cache, for a caller that resolves the universe once per epoch rather
+// than once per run. The crawl is 304 sequential /account_list requests for
+// Preview's 303k accounts, and paying it per epoch is why the in-process
+// observer could not keep pace with a syncing node (dingo #3796).
+//
+// notBefore is the point the cached crawl has to be no older than — the end of
+// the epoch being checked. An account that earned a reward in a closed epoch
+// registered before that epoch ended, so a crawl taken after it is complete
+// for that epoch no matter how much later the check runs. A crawl taken before
+// it may be missing an account that registered in between, so it is refused
+// and re-crawled. A zero notBefore (an epoch whose end time the cache does not
+// carry) falls back to accountUniverseMaxAge.
+//
+// A refresh that fails does not fall back to the stale set: an incomplete
+// universe silently skips accounts, which reads as a pass.
+func ResolveKoiosAccountUniverseCached(
+	ctx context.Context,
+	koios *KoiosClient,
+	cache *Cache,
+	network string,
+	notBefore time.Time,
+	logger *slog.Logger,
+) ([]string, error) {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	if cache != nil {
+		addrs, fetchedAt, err := cache.GetAccountUniverse(network)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) > 0 && accountUniverseFresh(fetchedAt, notBefore) {
+			logger.Debug(
+				"koiosparity: reusing cached Koios account universe",
+				"network", network,
+				"addresses", len(addrs),
+				"fetched_at", fetchedAt,
+			)
+			return addrs, nil
+		}
+	}
+	logger.Info(
+		"koiosparity: crawling Koios account universe",
+		"network", network,
+	)
+	started := time.Now()
+	addrs, err := koios.GetAllAccountAddressesWithProgress(ctx, logger)
+	if err != nil {
+		return nil, fmt.Errorf("get all koios account addresses: %w", err)
+	}
+	logger.Info(
+		"koiosparity: Koios account universe crawled",
+		"network", network,
+		"addresses", len(addrs),
+		"elapsed", time.Since(started),
+	)
+	if cache != nil {
+		if err := cache.SaveAccountUniverse(
+			network, addrs, started,
+		); err != nil {
+			return nil, err
+		}
+	}
+	return addrs, nil
+}
+
+// accountUniverseMaxAge bounds how stale a cached crawl may be when the epoch
+// being checked carries no end time to measure against.
+const accountUniverseMaxAge = time.Hour
+
+// accountUniverseFresh reports whether a crawl taken at fetchedAt covers an
+// epoch that ended at notBefore. See ResolveKoiosAccountUniverseCached.
+func accountUniverseFresh(fetchedAt, notBefore time.Time) bool {
+	if fetchedAt.IsZero() {
+		return false
+	}
+	if notBefore.IsZero() {
+		return time.Since(fetchedAt) < accountUniverseMaxAge
+	}
+	return !fetchedAt.Before(notBefore)
+}
+
 // BuildAccountAddressUniverse returns the union of koiosAddrs (Koios's full
 // historical account list — see ResolveKoiosAccountUniverse) and Dingo's own
 // committed reward-account addresses at stakeEpoch (the koiosStakeEpoch(K-1)

--- a/internal/koiosparity/fetch_accounts.go
+++ b/internal/koiosparity/fetch_accounts.go
@@ -85,11 +85,11 @@ func ResolveKoiosAccountUniverseCached(
 		logger = slog.New(slog.DiscardHandler)
 	}
 	if cache != nil {
-		addrs, fetchedAt, err := cache.GetAccountUniverse(network)
+		addrs, fetchedAt, cached, err := cache.GetAccountUniverse(network)
 		if err != nil {
 			return nil, err
 		}
-		if len(addrs) > 0 && accountUniverseFresh(fetchedAt, notBefore) {
+		if cached && accountUniverseFresh(fetchedAt, notBefore) {
 			logger.Debug(
 				"koiosparity: reusing cached Koios account universe",
 				"network", network,

--- a/internal/koiosparity/koios_client.go
+++ b/internal/koiosparity/koios_client.go
@@ -967,6 +967,7 @@ func (k *KoiosClient) getAllAccountAddresses(
 	seen := make(map[string]bool)
 	var addrs []string
 	total := 0
+	pages := 0
 	for start := 0; ; start += koiosPageSize {
 		end := start + koiosPageSize - 1
 		resp, err := k.get(
@@ -978,17 +979,7 @@ func (k *KoiosClient) getAllAccountAddresses(
 		if err != nil {
 			return nil, err
 		}
-		// Preview answers 303k accounts in 304 sequential pages. Without a
-		// progress line the whole walk is silent, which is indistinguishable
-		// from a stalled fetch (dingo #3796).
-		if logger != nil && start > 0 &&
-			start%(koiosPageSize*accountListLogEveryPages) == 0 {
-			logger.Info(
-				"koiosparity: crawling Koios account list",
-				"fetched", len(addrs),
-				"total", total,
-			)
-		}
+
 		if resp.StatusCode != http.StatusOK &&
 			resp.StatusCode != http.StatusPartialContent {
 			return nil, fmt.Errorf(
@@ -1009,6 +1000,20 @@ func (k *KoiosClient) getAllAccountAddresses(
 				seen[item.StakeAddress] = true
 				addrs = append(addrs, item.StakeAddress)
 			}
+		}
+		// Preview answers 303k accounts in 304 sequential pages. Without a
+		// progress line the whole walk is silent, which is indistinguishable
+		// from a stalled fetch (dingo #3796). Emitted after the page is
+		// folded in, so a crawl ending on exactly a milestone page still
+		// reports it before the loop breaks below.
+		pages++
+		if logger != nil && pages%accountListLogEveryPages == 0 {
+			logger.Info(
+				"koiosparity: crawling Koios account list",
+				"pages", pages,
+				"fetched", len(addrs),
+				"total", total,
+			)
 		}
 		if len(page) < koiosPageSize {
 			break

--- a/internal/koiosparity/koios_client.go
+++ b/internal/koiosparity/koios_client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -942,11 +943,30 @@ func (k *KoiosClient) GetPoolEpochHistory(
 func (k *KoiosClient) GetAllAccountAddresses(
 	ctx context.Context,
 ) ([]string, error) {
+	return k.getAllAccountAddresses(ctx, nil)
+}
+
+// GetAllAccountAddressesWithProgress is GetAllAccountAddresses with a progress
+// line every accountListLogEveryPages pages. The logger is a parameter rather
+// than a client field because the same client serves the concurrent chunk
+// fetchers, and a field written here would be read by them (dingo #3796).
+func (k *KoiosClient) GetAllAccountAddressesWithProgress(
+	ctx context.Context,
+	logger *slog.Logger,
+) ([]string, error) {
+	return k.getAllAccountAddresses(ctx, logger)
+}
+
+func (k *KoiosClient) getAllAccountAddresses(
+	ctx context.Context,
+	logger *slog.Logger,
+) ([]string, error) {
 	type listItem struct {
 		StakeAddress string `json:"stake_address"`
 	}
 	seen := make(map[string]bool)
 	var addrs []string
+	total := 0
 	for start := 0; ; start += koiosPageSize {
 		end := start + koiosPageSize - 1
 		resp, err := k.get(
@@ -957,6 +977,17 @@ func (k *KoiosClient) GetAllAccountAddresses(
 		)
 		if err != nil {
 			return nil, err
+		}
+		// Preview answers 303k accounts in 304 sequential pages. Without a
+		// progress line the whole walk is silent, which is indistinguishable
+		// from a stalled fetch (dingo #3796).
+		if logger != nil && start > 0 &&
+			start%(koiosPageSize*accountListLogEveryPages) == 0 {
+			logger.Info(
+				"koiosparity: crawling Koios account list",
+				"fetched", len(addrs),
+				"total", total,
+			)
 		}
 		if resp.StatusCode != http.StatusOK &&
 			resp.StatusCode != http.StatusPartialContent {
@@ -982,13 +1013,17 @@ func (k *KoiosClient) GetAllAccountAddresses(
 		if len(page) < koiosPageSize {
 			break
 		}
-		total := parseTotalFromContentRange(resp.Header.Get("Content-Range"))
+		total = parseTotalFromContentRange(resp.Header.Get("Content-Range"))
 		if total > 0 && start+len(page) >= total {
 			break
 		}
 	}
 	return addrs, nil
 }
+
+// accountListLogEveryPages is how many /account_list pages pass between
+// progress lines during the universe crawl.
+const accountListLogEveryPages = 50
 
 // KoiosAccountRewardHistoryItem is one row from /account_reward_history,
 // covering every documented field. PoolIDBech32 is null for reward types with

--- a/internal/koiosparity/observer.go
+++ b/internal/koiosparity/observer.go
@@ -678,7 +678,15 @@ func (o *Observer) fetchAccountsIfNeeded(
 	var lastErr error
 	for attempt := 0; attempt < o.cfg.FetchRetryAttempts; attempt++ {
 		if !addrsResolved {
-			addrs, err := ResolveKoiosAccountUniverse(ctx, o.koios)
+			// The epoch's own end time is what the cached crawl has to be
+			// no older than; see ResolveKoiosAccountUniverseCached.
+			var notBefore time.Time
+			if info != nil {
+				notBefore = info.EpochEndTime
+			}
+			addrs, err := ResolveKoiosAccountUniverseCached(
+				ctx, o.koios, o.cache, o.cfg.Network, notBefore, o.cfg.Logger,
+			)
 			if err != nil {
 				if errors.Is(err, ErrKoiosPermanent) {
 					return err


### PR DESCRIPTION
Closes blinklabs-io/dingo#3796

The in-process observer resolves the Koios account universe once per epoch, and
that resolution is a sequential Range-paginated walk of `/account_list` —
304 requests for Preview's 303,003 accounts, repeated every epoch with nothing
cached between them.

## Observed

Preview genesis replay, `--koios-parity-enabled --koios-parity-strict`, accounts
left at the default:

```
13:19:43  koiosparity observer: epoch validated  epoch=0
13:20:12  koiosparity observer: epoch validated  epoch=1
          (nothing for 7m23s)
```

At 13:27 the cache held epoch-2 `koios_epoch_info` and `koios_pool_epoch` rows
and zero rows in `koios_account_rewards`, `koios_account_fetch_staged_rows`,
`koios_account_checked` and `koios_account_coverage`; the WAL had not been
written since 13:20. The node meanwhile reached epoch 18 — a Preview genesis
replay closes an epoch about every 25 seconds. Restarting the same data
directory with `--koios-parity-accounts=false` validated epoch 2 in under a
second and epochs 3 through 13 in the next 40 seconds, so the account phase is
the whole cost.

The observer therefore falls behind monotonically and never recovers, and it is
silent while it happens.

## The fix

The crawl is cached per network in a new `koios_account_universe` table and
reused across epochs by `ResolveKoiosAccountUniverseCached`.

Reuse is bounded by the epoch being checked rather than by a fixed age: an
account that earned a reward in a closed epoch registered before that epoch
ended, so a crawl taken after the epoch closed is complete for it, while an
earlier crawl may be missing an account. An epoch carrying no end time falls
back to a one-hour maximum age. A refresh that fails is an error rather than a
fallback to the stale set — a short universe silently skips accounts, which
reads as a pass.

`GetAllAccountAddressesWithProgress` logs a line every 50 pages so a long crawl
is distinguishable from a stalled one. The logger is a parameter rather than a
client field because the same client serves the concurrent chunk fetchers, and a
field written here would be read by them.

## Tests

- `TestResolveKoiosAccountUniverseCachedReusesCrawlAcrossEpochs` — a second
  epoch covered by the cached crawl does not touch Koios, with a control call
  through the uncached resolver proving the request counter detects a re-crawl.
- `TestResolveKoiosAccountUniverseCachedRefreshesForNewerEpoch` — an epoch that
  closed after the crawl forces a refresh.
- `TestAccountUniverseCacheRoundTrip` — a save replaces the set wholesale rather
  than merging, and networks are independent.
- `TestAccountUniverseFreshFallsBackToMaxAge`.

## Checks

- `go build ./...`, `go vet ./internal/koiosparity/`, and the full
  `internal/koiosparity` package pass.
- Not exercised: a live Preview run with `--koios-parity-accounts` enabled long
  enough to observe the observer keeping pace. The crawl cost above is measured;
  the reuse is covered by the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the Koios account universe across epochs so the parity observer no longer falls behind a syncing node. Previously the observer re-resolved the full account list every epoch, which on Preview meant 304 sequential `/account_list` requests for 303k accounts—enough to stall the observer for minutes while the node advanced many epochs. Now the crawl is stored per network in `koios_account_universe` and reused if it was taken after the epoch being checked ended. Crawl presence is tracked separately from the address rows, so an empty crawl is still cached and reusable. An epoch with no recorded end time is never reused, and a failed refresh is an error rather than a fallback to stale data; either could silently skip accounts. The crawl also logs progress every 50 pages so a long fetch is distinguishable from a stalled one. Caches created before the state table existed get the state row backfilled from existing rows on open, so an upgrade doesn't re-crawl once.

Closes blinklabs-io/dingo#3796.

<sup>Written for commit 99684ffc747fa98a0b8c6c783e7e8eab898453ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

