### PR TITLE
fix(chain): reject invalid ranges and preserve rollback atomicity

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -838,9 +838,10 @@ func (c *Chain) rollbackPointBlock(
 // findQueuedHeader scans queued headers backward for the rollback point
 // without mutating them, and returns one of three outcomes:
 //   - (index, nil) if a queued header matches point exactly.
-//   - (-1, nil) if every queued header is ahead of point, meaning point
-//     predates the queue and rollback must fall through to the
-//     block-committed chain.
+//   - (-1, nil) if every queued header is strictly ahead of point, or if
+//     point's slot matches the oldest queued header's under a different
+//     hash — either way point is not a queued header, so rollback falls
+//     through to the block-committed chain.
 //   - (-1, models.ErrBlockNotFound) if point falls strictly between two
 //     queued headers, or beyond the newest one without matching it — a
 //     target that is not a valid rollback point.

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -836,10 +836,14 @@ func (c *Chain) rollbackPointBlock(
 }
 
 // findQueuedHeader scans queued headers backward for the rollback point
-// without mutating them. It returns the index of the header matching point
-// exactly, or -1 if point is not found among the queued headers (either
-// because every queued header is ahead of point, or because
-// models.ErrBlockNotFound is returned for a point that predates them).
+// without mutating them, and returns one of three outcomes:
+//   - (index, nil) if a queued header matches point exactly.
+//   - (-1, nil) if every queued header is ahead of point, meaning point
+//     predates the queue and rollback must fall through to the
+//     block-committed chain.
+//   - (-1, models.ErrBlockNotFound) if point falls strictly between two
+//     queued headers, or beyond the newest one without matching it — a
+//     target that is not a valid rollback point.
 //
 // Callers must hold c.mutex.
 func (c *Chain) findQueuedHeader(point ocommon.Point) (int, error) {

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -835,6 +835,29 @@ func (c *Chain) rollbackPointBlock(
 	)
 }
 
+// findQueuedHeader scans queued headers backward for the rollback point
+// without mutating them. It returns the index of the header matching point
+// exactly, or -1 if point is not found among the queued headers (either
+// because every queued header is ahead of point, or because
+// models.ErrBlockNotFound is returned for a point that predates them).
+//
+// Callers must hold c.mutex.
+func (c *Chain) findQueuedHeader(point ocommon.Point) (int, error) {
+	for i, header := range slices.Backward(c.headers) {
+		if header.point.Slot > point.Slot {
+			continue
+		}
+		if header.point.Slot == point.Slot &&
+			bytes.Equal(header.point.Hash, point.Hash) {
+			return i, nil
+		}
+		if header.point.Slot < point.Slot {
+			return -1, models.ErrBlockNotFound
+		}
+	}
+	return -1, nil
+}
+
 // ValidateRollback verifies that Rollback(point) would be accepted without
 // mutating chain state. Callers can use this to avoid applying external
 // side effects before the chain's rollback pre-checks have run.
@@ -855,19 +878,12 @@ func (c *Chain) ValidateRollback(point ocommon.Point) error {
 	}
 	// Check headers for rollback point without mutating them
 	if len(c.headers) > 0 {
-		var header queuedHeader
-		for _, v := range slices.Backward(c.headers) {
-			header = v
-			if header.point.Slot > point.Slot {
-				continue
-			}
-			if header.point.Slot == point.Slot &&
-				bytes.Equal(header.point.Hash, point.Hash) {
-				return nil
-			}
-			if header.point.Slot < point.Slot {
-				return models.ErrBlockNotFound
-			}
+		idx, err := c.findQueuedHeader(point)
+		if err != nil {
+			return err
+		}
+		if idx >= 0 {
+			return nil
 		}
 	}
 	// Lookup block for rollback point
@@ -919,24 +935,19 @@ func (c *Chain) rollbackLocked(
 	if c.persistent && c.manager.securityParam <= 0 {
 		return nil, ErrSecurityParamNotConfigured
 	}
-	// Check headers for rollback point
+	// Check headers for rollback point. The scan itself does not mutate
+	// c.headers, so a not-found error leaves the queue untouched; headers
+	// are only deleted once we know the rollback will actually apply.
 	if len(c.headers) > 0 {
-		// Iterate backwards to make deletion safe
-		var header queuedHeader
-		for i, v := range slices.Backward(c.headers) {
-			header = v
-			// Remove headers after rollback slot
-			if header.point.Slot > point.Slot {
-				c.headers = slices.Delete(c.headers, i, i+1)
-				continue
-			}
-			if header.point.Slot == point.Slot &&
-				bytes.Equal(header.point.Hash, point.Hash) {
-				return nil, nil
-			}
-			if header.point.Slot < point.Slot {
-				return nil, models.ErrBlockNotFound
-			}
+		idx, err := c.findQueuedHeader(point)
+		if err != nil {
+			return nil, err
+		}
+		if idx >= 0 {
+			// Rollback point is a queued header. Drop only the headers
+			// after it and leave the matched header itself queued.
+			c.headers = slices.Delete(c.headers, idx+1, len(c.headers))
+			return nil, nil
 		}
 	}
 	// Lookup block for rollback point
@@ -1305,7 +1316,7 @@ func (c *Chain) firstHeaderMatchesPoint(
 }
 
 func (c *Chain) HeaderRange(count int) (ocommon.Point, ocommon.Point) {
-	if c == nil {
+	if c == nil || count <= 0 {
 		return ocommon.Point{}, ocommon.Point{}
 	}
 	c.mutex.RLock()

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -980,6 +980,150 @@ func TestChainHeaderRange(t *testing.T) {
 	}
 }
 
+// TestChainHeaderRangeNonPositiveCount ensures HeaderRange returns zero-value
+// points instead of panicking on an out-of-range slice index when count is
+// zero or negative (issue #3531).
+func TestChainHeaderRangeNonPositiveCount(t *testing.T) {
+	for _, count := range []int{0, -1, -1000} {
+		t.Run(fmt.Sprintf("count=%d", count), func(t *testing.T) {
+			cm, err := chain.NewManager(nil, nil)
+			if err != nil {
+				t.Fatalf("unexpected error creating chain manager: %s", err)
+			}
+			c := cm.PrimaryChain()
+			for _, testBlock := range testBlocks {
+				if err := c.AddBlockHeader(testBlock); err != nil {
+					t.Fatalf(
+						"unexpected error adding header to chain: %s",
+						err,
+					)
+				}
+			}
+			start, end := c.HeaderRange(count)
+			if start.Slot != 0 || len(start.Hash) != 0 {
+				t.Fatalf(
+					"expected zero-value start point for count=%d, got %#v",
+					count,
+					start,
+				)
+			}
+			if end.Slot != 0 || len(end.Hash) != 0 {
+				t.Fatalf(
+					"expected zero-value end point for count=%d, got %#v",
+					count,
+					end,
+				)
+			}
+		})
+	}
+}
+
+// TestChainRollbackInvalidHeaderTargetPreservesQueue rolls back to a point
+// that falls between two queued headers and matches neither. The rollback
+// must fail without deleting any of the queued headers that a naive scan
+// would have already pruned by the time it discovers the target is invalid
+// (issue #3531).
+func TestChainRollbackInvalidHeaderTargetPreservesQueue(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	// Queue headers at slots 60, 80, 100.
+	queuedBlocks := testBlocks[3:]
+	for _, testBlock := range queuedBlocks {
+		if err := c.AddBlockHeader(testBlock); err != nil {
+			t.Fatalf("unexpected error adding header to chain: %s", err)
+		}
+	}
+	beforeStart, beforeEnd := c.HeaderRange(len(queuedBlocks))
+
+	// Slot 70 falls strictly between the queued headers at 60 and 80 and
+	// matches neither, so it is not a valid rollback target.
+	invalidPoint := ocommon.Point{Slot: 70, Hash: []byte("not-a-real-hash")}
+	err = c.Rollback(invalidPoint)
+	if !errors.Is(err, models.ErrBlockNotFound) {
+		t.Fatalf(
+			"expected models.ErrBlockNotFound rolling back to an invalid target, got: %v",
+			err,
+		)
+	}
+
+	afterStart, afterEnd := c.HeaderRange(len(queuedBlocks))
+	if afterStart.Slot != beforeStart.Slot ||
+		!bytes.Equal(afterStart.Hash, beforeStart.Hash) ||
+		afterEnd.Slot != beforeEnd.Slot ||
+		!bytes.Equal(afterEnd.Hash, beforeEnd.Hash) {
+		t.Fatalf(
+			"queued headers were mutated by a failed rollback: before=(%#v,%#v) after=(%#v,%#v)",
+			beforeStart, beforeEnd, afterStart, afterEnd,
+		)
+	}
+}
+
+// TestChainRollbackToQueuedHeaderSucceeds rolls back to a point that exactly
+// matches a queued header. Only the headers after the matched one should be
+// discarded; the matched header itself stays queued and the chain tip moves
+// to it (issue #3531).
+func TestChainRollbackToQueuedHeaderSucceeds(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	// Queue headers at slots 60, 80, 100.
+	queuedBlocks := testBlocks[3:]
+	for _, testBlock := range queuedBlocks {
+		if err := c.AddBlockHeader(testBlock); err != nil {
+			t.Fatalf("unexpected error adding header to chain: %s", err)
+		}
+	}
+	rollbackBlock := queuedBlocks[1] // slot 80
+	rollbackPoint := ocommon.Point{
+		Slot: rollbackBlock.SlotNumber(),
+		Hash: rollbackBlock.Hash().Bytes(),
+	}
+	if err := c.Rollback(rollbackPoint); err != nil {
+		t.Fatalf("unexpected error rolling back to queued header: %s", err)
+	}
+	// The header at slot 100 must be pruned; slots 60 and 80 remain queued.
+	start, end := c.HeaderRange(2)
+	firstBlock := queuedBlocks[0]
+	if start.Slot != firstBlock.SlotNumber() ||
+		string(start.Hash) != string(firstBlock.Hash().Bytes()) {
+		t.Fatalf(
+			"did not get expected start point after rollback: got %d.%x, wanted %d.%s",
+			start.Slot,
+			start.Hash,
+			firstBlock.SlotNumber(),
+			firstBlock.Hash().String(),
+		)
+	}
+	if end.Slot != rollbackPoint.Slot ||
+		string(end.Hash) != string(rollbackPoint.Hash) {
+		t.Fatalf(
+			"did not get expected end point after rollback: got %d.%x, wanted %d.%x",
+			end.Slot,
+			end.Hash,
+			rollbackPoint.Slot,
+			rollbackPoint.Hash,
+		)
+	}
+	// The queued header at the rollback point is retained (only headers
+	// after it are pruned), so the header tip now names that point.
+	headerTip := c.HeaderTip()
+	if headerTip.Point.Slot != rollbackPoint.Slot ||
+		string(headerTip.Point.Hash) != string(rollbackPoint.Hash) {
+		t.Fatalf(
+			"header tip does not match rollback point: got %d.%x, wanted %d.%x",
+			headerTip.Point.Slot,
+			headerTip.Point.Hash,
+			rollbackPoint.Slot,
+			rollbackPoint.Hash,
+		)
+	}
+}
+
 func TestChainFirstVerifiedHeaderMatchesPointRequiresVerifiedHeader(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Fixes #3531

- `HeaderRange` panicked on a nonpositive `count` via a negative slice index. It now returns zero-value points instead.
- `rollbackLocked` deleted queued headers during the backward scan for the rollback point, before later checks (block lookup, fork depth, security param, ephemeral buffer span) could still fail. A failing check left the header queue partially pruned. The scan is now a non-mutating helper (`findQueuedHeader`) shared with `ValidateRollback`; headers are only spliced once the rollback outcome is known.

Tests added: zero and negative `HeaderRange` count, an invalid rollback target that must leave the header queue untouched, and a successful rollback to a queued header. Confirmed each new test fails without the corresponding fix.

Validated: `go build ./...`, `go vet ./...`, `golangci-lint run ./chain/...`, `nilaway ./chain/...`, `modernize ./chain/...`, `golines`, `make import-boundaries`, `make docs-parity` (ARCHITECTURE.md/DATABASE.md unaffected — private-method-level fix, no new component/schema/EventBus surface), and full `make test` (`-race`, whole module).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3531: `HeaderRange` no longer panics on nonpositive counts, and failed rollbacks no longer leave the header queue partially pruned.

- `HeaderRange` returns zero-value points when `count` is zero or negative instead of panicking on a negative slice index.
- Rollback now locates the rollback point with `findQueuedHeader`, a non-mutating helper shared with `ValidateRollback`, and splices headers only after all rollback checks pass.
- A successful rollback to a queued header keeps that header queued and removes only the headers after it.
- Adds tests for nonpositive `HeaderRange` counts, an invalid rollback target that leaves the queue untouched, and a successful rollback to a queued header.

<sup>Written for commit 14a3cc5057f47cb0d8c26e035b07ddcd4708f1a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain rollback behavior when targeting queued headers.
  * Rollbacks now preserve the selected header while removing only headers that follow it.
  * Invalid rollback targets no longer modify the queued header state.
  * Header range requests with zero or negative counts now return an empty result instead of causing an error.
  * Added regression coverage for rollback and header range edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->