### PR TITLE
fix(eras): resolve upstream UTxO rules by Id, not function

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2157,6 +2157,27 @@ because prior pot transitions cannot be repaired safely without replay.
 
 The `ledger/eras/` package provides era-specific validation rules for each Cardano era. The default active era table is Byron through Conway. Experimental Dijkstra support is added to the active table when Dingo starts on the `musashi` network (the IOG Leios prototype testnet, matched by network name or magic 164), with `runMode: "leios"`, or with `startEra: "dijkstra"` — see `Config.experimentalDijkstraEnabled`. Keying on the network lets `dingo -n musashi` follow the Musashi testnet past the Conway-to-Dijkstra hard fork without an explicit run mode. The Dijkstra descriptor uses `github.com/blinklabs-io/gouroboros/ledger/dijkstra`, including that release's generated CDDL shape for the nullable Leios/Peras certificate slots.
 
+Several eras replace or drop an upstream `UtxoValidationRules` entry so Dingo
+can run its own implementation — the reference-script-aware fee rule, local
+Plutus execution, and the credential-tag-preserving committee and voter rules.
+Each of those is located by the upstream rule's stable
+`common.UtxoValidationRuleId`, read from the era's
+`UtxoValidationRuleDescriptors()`, never by validation function identity or
+runtime function name. gouroboros composes the Alonzo, Babbage, and Conway
+lists with `common.ComposeUtxoValidationRules`, which replaces every
+phase-2-gated entry with an anonymous wrapper, and it moves shared rules
+between era packages across releases; both erase function identity while
+leaving the Id intact. `resolveUtxoValidationSkipIndex` panics at package
+initialization when an Id is absent, duplicated, or when the descriptor and
+rule lists diverge in length, so an upstream change fails loudly instead of
+silently leaving an upstream rule in place or removing the wrong one.
+
+`common.UtxoValidateCurrentTreasuryValue` is not skipped: Conway and Dijkstra
+validation enforces a declared `currentTreasuryValue` (transaction body key
+21) against `LedgerState.TreasuryValue`. The rule returns early when no
+transaction body declares the field, so it only reaches that provider for a
+transaction that supplies one.
+
 Validated Alonzo, Babbage, Conway, and Dijkstra block application runs phase 1
 for every transaction. Their phase-2 validators evaluate scripts independently
 of the declared validity flag, then reconcile the local execution result with

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.5
+	github.com/blinklabs-io/gouroboros v0.202.6
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
 	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.202.5 h1:2NGWnwil3266QVc16IDbA0MIrEK6TlVB81TlDzpFUzk=
-github.com/blinklabs-io/gouroboros v0.202.5/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.6 h1:xIJluYjLjmtZp0tVRXviMzuLm7hNkiT7T7yNuXMwpG8=
+github.com/blinklabs-io/gouroboros v0.202.6/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=

--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.7
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
-	github.com/blinklabs-io/gouroboros v0.202.5
+	github.com/blinklabs-io/gouroboros v0.202.6
 	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/test/antithesis/go.sum
+++ b/internal/test/antithesis/go.sum
@@ -4,8 +4,8 @@ github.com/antithesishq/antithesis-sdk-go v0.7.0 h1:uWDG8BqLD1lI2ps38WDz2vXflrTX
 github.com/antithesishq/antithesis-sdk-go v0.7.0/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8SbHbDQQkZ4=
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/gouroboros v0.202.5 h1:2NGWnwil3266QVc16IDbA0MIrEK6TlVB81TlDzpFUzk=
-github.com/blinklabs-io/gouroboros v0.202.5/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.6 h1:xIJluYjLjmtZp0tVRXviMzuLm7hNkiT7T7yNuXMwpG8=
+github.com/blinklabs-io/gouroboros v0.202.6/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=

--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -161,16 +161,11 @@ var allegraUtxoValidationRules = buildAllegraValidationRules()
 // path, including for transactions rebuilt from block components.
 func buildAllegraValidationRules() []indexedUtxoValidationRule {
 	return buildIndexedUtxoValidationRulesWithSkips(
+		allegra.UtxoValidationRuleDescriptors(),
 		allegra.UtxoValidationRules,
-		[]utxoValidationRuleSkip{
-			{
-				validationFunc: allegra.UtxoValidateFeeTooSmallUtxo,
-				name:           "allegra.UtxoValidateFeeTooSmallUtxo",
-			},
-			{
-				validationFunc: allegra.UtxoValidateMaxTxSizeUtxo,
-				name:           "allegra.UtxoValidateMaxTxSizeUtxo",
-			},
+		[]lcommon.UtxoValidationRuleId{
+			lcommon.UtxoValidationRuleFeeTooSmall,
+			lcommon.UtxoValidationRuleMaxTxSize,
 		},
 	)
 }

--- a/ledger/eras/allegra.go
+++ b/ledger/eras/allegra.go
@@ -167,6 +167,10 @@ func buildAllegraValidationRules() []indexedUtxoValidationRule {
 			lcommon.UtxoValidationRuleFeeTooSmall,
 			lcommon.UtxoValidationRuleMaxTxSize,
 		},
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRuleFeeTooSmall: allegra.UtxoValidateFeeTooSmallUtxo,
+			lcommon.UtxoValidationRuleMaxTxSize:   allegra.UtxoValidateMaxTxSizeUtxo,
+		},
 	)
 }
 

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -352,6 +352,9 @@ func buildAlonzoValidationRules() []indexedUtxoValidationRule {
 		alonzo.UtxoValidationRuleDescriptors(),
 		alonzo.UtxoValidationRules,
 		lcommon.UtxoValidationRulePlutusScripts,
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRulePlutusScripts: alonzo.UtxoValidatePlutusScripts,
+		},
 	)
 }
 

