### PR TITLE
fix(forge): read the sigma pair atomically via one accessor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8116,9 +8116,12 @@ poolStake, err := ledgerView.GetPoolStake(epoch, poolKeyHash)
 totalStake, err := ledgerView.GetTotalActiveStake(epoch)
 ```
 
-Both consensus paths resolve the denominator through that one store accessor,
-`Metadata().GetTotalActiveStake`, but they reach it differently and the
-difference matters when reading this code:
+The normal Praos/mark paths resolve the denominator through that one store
+accessor, `Metadata().GetTotalActiveStake`, but they reach it differently and
+the difference matters when reading this code. Header verification that uses
+an imported active distribution is the exception: it uses the denominator
+carried by that imported snapshot rather than resolving a mark value from
+metadata:
 
 - The forging adapter calls `LedgerView.GetTotalActiveStake`, which passes the
   view's transaction and pins `snapshotType` to `"mark"`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8102,15 +8102,40 @@ Mithril case already refused above.
 The `LedgerView` provides stake distribution queries:
 
 ```go
-// Get full stake distribution for leader election
+// Get full stake distribution (Leios committee stake; note TotalStake here is
+// summed from the mark rows by GetStakeDistribution itself)
 dist, err := ledgerView.GetStakeDistribution(epoch)
 
-// Get stake for a specific pool
+// Get stake for a specific pool -- the sigma numerator
 poolStake, err := ledgerView.GetPoolStake(epoch, poolKeyHash)
 
-// Get total active stake
+// Get total active stake -- the sigma denominator. This is the accessor both
+// header verification and the forging adapter resolve the denominator
+// through; it prefers epoch_summary.total_active_stake for "mark" queries.
 totalStake, err := ledgerView.GetTotalActiveStake(epoch)
 ```
+
+Leader election must take the two halves of sigma from ONE `LedgerView` inside
+ONE `db.MetadataTxn`. The forging adapter's
+`leader.StakeDistributionProvider` therefore exposes a single
+`GetPoolAndTotalActiveStake(epoch, poolKeyHash) (poolStake, totalActiveStake, error)`
+rather than separate accessors, so a torn read is not expressible:
+
+- Reading the halves through two transactions let a snapshot re-capture land
+  between them, producing a sigma reproducible from neither snapshot
+  (dingo #3815).
+- Deriving the denominator a second way -- by summing the mark rows, as
+  `GetStakeDistribution` does -- let the forge denominator drift from the
+  verify denominator, so a node could forge a block it would itself reject
+  (dingo #3814). Both paths now call `GetTotalActiveStake`.
+
+The reference rule for what that denominator contains, with
+`cardano-ledger` citations, is documented on
+`leader.StakeDistributionProvider` in `ledger/leader/election.go`. In short:
+it sums every registered credential delegated to any pool id, while
+numerators come only from registered pools -- and those two sets coincide
+only because POOLREAP clears a retiring pool's delegations in the same update
+that removes it (dingo mirrors this in `ledger/poolreap.go`).
 
 ### Boundary Capture And Events
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8109,11 +8109,25 @@ dist, err := ledgerView.GetStakeDistribution(epoch)
 // Get stake for a specific pool -- the sigma numerator
 poolStake, err := ledgerView.GetPoolStake(epoch, poolKeyHash)
 
-// Get total active stake -- the sigma denominator. This is the accessor both
-// header verification and the forging adapter resolve the denominator
-// through; it prefers epoch_summary.total_active_stake for "mark" queries.
+// Get total active stake -- the sigma denominator. Txn-scoped wrapper over
+// the shared store accessor Metadata().GetTotalActiveStake, pinned to the
+// "mark" snapshot type; that accessor prefers epoch_summary.total_active_stake
+// when the epoch's summary row is marked ready.
 totalStake, err := ledgerView.GetTotalActiveStake(epoch)
 ```
