### PR TITLE
fix(ledger): engage replay recovery only for a real provenance gap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3653,6 +3653,22 @@ queued primary chain, so late bodies from an abandoned fetch cannot seed its
 producer window. Its diagnostic database probes are also capped per block
 while the blockfetch pipeline lock is held; this keeps the audit bounded and
 non-blocking for pathological transaction counts.
+Replay recovery engages only for the failure it can repair. `txValidationError`
+carries every referenced input of the failing transaction regardless of what
+the transaction failed on, so a failure with nothing missing — a script data
+hash mismatch, say — arrived at the candidate search with a full input list.
+`resolveReplayRecoveryProducer` returns a nil producer both for an input that
+is present in the UTxO set (nothing to find) and for one that is missing with
+no producer locatable, and folding the two together made every input of such a
+transaction look unresolved: recovery rewound, the deterministic failure
+reproduced on replay, and the pipeline looped without converging and without
+halting (issue #3805). The two are now distinguished — a present input is
+reported as present and skipped — so a transaction whose inputs all resolve
+yields no candidate and the branch is rejected instead. Presence is asked of
+`Database.UtxoExists`, which does not materialize the output's CBOR: `UtxoByRef`
+reconstructs it by decoding the producing block on a blob miss, which turned a
+UTxO that demonstrably exists into a hard error out of recovery.
+
 The unresolved-producer fallback also tracks the applied ledger high-water
 mark across attempts. Different candidate continuations can move the failing
 block forward slightly while rebuilding to the same applied tip, so failure

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -494,6 +494,32 @@ func (d *Database) UtxoByRef(
 	return utxo, nil
 }
 
+// UtxoExists reports whether a live UTxO is recorded for the reference, without
+// materializing its CBOR.
+//
+// UtxoByRef resolves the output's bytes from the blob store and, on a miss,
+// reconstructs them by decoding the producing block. A caller that only needs
+// to know whether the output is still there pays for all of that, and — worse —
+// turns a CBOR that cannot be recovered into a hard error about a UTxO that
+// demonstrably exists. Replay recovery asks exactly that question of every
+// referenced input of a failing transaction (see
+// LedgerState.findReplayRecoveryCandidate), so it uses this instead.
+func (d *Database) UtxoExists(
+	txId []byte,
+	outputIdx uint32,
+	txn *Txn,
+) (bool, error) {
+	if txn == nil {
+		txn = d.Transaction(false)
+		defer txn.Release()
+	}
+	utxo, err := d.utxoStore().GetUtxo(txId, outputIdx, txn.Metadata())
+	if err != nil {
+		return false, err
+	}
+	return utxo != nil, nil
+}
+
 // UtxosByRefs returns the live UTxOs matching the given references in a
 // single batch. Refs with no matching live UTxO are simply absent from the
 // result.

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -1296,12 +1296,16 @@ func (ls *LedgerState) findReplayRecoveryCandidate(
 			continue
 		}
 		seenInputs[inputKey] = struct{}{}
-		resolved, err := ls.resolveReplayRecoveryProducer(
+		resolved, present, err := ls.resolveReplayRecoveryProducer(
 			pending,
 			chainIndex,
 		)
 		if err != nil {
 			return nil, err
+		}
+		if present {
+			// Nothing to repair for this input; it is still in the UTxO set.
+			continue
 		}
 		if resolved == nil {
 			unresolvedInputs = append(unresolvedInputs, pending.Input)
@@ -1437,31 +1441,43 @@ func (ls *LedgerState) buildReplayRecoveryChainIndex(
 	return index, nil
 }
 
+// resolveReplayRecoveryProducer locates the block that produced pending.Input.
+//
+// The bool reports that the input is present in the UTxO set, which is a
+// different answer from a nil producer: present means nothing about this input
+// needs repairing, while a nil producer with present false means the input is
+// missing and its producer could not be found either.
 func (ls *LedgerState) resolveReplayRecoveryProducer(
 	pending replayRecoveryPendingInput,
 	chainIndex *replayRecoveryChainIndex,
-) (*replayRecoveryResolvedProducer, error) {
-	utxo, err := ls.db.UtxoByRef(
+) (*replayRecoveryResolvedProducer, bool, error) {
+	present, err := ls.db.UtxoExists(
 		pending.Input.Id().Bytes(),
 		pending.Input.Index(),
 		nil,
 	)
 	if err != nil && !errors.Is(err, database.ErrUtxoNotFound) {
-		return nil, fmt.Errorf(
+		return nil, false, fmt.Errorf(
 			"lookup validation input %s: %w",
 			pending.Input.String(),
 			err,
 		)
 	}
-	if utxo != nil {
-		return nil, nil
+	if present {
+		// The input is in the UTxO set, so there is no provenance gap here
+		// whatever the transaction failed on. Reported as present rather than
+		// as a nil producer so the caller does not fold it into
+		// unresolvedInputs, which is what let a failure with nothing missing
+		// -- a script data hash mismatch, say -- drive a rewind that could
+		// never fix it (dingo #3805).
+		return nil, true, nil
 	}
 	producerTx, err := ls.db.GetTransactionByHash(
 		pending.Input.Id().Bytes(),
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, false, fmt.Errorf(
 			"lookup producer tx %s: %w",
 			pending.Input.Id().String(),
 			err,
@@ -1470,14 +1486,14 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 	if producerTx != nil && len(producerTx.BlockHash) > 0 {
 		producerBlock, err := database.BlockByHash(ls.db, producerTx.BlockHash)
 		if err != nil {
-			return nil, fmt.Errorf(
+			return nil, false, fmt.Errorf(
 				"lookup producer block %x: %w",
 				producerTx.BlockHash,
 				err,
 			)
 		}
 		if producerBlock.Slot >= pending.MaxSlot {
-			return nil, nil
+			return nil, false, nil
 		}
 		tx := ls.replayRecoveryResolveTxFromBlock(
 			producerBlock,
@@ -1490,17 +1506,17 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 			ProducerBlock: producerBlock,
 			Tx:            tx,
 			Strategy:      "metadata",
-		}, nil
+		}, false, nil
 	}
 	producerBlock, found, err := ls.replayRecoveryBlockFromTxBlob(
 		pending.Input.Id().Bytes(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if found {
 		if producerBlock.Slot >= pending.MaxSlot {
-			return nil, nil
+			return nil, false, nil
 		}
 		tx := ls.replayRecoveryResolveTxFromBlock(
 			producerBlock,
@@ -1512,7 +1528,7 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 			ProducerBlock: producerBlock,
 			Tx:            tx,
 			Strategy:      "tx-blob",
-		}, nil
+		}, false, nil
 	}
 	if chainIndex != nil {
 		chainTx, ok := chainIndex.Txs[string(pending.Input.Id().Bytes())]
@@ -1522,10 +1538,10 @@ func (ls *LedgerState) resolveReplayRecoveryProducer(
 				ProducerBlock: chainTx.Block,
 				Tx:            chainTx.Tx,
 				Strategy:      "chain-scan",
-			}, nil
+			}, false, nil
 		}
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func (ls *LedgerState) replayRecoveryResolveTxFromBlock(

--- a/ledger/replay_recovery_test.go
+++ b/ledger/replay_recovery_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/event"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
@@ -2272,4 +2273,168 @@ func TestIsGenesisPrevHashRejectsMalformedHashes(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestTryRecoverFromTxValidationErrorIgnoresFailureWithResolvableInputs is the
+// dingo #3805 regression.
+//
+// Replay recovery exists to repair one thing: a transaction spending an input
+// whose producer is missing from the applied chain. txValidationError carries
+// every referenced input of the failing transaction regardless of why it
+// failed, so a failure that has nothing to do with input provenance -- a script
+// data hash mismatch, say -- arrived here with a full input list and was
+// diagnosed as inconsistent local state.
+//
+// The failure is deterministic, so replaying after the rewind fails identically
+// and the pipeline loops. Observed on preview: 230 rewinds over 45 minutes at a
+// frozen tip, with the "missing" input present and unspent in the node's own
+// UTxO set the whole time.
+//
+// An input that resolves is not evidence of a gap. With every input resolvable
+// there is no candidate, and the caller rejects the branch instead.
+func TestTryRecoverFromTxValidationErrorIgnoresFailureWithResolvableInputs(
+	t *testing.T,
+) {
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+
+	parentBlock := testRawBlock("resolvable-parent", 100, 1, nil)
+	producerBlock := testRawBlock(
+		"resolvable-producer",
+		120,
+		2,
+		parentBlock.Hash,
+	)
+	currentBlock := testRawBlock(
+		"resolvable-current",
+		160,
+		3,
+		producerBlock.Hash,
+	)
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(
+		[]chain.RawBlock{parentBlock, producerBlock, currentBlock},
+	))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	currentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(currentBlock.Slot, currentBlock.Hash),
+		BlockNumber: currentBlock.BlockNumber,
+	}
+	require.NoError(t, db.SetBlockNonce(
+		currentTip.Point.Hash, currentTip.Point.Slot,
+		[]byte("nonce-current"), false, nil,
+	))
+	require.NoError(t, db.SetTip(currentTip, nil))
+	ls.currentTip = currentTip
+	ls.currentTipBlockNonce = []byte("nonce-current")
+	ls.publishSnapshotsLocked()
+
+	// The producer transaction is on the applied chain and its output is in
+	// the UTxO set, unspent -- exactly the state the preview node was in while
+	// it rewound 230 times.
+	producerTxHash := testHashBytes("resolvable-producer-tx")
+	seedReplayRecoveryTransaction(
+		t, db, producerTxHash, producerBlock.Hash, producerBlock.Slot,
+	)
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId:      producerTxHash,
+		OutputIdx: 1,
+		Amount:    types.Uint64(11688720),
+		AddedSlot: producerBlock.Slot,
+	}))
+
+	validationErr := &txValidationError{
+		BlockPoint: currentTip.Point,
+		TxHash:     testHashBytes("script-data-hash-failing-tx"),
+		Inputs: []lcommon.TransactionInput{
+			&replayRecoveryInput{txId: producerTxHash, index: 1},
+		},
+		Cause: errors.New(
+			"script data hash mismatch: declared aa, computed bb",
+		),
+	}
+
+	// No candidate: with every referenced input present there is nothing for a
+	// rewind to repair, whatever the transaction failed on.
+	candidate, err := ls.findReplayRecoveryCandidate(validationErr)
+	require.NoError(t, err)
+	assert.Nil(t, candidate,
+		"a present input must not be folded into unresolvedInputs")
+
+	recovered, err := ls.tryRecoverFromTxValidationError(validationErr)
+	require.NoError(t, err)
+	assert.False(t, recovered,
+		"a failure whose inputs all resolve is a rejected block, not a local state gap")
+	assert.Equal(t, currentTip, ls.currentTip,
+		"nothing was rewound")
+	assert.Equal(t, currentTip, ls.chain.Tip())
+}
+
+// TestResolveReplayRecoveryProducerReportsPresentInput pins the distinction the
+// candidate search depends on. resolveReplayRecoveryProducer returns a nil
+// producer for two unrelated situations — the input is present so there is
+// nothing to find, and the input is missing and its producer could not be
+// located — and folding both into unresolvedInputs is what let a failure with
+// nothing missing drive a rewind (dingo #3805).
+func TestResolveReplayRecoveryProducerReportsPresentInput(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	presentTx := testHashBytes("present-producer-tx")
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId:      presentTx,
+		OutputIdx: 0,
+		Amount:    types.Uint64(1_000_000),
+		AddedSlot: 10,
+	}))
+
+	index := &replayRecoveryChainIndex{
+		Txs: make(map[string]replayRecoveryChainTx),
+	}
+
+	resolved, present, err := ls.resolveReplayRecoveryProducer(
+		replayRecoveryPendingInput{
+			Input:   &replayRecoveryInput{txId: presentTx, index: 0},
+			MaxSlot: 100,
+		},
+		index,
+	)
+	require.NoError(t, err)
+	assert.True(t, present, "a live UTxO is present")
+	assert.Nil(t, resolved, "and so has no producer to recover")
+
+	// A reference with no UTxO and no producer anywhere is the genuine gap.
+	resolved, present, err = ls.resolveReplayRecoveryProducer(
+		replayRecoveryPendingInput{
+			Input:   &replayRecoveryInput{txId: testHashBytes("absent"), index: 0},
+			MaxSlot: 100,
+		},
+		index,
+	)
+	require.NoError(t, err)
+	assert.False(t, present, "a missing UTxO is not present")
+	assert.Nil(t, resolved)
 }


### PR DESCRIPTION
Closes blinklabs-io/dingo#3805

`txValidationError` carries every referenced input of the failing transaction
regardless of what the transaction failed on, and `resolveReplayRecoveryProducer`
returned a nil producer for two unrelated situations: the input is present in
the UTxO set so there is nothing to find, and the input is missing with no
producer locatable. `findReplayRecoveryCandidate` folded both into
`unresolvedInputs`.

So a failure with nothing missing made every input of the transaction look
unresolved. Recovery rewound, the deterministic failure reproduced on replay,
and the pipeline looped — never converging, and never halting either.

## Observed

A preview genesis replay, wedged for 45 minutes on a script data hash mismatch:

```
level=WARN  msg="TX 557b728b… failed validation: script data hash mismatch:
  declared 15dd0a3a…, computed 5d1149cf…"
level=WARN  msg="detected inconsistent local ledger state during replay,
  rewinding primary chain and metadata state"
  recovery_strategy=security-param-fallback failing_block_slot=1796036
  missing_input=3b063fb1…#1 rollback_slot=1787815
level=ERROR msg="ledger pipeline stuck: repeated restarts are not advancing the
  tip, so the failure is deterministic and will not clear on its own; the node is
  no longer following the chain" consecutive_no_progress=230 tip_slot=1796008
```

The input the recovery names as missing was present and unspent in the node's own
store the entire time:

```sql
SELECT hex(tx_id), output_idx, amount, added_slot, deleted_slot FROM utxo
WHERE hex(tx_id) = upper('3b063fb1ab831a4d03e628a30a072394fc9bb3d0278b6b7f355e623e5baa462e');

3B063FB1…|1|11688720|1790127|0
```

## The fix

`resolveReplayRecoveryProducer` now reports presence separately from a nil
producer, and the candidate search skips a present input instead of folding it
into `unresolvedInputs`. A transaction whose inputs all resolve yields no
candidate, so `tryRecoverFromTxValidationError` returns false and the caller
rejects the branch — which is what a rejected block should get.

Presence is asked of a new `Database.UtxoExists`, which does not materialize the
output's CBOR. `UtxoByRef` resolves the bytes from the blob store and, on a miss,
reconstructs them by decoding the producing block; a caller that only needs to
know whether the output is still there pays for all of that and, worse, turns a
CBOR that cannot be recovered into a hard error about a UTxO that demonstrably
exists.

The genuine provenance gap this machinery exists for — an input with no producer
on the applied chain — is unchanged, and the same replay reaches it later at
slot 3363516, where recovery engages as intended.

## Scope

This is the misclassification only. The root cause of *this* particular block
being rejected is blinklabs-io/gouroboros#2188, fixed in
blinklabs-io/gouroboros#2189; that unblocks slot 1796036, while this change is
what keeps the next deterministic phase-1 rejection from looping the pipeline
instead of rejecting the branch.

## Tests

- `TestTryRecoverFromTxValidationErrorIgnoresFailureWithResolvableInputs` — a
  validation failure whose single input is present produces no candidate, no
  recovery, and no rewind. It does not pass on `main`.
- `TestResolveReplayRecoveryProducerReportsPresentInput` — pins the distinction
  directly: a live UTxO reports present with a nil producer, an absent reference
  reports not-present with a nil producer.
- Every existing replay-recovery test passes unchanged, including the
  unresolved-producer, fallback, and non-converging-hold cases.
- `go build ./...`, `go vet`, `go test ./ledger/... ./database/...` and
  `go test ./internal/test/conformance/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes replay recovery engaging on transaction failures unrelated to input provenance, which caused endless rewind/replay loops (e.g., a script data hash mismatch drove 230 rewinds on preview). Now recovery only triggers for a genuine provenance gap: an input missing from the applied chain with no locatable producer.

- `resolveReplayRecoveryProducer` now reports a present input separately from a nil producer, and the candidate search skips present inputs instead of folding them into `unresolvedInputs`.
- Adds `Database.UtxoExists` to check presence without materializing the output's CBOR, avoiding hard errors on outputs that exist but have unrecoverable CBOR.
- Adds regression tests for the misclassification and the new presence check.

<sup>Written for commit 74a6cacdcb20df8df75c4efe2392dee9f90a5202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay recovery to distinguish existing UTxO inputs from genuinely missing inputs.
  * Prevented unnecessary chain rewinds when transaction inputs are already present.
  * Avoided repeated recovery loops caused by deterministic transaction failures.
  * Rejected transactions with no recoverable missing inputs without attempting recovery.

* **Tests**
  * Added regression coverage for transactions with resolvable inputs and missing producer detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->