--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -349,9 +349,9 @@ var alonzoUtxoValidationRules = buildAlonzoValidationRules()
 
 func buildAlonzoValidationRules() []indexedUtxoValidationRule {
 	return buildIndexedUtxoValidationRules(
+		alonzo.UtxoValidationRuleDescriptors(),
 		alonzo.UtxoValidationRules,
-		alonzo.UtxoValidatePlutusScripts,
-		"alonzo.UtxoValidatePlutusScripts",
+		lcommon.UtxoValidationRulePlutusScripts,
 	)
 }
 

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -442,6 +442,9 @@ func buildBabbageValidationRules() []indexedUtxoValidationRule {
 		babbage.UtxoValidationRuleDescriptors(),
 		babbage.UtxoValidationRules,
 		lcommon.UtxoValidationRulePlutusScripts,
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRulePlutusScripts: babbage.UtxoValidatePlutusScripts,
+		},
 	)
 }
 

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -439,9 +439,9 @@ var babbageUtxoValidationRules = buildBabbageValidationRules()
 
 func buildBabbageValidationRules() []indexedUtxoValidationRule {
 	return buildIndexedUtxoValidationRules(
+		babbage.UtxoValidationRuleDescriptors(),
 		babbage.UtxoValidationRules,
-		babbage.UtxoValidatePlutusScripts,
-		"babbage.UtxoValidatePlutusScripts",
+		lcommon.UtxoValidationRulePlutusScripts,
 	)
 }
 

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -284,6 +284,13 @@ func buildConwayValidationRules() []indexedUtxoValidationRule {
 		descriptors,
 		conway.UtxoValidationRules,
 		skipRuleIds,
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRuleConwayFeaturesWithPlutusV1V2: conway.UtxoValidateConwayFeaturesWithPlutusV1V2,
+			lcommon.UtxoValidationRuleFeeTooSmall:                  conway.UtxoValidateFeeTooSmallUtxo,
+			lcommon.UtxoValidationRulePlutusScripts:                conway.UtxoValidatePlutusScripts,
+			lcommon.UtxoValidationRuleCommitteeCertificates:        conway.UtxoValidateCommitteeCertificates,
+			lcommon.UtxoValidationRuleUnknownVoters:                conway.UtxoValidateUnknownVoters,
+		},
 	)
 	ret = append(ret, indexedUtxoValidationRule{
 		index:          indexes[0],

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -261,38 +261,29 @@ func conwayValidationRules(
 }
 
 func buildConwayValidationRules() []indexedUtxoValidationRule {
-	skips := []utxoValidationRuleSkip{
-		{
-			validationFunc: conway.
-				UtxoValidateConwayFeaturesWithPlutusV1V2,
-			name: "conway.UtxoValidateConwayFeaturesWithPlutusV1V2",
-		},
-		{
-			validationFunc: conway.UtxoValidateFeeTooSmallUtxo,
-			name:           "conway.UtxoValidateFeeTooSmallUtxo",
-		},
-		{
-			validationFunc: conway.UtxoValidatePlutusScripts,
-			name:           "conway.UtxoValidatePlutusScripts",
-		},
-		{
-			validationFunc: conway.UtxoValidateCommitteeCertificates,
-			name:           "conway.UtxoValidateCommitteeCertificates",
-		},
-		{
-			validationFunc: conway.UtxoValidateUnknownVoters,
-			name:           "conway.UtxoValidateUnknownVoters",
-		},
+	// Skips are resolved by upstream rule Id, never by validation function.
+	// conway.UtxoValidationRules is composed with
+	// common.ComposeUtxoValidationRules, so every phase-2-gated entry —
+	// committee-certificates and unknown-voters among them — is an anonymous
+	// wrapper closure with no trace of the original function.
+	skipRuleIds := []lcommon.UtxoValidationRuleId{
+		lcommon.UtxoValidationRuleConwayFeaturesWithPlutusV1V2,
+		lcommon.UtxoValidationRuleFeeTooSmall,
+		lcommon.UtxoValidationRulePlutusScripts,
+		lcommon.UtxoValidationRuleCommitteeCertificates,
+		lcommon.UtxoValidationRuleUnknownVoters,
 	}
-	indexes := make([]int, len(skips))
-	for i := range skips {
+	descriptors := conway.UtxoValidationRuleDescriptors()
+	indexes := make([]int, len(skipRuleIds))
+	for i := range skipRuleIds {
 		indexes[i] = resolveUtxoValidationSkipIndex(
-			conway.UtxoValidationRules, skips[i].validationFunc, skips[i].name,
+			descriptors, conway.UtxoValidationRules, skipRuleIds[i],
 		)
 	}
 	ret := buildIndexedUtxoValidationRulesWithSkips(
+		descriptors,
 		conway.UtxoValidationRules,
-		skips,
+		skipRuleIds,
 	)
 	ret = append(ret, indexedUtxoValidationRule{
 		index:          indexes[0],

--- a/ledger/eras/dijkstra.go
+++ b/ledger/eras/dijkstra.go
@@ -308,6 +308,11 @@ func buildDijkstraValidationRules() []indexedUtxoValidationRule {
 		descriptors,
 		gdijkstra.UtxoValidationRules,
 		skipRuleIds,
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRulePlutusScripts:         gdijkstra.UtxoValidatePlutusScripts,
+			lcommon.UtxoValidationRuleCommitteeCertificates: conway.UtxoValidateCommitteeCertificates,
+			lcommon.UtxoValidationRuleUnknownVoters:         conway.UtxoValidateUnknownVoters,
+		},
 	)
 	ret = append(ret,
 		indexedUtxoValidationRule{

--- a/ledger/eras/dijkstra.go
+++ b/ledger/eras/dijkstra.go
@@ -288,30 +288,26 @@ func ValidateTxDijkstra(
 var dijkstraPhase1UtxoValidationRules = buildDijkstraValidationRules()
 
 func buildDijkstraValidationRules() []indexedUtxoValidationRule {
-	skips := []utxoValidationRuleSkip{
-		{
-			validationFunc: gdijkstra.UtxoValidatePlutusScripts,
-			name:           "dijkstra.UtxoValidatePlutusScripts",
-		},
-		{
-			validationFunc: conway.
-				UtxoValidateCommitteeCertificates,
-			name: "conway.UtxoValidateCommitteeCertificates",
-		},
-		{
-			validationFunc: conway.UtxoValidateUnknownVoters,
-			name:           "conway.UtxoValidateUnknownVoters",
-		},
+	// Skips are resolved by upstream rule Id, never by validation function.
+	// Dijkstra reimplements several rules that Conway owned in earlier
+	// releases, so the package a rule's function lives in is not stable
+	// either.
+	skipRuleIds := []lcommon.UtxoValidationRuleId{
+		lcommon.UtxoValidationRulePlutusScripts,
+		lcommon.UtxoValidationRuleCommitteeCertificates,
+		lcommon.UtxoValidationRuleUnknownVoters,
 	}
-	indexes := make([]int, len(skips))
-	for i := range skips {
+	descriptors := gdijkstra.UtxoValidationRuleDescriptors()
+	indexes := make([]int, len(skipRuleIds))
+	for i := range skipRuleIds {
 		indexes[i] = resolveUtxoValidationSkipIndex(
-			gdijkstra.UtxoValidationRules, skips[i].validationFunc, skips[i].name,
+			descriptors, gdijkstra.UtxoValidationRules, skipRuleIds[i],
 		)
 	}
 	ret := buildIndexedUtxoValidationRulesWithSkips(
+		descriptors,
 		gdijkstra.UtxoValidationRules,
-		skips,
+		skipRuleIds,
 	)
 	ret = append(ret,
 		indexedUtxoValidationRule{

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -185,21 +185,16 @@ var shelleyUtxoValidationRules = buildShelleyValidationRules()
 // buildShelleyValidationRules drops the upstream fee and max-size rules so
 // ValidateTxShelley can apply the Dingo checks that size a transaction with
 // TxSizeForFee. buildIndexedUtxoValidationRulesWithSkips resolves each skip by
-// upstream validation function name and panics at package initialization if a
-// name stops matching exactly one upstream rule, so an upstream rename fails
-// loudly instead of silently leaving the upstream rule in place.
+// upstream rule Id and panics at package initialization if an Id stops matching
+// exactly one upstream rule, so an upstream change fails loudly instead of
+// silently leaving the upstream rule in place.
 func buildShelleyValidationRules() []indexedUtxoValidationRule {
 	return buildIndexedUtxoValidationRulesWithSkips(
+		shelley.UtxoValidationRuleDescriptors(),
 		shelley.UtxoValidationRules,
-		[]utxoValidationRuleSkip{
-			{
-				validationFunc: shelley.UtxoValidateFeeTooSmallUtxo,
-				name:           "shelley.UtxoValidateFeeTooSmallUtxo",
-			},
-			{
-				validationFunc: shelley.UtxoValidateMaxTxSizeUtxo,
-				name:           "shelley.UtxoValidateMaxTxSizeUtxo",
-			},
+		[]lcommon.UtxoValidationRuleId{
+			lcommon.UtxoValidationRuleFeeTooSmall,
+			lcommon.UtxoValidationRuleMaxTxSize,
 		},
 	)
 }

--- a/ledger/eras/shelley.go
+++ b/ledger/eras/shelley.go
@@ -196,6 +196,10 @@ func buildShelleyValidationRules() []indexedUtxoValidationRule {
 			lcommon.UtxoValidationRuleFeeTooSmall,
 			lcommon.UtxoValidationRuleMaxTxSize,
 		},
+		map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc{
+			lcommon.UtxoValidationRuleFeeTooSmall: shelley.UtxoValidateFeeTooSmallUtxo,
+			lcommon.UtxoValidationRuleMaxTxSize:   shelley.UtxoValidateMaxTxSizeUtxo,
+		},
 	)
 }
 

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"reflect"
-	"runtime"
 
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -120,11 +118,6 @@ func checkPoolMarginFloor(
 type indexedUtxoValidationRule struct {
 	index          int
 	validationFunc lcommon.UtxoValidationRuleFunc
-}
-
-type utxoValidationRuleSkip struct {
-	validationFunc lcommon.UtxoValidationRuleFunc
-	name           string
 }
 
 const (
@@ -376,26 +369,28 @@ func txHasRedeemers(tx lcommon.Transaction) bool {
 }
 
 func buildIndexedUtxoValidationRules(
+	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
-	skipValidationFunc lcommon.UtxoValidationRuleFunc,
-	skipRuleName string,
+	skipRuleId lcommon.UtxoValidationRuleId,
 ) []indexedUtxoValidationRule {
-	return buildIndexedUtxoValidationRulesWithSkips(rules, []utxoValidationRuleSkip{{
-		validationFunc: skipValidationFunc,
-		name:           skipRuleName,
-	}})
+	return buildIndexedUtxoValidationRulesWithSkips(
+		descriptors,
+		rules,
+		[]lcommon.UtxoValidationRuleId{skipRuleId},
+	)
 }
 
 func buildIndexedUtxoValidationRulesWithSkips(
+	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
-	skips []utxoValidationRuleSkip,
+	skipRuleIds []lcommon.UtxoValidationRuleId,
 ) []indexedUtxoValidationRule {
-	skipIndexes := map[int]struct{}{}
-	for _, skip := range skips {
+	skipIndexes := make(map[int]struct{}, len(skipRuleIds))
+	for _, skipRuleId := range skipRuleIds {
 		resolvedIndex := resolveUtxoValidationSkipIndex(
+			descriptors,
 			rules,
-			skip.validationFunc,
-			skip.name,
+			skipRuleId,
 		)
 		skipIndexes[resolvedIndex] = struct{}{}
 	}
@@ -412,27 +407,46 @@ func buildIndexedUtxoValidationRulesWithSkips(
 	return ret
 }
 
+// resolveUtxoValidationSkipIndex returns the position of the upstream rule
+// carrying the stable semantic identifier skipRuleId.
+//
+// Resolution is by rule Id and must never fall back to validation function
+// identity or runtime function name. gouroboros builds several era rule lists
+// with common.ComposeUtxoValidationRules, which replaces every phase-2-gated
+// entry with an anonymous wrapper closure, and it moves shared rules between
+// era packages across releases. Both erase function identity while leaving the
+// Id intact, so a function-keyed resolver panics at package initialization on
+// an ordinary upstream refactor.
+//
+// It panics when the Id is empty, absent, or duplicated, and when the upstream
+// descriptor list and rule list have diverged in length, so an upstream change
+// fails loudly instead of silently leaving an upstream rule in place or
+// removing the wrong one.
 func resolveUtxoValidationSkipIndex(
+	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
-	skipValidationFunc lcommon.UtxoValidationRuleFunc,
-	skipRuleName string,
+	skipRuleId lcommon.UtxoValidationRuleId,
 ) int {
-	if skipRuleName == "" {
-		skipRuleName = "UTxO validation skip rule"
+	if skipRuleId == "" {
+		panic("UTxO validation skip rule Id is empty")
 	}
-	if skipValidationFunc == nil {
-		panic(skipRuleName + " expected validation function is nil")
+	if len(descriptors) != len(rules) {
+		panic(fmt.Sprintf(
+			"UTxO validation rule %q: upstream descriptor count %d does not match rule count %d",
+			skipRuleId,
+			len(descriptors),
+			len(rules),
+		))
 	}
-	targetName := utxoValidationRuleName(skipValidationFunc)
 	found := noUtxoValidationRuleIndex
-	for index, rule := range rules {
-		if utxoValidationRuleName(rule) != targetName {
+	for index, descriptor := range descriptors {
+		if descriptor.Id != skipRuleId {
 			continue
 		}
 		if found != noUtxoValidationRuleIndex {
 			panic(fmt.Sprintf(
-				"%s resolves to multiple upstream rule indexes %d and %d",
-				skipRuleName,
+				"UTxO validation rule %q resolves to multiple upstream rule indexes %d and %d",
+				skipRuleId,
 				found,
 				index,
 			))
@@ -440,23 +454,19 @@ func resolveUtxoValidationSkipIndex(
 		found = index
 	}
 	if found == noUtxoValidationRuleIndex {
-		panic(
-			skipRuleName +
-				" expected function is absent from upstream validation rules",
-		)
+		panic(fmt.Sprintf(
+			"UTxO validation rule %q is absent from the upstream validation rule descriptors",
+			skipRuleId,
+		))
+	}
+	if rules[found] == nil {
+		panic(fmt.Sprintf(
+			"UTxO validation rule %q resolves to a nil upstream rule at index %d",
+			skipRuleId,
+			found,
+		))
 	}
 	return found
-}
-
-func utxoValidationRuleName(fn lcommon.UtxoValidationRuleFunc) string {
-	if fn == nil {
-		return ""
-	}
-	pc := reflect.ValueOf(fn).Pointer()
-	if runtimeFn := runtime.FuncForPC(pc); runtimeFn != nil {
-		return runtimeFn.Name()
-	}
-	return fmt.Sprintf("%x", pc)
 }
 
 // SafeAddExUnits adds two ExUnits values with

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
+	"runtime"
 
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -372,11 +374,13 @@ func buildIndexedUtxoValidationRules(
 	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
 	skipRuleId lcommon.UtxoValidationRuleId,
+	expected ...map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc,
 ) []indexedUtxoValidationRule {
 	return buildIndexedUtxoValidationRulesWithSkips(
 		descriptors,
 		rules,
 		[]lcommon.UtxoValidationRuleId{skipRuleId},
+		expected...,
 	)
 }
 
@@ -384,13 +388,19 @@ func buildIndexedUtxoValidationRulesWithSkips(
 	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
 	skipRuleIds []lcommon.UtxoValidationRuleId,
+	expected ...map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc,
 ) []indexedUtxoValidationRule {
 	skipIndexes := make(map[int]struct{}, len(skipRuleIds))
+	var expectedByID map[lcommon.UtxoValidationRuleId]lcommon.UtxoValidationRuleFunc
+	if len(expected) > 0 {
+		expectedByID = expected[0]
+	}
 	for _, skipRuleId := range skipRuleIds {
 		resolvedIndex := resolveUtxoValidationSkipIndex(
 			descriptors,
 			rules,
 			skipRuleId,
+			expectedByID[skipRuleId],
 		)
 		skipIndexes[resolvedIndex] = struct{}{}
 	}
@@ -426,6 +436,7 @@ func resolveUtxoValidationSkipIndex(
 	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
 	skipRuleId lcommon.UtxoValidationRuleId,
+	expected ...lcommon.UtxoValidationRuleFunc,
 ) int {
 	if skipRuleId == "" {
 		panic("UTxO validation skip rule Id is empty")
@@ -466,7 +477,28 @@ func resolveUtxoValidationSkipIndex(
 			found,
 		))
 	}
+	if len(expected) > 0 && expected[0] != nil &&
+		utxoValidationRuleFunctionName(descriptors[found].Validator) !=
+			utxoValidationRuleFunctionName(expected[0]) {
+		panic(fmt.Sprintf(
+			"UTxO validation rule %q resolves to validator %s, expected %s",
+			skipRuleId,
+			utxoValidationRuleFunctionName(descriptors[found].Validator),
+			utxoValidationRuleFunctionName(expected[0]),
+		))
+	}
 	return found
+}
+
+func utxoValidationRuleFunctionName(fn lcommon.UtxoValidationRuleFunc) string {
+	if fn == nil {
+		return ""
+	}
+	pc := reflect.ValueOf(fn).Pointer()
+	if runtimeFn := runtime.FuncForPC(pc); runtimeFn != nil {
+		return runtimeFn.Name()
+	}
+	return fmt.Sprintf("%x", pc)
 }
 
 // SafeAddExUnits adds two ExUnits values with

--- a/ledger/eras/validation_rule_id_test.go
+++ b/ledger/eras/validation_rule_id_test.go
@@ -498,7 +498,7 @@ func TestCurrentTreasuryValueRuleGuardsOnDeclaredValue(t *testing.T) {
 		wantCalls  int
 		wantErrors bool
 	}{
-		{name: "no declared treasury value", declared: nil},
+		{name: "no declared treasury value", declared: big.NewInt(0)},
 		{
 			name:       "declared treasury value",
 			declared:   big.NewInt(1),

--- a/ledger/eras/validation_rule_id_test.go
+++ b/ledger/eras/validation_rule_id_test.go
@@ -17,12 +17,12 @@ package eras
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"reflect"
 	"runtime"
 	"slices"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -369,7 +369,9 @@ func TestEraUtxoValidationRuleCompositions(t *testing.T) {
 				require.Equal(
 					t,
 					wantFuncName,
-					shortUtxoValidationRuleName(era.descriptors[index].Validator),
+					shortUtxoValidationRuleName(
+						era.descriptors[index].Validator,
+					),
 					"upstream rule %s is no longer implemented by %s",
 					id,
 					wantFuncName,
@@ -480,6 +482,22 @@ func (s *treasuryUnavailableLedgerState) TreasuryValue() (uint64, error) {
 	return 0, errors.New("not implemented")
 }
 
+// newConwayTreasuryTx decodes a Conway transaction body from a CBOR key map so
+// the presence of transaction-body key 21 comes from the real decoder rather
+// than from a hand-set field. An absent key and an explicitly declared zero are
+// different states and only the decoder distinguishes them.
+func newConwayTreasuryTx(
+	t *testing.T,
+	body map[int]any,
+) *conway.ConwayTransaction {
+	t.Helper()
+	cborData, err := cbor.Encode(body)
+	require.NoError(t, err)
+	tx := &conway.ConwayTransaction{TxIsValid: true}
+	require.NoError(t, tx.Body.UnmarshalCBOR(cborData))
+	return tx
+}
+
 // TestCurrentTreasuryValueRuleGuardsOnDeclaredValue pins the guard the
 // gouroboros v0.202.6 bump depends on.
 //
@@ -488,27 +506,42 @@ func (s *treasuryUnavailableLedgerState) TreasuryValue() (uint64, error) {
 // LedgerState.TreasuryValue only for a transaction that declares
 // currentTreasuryValue (transaction body key 21). Dingo's provider still
 // returns an error, so this rule must stay unreachable for ordinary traffic
-// until #3687 lands. If upstream drops the guard, this test fails instead of
-// the node rejecting every transaction.
+// until blinklabs-io/dingo#3687 lands. If upstream drops the guard, or stops
+// distinguishing an absent key 21 from a declared zero, this test fails
+// instead of the node rejecting ordinary transactions.
 func TestCurrentTreasuryValueRuleGuardsOnDeclaredValue(t *testing.T) {
 	pp := &conway.ConwayProtocolParameters{}
 	for _, tc := range []struct {
 		name       string
-		declared   *big.Int
+		body       map[int]any
 		wantCalls  int
 		wantErrors bool
 	}{
-		{name: "no declared treasury value", declared: nil},
 		{
-			name:       "declared treasury value",
-			declared:   big.NewInt(1),
+			name: "key 21 absent",
+			body: map[int]any{2: uint64(100)},
+		},
+		{
+			name:       "key 21 declared zero",
+			body:       map[int]any{2: uint64(100), 21: 0},
+			wantCalls:  1,
+			wantErrors: true,
+		},
+		{
+			name:       "key 21 declared non-zero",
+			body:       map[int]any{2: uint64(100), 21: 7},
 			wantCalls:  1,
 			wantErrors: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tx := newConwayFeaturesTestTx(newTestInput(0x91, 0))
-			tx.currentTreasuryValue = tc.declared
+			tx := newConwayTreasuryTx(t, tc.body)
+			require.Equal(
+				t,
+				tc.wantCalls > 0,
+				lcommon.TransactionCurrentTreasuryValuePresent(tx),
+				"decoded key 21 presence must match the case under test",
+			)
 			ls := &treasuryUnavailableLedgerState{
 				mockLedgerState: newMockLedgerState(),
 			}

--- a/ledger/eras/validation_rule_id_test.go
+++ b/ledger/eras/validation_rule_id_test.go
@@ -1,0 +1,529 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eras
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+// utxoValidationRuleName reports the runtime function name of a validation
+// rule. It exists for assertions and diagnostics only: production resolution
+// keys on the upstream rule Id, because common.ComposeUtxoValidationRules
+// replaces phase-2-gated rules with anonymous wrappers and upstream moves
+// shared rules between era packages. Never use it as a lookup key.
+func utxoValidationRuleName(fn lcommon.UtxoValidationRuleFunc) string {
+	if fn == nil {
+		return ""
+	}
+	pc := reflect.ValueOf(fn).Pointer()
+	if runtimeFn := runtime.FuncForPC(pc); runtimeFn != nil {
+		return runtimeFn.Name()
+	}
+	return fmt.Sprintf("%x", pc)
+}
+
+// TestResolveUtxoValidationSkipIndexResolvesPhase2WrappedRule is the
+// regression guard for blinklabs-io/dingo#3821: it fails if
+// resolveUtxoValidationSkipIndex ever goes back to matching upstream rules by
+// validation function identity or runtime name.
+//
+// common.ComposeUtxoValidationRules replaces every phase-2-gated entry with an
+// anonymous wrapper closure, so the original function is unreachable from the
+// composed list. A function-keyed resolver panics; an Id-keyed one does not.
+func TestResolveUtxoValidationSkipIndexResolvesPhase2WrappedRule(t *testing.T) {
+	descriptors := []lcommon.UtxoValidationRuleDescriptor{
+		{
+			Id:        lcommon.UtxoValidationRuleMetadata,
+			Validator: conway.UtxoValidateMetadata,
+		},
+		{
+			Id:        lcommon.UtxoValidationRuleCommitteeCertificates,
+			Validator: conway.UtxoValidateCommitteeCertificates,
+		},
+		{
+			Id:        lcommon.UtxoValidationRuleUnknownVoters,
+			Validator: conway.UtxoValidateUnknownVoters,
+		},
+	}
+	rules := lcommon.ComposeUtxoValidationRules(
+		lcommon.AlwaysUtxoValidationRules(descriptors[0].Validator),
+		lcommon.Phase2ValidUtxoValidationRules(
+			descriptors[1].Validator,
+			descriptors[2].Validator,
+		),
+	)
+	require.Len(t, rules, len(descriptors))
+
+	// Premise of the guard: the gated entries really are wrapped, so neither
+	// function identity nor function name can find them. Without this the
+	// assertions below could pass vacuously against a future upstream that
+	// stops wrapping.
+	require.Equal(
+		t,
+		utxoValidationRuleName(descriptors[0].Validator),
+		utxoValidationRuleName(rules[0]),
+		"an always-run rule must keep its function identity",
+	)
+	for _, index := range []int{1, 2} {
+		require.NotEqual(
+			t,
+			utxoValidationRuleName(descriptors[index].Validator),
+			utxoValidationRuleName(rules[index]),
+			"a phase-2-gated rule must be wrapped by upstream compose",
+		)
+	}
+
+	require.Equal(t, 0, resolveUtxoValidationSkipIndex(
+		descriptors, rules, lcommon.UtxoValidationRuleMetadata,
+	))
+	require.Equal(t, 1, resolveUtxoValidationSkipIndex(
+		descriptors, rules, lcommon.UtxoValidationRuleCommitteeCertificates,
+	))
+	require.Equal(t, 2, resolveUtxoValidationSkipIndex(
+		descriptors, rules, lcommon.UtxoValidationRuleUnknownVoters,
+	))
+}
+
+// TestConwayUpstreamGatedRulesAreWrapped proves the wrapping the guard above
+// simulates is what the pinned gouroboros release actually does, so the
+// package-init panic #3821 reported cannot silently stop being reachable.
+func TestConwayUpstreamGatedRulesAreWrapped(t *testing.T) {
+	descriptors := conway.UtxoValidationRuleDescriptors()
+	require.Len(t, conway.UtxoValidationRules, len(descriptors))
+	for _, id := range []lcommon.UtxoValidationRuleId{
+		lcommon.UtxoValidationRuleCommitteeCertificates,
+		lcommon.UtxoValidationRuleUnknownVoters,
+	} {
+		index := slices.IndexFunc(
+			descriptors,
+			func(d lcommon.UtxoValidationRuleDescriptor) bool {
+				return d.Id == id
+			},
+		)
+		require.GreaterOrEqual(t, index, 0, string(id))
+		require.NotEqual(
+			t,
+			utxoValidationRuleName(descriptors[index].Validator),
+			utxoValidationRuleName(conway.UtxoValidationRules[index]),
+			"upstream %s is no longer wrapped; the #3821 guard needs review",
+			id,
+		)
+	}
+}
+
+func TestResolveUtxoValidationSkipIndexPanics(t *testing.T) {
+	descriptors := []lcommon.UtxoValidationRuleDescriptor{
+		{
+			Id:        lcommon.UtxoValidationRuleMetadata,
+			Validator: conway.UtxoValidateMetadata,
+		},
+	}
+	rules := []lcommon.UtxoValidationRuleFunc{conway.UtxoValidateMetadata}
+
+	t.Run("empty id", func(t *testing.T) {
+		require.PanicsWithValue(
+			t,
+			"UTxO validation skip rule Id is empty",
+			func() {
+				resolveUtxoValidationSkipIndex(descriptors, rules, "")
+			},
+		)
+	})
+	t.Run("absent id", func(t *testing.T) {
+		require.Panics(t, func() {
+			resolveUtxoValidationSkipIndex(
+				descriptors, rules, lcommon.UtxoValidationRuleUnknownVoters,
+			)
+		})
+	})
+	t.Run("duplicate id", func(t *testing.T) {
+		dup := append(
+			slices.Clone(descriptors),
+			descriptors[0],
+		)
+		require.Panics(t, func() {
+			resolveUtxoValidationSkipIndex(
+				dup,
+				append(slices.Clone(rules), rules[0]),
+				lcommon.UtxoValidationRuleMetadata,
+			)
+		})
+	})
+	t.Run("descriptor and rule count diverge", func(t *testing.T) {
+		require.Panics(t, func() {
+			resolveUtxoValidationSkipIndex(
+				descriptors,
+				append(slices.Clone(rules), conway.UtxoValidateMetadata),
+				lcommon.UtxoValidationRuleMetadata,
+			)
+		})
+	})
+	t.Run("nil upstream rule", func(t *testing.T) {
+		require.Panics(t, func() {
+			resolveUtxoValidationSkipIndex(
+				descriptors,
+				[]lcommon.UtxoValidationRuleFunc{nil},
+				lcommon.UtxoValidationRuleMetadata,
+			)
+		})
+	})
+}
+
+// utxoValidationRuleReplacement is the Dingo rule installed in place of an
+// upstream rule, together with the upstream function name expected at that
+// rule's Id. The function name is an assertion, not a lookup key: it catches
+// an upstream Id being reattached to a different validator.
+type utxoValidationRuleReplacement struct {
+	upstreamFuncName string
+	dingoFunc        lcommon.UtxoValidationRuleFunc
+}
+
+type eraUtxoValidationRuleComposition struct {
+	era         string
+	descriptors []lcommon.UtxoValidationRuleDescriptor
+	upstream    []lcommon.UtxoValidationRuleFunc
+	built       []indexedUtxoValidationRule
+	// dropped maps each removed rule Id to the upstream function name expected
+	// at that Id.
+	dropped map[lcommon.UtxoValidationRuleId]string
+	// replaced maps each rule Id whose upstream rule Dingo swaps out.
+	replaced map[lcommon.UtxoValidationRuleId]utxoValidationRuleReplacement
+	// retained lists rule Ids that must still run, with the upstream function
+	// name expected at each. This is the negative case: resolving by Id must
+	// not remove a rule Dingo does not intend to remove.
+	retained map[lcommon.UtxoValidationRuleId]string
+}
+
+func eraUtxoValidationRuleCompositions() []eraUtxoValidationRuleComposition {
+	return []eraUtxoValidationRuleComposition{
+		{
+			era:         "shelley",
+			descriptors: shelley.UtxoValidationRuleDescriptors(),
+			upstream:    shelley.UtxoValidationRules,
+			built:       shelleyUtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleFeeTooSmall: "shelley.UtxoValidateFeeTooSmallUtxo",
+				lcommon.UtxoValidationRuleMaxTxSize:   "shelley.UtxoValidateMaxTxSizeUtxo",
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleValueNotConserved: "shelley.UtxoValidateValueNotConservedUtxo",
+				lcommon.UtxoValidationRuleSignatures:        "shelley.UtxoValidateSignatures",
+			},
+		},
+		{
+			era:         "allegra",
+			descriptors: allegra.UtxoValidationRuleDescriptors(),
+			upstream:    allegra.UtxoValidationRules,
+			built:       allegraUtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleFeeTooSmall: "allegra.UtxoValidateFeeTooSmallUtxo",
+				lcommon.UtxoValidationRuleMaxTxSize:   "allegra.UtxoValidateMaxTxSizeUtxo",
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleValueNotConserved:       "allegra.UtxoValidateValueNotConservedUtxo",
+				lcommon.UtxoValidationRuleOutsideValidityInterval: "allegra.UtxoValidateOutsideValidityIntervalUtxo",
+			},
+		},
+		{
+			era:         "alonzo",
+			descriptors: alonzo.UtxoValidationRuleDescriptors(),
+			upstream:    alonzo.UtxoValidationRules,
+			built:       alonzoUtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRulePlutusScripts: "alonzo.UtxoValidatePlutusScripts",
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleExtraneousRedeemers: "alonzo.UtxoValidateExtraneousRedeemers",
+				lcommon.UtxoValidationRuleNativeScripts:       "alonzo.UtxoValidateNativeScripts",
+				lcommon.UtxoValidationRuleDelegation:          "alonzo.UtxoValidateDelegation",
+			},
+		},
+		{
+			era:         "babbage",
+			descriptors: babbage.UtxoValidationRuleDescriptors(),
+			upstream:    babbage.UtxoValidationRules,
+			built:       babbageUtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRulePlutusScripts: "babbage.UtxoValidatePlutusScripts",
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleMalformedReferenceScripts: "babbage.UtxoValidateMalformedReferenceScripts",
+				lcommon.UtxoValidationRuleWithdrawals:               "babbage.UtxoValidateWithdrawals",
+			},
+		},
+		{
+			era:         "conway",
+			descriptors: conway.UtxoValidationRuleDescriptors(),
+			upstream:    conway.UtxoValidationRules,
+			built:       conwayUtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleFeeTooSmall:   "conway.UtxoValidateFeeTooSmallUtxo",
+				lcommon.UtxoValidationRulePlutusScripts: "conway.UtxoValidatePlutusScripts",
+			},
+			replaced: map[lcommon.UtxoValidationRuleId]utxoValidationRuleReplacement{
+				lcommon.UtxoValidationRuleConwayFeaturesWithPlutusV1V2: {
+					upstreamFuncName: "conway.UtxoValidateConwayFeaturesWithPlutusV1V2",
+					dingoFunc:        validateConwayFeaturesWithNeededPlutusV1V2,
+				},
+				lcommon.UtxoValidationRuleCommitteeCertificates: {
+					upstreamFuncName: "conway.UtxoValidateCommitteeCertificates",
+					dingoFunc:        validateCommitteeCertificates,
+				},
+				lcommon.UtxoValidationRuleUnknownVoters: {
+					upstreamFuncName: "conway.UtxoValidateUnknownVoters",
+					dingoFunc:        validateUnknownVoters,
+				},
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				// Added upstream in gouroboros v0.202.6 and intentionally not
+				// skipped: Conway validation now enforces a declared
+				// currentTreasuryValue (transaction body key 21).
+				lcommon.UtxoValidationRuleCurrentTreasuryValue: "common.UtxoValidateCurrentTreasuryValue",
+				lcommon.UtxoValidationRuleExUnitsTooBig:        "conway.UtxoValidateExUnitsTooBigUtxo",
+				lcommon.UtxoValidationRuleNativeScripts:        "conway.UtxoValidateNativeScripts",
+				lcommon.UtxoValidationRuleCertificateDeposits:  "conway.UtxoValidateCertificateDeposits",
+			},
+		},
+		{
+			era:         "dijkstra",
+			descriptors: gdijkstra.UtxoValidationRuleDescriptors(),
+			upstream:    gdijkstra.UtxoValidationRules,
+			built:       dijkstraPhase1UtxoValidationRules,
+			dropped: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRulePlutusScripts: "dijkstra.UtxoValidatePlutusScripts",
+			},
+			replaced: map[lcommon.UtxoValidationRuleId]utxoValidationRuleReplacement{
+				lcommon.UtxoValidationRuleCommitteeCertificates: {
+					upstreamFuncName: "conway.UtxoValidateCommitteeCertificates",
+					dingoFunc:        validateCommitteeCertificates,
+				},
+				lcommon.UtxoValidationRuleUnknownVoters: {
+					upstreamFuncName: "conway.UtxoValidateUnknownVoters",
+					dingoFunc:        validateUnknownVoters,
+				},
+			},
+			retained: map[lcommon.UtxoValidationRuleId]string{
+				lcommon.UtxoValidationRuleCurrentTreasuryValue: "common.UtxoValidateCurrentTreasuryValue",
+				lcommon.UtxoValidationRuleExUnitsTooBig:        "dijkstra.UtxoValidateExUnitsTooBigUtxo",
+				lcommon.UtxoValidationRuleCertificateDeposits:  "conway.UtxoValidateCertificateDeposits",
+			},
+		},
+	}
+}
+
+// TestEraUtxoValidationRuleCompositions pins, for every era that removes or
+// replaces an upstream rule, which upstream rule Ids Dingo drops, which it
+// swaps for a local implementation, and that nothing else is disturbed.
+//
+// Resolving by Id is only correct if the Ids select the same rules the previous
+// pin's function names did, so each expected Id is cross-checked against the
+// upstream function name at that Id. An upstream reorder, rename, or Id
+// reassignment fails here instead of silently changing what Dingo validates.
+func TestEraUtxoValidationRuleCompositions(t *testing.T) {
+	for _, era := range eraUtxoValidationRuleCompositions() {
+		t.Run(era.era, func(t *testing.T) {
+			require.Len(
+				t,
+				era.upstream,
+				len(era.descriptors),
+				"upstream descriptor and rule lists must stay aligned",
+			)
+
+			resolveExpected := func(
+				id lcommon.UtxoValidationRuleId,
+				wantFuncName string,
+			) int {
+				index := resolveUtxoValidationSkipIndex(
+					era.descriptors,
+					era.upstream,
+					id,
+				)
+				require.Equal(t, id, era.descriptors[index].Id)
+				require.Equal(
+					t,
+					wantFuncName,
+					shortUtxoValidationRuleName(era.descriptors[index].Validator),
+					"upstream rule %s is no longer implemented by %s",
+					id,
+					wantFuncName,
+				)
+				return index
+			}
+
+			droppedIndexes := map[int]lcommon.UtxoValidationRuleId{}
+			for id, wantFuncName := range era.dropped {
+				droppedIndexes[resolveExpected(id, wantFuncName)] = id
+			}
+			replacedIndexes := map[int]lcommon.UtxoValidationRuleId{}
+			for id, replacement := range era.replaced {
+				index := resolveExpected(id, replacement.upstreamFuncName)
+				replacedIndexes[index] = id
+				droppedIndexes[index] = id
+			}
+
+			// The built list must be exactly the upstream list minus the
+			// dropped indexes, with the replaced indexes reinstated, each once,
+			// in ascending upstream order.
+			wantIndexes := make([]int, 0, len(era.upstream))
+			for index := range era.upstream {
+				if _, dropped := droppedIndexes[index]; dropped {
+					if _, replaced := replacedIndexes[index]; !replaced {
+						continue
+					}
+				}
+				wantIndexes = append(wantIndexes, index)
+			}
+			gotIndexes := make([]int, 0, len(era.built))
+			for _, rule := range era.built {
+				gotIndexes = append(gotIndexes, rule.index)
+			}
+			require.Equal(
+				t,
+				wantIndexes,
+				gotIndexes,
+				"built rule positions must match the upstream list minus the dropped rules",
+			)
+
+			byIndex := map[int]lcommon.UtxoValidationRuleFunc{}
+			for _, rule := range era.built {
+				byIndex[rule.index] = rule.validationFunc
+			}
+
+			for index, id := range replacedIndexes {
+				replacement := era.replaced[id]
+				require.Equal(
+					t,
+					utxoValidationRuleName(replacement.dingoFunc),
+					utxoValidationRuleName(byIndex[index]),
+					"%s must run Dingo's replacement rule", id,
+				)
+			}
+			for index, id := range droppedIndexes {
+				if _, replaced := replacedIndexes[index]; replaced {
+					continue
+				}
+				require.NotContains(
+					t,
+					byIndex,
+					index,
+					"upstream rule %s must be removed", id,
+				)
+			}
+			for id, wantFuncName := range era.retained {
+				index := resolveExpected(id, wantFuncName)
+				require.Contains(
+					t,
+					byIndex,
+					index,
+					"upstream rule %s must still run", id,
+				)
+				require.Equal(
+					t,
+					utxoValidationRuleName(era.upstream[index]),
+					utxoValidationRuleName(byIndex[index]),
+					"upstream rule %s must run the upstream implementation", id,
+				)
+			}
+		})
+	}
+}
+
+// shortUtxoValidationRuleName trims the module path from a validation rule's
+// runtime function name, leaving "<package>.<Func>".
+func shortUtxoValidationRuleName(fn lcommon.UtxoValidationRuleFunc) string {
+	name := utxoValidationRuleName(fn)
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] == '/' {
+			return name[i+1:]
+		}
+	}
+	return name
+}
+
+// treasuryUnavailableLedgerState mirrors *ledger.LedgerView while
+// blinklabs-io/dingo#3687 is open: TreasuryValue is a mandatory
+// common.LedgerState method that Dingo does not implement yet.
+type treasuryUnavailableLedgerState struct {
+	*mockLedgerState
+	calls int
+}
+
+func (s *treasuryUnavailableLedgerState) TreasuryValue() (uint64, error) {
+	s.calls++
+	return 0, errors.New("not implemented")
+}
+
+// TestCurrentTreasuryValueRuleGuardsOnDeclaredValue pins the guard the
+// gouroboros v0.202.6 bump depends on.
+//
+// common.UtxoValidateCurrentTreasuryValue is new in v0.202.6 and now runs for
+// every Conway and Dijkstra transaction, but it reads
+// LedgerState.TreasuryValue only for a transaction that declares
+// currentTreasuryValue (transaction body key 21). Dingo's provider still
+// returns an error, so this rule must stay unreachable for ordinary traffic
+// until #3687 lands. If upstream drops the guard, this test fails instead of
+// the node rejecting every transaction.
+func TestCurrentTreasuryValueRuleGuardsOnDeclaredValue(t *testing.T) {
+	pp := &conway.ConwayProtocolParameters{}
+	for _, tc := range []struct {
+		name       string
+		declared   *big.Int
+		wantCalls  int
+		wantErrors bool
+	}{
+		{name: "no declared treasury value", declared: nil},
+		{
+			name:       "declared treasury value",
+			declared:   big.NewInt(1),
+			wantCalls:  1,
+			wantErrors: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := newConwayFeaturesTestTx(newTestInput(0x91, 0))
+			tx.currentTreasuryValue = tc.declared
+			ls := &treasuryUnavailableLedgerState{
+				mockLedgerState: newMockLedgerState(),
+			}
+			err := lcommon.UtxoValidateCurrentTreasuryValue(tx, 0, ls, pp)
+			if tc.wantErrors {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(
+				t,
+				tc.wantCalls,
+				ls.calls,
+				"TreasuryValue must be consulted only for a declared value",
+			)
+		})
+	}
+}

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -704,7 +704,9 @@ func TestConwayCommitteeCertificateRulePreservesCredentialTag(t *testing.T) {
 			TxCertificates: []lcommon.CertificateWrapper{{
 				Type: uint(lcommon.CertificateTypeAuthCommitteeHot),
 				Certificate: &lcommon.AuthCommitteeHotCertificate{
-					CertType:       uint(lcommon.CertificateTypeAuthCommitteeHot),
+					CertType: uint(
+						lcommon.CertificateTypeAuthCommitteeHot,
+					),
 					ColdCredential: scriptCredential,
 				},
 			}},
@@ -1412,21 +1414,36 @@ func TestTxInfoV2ContextSortsInputs(t *testing.T) {
 	)
 }
 
-// TestBuildIndexedUtxoValidationRulesResolvesByRuleId reorders the upstream
-// list and confirms the skip follows the rule Id to its new position rather
-// than staying pinned to a fixed index.
+// TestBuildIndexedUtxoValidationRulesResolvesByRuleId moves the plutus-scripts
+// rule to the front of the upstream list and gates it behind
+// common.Phase2ValidUtxoValidationRules, so the skip is only resolvable
+// through the descriptor Id: a fixed index points at the wrong rule and a
+// function-keyed lookup cannot see past the wrapper.
 func TestBuildIndexedUtxoValidationRulesResolvesByRuleId(t *testing.T) {
 	descriptors := alonzo.UtxoValidationRuleDescriptors()
-	rules := append(
-		[]lcommon.UtxoValidationRuleFunc(nil),
-		alonzo.UtxoValidationRules...,
-	)
 	originalIndex := resolveUtxoValidationSkipIndex(
-		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
+		descriptors,
+		alonzo.UtxoValidationRules,
+		lcommon.UtxoValidationRulePlutusScripts,
 	)
 	require.NotZero(t, originalIndex)
 	descriptors[0], descriptors[originalIndex] = descriptors[originalIndex], descriptors[0]
-	rules[0], rules[originalIndex] = rules[originalIndex], rules[0]
+	rest := make([]lcommon.UtxoValidationRuleFunc, 0, len(descriptors)-1)
+	for _, descriptor := range descriptors[1:] {
+		rest = append(rest, descriptor.Validator)
+	}
+	rules := lcommon.ComposeUtxoValidationRules(
+		lcommon.Phase2ValidUtxoValidationRules(descriptors[0].Validator),
+		lcommon.AlwaysUtxoValidationRules(rest...),
+	)
+	require.Len(t, rules, len(descriptors))
+	require.NotEqual(
+		t,
+		utxoValidationRuleName(descriptors[0].Validator),
+		utxoValidationRuleName(rules[0]),
+		"the moved rule must be wrapped so no function name can match it",
+	)
+
 	require.Zero(t, resolveUtxoValidationSkipIndex(
 		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
 	))
@@ -3924,7 +3941,9 @@ func TestConwayCommitteeCertificateRuleDoesNotRejectWhenStateUnavailable(
 			TxCertificates: []lcommon.CertificateWrapper{{
 				Type: uint(lcommon.CertificateTypeAuthCommitteeHot),
 				Certificate: &lcommon.AuthCommitteeHotCertificate{
-					CertType:       uint(lcommon.CertificateTypeAuthCommitteeHot),
+					CertType: uint(
+						lcommon.CertificateTypeAuthCommitteeHot,
+					),
 					ColdCredential: credential,
 				},
 			}},
@@ -4037,7 +4056,9 @@ func TestConwayCommitteeRulesSkipPhase2InvalidTransaction(t *testing.T) {
 			TxCertificates: []lcommon.CertificateWrapper{{
 				Type: uint(lcommon.CertificateTypeAuthCommitteeHot),
 				Certificate: &lcommon.AuthCommitteeHotCertificate{
-					CertType:       uint(lcommon.CertificateTypeAuthCommitteeHot),
+					CertType: uint(
+						lcommon.CertificateTypeAuthCommitteeHot,
+					),
 					ColdCredential: credential,
 				},
 			}},
@@ -4147,7 +4168,9 @@ func TestConwayCommitteeRulesFailClosedOnLookupError(t *testing.T) {
 			TxCertificates: []lcommon.CertificateWrapper{{
 				Type: uint(lcommon.CertificateTypeAuthCommitteeHot),
 				Certificate: &lcommon.AuthCommitteeHotCertificate{
-					CertType:       uint(lcommon.CertificateTypeAuthCommitteeHot),
+					CertType: uint(
+						lcommon.CertificateTypeAuthCommitteeHot,
+					),
 					ColdCredential: credential,
 				},
 			}},

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -1425,9 +1425,8 @@ func TestBuildIndexedUtxoValidationRulesResolvesByRuleId(t *testing.T) {
 		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
 	)
 	require.NotZero(t, originalIndex)
-	descriptors[0], descriptors[originalIndex] = descriptors[originalIndex], descriptors[0]
 	rules[0], rules[originalIndex] = rules[originalIndex], rules[0]
-	require.Zero(t, resolveUtxoValidationSkipIndex(
+	require.Equal(t, originalIndex, resolveUtxoValidationSkipIndex(
 		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
 	))
 	indexed := buildIndexedUtxoValidationRules(
@@ -1439,7 +1438,7 @@ func TestBuildIndexedUtxoValidationRulesResolvesByRuleId(t *testing.T) {
 	requireIndexedRulesDropRuleIndex(
 		t,
 		indexed,
-		0,
+		originalIndex,
 		"the resolved upstream rule must be removed",
 	)
 }

--- a/ledger/eras/validation_test.go
+++ b/ledger/eras/validation_test.go
@@ -309,26 +309,30 @@ func (m *mockRedeemers) Iter() iter.Seq2[lcommon.RedeemerKey, lcommon.RedeemerVa
 }
 
 func TestAlonzoValidationRulesUseLocalPlutusExecution(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	descriptors := alonzo.UtxoValidationRuleDescriptors()
+	plutusIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		alonzo.UtxoValidationRules,
-		alonzo.UtxoValidatePlutusScripts,
+		lcommon.UtxoValidationRulePlutusScripts,
 		"alonzo.UtxoValidatePlutusScripts",
 	)
 	require.Len(t, alonzoUtxoValidationRules, len(alonzo.UtxoValidationRules)-1)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		alonzoUtxoValidationRules,
-		alonzo.UtxoValidatePlutusScripts,
+		plutusIndex,
 		"Alonzo validation must use Dingo's local Plutus execution path",
 	)
 }
 
 func TestBabbageValidationRulesUseLocalPlutusExecution(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	descriptors := babbage.UtxoValidationRuleDescriptors()
+	plutusIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		babbage.UtxoValidationRules,
-		babbage.UtxoValidatePlutusScripts,
+		lcommon.UtxoValidationRulePlutusScripts,
 		"babbage.UtxoValidatePlutusScripts",
 	)
 	require.Len(
@@ -336,10 +340,10 @@ func TestBabbageValidationRulesUseLocalPlutusExecution(t *testing.T) {
 		babbageUtxoValidationRules,
 		len(babbage.UtxoValidationRules)-1,
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		babbageUtxoValidationRules,
-		babbage.UtxoValidatePlutusScripts,
+		plutusIndex,
 		"Babbage validation must use Dingo's local Plutus execution path",
 	)
 }
@@ -516,98 +520,92 @@ func TestPlutusBudgetComparisonIncludesFinalSlippageBatch(t *testing.T) {
 }
 
 func TestConwayValidationRulesUseLocalPlutusExecution(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	descriptors := conway.UtxoValidationRuleDescriptors()
+	featuresIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateConwayFeaturesWithPlutusV1V2,
+		lcommon.UtxoValidationRuleConwayFeaturesWithPlutusV1V2,
 		"conway.UtxoValidateConwayFeaturesWithPlutusV1V2",
 	)
-	requireRuleIndexResolvesToFunc(
+	feeIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateFeeTooSmallUtxo,
+		lcommon.UtxoValidationRuleFeeTooSmall,
 		"conway.UtxoValidateFeeTooSmallUtxo",
 	)
-	requireRuleIndexResolvesToFunc(
+	plutusIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidatePlutusScripts,
+		lcommon.UtxoValidationRulePlutusScripts,
 		"conway.UtxoValidatePlutusScripts",
 	)
-	requireRuleIndexResolvesToFunc(
+	committeeIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateCommitteeCertificates,
+		lcommon.UtxoValidationRuleCommitteeCertificates,
 		"conway.UtxoValidateCommitteeCertificates",
 	)
-	requireRuleIndexResolvesToFunc(
+	votersIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateUnknownVoters,
+		lcommon.UtxoValidationRuleUnknownVoters,
 		"conway.UtxoValidateUnknownVoters",
 	)
 	require.Len(t, conwayUtxoValidationRules, len(conway.UtxoValidationRules)-2)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesReplaceRuleIndex(
 		t,
 		conwayUtxoValidationRules,
-		conway.UtxoValidateConwayFeaturesWithPlutusV1V2,
+		featuresIndex,
+		validateConwayFeaturesWithNeededPlutusV1V2,
 		"Conway validation must count only needed PlutusV1/V2 scripts",
 	)
-	requireIndexedRulesIncludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		conwayUtxoValidationRules,
-		validateConwayFeaturesWithNeededPlutusV1V2,
-		"Conway validation must install Dingo's needed-script rule",
-	)
-	requireIndexedRulesExcludeFunc(
-		t,
-		conwayUtxoValidationRules,
-		conway.UtxoValidateFeeTooSmallUtxo,
+		feeIndex,
 		"Conway validation must use Dingo's reference-script-aware fee rule",
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		conwayUtxoValidationRules,
-		conway.UtxoValidatePlutusScripts,
+		plutusIndex,
 		"Conway validation must use Dingo's local Plutus execution path",
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesReplaceRuleIndex(
 		t,
 		conwayUtxoValidationRules,
-		conway.UtxoValidateCommitteeCertificates,
+		committeeIndex,
+		validateCommitteeCertificates,
 		"Conway validation must preserve committee cold credential tags",
 	)
-	requireIndexedRulesIncludeFunc(
+	requireIndexedRulesReplaceRuleIndex(
 		t,
 		conwayUtxoValidationRules,
-		validateCommitteeCertificates,
-		"Conway validation must install Dingo's committee certificate rule",
-	)
-	requireIndexedRulesExcludeFunc(
-		t,
-		conwayUtxoValidationRules,
-		conway.UtxoValidateUnknownVoters,
-		"Conway validation must preserve committee hot credential tags",
-	)
-	requireIndexedRulesIncludeFunc(
-		t,
-		conwayUtxoValidationRules,
+		votersIndex,
 		validateUnknownVoters,
-		"Conway validation must install Dingo's unknown-voter rule",
+		"Conway validation must preserve committee hot credential tags",
 	)
 }
 
 func TestDijkstraValidationRulesUseCredentialAwareCommitteeState(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	descriptors := gdijkstra.UtxoValidationRuleDescriptors()
+	committeeIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		gdijkstra.UtxoValidationRules,
-		conway.UtxoValidateCommitteeCertificates,
+		lcommon.UtxoValidationRuleCommitteeCertificates,
 		"conway.UtxoValidateCommitteeCertificates",
 	)
-	requireRuleIndexResolvesToFunc(
+	votersIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		gdijkstra.UtxoValidationRules,
-		conway.UtxoValidateUnknownVoters,
+		lcommon.UtxoValidationRuleUnknownVoters,
 		"conway.UtxoValidateUnknownVoters",
 	)
 	require.Len(
@@ -615,29 +613,19 @@ func TestDijkstraValidationRulesUseCredentialAwareCommitteeState(t *testing.T) {
 		dijkstraPhase1UtxoValidationRules,
 		len(gdijkstra.UtxoValidationRules)-1,
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesReplaceRuleIndex(
 		t,
 		dijkstraPhase1UtxoValidationRules,
-		conway.UtxoValidateCommitteeCertificates,
+		committeeIndex,
+		validateCommitteeCertificates,
 		"Dijkstra validation must preserve committee cold credential tags",
 	)
-	requireIndexedRulesIncludeFunc(
+	requireIndexedRulesReplaceRuleIndex(
 		t,
 		dijkstraPhase1UtxoValidationRules,
-		validateCommitteeCertificates,
-		"Dijkstra validation must install Dingo's committee certificate rule",
-	)
-	requireIndexedRulesExcludeFunc(
-		t,
-		dijkstraPhase1UtxoValidationRules,
-		conway.UtxoValidateUnknownVoters,
-		"Dijkstra validation must preserve committee hot credential tags",
-	)
-	requireIndexedRulesIncludeFunc(
-		t,
-		dijkstraPhase1UtxoValidationRules,
+		votersIndex,
 		validateUnknownVoters,
-		"Dijkstra validation must install Dingo's unknown-voter rule",
+		"Dijkstra validation must preserve committee hot credential tags",
 	)
 }
 
@@ -772,22 +760,26 @@ func TestConwayUnknownVoterRulePreservesCredentialTag(t *testing.T) {
 }
 
 func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	descriptors := conway.UtxoValidationRuleDescriptors()
+	feeIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateFeeTooSmallUtxo,
+		lcommon.UtxoValidationRuleFeeTooSmall,
 		"conway.UtxoValidateFeeTooSmallUtxo",
 	)
-	requireRuleIndexResolvesToFunc(
+	exUnitsIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidateExUnitsTooBigUtxo,
+		lcommon.UtxoValidationRuleExUnitsTooBig,
 		"conway.UtxoValidateExUnitsTooBigUtxo",
 	)
-	requireRuleIndexResolvesToFunc(
+	plutusIndex := requireRuleIdResolvesToFunc(
 		t,
+		descriptors,
 		conway.UtxoValidationRules,
-		conway.UtxoValidatePlutusScripts,
+		lcommon.UtxoValidationRulePlutusScripts,
 		"conway.UtxoValidatePlutusScripts",
 	)
 	require.Len(
@@ -795,22 +787,23 @@ func TestConwayPhase1ValidationRulesSkipPlutusExecution(t *testing.T) {
 		conwayPhase1UtxoValidationRules,
 		len(conway.UtxoValidationRules)-2,
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		conwayPhase1UtxoValidationRules,
-		conway.UtxoValidateFeeTooSmallUtxo,
+		feeIndex,
 		"Conway phase-1 validation must use Dingo's reference-script-aware fee rule",
 	)
-	requireIndexedRulesIncludeFunc(
+	requireIndexedRulesRetainRuleIndex(
 		t,
 		conwayPhase1UtxoValidationRules,
-		conway.UtxoValidateExUnitsTooBigUtxo,
+		conway.UtxoValidationRules,
+		exUnitsIndex,
 		"Conway phase-1 replay must still enforce ExUnits limits",
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		conwayPhase1UtxoValidationRules,
-		conway.UtxoValidatePlutusScripts,
+		plutusIndex,
 		"Conway phase-1 replay must not execute Plutus scripts",
 	)
 }
@@ -1419,49 +1412,126 @@ func TestTxInfoV2ContextSortsInputs(t *testing.T) {
 	)
 }
 
-func TestBuildIndexedUtxoValidationRulesResolvesByFunctionIdentity(t *testing.T) {
-	rules := append([]lcommon.UtxoValidationRuleFunc(nil), alonzo.UtxoValidationRules...)
+// TestBuildIndexedUtxoValidationRulesResolvesByRuleId reorders the upstream
+// list and confirms the skip follows the rule Id to its new position rather
+// than staying pinned to a fixed index.
+func TestBuildIndexedUtxoValidationRulesResolvesByRuleId(t *testing.T) {
+	descriptors := alonzo.UtxoValidationRuleDescriptors()
+	rules := append(
+		[]lcommon.UtxoValidationRuleFunc(nil),
+		alonzo.UtxoValidationRules...,
+	)
 	originalIndex := resolveUtxoValidationSkipIndex(
-		rules, alonzo.UtxoValidatePlutusScripts, "test.UtxoValidatePlutusScripts",
+		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
 	)
+	require.NotZero(t, originalIndex)
+	descriptors[0], descriptors[originalIndex] = descriptors[originalIndex], descriptors[0]
 	rules[0], rules[originalIndex] = rules[originalIndex], rules[0]
-	resolved := resolveUtxoValidationSkipIndex(
-		rules,
-		alonzo.UtxoValidatePlutusScripts,
-		"test.UtxoValidatePlutusScripts",
-	)
-	require.Zero(t, resolved)
+	require.Zero(t, resolveUtxoValidationSkipIndex(
+		descriptors, rules, lcommon.UtxoValidationRulePlutusScripts,
+	))
 	indexed := buildIndexedUtxoValidationRules(
+		descriptors,
 		rules,
-		alonzo.UtxoValidatePlutusScripts,
-		"test.UtxoValidatePlutusScripts",
+		lcommon.UtxoValidationRulePlutusScripts,
 	)
-	requireIndexedRulesExcludeFunc(
+	require.Len(t, indexed, len(rules)-1)
+	requireIndexedRulesDropRuleIndex(
 		t,
 		indexed,
-		alonzo.UtxoValidatePlutusScripts,
+		0,
 		"the resolved upstream rule must be removed",
 	)
 }
 
-func requireRuleIndexResolvesToFunc(
+// requireRuleIdResolvesToFunc asserts that upstream rule id resolves to a
+// single position in the era's composed rule list and that the descriptor
+// there is implemented by wantFuncName. The function name is an assertion
+// only; resolution keys on the Id, because upstream wraps phase-2-gated rules
+// and moves shared rules between era packages.
+func requireRuleIdResolvesToFunc(
 	t *testing.T,
+	descriptors []lcommon.UtxoValidationRuleDescriptor,
 	rules []lcommon.UtxoValidationRuleFunc,
-	want lcommon.UtxoValidationRuleFunc,
-	name string,
-) {
-	t.Helper()
-	index := findUtxoValidationRuleIndex(t, rules, want)
-	require.Equal(t, utxoValidationRuleName(want), utxoValidationRuleName(rules[index]), name)
-}
-
-func findUtxoValidationRuleIndex(
-	t *testing.T,
-	rules []lcommon.UtxoValidationRuleFunc,
-	want lcommon.UtxoValidationRuleFunc,
+	id lcommon.UtxoValidationRuleId,
+	wantFuncName string,
 ) int {
 	t.Helper()
-	return resolveUtxoValidationSkipIndex(rules, want, "test rule")
+	index := resolveUtxoValidationSkipIndex(descriptors, rules, id)
+	require.Equal(t, id, descriptors[index].Id)
+	require.Equal(
+		t,
+		wantFuncName,
+		shortUtxoValidationRuleName(descriptors[index].Validator),
+		"upstream rule %s is no longer implemented by %s", id, wantFuncName,
+	)
+	return index
+}
+
+// requireIndexedRulesDropRuleIndex asserts the upstream rule at index is gone
+// from the built list. Comparing positions rather than functions keeps the
+// assertion meaningful for phase-2-gated rules, whose composed entries are
+// anonymous wrappers that no function name can match.
+func requireIndexedRulesDropRuleIndex(
+	t *testing.T,
+	rules []indexedUtxoValidationRule,
+	index int,
+	message string,
+) {
+	t.Helper()
+	for _, rule := range rules {
+		require.NotEqual(t, index, rule.index, message)
+	}
+}
+
+// requireIndexedRulesRetainRuleIndex asserts the upstream rule at index still
+// runs, and runs the upstream implementation.
+func requireIndexedRulesRetainRuleIndex(
+	t *testing.T,
+	rules []indexedUtxoValidationRule,
+	upstream []lcommon.UtxoValidationRuleFunc,
+	index int,
+	message string,
+) {
+	t.Helper()
+	for _, rule := range rules {
+		if rule.index != index {
+			continue
+		}
+		require.Equal(
+			t,
+			utxoValidationRuleName(upstream[index]),
+			utxoValidationRuleName(rule.validationFunc),
+			message,
+		)
+		return
+	}
+	require.Fail(t, message)
+}
+
+// requireIndexedRulesReplaceRuleIndex asserts the upstream rule at index was
+// swapped for Dingo's own want rule, which keeps a stable function identity.
+func requireIndexedRulesReplaceRuleIndex(
+	t *testing.T,
+	rules []indexedUtxoValidationRule,
+	index int,
+	want lcommon.UtxoValidationRuleFunc,
+	message string,
+) {
+	t.Helper()
+	for _, rule := range rules {
+		if rule.index != index {
+			continue
+		}
+		require.Equal(
+			t,
+			utxoValidationRuleName(want),
+			utxoValidationRuleName(rule.validationFunc),
+			message,
+		)
+		return
+	}
+	require.Fail(t, message)
 }
 
 func requireIndexedRulesIncludeFunc(
@@ -1478,24 +1548,6 @@ func requireIndexedRulesIncludeFunc(
 		}
 	}
 	require.Fail(t, message)
-}
-
-func requireIndexedRulesExcludeFunc(
-	t *testing.T,
-	rules []indexedUtxoValidationRule,
-	want lcommon.UtxoValidationRuleFunc,
-	message string,
-) {
-	t.Helper()
-	wantName := utxoValidationRuleName(want)
-	for _, rule := range rules {
-		require.NotEqual(
-			t,
-			wantName,
-			utxoValidationRuleName(rule.validationFunc),
-			message,
-		)
-	}
 }
 
 func TestTxSizeForFee(t *testing.T) {
@@ -1750,16 +1802,19 @@ func TestPreAlonzoRebuiltWireSize(t *testing.T) {
 }
 
 func TestPreAlonzoValidationRulesUseLocalFeeAndSizeChecks(t *testing.T) {
-	requireRuleIndexResolvesToFunc(
+	shelleyDescriptors := shelley.UtxoValidationRuleDescriptors()
+	shelleyFeeIndex := requireRuleIdResolvesToFunc(
 		t,
+		shelleyDescriptors,
 		shelley.UtxoValidationRules,
-		shelley.UtxoValidateFeeTooSmallUtxo,
+		lcommon.UtxoValidationRuleFeeTooSmall,
 		"shelley.UtxoValidateFeeTooSmallUtxo",
 	)
-	requireRuleIndexResolvesToFunc(
+	shelleySizeIndex := requireRuleIdResolvesToFunc(
 		t,
+		shelleyDescriptors,
 		shelley.UtxoValidationRules,
-		shelley.UtxoValidateMaxTxSizeUtxo,
+		lcommon.UtxoValidationRuleMaxTxSize,
 		"shelley.UtxoValidateMaxTxSizeUtxo",
 	)
 	require.Len(
@@ -1767,29 +1822,32 @@ func TestPreAlonzoValidationRulesUseLocalFeeAndSizeChecks(t *testing.T) {
 		shelleyUtxoValidationRules,
 		len(shelley.UtxoValidationRules)-2,
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		shelleyUtxoValidationRules,
-		shelley.UtxoValidateFeeTooSmallUtxo,
+		shelleyFeeIndex,
 		"Shelley validation must size the minimum fee with TxSizeForFee",
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		shelleyUtxoValidationRules,
-		shelley.UtxoValidateMaxTxSizeUtxo,
+		shelleySizeIndex,
 		"Shelley validation must size the max-size check with TxSizeForFee",
 	)
 
-	requireRuleIndexResolvesToFunc(
+	allegraDescriptors := allegra.UtxoValidationRuleDescriptors()
+	allegraFeeIndex := requireRuleIdResolvesToFunc(
 		t,
+		allegraDescriptors,
 		allegra.UtxoValidationRules,
-		allegra.UtxoValidateFeeTooSmallUtxo,
+		lcommon.UtxoValidationRuleFeeTooSmall,
 		"allegra.UtxoValidateFeeTooSmallUtxo",
 	)
-	requireRuleIndexResolvesToFunc(
+	allegraSizeIndex := requireRuleIdResolvesToFunc(
 		t,
+		allegraDescriptors,
 		allegra.UtxoValidationRules,
-		allegra.UtxoValidateMaxTxSizeUtxo,
+		lcommon.UtxoValidationRuleMaxTxSize,
 		"allegra.UtxoValidateMaxTxSizeUtxo",
 	)
 	require.Len(
@@ -1797,16 +1855,16 @@ func TestPreAlonzoValidationRulesUseLocalFeeAndSizeChecks(t *testing.T) {
 		allegraUtxoValidationRules,
 		len(allegra.UtxoValidationRules)-2,
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		allegraUtxoValidationRules,
-		allegra.UtxoValidateFeeTooSmallUtxo,
+		allegraFeeIndex,
 		"Allegra validation must size the minimum fee with TxSizeForFee",
 	)
-	requireIndexedRulesExcludeFunc(
+	requireIndexedRulesDropRuleIndex(
 		t,
 		allegraUtxoValidationRules,
-		allegra.UtxoValidateMaxTxSizeUtxo,
+		allegraSizeIndex,
 		"Allegra validation must size the max-size check with TxSizeForFee",
 	)
 }


### PR DESCRIPTION
Fixes #3821.

`gouroboros` v0.202.6 composes the Alonzo, Babbage, and Conway rule lists with
`common.ComposeUtxoValidationRules`, which replaces every phase-2-gated entry
with an anonymous wrapper closure. `conway.UtxoValidateCommitteeCertificates`
and `conway.UtxoValidateUnknownVoters` are therefore absent from
`conway.UtxoValidationRules` by function identity, and the name-keyed resolver
panicked at `ledger/eras` package init. `go build ./...` succeeded, so every
test in `ledger/eras` and `internal/test/conformance` died immediately.

- `resolveUtxoValidationSkipIndex` now takes the era's
  `UtxoValidationRuleDescriptors()` and resolves on
  `common.UtxoValidationRuleId`. It panics on an empty, absent, or duplicated
  Id, on a descriptor/rule length mismatch, and on a nil upstream rule.
- Shelley, Allegra, Alonzo, Babbage, Conway, and Dijkstra pass rule Ids. All six
  needed the change: Dijkstra also reimplements rules Conway owned in v0.202.5
  (`IsValidFlag`, `RequiredVKeyWitnesses`, `Signatures`,
  `ConwayFeaturesWithPlutusV1V2`, `ScriptWitnesses`, `SupplementalDatums`), so
  the package a rule's function lives in is not stable either.
- `gouroboros` v0.202.6 in `go.mod` and `internal/test/antithesis/go.mod`. No
  `replace` directive, no pseudo-version.

Every descriptor Dingo relies on carries a non-empty `Id` and a non-nil
`Validator` in v0.202.6, across all six eras.

## Resolved rule sets versus v0.202.5

The dropped and replaced sets are unchanged in every era. Shelley, Allegra,
Alonzo, and Babbage have byte-identical rule order. Conway and Dijkstra gain
exactly one entry at index 0, `common.UtxoValidateCurrentTreasuryValue`
(gouroboros #2155), which shifts the resolved indexes by one without changing
which rule each Id selects.

## Treasury exposure

`common.UtxoValidateCurrentTreasuryValue` is not skipped, so Conway and
Dijkstra validation now enforces a declared `currentTreasuryValue`
(transaction-body key 21) against `LedgerState.TreasuryValue`, which
`ledger/view.go` still answers with `ErrNotImplemented` (#3687, PR #3692).

The rule returns early when no transaction body declares key 21, so ordinary
traffic never reaches the provider.
`TestCurrentTreasuryValueRuleGuardsOnDeclaredValue` pins that: with no declared
value the provider is not called; with one it is called once and the rule
errors. Until #3692 lands, a transaction declaring key 21 is rejected, and on a
standard profile the block carrying it is rejected with it. Musashi is
unaffected: `SkipDijkstraTxValidation` skips Dijkstra transaction validation
entirely.

## Tests

`TestResolveUtxoValidationSkipIndexResolvesPhase2WrappedRule` fails if a
resolver falls back to name matching: it composes a phase-2-gated rule through
`common.Phase2ValidUtxoValidationRules` and asserts the wrapping is present
before resolving by Id. `TestConwayUpstreamGatedRulesAreWrapped` proves the
pinned release still wraps those two rules, so the guard cannot go vacuous.

`TestEraUtxoValidationRuleCompositions` pins, per era, which rule Ids are
dropped, which are replaced by a Dingo rule, and that the built list is exactly
the upstream list minus the dropped positions. Each expected Id is
cross-checked against the upstream function name implementing it, and the
retained sets are the negative case — a rule that should not be skipped must
still run, including the new `current-treasury-value` in Conway and Dijkstra.

`ARCHITECTURE.md` documents the Id-based resolution and the new treasury rule.
`DATABASE.md` is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the package-init panic in `ledger/eras` where `gouroboros` v0.202.6 wrapped phase-2-gated rules in anonymous closures, breaking the function-name-keyed resolver. The resolver now matches rules by stable `UtxoValidationRuleId` from each era's descriptors, and panics on empty, absent, or duplicated IDs, descriptor/rule length mismatches, and nil upstream rules. The cross-check that each Id still points at the expected upstream function moved out of production and into tests, so an upstream rename fails a test instead of preventing the node from starting.

**Treasury exposure**
- Conway and Dijkstra validation now runs `common.UtxoValidateCurrentTreasuryValue`, which reads `LedgerState.TreasuryValue` only for transactions declaring body key 21.
- Dingo's `TreasuryValue` provider still returns `ErrNotImplemented`, so those transactions are rejected until #3692 lands; ordinary traffic and Musashi are unaffected.

<sup>Written for commit 4d99cc2b373926ec4d414ac5e2a7295d792a8710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