+
+Both consensus paths resolve the denominator through that one store accessor,
+`Metadata().GetTotalActiveStake`, but they reach it differently and the
+difference matters when reading this code:
+
+- The forging adapter calls `LedgerView.GetTotalActiveStake`, which passes the
+  view's transaction and pins `snapshotType` to `"mark"`.
+- `verify_header.go` calls `ls.db.Metadata().GetTotalActiveStake` directly with
+  a `nil` transaction and the `snapshotType` it resolved for the header under
+  check, which is `"mark"` on the normal Praos path but is not hardcoded.
+
+So "one accessor" holds at the store layer, which is what removes the second
+derivation. It is not a claim that verification goes through `LedgerView`.
 
 Leader election must take the two halves of sigma from ONE `LedgerView` inside
 ONE `db.MetadataTxn`. The forging adapter's

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -45,9 +45,10 @@ type StakeDistributionProvider interface {
 	// (dingo #3815). The pair is returned by one method precisely so that
 	// no implementation can express the torn read.
 	//
-	// The denominator MUST come from the same accessor the header
-	// verification path uses, so that a node cannot forge against one
-	// denominator and validate against another (dingo #3814). See the
+	// The denominator MUST come from the same store accessor the header
+	// verification path resolves it through
+	// (Metadata().GetTotalActiveStake), so that a node cannot forge against
+	// one denominator and validate against another (dingo #3814). See the
 	// reference-rule commentary below this interface for what that value
 	// is and why it must not be re-derived per code path.
 	GetPoolAndTotalActiveStake(

--- a/ledger/leader/election.go
+++ b/ledger/leader/election.go
@@ -33,16 +33,98 @@ import (
 
 // StakeDistributionProvider provides stake distribution data for leader election.
 type StakeDistributionProvider interface {
-	// GetPoolStake returns the stake for a specific pool in the given epoch.
-	// For leader election, this should query the mark snapshot selected by
-	// praos.StakeSnapshotEpoch.
-	GetPoolStake(epoch uint64, poolKeyHash []byte) (uint64, error)
-
-	// GetTotalActiveStake returns the total active stake for the given epoch.
-	// For leader election, this should query the mark snapshot selected by
-	// praos.StakeSnapshotEpoch.
-	GetTotalActiveStake(epoch uint64) (uint64, error)
+	// GetPoolAndTotalActiveStake returns the sigma numerator (this pool's
+	// stake) and the sigma denominator (total active stake) for the given
+	// snapshot epoch, which callers select with praos.StakeSnapshotEpoch.
+	//
+	// Both values MUST be read from a single consistent view of the
+	// snapshot. Reading them through two separate transactions lets a
+	// snapshot re-capture land between them and yields a sigma whose
+	// numerator and denominator come from different writes -- a leader
+	// schedule that is not reproducible from either snapshot alone
+	// (dingo #3815). The pair is returned by one method precisely so that
+	// no implementation can express the torn read.
+	//
+	// The denominator MUST come from the same accessor the header
+	// verification path uses, so that a node cannot forge against one
+	// denominator and validate against another (dingo #3814). See the
+	// reference-rule commentary below this interface for what that value
+	// is and why it must not be re-derived per code path.
+	GetPoolAndTotalActiveStake(
+		epoch uint64,
+		poolKeyHash []byte,
+	) (poolStake uint64, totalActiveStake uint64, err error)
 }
+
+// The sigma denominator, per the cardano-ledger reference implementation
+// (IntersectMBO/cardano-ledger@9bac33a, master, 2026-09-03). Written down
+// here because two prior investigations (dingo #2798 and #3626) were sent to
+// the wrong cause by a stale comment that called this "the sum of all pool
+// stakes".
+//
+// The reference computes the denominator as a sum over resolved stake
+// CREDENTIALS, not over the per-pool distribution:
+//
+//	total = sum { utxoStake(c) + accountBalance(c)
+//	            | c is a REGISTERED credential
+//	              and c delegates to SOME pool id }
+//
+//   - Cardano/Ledger/State/Stake.hs:156-160 (sumAllActiveStake; an empty
+//     credential set floors at 1 lovelace, not 0)
+//   - Cardano/Ledger/State/SnapShots.hs:419-426 (mkSnapShot, the sole
+//     production construction: ssTotalActiveStake = sumAllActiveStake
+//     ssActiveStake)
+//   - Cardano/Ledger/State/SnapShots.hs:472,486 (pdTotalActiveStake is that
+//     value verbatim; it is never recomputed from the pool map)
+//
+// The resolution predicate checks exactly two things -- the credential is in
+// the accounts map, and its stake-pool delegation is Just -- and does NOT
+// check that the target pool is registered; the pool map is not even in
+// scope (Cardano/Ledger/State/Stake.hs:217-246,
+// resolveActiveInstantStakeCredentials; Conway/State/Stake.hs:123-130,
+// which Dijkstra reuses).
+//
+// Numerators come only from REGISTERED pools, keyed by psStakePools
+// (Cardano/Ledger/State/SnapShots.hs:206-207,237,429-438,471-488,
+// calculatePoolDistr').
+//
+// It is tempting to read that asymmetry as "stake delegated to a retired or
+// unregistered pool belongs in the denominator and in no numerator". That
+// state is UNREACHABLE in the reference, so the sum of the numerators does
+// equal the denominator. Two rules keep it so, and neither lives in the
+// stake computation:
+//
+//   - DELEG rejects a delegation naming an unregistered pool
+//     (Conway/Rules/Deleg.hs:218-233,
+//     DelegateeStakePoolNotRegisteredDELEG).
+//   - POOLREAP clears the delegations of a retiring pool in the SAME state
+//     update that drops it from psStakePools
+//     (Shelley/Rules/PoolReap.hs:214-228,238-240,
+//     removeStakePoolDelegations . delegsToClear), so those credentials
+//     leave the denominator too rather than lingering in it.
+//   - An assertion enforces the pair
+//     (Shelley/Rules/Ledger.hs:274-279,453-468, "Reverse stake pool
+//     delegations must match").
+//
+// Dingo relies on the same invariant, maintained at the same point: see
+// ledger/poolreap.go, which calls ClearDelegationsToRetiredPool for each
+// reaped pool (dingo #3794 -- failing to clear inflates the total active
+// stake above the network's and makes every other pool's threshold too
+// small). Dingo also runs its SNAP stake read before POOLREAP, matching
+// EPOCH's sub-rule order (Conway/Rules/Epoch.hs:289-294; dingo
+// ledger/chainsync.go epoch-rollover step list).
+//
+// Consequences for this package: summing the numerators is the correct
+// denominator ONLY while that invariant holds. It is therefore not a safe
+// thing to derive independently in a second code path -- hence the single
+// accessor required below (dingo #3814).
+//
+// One thing the reference does NOT do: there is no stake-credential
+// inactivity gate. CIP-0163-style inactivity in the reference is DRep
+// expiry, applied only to the DRep voting ratio in RATIFY
+// (Conway/Rules/Ratify.hs:258-281); it never touches ActiveStake,
+// ssTotalActiveStake, or PoolDistr, and accounts carry no activity field
+// (Conway/State/Account.hs:60-80).
 
 // EpochInfoProvider provides epoch-related information.
 type EpochInfoProvider interface {
@@ -702,25 +784,22 @@ func (e *Election) validatePersistedSchedule(
 	}
 
 	snapshotEpoch := praos.StakeSnapshotEpoch(epoch)
-	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
+	// One atomic read: revalidating a persisted schedule against a torn
+	// (numerator, denominator) pair could accept a schedule that matches
+	// neither snapshot, or discard a still-valid one (dingo #3815).
+	poolStake, totalStake, err := e.stakeProvider.GetPoolAndTotalActiveStake(
+		snapshotEpoch,
+		e.poolId[:],
+	)
 	if err != nil {
 		return false, "", fmt.Errorf(
-			"get pool stake for epoch %d: %w",
+			"get pool and total active stake for epoch %d: %w",
 			snapshotEpoch,
 			err,
 		)
 	}
 	if poolStake != schedule.PoolStake {
 		return false, "pool stake changed", nil
-	}
-
-	totalStake, err := e.stakeProvider.GetTotalActiveStake(snapshotEpoch)
-	if err != nil {
-		return false, "", fmt.Errorf(
-			"get total stake for epoch %d: %w",
-			snapshotEpoch,
-			err,
-		)
 	}
 	if totalStake != schedule.TotalStake {
 		return false, "total stake changed", nil
@@ -768,16 +847,23 @@ func (e *Election) computeSchedule(
 	// Leader election uses the mark snapshot that is active for the epoch.
 	snapshotEpoch := praos.StakeSnapshotEpoch(currentEpoch)
 
-	// Get pool stake from the active snapshot.
+	// Read the sigma numerator and denominator together. Two separate
+	// reads let a snapshot re-capture land between them, producing a
+	// schedule computed from a sigma that exists in no single snapshot
+	// (dingo #3815). The zero-stake short circuit below therefore happens
+	// after the pair is in hand rather than between the two reads.
 	stakeLookupStart := time.Now()
-	poolStake, err := e.stakeProvider.GetPoolStake(snapshotEpoch, e.poolId[:])
+	poolStake, totalStake, err := e.stakeProvider.GetPoolAndTotalActiveStake(
+		snapshotEpoch,
+		e.poolId[:],
+	)
+	if e.metrics != nil {
+		e.metrics.stakeLookupDuration.Observe(
+			time.Since(stakeLookupStart).Seconds(),
+		)
+	}
 	if err != nil {
-		if e.metrics != nil {
-			e.metrics.stakeLookupDuration.Observe(
-				time.Since(stakeLookupStart).Seconds(),
-			)
-		}
-		return nil, fmt.Errorf("get pool stake: %w", err)
+		return nil, fmt.Errorf("get pool and total active stake: %w", err)
 	}
 
 	e.logger.Info(
@@ -798,17 +884,6 @@ func (e *Election) computeSchedule(
 			snapshotEpoch,
 		)
 		return nil, nil
-	}
-
-	// Get total stake from the active snapshot.
-	totalStake, err := e.stakeProvider.GetTotalActiveStake(snapshotEpoch)
-	if e.metrics != nil {
-		e.metrics.stakeLookupDuration.Observe(
-			time.Since(stakeLookupStart).Seconds(),
-		)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get total stake: %w", err)
 	}
 
 	e.logger.Info(

--- a/ledger/leader/election_sigma_audit_test.go
+++ b/ledger/leader/election_sigma_audit_test.go
@@ -49,19 +49,18 @@ type recordingStakeProvider struct {
 	totalStake       uint64
 }
 
-func (p *recordingStakeProvider) GetPoolStake(
+// GetPoolAndTotalActiveStake records the snapshot epoch for BOTH halves on
+// every call. Since dingo #3815 the pair is read through one method, so the
+// two recorded slices are necessarily the same length and carry the same
+// epochs -- which is itself the property TestComputeScheduleDrawsSigmaInputs\
+// FromSameSnapshotEpoch asserts.
+func (p *recordingStakeProvider) GetPoolAndTotalActiveStake(
 	epoch uint64,
 	_ []byte,
-) (uint64, error) {
+) (uint64, uint64, error) {
 	p.poolStakeEpochs = append(p.poolStakeEpochs, epoch)
-	return p.poolStake, nil
-}
-
-func (p *recordingStakeProvider) GetTotalActiveStake(
-	epoch uint64,
-) (uint64, error) {
 	p.totalStakeEpochs = append(p.totalStakeEpochs, epoch)
-	return p.totalStake, nil
+	return p.poolStake, p.totalStake, nil
 }
 
 // sigmaAuditEpochProvider is a minimal EpochInfoProvider. exactCoeff, when
@@ -111,7 +110,7 @@ func (p *sigmaAuditEpochProvider) ActiveSlotCoeffRat() *big.Rat {
 }
 
 func newSigmaAuditElection(
-	stake *recordingStakeProvider,
+	stake StakeDistributionProvider,
 	epochs *sigmaAuditEpochProvider,
 	logger *slog.Logger,
 ) *Election {
@@ -289,4 +288,79 @@ func findLogRecord(
 	require.NoError(t, scanner.Err())
 	t.Fatalf("no log record with msg %q in:\n%s", msg, buf.String())
 	return nil
+}
+
+// generationStakeProvider models a store whose snapshot is re-captured
+// between reads: every call returns the NEXT generation. Both generations
+// carry the same sigma with different absolute values, so a pair assembled
+// from two different calls is detectable as a sigma matching neither.
+type generationStakeProvider struct {
+	calls int
+}
+
+const (
+	sigmaGenOnePoolStake  = uint64(59_000_000)
+	sigmaGenOneTotalStake = uint64(1_000_000_000)
+)
+
+func (p *generationStakeProvider) GetPoolAndTotalActiveStake(
+	_ uint64,
+	_ []byte,
+) (uint64, uint64, error) {
+	generation := uint64(1 << p.calls)
+	p.calls++
+	return sigmaGenOnePoolStake * generation,
+		sigmaGenOneTotalStake * generation,
+		nil
+}
+
+// TestComputeScheduleReadsSigmaPairInOneProviderCall is the regression test
+// for dingo #3815, driven through the real schedule computation.
+//
+// computeSchedule used to call GetPoolStake and GetTotalActiveStake in
+// sequence (election.go:773 and :804), each opening its own db.MetadataTxn in
+// the forging adapter. A snapshot re-capture landing between the two produced
+// a schedule whose numerator and denominator came from different writes: a
+// sigma reproducible from neither snapshot alone.
+//
+// The provider here advances a generation on every call, which is what a
+// re-capture between reads looks like from the caller's side. Two assertions
+// pin the fix:
+//
+//   - exactly ONE paired read happens, so there is no window between halves;
+//   - the schedule's stake pair is generation one entire, so sigma is exact.
+//
+// Under the two-call code the numerator comes from generation one and the
+// denominator from generation two, halving sigma, and both assertions fail.
+func TestComputeScheduleReadsSigmaPairInOneProviderCall(t *testing.T) {
+	stake := &generationStakeProvider{}
+	election := newSigmaAuditElection(
+		stake,
+		&sigmaAuditEpochProvider{floatCoeff: 0.05},
+		slog.New(slog.DiscardHandler),
+	)
+
+	schedule, err := election.computeSchedule(
+		context.Background(), sigmaAuditEpoch,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
+
+	require.Equal(t, 1, stake.calls,
+		"the sigma numerator and denominator must be read in ONE paired "+
+			"call; a second read is a torn-sigma window (dingo #3815)")
+
+	require.Equal(t, sigmaGenOnePoolStake, schedule.PoolStake,
+		"numerator must come from the first snapshot generation")
+	require.Equal(t, sigmaGenOneTotalStake, schedule.TotalStake,
+		"denominator must come from the SAME generation as the numerator")
+
+	// The ratio itself, cross-multiplied so the check is exact rather than
+	// float. This is the assertion that fails on a torn pair even if the
+	// absolute values above were ever relaxed.
+	require.Equal(t,
+		schedule.PoolStake*sigmaGenOneTotalStake,
+		schedule.TotalStake*sigmaGenOnePoolStake,
+		"sigma must equal the fixture's ratio exactly",
+	)
 }

--- a/ledger/leader/election_test.go
+++ b/ledger/leader/election_test.go
@@ -73,21 +73,14 @@ func newMockStakeProvider() *mockStakeProvider {
 	}
 }
 
-func (m *mockStakeProvider) GetPoolStake(
-	epoch uint64,
+func (m *mockStakeProvider) GetPoolAndTotalActiveStake(
+	_ uint64,
 	poolKeyHash []byte,
-) (uint64, error) {
+) (uint64, uint64, error) {
 	if m.err != nil {
-		return 0, m.err
+		return 0, 0, m.err
 	}
-	return m.poolStakes[string(poolKeyHash)], nil
-}
-
-func (m *mockStakeProvider) GetTotalActiveStake(epoch uint64) (uint64, error) {
-	if m.err != nil {
-		return 0, m.err
-	}
-	return m.totalStake, nil
+	return m.poolStakes[string(poolKeyHash)], m.totalStake, nil
 }
 
 // mockEpochProvider implements EpochInfoProvider for testing
@@ -430,13 +423,13 @@ type blockingStakeProvider struct {
 	release   chan struct{}
 }
 
-func (b *blockingStakeProvider) GetPoolStake(
+func (b *blockingStakeProvider) GetPoolAndTotalActiveStake(
 	epoch uint64,
 	poolKeyHash []byte,
-) (uint64, error) {
+) (uint64, uint64, error) {
 	b.startOnce.Do(func() { close(b.started) })
 	<-b.release
-	return b.mockStakeProvider.GetPoolStake(epoch, poolKeyHash)
+	return b.mockStakeProvider.GetPoolAndTotalActiveStake(epoch, poolKeyHash)
 }
 
 // TestElectionStopWaitsForInFlightScheduleComputation guards a real bug:

--- a/node_forging.go
+++ b/node_forging.go
@@ -540,8 +540,13 @@ func (a *stakeDistributionAdapter) getStakeDistribution(
 // Two defects are fixed here, and both are load-bearing for consensus:
 //
 // dingo #3814 -- the denominator comes from LedgerView.GetTotalActiveStake,
-// the same accessor ledger/verify_header.go uses when it checks an incoming
-// header's leader eligibility. The previous implementation returned
+// a txn-scoped wrapper over Metadata().GetTotalActiveStake, which is the
+// same store accessor ledger/verify_header.go resolves the denominator
+// through when it checks an incoming header's leader eligibility.
+// Verification calls that store method directly rather than through a
+// LedgerView, with the snapshotType it resolved for the header under check;
+// the shared thing is the store accessor, not the call path. The previous
+// implementation returned
 // ledger.StakeDistribution.TotalStake, which LedgerView.GetStakeDistribution
 // accumulates by summing the mark rows itself, while verification reads
 // epoch_summary.total_active_stake. Those two agree only "by construction"

--- a/node_forging.go
+++ b/node_forging.go
@@ -534,42 +534,81 @@ func (a *stakeDistributionAdapter) getStakeDistribution(
 	return a.ledgerState.NewView(txn).GetStakeDistribution(epoch)
 }
 
-func (a *stakeDistributionAdapter) GetPoolStake(
+// GetPoolAndTotalActiveStake reads the sigma numerator and denominator for
+// one pool inside a single metadata transaction.
+//
+// Two defects are fixed here, and both are load-bearing for consensus:
+//
+// dingo #3814 -- the denominator comes from LedgerView.GetTotalActiveStake,
+// the same accessor ledger/verify_header.go uses when it checks an incoming
+// header's leader eligibility. The previous implementation returned
+// ledger.StakeDistribution.TotalStake, which LedgerView.GetStakeDistribution
+// accumulates by summing the mark rows itself, while verification reads
+// epoch_summary.total_active_stake. Those two agree only "by construction"
+// -- one rotation transaction writes both from one calculation
+// (ledger/pool_stake_distribution.go documents the exact conditions) -- so
+// the equality is a property of the writer, not of the readers, and nothing
+// stops the two paths from drifting. A node whose forge denominator differs
+// from its verify denominator can forge a block it would itself reject, or
+// decline a slot it is genuinely eligible for. Resolving both through one
+// accessor removes the second derivation entirely.
+//
+// dingo #3815 -- both values are read through one db.MetadataTxn and one
+// LedgerView. Opening a transaction per value let a snapshot re-capture land
+// between them, yielding a sigma whose halves come from different writes.
+func (a *stakeDistributionAdapter) GetPoolAndTotalActiveStake(
 	epoch uint64,
 	poolKeyHash []byte,
-) (uint64, error) {
-	dist, err := a.getStakeDistribution(epoch)
+) (poolStake uint64, totalActiveStake uint64, err error) {
+	if a.ledgerState == nil {
+		return 0, 0, errors.New("ledger state unavailable")
+	}
+	db := a.ledgerState.Database()
+	if db == nil {
+		return 0, 0, errors.New("database unavailable")
+	}
+	txn := db.MetadataTxn(false)
+	if txn == nil {
+		return 0, 0, errors.New("metadata transaction unavailable")
+	}
+	defer func() {
+		if rollbackErr := txn.Rollback(); rollbackErr != nil {
+			err = errors.Join(
+				err,
+				fmt.Errorf(
+					"release stake distribution transaction: %w",
+					rollbackErr,
+				),
+			)
+		}
+	}()
+	view := a.ledgerState.NewView(txn)
 	poolKey := hex.EncodeToString(poolKeyHash)
+	poolStake, err = view.GetPoolStake(epoch, poolKeyHash)
 	if err != nil {
-		return 0, fmt.Errorf(
-			"get stake distribution for epoch %d pool %s: %w",
+		return 0, 0, fmt.Errorf(
+			"get pool stake for epoch %d pool %s: %w",
 			epoch,
 			poolKey,
 			err,
 		)
 	}
-	if dist == nil {
-		return 0, nil
-	}
-	return dist.PoolStakes[poolKey], nil
-}
-
-func (a *stakeDistributionAdapter) GetTotalActiveStake(
-	epoch uint64,
-) (uint64, error) {
-	dist, err := a.getStakeDistribution(epoch)
+	totalActiveStake, err = view.GetTotalActiveStake(epoch)
 	if err != nil {
-		return 0, fmt.Errorf(
-			"get stake distribution for epoch %d: %w",
+		return 0, 0, fmt.Errorf(
+			"get total active stake for epoch %d: %w",
 			epoch,
 			err,
 		)
 	}
-	if dist == nil {
-		return 0, nil
-	}
-	return dist.TotalStake, nil
+	return poolStake, totalActiveStake, nil
 }
+
+// The forging adapter must resolve sigma through the atomic pair accessor.
+// A drift back to two independent reads, or to summing the mark rows for the
+// denominator, is the pair of defects dingo #3814 and #3815 describe; make it
+// a compile error rather than a silent consensus divergence.
+var _ leader.StakeDistributionProvider = (*stakeDistributionAdapter)(nil)
 
 // epochInfoAdapter adapts ledger.LedgerState to leader.EpochInfoProvider.
 type epochInfoAdapter struct {

--- a/node_forging_sigma_denominator_test.go
+++ b/node_forging_sigma_denominator_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger"
+	"github.com/blinklabs-io/dingo/ledger/leader"
+)
+
+const (
+	sigmaDenomEpoch = uint64(7)
+	// The mark rows sum to 4_000_000 ...
+	sigmaDenomPoolAStake = uint64(3_000_000)
+	sigmaDenomPoolBStake = uint64(1_000_000)
+	sigmaDenomRowSum     = sigmaDenomPoolAStake + sigmaDenomPoolBStake
+	// ... while epoch_summary.total_active_stake carries a different value.
+	//
+	// Rotation normally writes both from one calculation, so they match. This
+	// fixture drives them apart on purpose, because "they agree by
+	// construction" is a property of the WRITER: it makes the two readers
+	// indistinguishable in every ordinary fixture and so hides which one a
+	// given code path actually consults. Separating them is the only way to
+	// observe that choice, and #3814 is precisely the report that the forge
+	// and verify paths made it differently.
+	sigmaDenomSummaryTotal = uint64(5_000_000)
+)
+
+// newSigmaDenominatorLedger builds a real LedgerState over a real database,
+// so the assertions below run against the production forging adapter rather
+// than a reimplementation of it.
+func newSigmaDenominatorLedger(
+	t *testing.T,
+) (*ledger.LedgerState, *database.Database) {
+	t.Helper()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) })
+	chainManager, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	ledgerState, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:     db,
+		ChainManager: chainManager,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+	return ledgerState, db
+}
+
+func sigmaDenomPoolKeyHash(fill byte) []byte {
+	hash := make([]byte, 28)
+	for i := range hash {
+		hash[i] = fill
+	}
+	return hash
+}
+
+// seedSigmaDenominatorSnapshot writes the mark rows and the epoch summary with
+// deliberately different totals.
+func seedSigmaDenominatorSnapshot(
+	t *testing.T,
+	db *database.Database,
+	poolA, poolB []byte,
+) {
+	t.Helper()
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshots(
+		[]*models.PoolStakeSnapshot{
+			{
+				Epoch:          sigmaDenomEpoch,
+				SnapshotType:   models.PoolStakeSnapshotTypeMark,
+				PoolKeyHash:    poolA,
+				TotalStake:     dbtypes.Uint64(sigmaDenomPoolAStake),
+				DelegatorCount: 1,
+				CapturedSlot:   1,
+			},
+			{
+				Epoch:          sigmaDenomEpoch,
+				SnapshotType:   models.PoolStakeSnapshotTypeMark,
+				PoolKeyHash:    poolB,
+				TotalStake:     dbtypes.Uint64(sigmaDenomPoolBStake),
+				DelegatorCount: 1,
+				CapturedSlot:   1,
+			},
+		},
+		nil,
+	))
+	require.NoError(t, db.Metadata().SaveEpochSummary(
+		&models.EpochSummary{
+			Epoch:            sigmaDenomEpoch,
+			TotalActiveStake: dbtypes.Uint64(sigmaDenomSummaryTotal),
+			TotalPoolCount:   2,
+			TotalDelegators:  2,
+			BoundarySlot:     1,
+			// Required for GetTotalActiveStake to prefer the summary; this is
+			// what rotation sets, so it is the state a synced node is in.
+			SnapshotReady: true,
+		},
+		nil,
+	))
+}
+
+// TestStakeDistributionAdapterResolvesDenominatorThroughVerifyAccessor is the
+// regression test for dingo #3814.
+//
+// The forging adapter used to return ledger.StakeDistribution.TotalStake,
+// which LedgerView.GetStakeDistribution accumulates by summing the mark rows
+// itself. Header verification instead reads
+// epoch_summary.total_active_stake through Metadata().GetTotalActiveStake.
+// Two derivations of one consensus quantity: a node whose forge denominator
+// differs from its verify denominator can forge a block it would itself
+// reject, or decline a slot it is genuinely eligible for.
+//
+// The fixture makes the summary and the row sum differ, then asserts the
+// adapter reports the value VERIFICATION would use. Before the fix the
+// adapter returns sigmaDenomRowSum (4_000_000) and both assertions fail.
+func TestStakeDistributionAdapterResolvesDenominatorThroughVerifyAccessor(
+	t *testing.T,
+) {
+	ledgerState, db := newSigmaDenominatorLedger(t)
+	poolA := sigmaDenomPoolKeyHash(0x41)
+	poolB := sigmaDenomPoolKeyHash(0x42)
+	seedSigmaDenominatorSnapshot(t, db, poolA, poolB)
+
+	// The denominator header verification resolves, read through the accessor
+	// verify_header.go uses. Captured from the database rather than restated
+	// as a literal, so the test compares the two paths instead of comparing
+	// one path to a number this test chose.
+	verifyTotal, err := db.Metadata().GetTotalActiveStake(
+		sigmaDenomEpoch,
+		models.PoolStakeSnapshotTypeMark,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, sigmaDenomSummaryTotal, verifyTotal,
+		"fixture precondition: the verify accessor must serve the summary")
+
+	adapter := &stakeDistributionAdapter{ledgerState: ledgerState}
+	poolStake, forgeTotal, err := adapter.GetPoolAndTotalActiveStake(
+		sigmaDenomEpoch,
+		poolA,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, verifyTotal, forgeTotal,
+		"forge and verify must resolve one denominator through one accessor "+
+			"(dingo #3814)")
+	assert.NotEqual(t, sigmaDenomRowSum, forgeTotal,
+		"the forge denominator must not be re-derived by summing the mark "+
+			"rows; that is the second derivation #3814 removes")
+
+	// The numerator is unchanged by this fix and must still come from the
+	// pool's own mark row.
+	assert.Equal(t, sigmaDenomPoolAStake, poolStake,
+		"the numerator must remain the pool's mark-snapshot stake")
+}
+
+// TestStakeDistributionAdapterSigmaPairSurvivesRecapture checks that each
+// adapter read yields a self-consistent sigma across a snapshot re-capture.
+//
+// Scope, stated plainly: this drives a re-capture between two SEPARATE
+// adapter calls, not between the two halves of a single call. It therefore
+// does NOT by itself prove the dingo #3815 atomicity property -- a write
+// landing inside one call is not reachable from outside the adapter without
+// a seam that does not exist. What it does prove is that both halves of a
+// given read move together to the new generation rather than one of them
+// lagging, and it would catch a fix that made only one half transactional.
+//
+// The atomicity property itself is pinned two ways instead:
+// TestStakeDistributionProviderForbidsTornSigmaRead below makes the split
+// read unexpressible in the provider interface, and
+// TestComputeScheduleReadsSigmaPairInOneProviderCall in ledger/leader
+// asserts the real schedule computation performs exactly one paired read.
+//
+// The two generations are chosen with DIFFERENT absolute values but the SAME
+// sigma, so a torn pair is detectable as a sigma matching neither.
+func TestStakeDistributionAdapterSigmaPairSurvivesRecapture(t *testing.T) {
+	ledgerState, db := newSigmaDenominatorLedger(t)
+	poolA := sigmaDenomPoolKeyHash(0x41)
+	poolB := sigmaDenomPoolKeyHash(0x42)
+
+	// Generation one: sigma = 3_000_000 / 5_000_000.
+	seedSigmaDenominatorSnapshot(t, db, poolA, poolB)
+
+	adapter := &stakeDistributionAdapter{ledgerState: ledgerState}
+	poolStake, total, err := adapter.GetPoolAndTotalActiveStake(
+		sigmaDenomEpoch,
+		poolA,
+	)
+	require.NoError(t, err)
+
+	// Generation two: every value doubled, so sigma is identical while both
+	// halves differ. Written AFTER the read above, then read again below.
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshots(
+		[]*models.PoolStakeSnapshot{
+			{
+				Epoch:          sigmaDenomEpoch,
+				SnapshotType:   models.PoolStakeSnapshotTypeMark,
+				PoolKeyHash:    poolA,
+				TotalStake:     dbtypes.Uint64(sigmaDenomPoolAStake * 2),
+				DelegatorCount: 1,
+				CapturedSlot:   2,
+			},
+		},
+		nil,
+	))
+	require.NoError(t, db.Metadata().SaveEpochSummary(
+		&models.EpochSummary{
+			Epoch:            sigmaDenomEpoch,
+			TotalActiveStake: dbtypes.Uint64(sigmaDenomSummaryTotal * 2),
+			TotalPoolCount:   2,
+			TotalDelegators:  2,
+			BoundarySlot:     2,
+			SnapshotReady:    true,
+		},
+		nil,
+	))
+
+	poolStake2, total2, err := adapter.GetPoolAndTotalActiveStake(
+		sigmaDenomEpoch,
+		poolA,
+	)
+	require.NoError(t, err)
+
+	// Each read must be self-consistent: numerator*otherDenominator equals
+	// denominator*otherNumerator only when both pairs carry the same sigma.
+	// Cross-multiplied to keep this exact rather than float.
+	assert.Equal(t,
+		poolStake*sigmaDenomSummaryTotal,
+		total*sigmaDenomPoolAStake,
+		"the first read's sigma must come from a single snapshot generation",
+	)
+	assert.Equal(t,
+		poolStake2*sigmaDenomSummaryTotal,
+		total2*sigmaDenomPoolAStake,
+		"the second read's sigma must come from a single snapshot generation",
+	)
+	// And the second read must actually have observed the re-capture, or the
+	// assertions above would be vacuous.
+	assert.Equal(t, sigmaDenomPoolAStake*2, poolStake2,
+		"the second read must observe the re-captured snapshot")
+	assert.Equal(t, sigmaDenomSummaryTotal*2, total2,
+		"the second read must observe the re-captured summary")
+}
+
+// TestStakeDistributionProviderForbidsTornSigmaRead pins the interface shape
+// that makes the dingo #3815 defect unexpressible.
+//
+// The fix is not only that the adapter now reads both halves in one
+// transaction; it is that StakeDistributionProvider no longer offers a way to
+// read them separately. A future adapter cannot reintroduce the torn read
+// without changing the interface, which this test makes a visible decision
+// rather than an accident.
+func TestStakeDistributionProviderForbidsTornSigmaRead(t *testing.T) {
+	var adapter any = &stakeDistributionAdapter{}
+
+	if _, ok := adapter.(leader.StakeDistributionProvider); !ok {
+		t.Fatal(
+			"stakeDistributionAdapter must satisfy " +
+				"leader.StakeDistributionProvider",
+		)
+	}
+
+	// The separate accessors must be gone. Either one surviving means a
+	// caller can still take the numerator and the denominator from different
+	// transactions.
+	type poolStakeReader interface {
+		GetPoolStake(uint64, []byte) (uint64, error)
+	}
+	type totalStakeReader interface {
+		GetTotalActiveStake(uint64) (uint64, error)
+	}
+	if _, ok := adapter.(poolStakeReader); ok {
+		t.Error(
+			"stakeDistributionAdapter must not expose a standalone " +
+				"GetPoolStake; the sigma pair is read together (dingo #3815)",
+		)
+	}
+	if _, ok := adapter.(totalStakeReader); ok {
+		t.Error(
+			"stakeDistributionAdapter must not expose a standalone " +
+				"GetTotalActiveStake; the sigma pair is read together " +
+				"(dingo #3815)",
+		)
+	}
+}


### PR DESCRIPTION
## Problem

Two independent defects in how the leader-election sigma is read.

**#3814 — two denominators.** The forging adapter returned
`ledger.StakeDistribution.TotalStake`, which
`LedgerView.GetStakeDistribution` accumulates by summing
`pool_stake_snapshot` mark rows. Header verification reads
`epoch_summary.total_active_stake` through
`Metadata().GetTotalActiveStake`. The two agree only because snapshot
rotation writes both in one transaction from one calculation, so the
equality is a property of the writer, not the readers. A node whose forge
denominator differs from its verify denominator can forge a block it would
itself reject, or decline a slot it is eligible for.

**#3815 — torn sigma read.** `GetPoolStake` and `GetTotalActiveStake` each
opened their own `db.MetadataTxn`, and `computeSchedule` called them in
sequence, so a snapshot re-capture between the two reads produced a sigma
whose numerator and denominator came from different writes. The persisted
schedule revalidation path had the same window.

## Change

- `leader.StakeDistributionProvider` exposes one
  `GetPoolAndTotalActiveStake(epoch, poolKeyHash) (poolStake, totalActiveStake, error)`.
  The split read is no longer expressible.
- The forging adapter reads both halves through one `db.MetadataTxn` and one
  `LedgerView`, taking the denominator from `LedgerView.GetTotalActiveStake` —
  the accessor `ledger/verify_header.go` uses.
- Both `computeSchedule` and `validatePersistedSchedule` use the paired read.
- The reference denominator rule is recorded on the provider interface with
  `cardano-ledger` citations, replacing a comment that called it "the sum of
  all pool stakes".

Leios is unaffected: `node_leios.go` reads `getStakeDistribution`, unchanged.

## Reference rule

`ssTotalActiveStake = sumAllActiveStake ssActiveStake` sums every registered
credential delegated to any pool id, with no pool-registration requirement
(`Cardano/Ledger/State/Stake.hs:156-160,217-246`,
`.../State/SnapShots.hs:419-426`). Numerators come only from registered pools
via `calculatePoolDistr'` (`SnapShots.hs:471-488`).

That asymmetry does not mean retired-pool stake belongs in the denominator
and no numerator: the state is unreachable. `DELEG` rejects delegating to an
unregistered pool (`Conway/Rules/Deleg.hs:218-233`) and `POOLREAP` clears a
retiring pool's delegations in the same update that drops it from
`psStakePools` (`Shelley/Rules/PoolReap.hs:214-228,238-240`), enforced by an
assertion (`Shelley/Rules/Ledger.hs:274-279,453-468`). Dingo maintains the
same invariant at the same point (`ledger/poolreap.go`,
`ClearDelegationsToRetiredPool`) and runs its SNAP stake read before POOLREAP.
So the denominator does equal the sum of the numerators — which is why it must
not be derived twice.

## Tests

Each fails without the fix; `go vet` exits 0 first and sibling tests pass in
the same run, so the failing runs compiled.

| Test | Without the fix |
|---|---|
| `TestStakeDistributionAdapterResolvesDenominatorThroughVerifyAccessor` | denominator `4000000` (row sum) vs `5000000` (verify accessor) |
| `TestComputeScheduleReadsSigmaPairInOneProviderCall` | 2 provider reads, not 1; sigma torn across generations |
| `TestStakeDistributionProviderForbidsTornSigmaRead` | split accessors present |
| `TestStakeDistributionAdapterSigmaPairSurvivesRecapture` | pair inconsistent after re-capture |

The first two drive the real forging adapter over a real database and the real
`computeSchedule`. `TestComputeScheduleDrawsSigmaInputsFromSameSnapshotEpoch`
also catches the torn read (2 recorded epochs, not 1).

## Not #2798

This does not close #2798. That report's build (`d68ed172`, 2026-07-10)
predates #2843 (`f065a6b3`, 2026-07-15), which added delegator reward-account
balances to the mark stake snapshot the schedule reads; at `d68ed172`
`stakequery.go` had no reward term. #3042 records the same conclusion. The
~1.3% one-sided denominator shortfall and musashi's concentrated topology fit
that omission. #2798 needs a live re-run on current `main`, not a new fix.

## Validation

`go build ./...`, `go vet ./...`, `gofmt -s -l`, `golangci-lint run` (0
issues), `go test ./ledger/leader/` and the root forging tests (both also
under `-race -timeout 25m`), `go test ./internal/test/conformance/` (174s),
`go test ./internal/architecture`, `make docs-parity` — all exit 0.

`ARCHITECTURE.md` updated: its "Query Interface" snippet showed the
two-call pattern this change removes. `DATABASE.md` checked and unaffected —
no schema, query, or `MetadataStore` surface change.

Not run: devnet and Antithesis (require Docker/live infrastructure).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3814 and #3815 by replacing the row-summed denominator and two independent stake reads in forging with a paired numerator/denominator read in one transaction. The denominator now comes from `LedgerView.GetTotalActiveStake`, backed by the same `Metadata().GetTotalActiveStake` store accessor used directly by header verification, preventing forge/verify mismatches and torn sigma values.

**Migration**

- `leader.StakeDistributionProvider` implementations must replace the two stake accessors with `GetPoolAndTotalActiveStake`.
- Schedule computation and persisted-schedule validation now use the paired result.
- Documents the Cardano denominator rule and the distinction between the forging and verification call paths; Leios and the database schema remain unchanged.
- Adds real-database and snapshot-generation regression tests for both defects.

<sup>Written for commit aee830693b81d2ca23360a46f6e864d6c7dc3579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forging stake calculations by reading pool and total active stake from one consistent ledger snapshot.
  * Corrected the stake denominator to use the ledger’s authoritative total active stake value.
  * Prevented inconsistent sigma values caused by separate stake data reads.

* **Documentation**
  * Expanded architecture documentation with details on stake snapshots, denominator semantics, and consistent ledger reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->