### PR TITLE
test(ledger): distinguish genuine Plutus failure from budget overage

### DIFF
--- a/ledger/eras/conway_plutus_script_failure_test.go
+++ b/ledger/eras/conway_plutus_script_failure_test.go
@@ -140,6 +140,10 @@ func TestConwayPhase2RejectsGenuineScriptFailureNotAsBudgetOverage(
 	assert.Equal(t, scriptHash, plutusErr.ScriptHash)
 	assert.Equal(t, lcommon.RedeemerTagMint, plutusErr.Tag)
 	assert.Equal(t, uint32(0), plutusErr.Index)
+	// The wrapped error is what distinguishes the two rejection reasons, so a
+	// nil here is itself a defect; assert it rather than panicking on the
+	// dereference below.
+	require.NotNil(t, plutusErr.Err)
 	assert.NotContains(
 		t,
 		plutusErr.Err.Error(),

--- a/ledger/eras/conway_plutus_script_failure_test.go
+++ b/ledger/eras/conway_plutus_script_failure_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConwayPhase2RejectsGenuineScriptFailureNotAsBudgetOverage covers the
+// discriminator between the two ways phase-2 can reject a Conway transaction.
+//
+// TestConwayPlutusBudgetComparisonIncludesFinalSlippageBatch pins the overage
+// arm: a script that succeeds but costs more than its redeemer declares is
+// rejected with "script exceeded declared budget". This is the other arm. A
+// script that evaluates to error is also rejected, but for a different reason,
+// and the two must not be conflated.
+//
+// The distinction is load-bearing because restrictive evaluation raises the
+// machine limit to MaxTxExUnits and compares the consumed amount against the
+// declared budget only *after* the script returns. A genuine evaluation error
+// returns before that comparison, so it must surface as the Plutus failure it
+// is. Reporting it as a budget overage would misattribute a script bug to the
+// fee the submitter declared, and would make an over-generous declared budget
+// look like the cause of a failure it cannot affect.
+//
+// The script is a V1 minting script applied to two arguments, redeemer and
+// script context, matching the shape the overage test uses so both arms
+// exercise the same production path: ValidateTxConway ->
+// validateTxPlutusConwayWithContext -> evaluateConwayPlutusScript.
+func TestConwayPhase2RejectsGenuineScriptFailureNotAsBudgetOverage(
+	t *testing.T,
+) {
+	// (redeemer, ctx) -> Error. The program is well formed and fully applied,
+	// so it reaches the CEK machine and fails there rather than failing to
+	// decode.
+	program := &syn.Program[syn.DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term: &syn.Lambda[syn.DeBruijn]{
+			Body: &syn.Lambda[syn.DeBruijn]{
+				Body: &syn.Error{},
+			},
+		},
+	}
+	flatProgram, err := syn.Encode(program)
+	require.NoError(t, err)
+	scriptBytes, err := cbor.Encode(flatProgram)
+	require.NoError(t, err)
+
+	origAll := conwayUtxoValidationRules
+	origPhase1 := conwayPhase1UtxoValidationRules
+	t.Cleanup(func() {
+		conwayUtxoValidationRules = origAll
+		conwayPhase1UtxoValidationRules = origPhase1
+	})
+	// Clear the phase-1 rule set so the phase-2 outcome is what fails, rather
+	// than a fee or UTxO check on the mock transaction.
+	conwayUtxoValidationRules = nil
+	conwayPhase1UtxoValidationRules = nil
+
+	plutusScript := lcommon.PlutusV1Script(scriptBytes)
+	scriptHash := plutusScript.Hash()
+	assetMint := lcommon.NewMultiAsset[lcommon.MultiAssetTypeMint](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeMint{
+			lcommon.Blake2b224(scriptHash): {
+				cbor.NewByteString([]byte("asset")): big.NewInt(1),
+			},
+		},
+	)
+
+	// The declared budget is deliberately far above the script's cost, so a
+	// budget overage cannot be the reason for rejection.
+	tx := &mockConwayFeeTx{
+		mockFeeTx: mockFeeTx{
+			txType: txTypeAlonzo,
+			witnesses: &mockWitnessSet{
+				plutusV1Scripts: []lcommon.PlutusV1Script{plutusScript},
+				redeemers: &mockRedeemers{
+					entries: []struct {
+						key lcommon.RedeemerKey
+						val lcommon.RedeemerValue
+					}{
+						{
+							key: lcommon.RedeemerKey{
+								Tag:   lcommon.RedeemerTagMint,
+								Index: 0,
+							},
+							val: lcommon.RedeemerValue{
+								ExUnits: lcommon.ExUnits{
+									Steps:  1_000_000,
+									Memory: 1_000_000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		assetMint: &assetMint,
+	}
+
+	err = ValidateTxConway(
+		tx,
+		0,
+		newMockLedgerState(),
+		&conway.ConwayProtocolParameters{
+			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+				Major: 9,
+			},
+			MaxTxExUnits: lcommon.ExUnits{
+				Steps:  1_000_000,
+				Memory: 1_000_000,
+			},
+		},
+	)
+	require.Error(t, err, "a genuine Plutus failure must be rejected")
+
+	var plutusErr conway.PlutusScriptFailedError
+	require.ErrorAs(t, err, &plutusErr)
+	assert.Equal(t, scriptHash, plutusErr.ScriptHash)
+	assert.Equal(t, lcommon.RedeemerTagMint, plutusErr.Tag)
+	assert.Equal(t, uint32(0), plutusErr.Index)
+	assert.NotContains(
+		t,
+		plutusErr.Err.Error(),
+		"script exceeded declared budget",
+		"a genuine script failure must not be reported as a budget overage",
+	)
+}


### PR DESCRIPTION
Conway phase-2 rejects a transaction two ways: the script exceeds its declared ex-unit budget, or the script evaluates to error. `TestConwayPlutusBudgetComparisonIncludesFinalSlippageBatch` covers the overage arm. Nothing covered the other one.

The distinction is load-bearing. Restrictive evaluation raises the machine limit to `MaxTxExUnits` and compares the consumed amount against the declared budget only after the script returns, so an evaluation error returns at `ledger/eras/conway.go:1186` before that comparison. Reporting it as an overage would attribute a script bug to the budget the submitter declared.

Adds `TestConwayPhase2RejectsGenuineScriptFailureNotAsBudgetOverage`: a V1 minting script whose body is `Error`, a declared budget far above its cost, asserted to fail as `conway.PlutusScriptFailedError` with the matching script hash, tag and index, and asserted not to mention `script exceeded declared budget`. It runs the production path, `ValidateTxConway` -> `validateTxPlutusConwayWithContext` -> `evaluateConwayPlutusScript`, with the same two-argument minting shape the overage test uses.

## Fails without the behaviour

Replacing the V1 branch error return at `ledger/eras/conway.go:1186` with a budget-overage error:

```
--- FAIL: TestConwayPhase2RejectsGenuineScriptFailureNotAsBudgetOverage
    Error: "script exceeded declared budget: mutated" should not contain "script exceeded declared budget"
```

Reverted, and green.

## Validation

- `go test ./ledger/eras/ -count=1` ok
- `go test ./ledger/eras/ -race -count=1` ok
- `go vet ./ledger/eras/` exit 0
- `golangci-lint run ledger/eras/...` 0 issues
- `gofmt` clean

Test-only; no production file is touched.

## Provenance

Ported from closed #3735. That PR proposed trusting producer-valid over-budget blocks; the root cause was upstream in the Conway ScriptContext validity-interval upper bound, fixed by gouroboros #2174 (`924de23`), released in `v0.202.5` and adopted by #3802. Shipped in `v0.70.5`. This test is the one piece of that branch with no equivalent on `main`. #3627 remains open pending a Mithril-backed Preprod replay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test covering the genuine Plutus script failure arm of Conway phase-2 rejection, which previously only covered budget overages. Restrictive evaluation returns before the budget comparison on evaluation error, so conflating the two would misattribute script bugs to declared budgets.

- Runs a V1 minting script that evaluates to `Error` with a declared budget far above its cost through the production validation path.
- Asserts rejection as `conway.PlutusScriptFailedError` with matching script hash, tag, and index.
- Asserts the wrapped error is non-nil (a nil there is itself a defect) and that it does not mention `script exceeded declared budget`.

<sup>Written for commit 575ebfa61a45c8f7a587ca675440b249becb3789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly distinguishes genuine Plutus script failures from execution budget overruns when validating Conway transactions.
  * Reports the appropriate script failure details, including the affected script and minting context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->