### PR TITLE
fix(blockfetch): count inverted ranges against stuck-peer recovery

### DIFF
--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -196,6 +196,12 @@ func (o *Ouroboros) blockfetchServerRequestRange(
 				err,
 			)
 		}
+		o.blockfetchRecordNoBlocksAndMaybeClose(
+			ctx.ConnectionId,
+			start,
+			"blockfetch: closing stuck peer after repeated inverted range requests",
+			"blockfetch: peer stuck on inverted range",
+		)
 		return nil
 	}
 	// Validate that the requested slot range is not too large

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -16,25 +16,59 @@ package ouroboros
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database/immutable"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
+
+// syncLogBuffer is a mutex-guarded log sink. The blockfetch server processes
+// requests on its own recvLoop goroutine, which logs concurrently with the
+// test goroutine reading those logs back -- a plain bytes.Buffer would race.
+type syncLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncLogBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncLogBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncLogBuffer) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf.Reset()
+}
 
 // testConnId creates a ConnectionId with valid net.Addr values for testing.
 func testConnId() ouroboros_conn.ConnectionId {
@@ -716,6 +750,188 @@ func TestBlockfetchRecordNoBlocks_CleanupResetsCounter(t *testing.T) {
 		o.blockfetchRecordNoBlocks(connId, start),
 		"should trigger again after reset",
 	)
+}
+
+// blockfetchServerPeer drives Dingo's real blockfetch server config
+// (blockfetchServerConnOpts, instrumentation wrappers included) over a real
+// muxer, so requests reach blockfetchServerRequestRange exactly as a real
+// peer's would and NoBlocks() actually goes out on the wire instead of
+// panicking on a nil CallbackContext.Server the way the direct-call tests
+// above do.
+type blockfetchServerPeer struct {
+	peerConn net.Conn
+	errChan  chan error
+}
+
+func newBlockfetchServerPeer(
+	t *testing.T,
+	o *Ouroboros,
+) *blockfetchServerPeer {
+	t.Helper()
+	serverConn, peerConn := net.Pipe()
+	m := muxer.New(serverConn)
+	errChan := make(chan error, 4)
+	cfg, err := blockfetch.NewConfig(o.blockfetchServerConnOpts()...)
+	require.NoError(t, err)
+	server := blockfetch.NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: ouroboros_conn.ConnectionId{
+				LocalAddr:  serverConn.LocalAddr(),
+				RemoteAddr: serverConn.RemoteAddr(),
+			},
+			ErrorChan: errChan,
+			Muxer:     m,
+			Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+		&cfg,
+	)
+	server.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Protocol.Stop()
+		m.Stop()
+		_ = serverConn.Close()
+		_ = peerConn.Close()
+	})
+	return &blockfetchServerPeer{peerConn: peerConn, errChan: errChan}
+}
+
+// send writes msg to the server as a block-fetch request segment.
+func (p *blockfetchServerPeer) send(t *testing.T, msg protocol.Message) {
+	t.Helper()
+	data, err := cbor.Encode(msg)
+	require.NoError(t, err)
+	segment := muxer.NewSegment(blockfetch.ProtocolId, data, false)
+	require.NotNil(t, segment)
+	buf := &bytes.Buffer{}
+	require.NoError(
+		t,
+		binary.Write(buf, binary.BigEndian, segment.SegmentHeader),
+	)
+	_, err = buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = p.peerConn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+// readResponse reads one response segment, bounded by timeout so a request
+// the server leaves pending fails the test instead of hanging it.
+func (p *blockfetchServerPeer) readResponse(
+	t *testing.T,
+	timeout time.Duration,
+) *muxer.Segment {
+	t.Helper()
+	require.NoError(t, p.peerConn.SetReadDeadline(time.Now().Add(timeout)))
+	header := muxer.SegmentHeader{}
+	require.NoError(t, binary.Read(p.peerConn, binary.BigEndian, &header))
+	payload := make([]byte, header.PayloadLength)
+	_, err := io.ReadFull(p.peerConn, payload)
+	require.NoError(t, err)
+	return &muxer.Segment{SegmentHeader: header, Payload: payload}
+}
+
+// TestBlockfetchServerRequestRange_RepeatedInvertedRangeClosesStuckPeer is
+// issue #3428: an inverted range (start after end) sent NoBlocks without
+// calling blockfetchRecordNoBlocksAndMaybeClose, the same valve oversized and
+// missing-point rejections use, so a peer repeating an inverted request never
+// counted toward blockfetchMaxConsecutiveNoBlocks and was never closed.
+//
+// This drives real MsgRequestRange traffic over a real blockfetch.Server/
+// muxer pair -- unlike TestBlockfetchServerRequestRange_StartAfterEnd above,
+// which only proves the check is reached before its NoBlocks call panics on a
+// nil Server -- so the shared valve's close-eligible WARN log fires for real
+// once the configured threshold is reached.
+func TestBlockfetchServerRequestRange_RepeatedInvertedRangeClosesStuckPeer(
+	t *testing.T,
+) {
+	const closeWarnMsg = "closing stuck peer after repeated inverted range requests"
+
+	logBuf := &syncLogBuffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	o := newOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	peer := newBlockfetchServerPeer(t, o)
+
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(50, []byte{0x02})
+
+	for i := 1; i <= blockfetchMaxConsecutiveNoBlocks; i++ {
+		logBuf.Reset()
+		peer.send(t, blockfetch.NewMsgRequestRange(start, end))
+
+		segment := peer.readResponse(t, 5*time.Second)
+		assert.Equal(t, blockfetch.ProtocolId, segment.GetProtocolId())
+		assert.Equal(
+			t,
+			[]byte{0x81, blockfetch.MessageTypeNoBlocks},
+			segment.Payload,
+			"request %d should be answered with NoBlocks",
+			i,
+		)
+
+		if i < blockfetchMaxConsecutiveNoBlocks {
+			// Below threshold, blockfetchRecordNoBlocksAndMaybeClose logs
+			// nothing at all -- the only log line for this request is the
+			// "start after end" one written before NoBlocks() was even
+			// enqueued, which readResponse above already happened-before.
+			assert.False(
+				t,
+				strings.Contains(logBuf.String(), closeWarnMsg),
+				"request %d should not yet reach the close threshold",
+				i,
+			)
+		} else {
+			// At threshold, the close-eligible WARN is logged after NoBlocks()
+			// is enqueued, on the server's own goroutine, with no ordering
+			// guarantee relative to the wire bytes readResponse observed --
+			// poll instead of asserting immediately.
+			testutil.WaitForCondition(
+				t,
+				func() bool {
+					return strings.Contains(logBuf.String(), closeWarnMsg)
+				},
+				2*time.Second,
+				"expected close-eligible WARN once the threshold is reached",
+			)
+		}
+	}
+}
+
+// TestBlockfetchServerRequestRange_RepeatedValidRangeNeverClosesPeer is the
+// control for the fix above: a valid (non-inverted, in-limit) range must
+// never be treated as an inverted-range rejection, however many times it is
+// repeated for the same connection and start point. LedgerState is nil, so a
+// valid range reaches GetChainFromPoint and panics there -- proving it passed
+// both the inverted-range and oversized-range checks without either
+// rejecting it.
+func TestBlockfetchServerRequestRange_RepeatedValidRangeNeverClosesPeer(
+	t *testing.T,
+) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	o := newOuroboros(OuroborosConfig{
+		Logger:   logger,
+		EventBus: event.NewEventBus(nil, logger),
+	})
+	start := ocommon.NewPoint(100, []byte{0x01})
+	end := ocommon.NewPoint(150, []byte{0x02})
+	ctx := blockfetch.CallbackContext{ConnectionId: testConnId()}
+
+	for range blockfetchMaxConsecutiveNoBlocks {
+		assert.Panics(t, func() {
+			_ = o.blockfetchServerRequestRange(ctx, start, end)
+		}, "valid range should reach LedgerState call, not get rejected")
+	}
+
+	logOutput := logBuf.String()
+	assert.NotContains(t, logOutput, "start after end")
+	assert.NotContains(t, logOutput, "inverted range")
 }
 
 func BenchmarkBlockfetchClientBlockMetrics(b *testing.B) {

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -830,8 +830,8 @@ func (p *blockfetchServerPeer) readResponse(
 	return &muxer.Segment{SegmentHeader: header, Payload: payload}
 }
 
-// TestBlockfetchServerRequestRange_RepeatedInvertedRangeClosesStuckPeer is
-// issue #3428: an inverted range (start after end) sent NoBlocks without
+// TestBlockfetchServerRequestRange_RepeatedInvertedRangeReachesCloseThreshold
+// is issue #3428: an inverted range (start after end) sent NoBlocks without
 // calling blockfetchRecordNoBlocksAndMaybeClose, the same valve oversized and
 // missing-point rejections use, so a peer repeating an inverted request never
 // counted toward blockfetchMaxConsecutiveNoBlocks and was never closed.
@@ -840,8 +840,14 @@ func (p *blockfetchServerPeer) readResponse(
 // muxer pair -- unlike TestBlockfetchServerRequestRange_StartAfterEnd above,
 // which only proves the check is reached before its NoBlocks call panics on a
 // nil Server -- so the shared valve's close-eligible WARN log fires for real
-// once the configured threshold is reached.
-func TestBlockfetchServerRequestRange_RepeatedInvertedRangeClosesStuckPeer(
+// once the configured threshold is reached. o.connManager is nil, so this
+// only proves the inverted-range branch now feeds the valve and the valve
+// reaches its close-eligible state; it does not assert an actual connection
+// close, which blockfetchRecordNoBlocksAndMaybeClose only attempts when
+// connManager is non-nil. closeBlockfetchConnection's Close() call is already
+// covered generically by TestBlockfetchServerSendBatch_ClosesConnectionWhenSendDrainStalls
+// and TestReportBlockfetchServerAsyncError_ClosesConnection above.
+func TestBlockfetchServerRequestRange_RepeatedInvertedRangeReachesCloseThreshold(
 	t *testing.T,
 ) {
 	const closeWarnMsg = "closing stuck peer after repeated inverted range requests"

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -16,7 +16,6 @@ package ouroboros
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"io"
 	"log/slog"
@@ -26,11 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
-	"github.com/blinklabs-io/gouroboros/muxer"
-	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -752,82 +748,20 @@ func TestBlockfetchRecordNoBlocks_CleanupResetsCounter(t *testing.T) {
 	)
 }
 
-// blockfetchServerPeer drives Dingo's real blockfetch server config
-// (blockfetchServerConnOpts, instrumentation wrappers included) over a real
-// muxer, so requests reach blockfetchServerRequestRange exactly as a real
-// peer's would and NoBlocks() actually goes out on the wire instead of
-// panicking on a nil CallbackContext.Server the way the direct-call tests
-// above do.
-type blockfetchServerPeer struct {
-	peerConn net.Conn
-	errChan  chan error
-}
-
-func newBlockfetchServerPeer(
-	t *testing.T,
-	o *Ouroboros,
-) *blockfetchServerPeer {
+// newBlockfetchServerPeer builds a muxerServerPeer driving Dingo's real
+// blockfetch server config (blockfetchServerConnOpts, instrumentation
+// wrappers included), so requests reach blockfetchServerRequestRange exactly
+// as a real peer's would and NoBlocks() actually goes out on the wire
+// instead of panicking on a nil CallbackContext.Server the way the
+// direct-call tests above do.
+func newBlockfetchServerPeer(t *testing.T, o *Ouroboros) *muxerServerPeer {
 	t.Helper()
-	serverConn, peerConn := net.Pipe()
-	m := muxer.New(serverConn)
-	errChan := make(chan error, 4)
+	opts, peer := newMuxerServerPeer(t)
 	cfg, err := blockfetch.NewConfig(o.blockfetchServerConnOpts()...)
 	require.NoError(t, err)
-	server := blockfetch.NewServer(
-		protocol.ProtocolOptions{
-			ConnectionId: ouroboros_conn.ConnectionId{
-				LocalAddr:  serverConn.LocalAddr(),
-				RemoteAddr: serverConn.RemoteAddr(),
-			},
-			ErrorChan: errChan,
-			Muxer:     m,
-			Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		},
-		&cfg,
-	)
-	server.Start()
-	m.Start()
-	t.Cleanup(func() {
-		server.Protocol.Stop()
-		m.Stop()
-		_ = serverConn.Close()
-		_ = peerConn.Close()
-	})
-	return &blockfetchServerPeer{peerConn: peerConn, errChan: errChan}
-}
-
-// send writes msg to the server as a block-fetch request segment.
-func (p *blockfetchServerPeer) send(t *testing.T, msg protocol.Message) {
-	t.Helper()
-	data, err := cbor.Encode(msg)
-	require.NoError(t, err)
-	segment := muxer.NewSegment(blockfetch.ProtocolId, data, false)
-	require.NotNil(t, segment)
-	buf := &bytes.Buffer{}
-	require.NoError(
-		t,
-		binary.Write(buf, binary.BigEndian, segment.SegmentHeader),
-	)
-	_, err = buf.Write(segment.Payload)
-	require.NoError(t, err)
-	_, err = p.peerConn.Write(buf.Bytes())
-	require.NoError(t, err)
-}
-
-// readResponse reads one response segment, bounded by timeout so a request
-// the server leaves pending fails the test instead of hanging it.
-func (p *blockfetchServerPeer) readResponse(
-	t *testing.T,
-	timeout time.Duration,
-) *muxer.Segment {
-	t.Helper()
-	require.NoError(t, p.peerConn.SetReadDeadline(time.Now().Add(timeout)))
-	header := muxer.SegmentHeader{}
-	require.NoError(t, binary.Read(p.peerConn, binary.BigEndian, &header))
-	payload := make([]byte, header.PayloadLength)
-	_, err := io.ReadFull(p.peerConn, payload)
-	require.NoError(t, err)
-	return &muxer.Segment{SegmentHeader: header, Payload: payload}
+	server := blockfetch.NewServer(opts, &cfg)
+	peer.start(t, server)
+	return peer
 }
 
 // TestBlockfetchServerRequestRange_RepeatedInvertedRangeReachesCloseThreshold
@@ -867,7 +801,11 @@ func TestBlockfetchServerRequestRange_RepeatedInvertedRangeReachesCloseThreshold
 
 	for i := 1; i <= blockfetchMaxConsecutiveNoBlocks; i++ {
 		logBuf.Reset()
-		peer.send(t, blockfetch.NewMsgRequestRange(start, end))
+		peer.send(
+			t,
+			blockfetch.ProtocolId,
+			blockfetch.NewMsgRequestRange(start, end),
+		)
 
 		segment := peer.readResponse(t, 5*time.Second)
 		assert.Equal(t, blockfetch.ProtocolId, segment.GetProtocolId())

--- a/ouroboros/leios_range_responder_test.go
+++ b/ouroboros/leios_range_responder_test.go
@@ -15,99 +15,27 @@
 package ouroboros
 
 import (
-	"bytes"
-	"encoding/binary"
-	"io"
-	"log/slog"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
-	"github.com/blinklabs-io/gouroboros/cbor"
-	gconnection "github.com/blinklabs-io/gouroboros/connection"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
-	"github.com/blinklabs-io/gouroboros/muxer"
-	"github.com/blinklabs-io/gouroboros/protocol"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/stretchr/testify/require"
 )
 
-// leiosFetchServerPeer drives Dingo's real leios-fetch server config
-// (leiosfetchServerConnOpts, instrumentation wrappers included) over a real
-// muxer, so the assertions are about what Dingo actually puts on the wire
-// rather than about what a callback returns.
-type leiosFetchServerPeer struct {
-	o        *Ouroboros
-	peerConn net.Conn
-	errChan  chan error
-}
-
-func newLeiosFetchServerPeer(
-	t *testing.T,
-	o *Ouroboros,
-) *leiosFetchServerPeer {
+// newLeiosFetchServerPeer builds a muxerServerPeer driving Dingo's real
+// leios-fetch server config (leiosfetchServerConnOpts, instrumentation
+// wrappers included), so the assertions are about what Dingo actually puts
+// on the wire rather than about what a callback returns.
+func newLeiosFetchServerPeer(t *testing.T, o *Ouroboros) *muxerServerPeer {
 	t.Helper()
-	serverConn, peerConn := net.Pipe()
-	m := muxer.New(serverConn)
-	errChan := make(chan error, 4)
+	opts, peer := newMuxerServerPeer(t)
 	cfg := oleiosfetch.NewConfig(o.leiosfetchServerConnOpts()...)
-	server := oleiosfetch.NewServer(
-		protocol.ProtocolOptions{
-			ConnectionId: gconnection.ConnectionId{
-				LocalAddr:  serverConn.LocalAddr(),
-				RemoteAddr: serverConn.RemoteAddr(),
-			},
-			ErrorChan: errChan,
-			Muxer:     m,
-			Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		},
-		&cfg,
-	)
-	server.Start()
-	m.Start()
-	t.Cleanup(func() {
-		server.Protocol.Stop()
-		m.Stop()
-		_ = serverConn.Close()
-		_ = peerConn.Close()
-	})
-	return &leiosFetchServerPeer{o: o, peerConn: peerConn, errChan: errChan}
-}
-
-// send writes msg to the server as a leios-fetch request segment.
-func (p *leiosFetchServerPeer) send(t *testing.T, msg protocol.Message) {
-	t.Helper()
-	data, err := cbor.Encode(msg)
-	require.NoError(t, err)
-	segment := muxer.NewSegment(oleiosfetch.ProtocolId, data, false)
-	require.NotNil(t, segment)
-	buf := &bytes.Buffer{}
-	require.NoError(
-		t,
-		binary.Write(buf, binary.BigEndian, segment.SegmentHeader),
-	)
-	_, err = buf.Write(segment.Payload)
-	require.NoError(t, err)
-	_, err = p.peerConn.Write(buf.Bytes())
-	require.NoError(t, err)
-}
-
-// readResponse reads one response segment, bounded by timeout so a request
-// that the server leaves pending fails the test instead of hanging it.
-func (p *leiosFetchServerPeer) readResponse(
-	t *testing.T,
-	timeout time.Duration,
-) *muxer.Segment {
-	t.Helper()
-	require.NoError(t, p.peerConn.SetReadDeadline(time.Now().Add(timeout)))
-	header := muxer.SegmentHeader{}
-	require.NoError(t, binary.Read(p.peerConn, binary.BigEndian, &header))
-	payload := make([]byte, header.PayloadLength)
-	_, err := io.ReadFull(p.peerConn, payload)
-	require.NoError(t, err)
-	return &muxer.Segment{SegmentHeader: header, Payload: payload}
+	server := oleiosfetch.NewServer(opts, &cfg)
+	peer.start(t, server)
+	return peer
 }
 
 // TestLeiosFetchBlockRangeRequestIsDeclined is the Dingo-owned half of issue
@@ -129,7 +57,7 @@ func TestLeiosFetchBlockRangeRequestIsDeclined(t *testing.T) {
 	o := newOuroboros(OuroborosConfig{EnableLeios: true})
 	peer := newLeiosFetchServerPeer(t, o)
 
-	peer.send(t, oleiosfetch.NewMsgBlockRangeRequest(
+	peer.send(t, oleiosfetch.ProtocolId, oleiosfetch.NewMsgBlockRangeRequest(
 		ocommon.NewPoint(3623, []byte{0x01, 0x02}),
 		ocommon.NewPoint(3700, []byte{0x03, 0x04}),
 	))
@@ -155,7 +83,7 @@ func TestLeiosFetchUnavailableBlockTxsAnswersNoBlockTxs(t *testing.T) {
 
 	// No endorser block is stored, so the callback reports
 	// ErrBlockTxsNotFound and the server answers MsgNoBlockTxs.
-	peer.send(t, oleiosfetch.NewMsgBlockTxsRequest(
+	peer.send(t, oleiosfetch.ProtocolId, oleiosfetch.NewMsgBlockTxsRequest(
 		ocommon.NewPoint(3623, make([]byte, lcommon.Blake2b256Size)),
 		map[uint16]uint64{0: 1 << 63},
 	))

--- a/ouroboros/muxer_server_peer_test.go
+++ b/ouroboros/muxer_server_peer_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gconnection "github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// muxerServer is the subset of a gouroboros protocol server
+// (*blockfetch.Server, *leiosfetch.Server, ...) that muxerServerPeer needs to
+// start and stop. Every protocol package's Server embeds *protocol.Protocol,
+// which defines both methods and is promoted onto the Server, so any of them
+// satisfies this interface unchanged.
+type muxerServer interface {
+	Start()
+	Stop()
+}
+
+// muxerServerPeer drives a real Dingo server-side protocol implementation
+// (blockfetch, leios-fetch, ...) over a real net.Pipe/muxer pair, so
+// assertions are about what Dingo actually puts on the wire rather than
+// about what a callback returns directly. Each protocol still builds its own
+// Config/Server -- gouroboros gives each protocol package distinct concrete
+// types with no shared constructor -- but the net.Pipe/muxer plumbing and the
+// send/readResponse wire mechanics below are identical across protocols, so
+// this type is shared; each protocol-specific test file supplies only its
+// own NewConfig/NewServer call (see newLeiosFetchServerPeer,
+// newBlockfetchServerPeer).
+type muxerServerPeer struct {
+	peerConn net.Conn
+	errChan  chan error
+	muxer    *muxer.Muxer
+}
+
+// newMuxerServerPeer creates the net.Pipe pair and muxer, and returns the
+// protocol.ProtocolOptions every protocol-specific *Server constructor needs
+// (blockfetch.NewServer, leiosfetch.NewServer, ...) alongside the peer side.
+// Build the protocol's Config/Server from opts, then call peer.start with it.
+func newMuxerServerPeer(
+	t *testing.T,
+) (opts protocol.ProtocolOptions, peer *muxerServerPeer) {
+	t.Helper()
+	serverConn, peerConn := net.Pipe()
+	m := muxer.New(serverConn)
+	errChan := make(chan error, 4)
+	opts = protocol.ProtocolOptions{
+		ConnectionId: gconnection.ConnectionId{
+			LocalAddr:  serverConn.LocalAddr(),
+			RemoteAddr: serverConn.RemoteAddr(),
+		},
+		ErrorChan: errChan,
+		Muxer:     m,
+		Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
+	peer = &muxerServerPeer{peerConn: peerConn, errChan: errChan, muxer: m}
+	t.Cleanup(func() {
+		m.Stop()
+		_ = serverConn.Close()
+		_ = peerConn.Close()
+	})
+	return opts, peer
+}
+
+// start starts the caller's protocol server, then the muxer -- gouroboros
+// requires the server to register itself with the muxer before the muxer
+// starts dispatching -- and arranges for the server to stop during
+// t.Cleanup. t.Cleanup runs LIFO, and this is registered after
+// newMuxerServerPeer's own cleanup, so server.Stop still runs before the
+// muxer/connection teardown that call registered, preserving the original
+// stop order.
+func (p *muxerServerPeer) start(t *testing.T, server muxerServer) {
+	t.Helper()
+	server.Start()
+	p.muxer.Start()
+	t.Cleanup(server.Stop)
+}
+
+// send writes msg to the server as a request segment for the given protocol.
+func (p *muxerServerPeer) send(
+	t *testing.T,
+	protocolId uint16,
+	msg protocol.Message,
+) {
+	t.Helper()
+	data, err := cbor.Encode(msg)
+	require.NoError(t, err)
+	segment := muxer.NewSegment(protocolId, data, false)
+	require.NotNil(t, segment)
+	buf := &bytes.Buffer{}
+	require.NoError(
+		t,
+		binary.Write(buf, binary.BigEndian, segment.SegmentHeader),
+	)
+	_, err = buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = p.peerConn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+// readResponse reads one response segment, bounded by timeout so a request
+// the server leaves pending fails the test instead of hanging it.
+func (p *muxerServerPeer) readResponse(
+	t *testing.T,
+	timeout time.Duration,
+) *muxer.Segment {
+	t.Helper()
+	require.NoError(t, p.peerConn.SetReadDeadline(time.Now().Add(timeout)))
+	header := muxer.SegmentHeader{}
+	require.NoError(t, binary.Read(p.peerConn, binary.BigEndian, &header))
+	payload := make([]byte, header.PayloadLength)
+	_, err := io.ReadFull(p.peerConn, payload)
+	require.NoError(t, err)
+	return &muxer.Segment{SegmentHeader: header, Payload: payload}
+}


### PR DESCRIPTION
Fixes #3428

## Problem

`ouroboros/blockfetch.go`'s inverted-range branch (start after end) sent
`NoBlocks` but never called `blockfetchRecordNoBlocksAndMaybeClose`, unlike
the oversized-range and missing-point branches. A peer repeating an inverted
request never counted toward the consecutive-NoBlocks threshold and was
never closed.

## Changes

- Wire the inverted-range branch to the same stuck-peer valve
  (`blockfetchRecordNoBlocksAndMaybeClose`) the other two rejection reasons
  already use, with matching log/close messages.
- Add `TestBlockfetchServerRequestRange_RepeatedInvertedRangeClosesStuckPeer`:
  drives real `MsgRequestRange` traffic over a real `blockfetch.Server`/muxer
  pair and proves the close-eligible WARN fires once the configured
  consecutive-NoBlocks threshold is reached. Confirmed to fail without the fix.
- Add `TestBlockfetchServerRequestRange_RepeatedValidRangeNeverClosesPeer` as
  the control case: a valid, repeated range is never mistaken for an
  inverted-range rejection.

## Checks

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./ouroboros/...`, `nilaway ./ouroboros/...`,
  `modernize ./ouroboros/...` — clean
- `make import-boundaries`, `make golines`, `make docs-parity` — clean, no diff
- `make govulncheck` — no vulnerabilities in reachable code
- `go test -race ./ouroboros/...` — pass
- `make test` (full module, race-enabled, all 84 packages including
  `internal/test/conformance`) — pass, no failures
- `ARCHITECTURE.md`/`DATABASE.md` checked: unaffected. This wires an
  already-documented mechanism (repeated NoBlocks closes the stuck peer,
  documented in ARCHITECTURE.md) into a third branch that already existed;
  it does not change component responsibilities, EventBus topics, or
  lifecycle/concurrency behavior.

## Skipped

- `internal/test/devnet/run-tests.sh` — Docker unavailable in the validation
  environment (permission denied on `docker.sock`). The change is confined to
  the blockfetch server's request-validation rejection path (an edge case a
  healthy sync never exercises), not block serving/streaming/consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3428 by counting inverted block-range requests toward stuck-peer recovery. Previously, requests with a start point after the end point returned `NoBlocks` without updating the consecutive counter; they now use the existing recovery path, so peers that repeat them can be closed after the configured threshold.

- Adds real blockfetch server/muxer coverage for the threshold behavior and a valid-range control case.
- Shares the `net.Pipe`/muxer server-peer test harness between blockfetch and Leios fetch tests.

<sup>Written for commit 46f82042e742f2bd9cb5b2497506c9731137ccb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid inverted block-range requests are now tracked consistently with other repeated invalid requests.
  - Peers that repeatedly send invalid inverted ranges can now be closed after reaching the configured threshold.
  - Valid block-range requests continue to be processed normally without triggering peer closure.

- **Tests**
  - Added coverage for repeated invalid ranges closing a peer.
  - Added coverage confirming valid ranges do not cause peer closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->