### PR TITLE
feat(chainselection): materialize per-peer candidate chain fragments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3025,10 +3025,12 @@ ChainSync intersection instead of making a density or rollback decision from
 an incomplete path.
 
 **Per-peer candidate chain fragments** (`chainselection.CandidateFragment`)
-materialize this rolling frontier as a first-class value — Dingo's analogue of
-the upstream consensus interface
-`readCandidateChains :: STM m (Map peer (AnchoredFragment header))`. Each
-tracked peer's `PeerChainTip` already records one delivered point per header
+materialize each peer's delivered-header history as a first-class value —
+Dingo's analogue of the upstream consensus interface
+`readCandidateChains :: STM m (Map peer (AnchoredFragment header))`. This is a
+separate structure from the density frontier above (`observedSlots`/
+`observedPoints`, bounded to the Genesis window): each tracked peer's
+`PeerChainTip` also records one delivered point per header
 (`recordObservedTipHistory`), bounded to `k+1` entries — enough that any valid
 rollback within `k` is representable — and trimmed on rollback
 (`PeerChainTip.ApplyRollback`); `CandidateFragment` snapshots that history into

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3024,6 +3024,29 @@ fails closed to a fresh
 ChainSync intersection instead of making a density or rollback decision from
 an incomplete path.
 
+**Per-peer candidate chain fragments** (`chainselection.CandidateFragment`)
+materialize this rolling frontier as a first-class value — Dingo's analogue of
+the upstream consensus interface
+`readCandidateChains :: STM m (Map peer (AnchoredFragment header))`. Each
+tracked peer's `PeerChainTip` already records one delivered point per header
+(`recordObservedTipHistory`), bounded to `k+1` entries — enough that any valid
+rollback within `k` is representable — and trimmed on rollback
+(`PeerChainTip.ApplyRollback`); `CandidateFragment` snapshots that history into
+an independently owned, ordered value with an explicit `Anchor` (its oldest
+retained point, which — per the upstream contract — need not intersect the
+primary chain or any other peer's fragment) and a `HeadPoint`. `ChainSelector`
+exposes the current set with `CandidateFragments()` (all tracked peers) and
+`GetCandidateFragment(connId)` (one peer), mirroring `GetAllPeerTips`/
+`GetPeerTip`. A fragment's lifetime is bound to its connection: it exists only
+while `ChainSelector.RemovePeer` has not yet dropped that peer's `PeerChainTip`,
+so a disconnect (or eviction under `maxTrackedPeers`) clears it, and a
+reconnect on a reused connection ID starts from an empty fragment rather than
+inheriting stale history. `CandidateFragment.Intersect` computes the highest
+point two fragments share by `(slot, hash)` — the primitive the Limit on
+Eagerness and the Genesis Density Disconnector need to find the intersection
+across candidate fragments and compare per-candidate density there; neither is
+implemented by this type.
+
 The trust problem Genesis solves for **biased fast-sync sources** — e.g. a
 local shallow peer or the Genesis Sync Accelerator (GSA), which serve blocks
 quickly but are not themselves trustworthy — is that the densest/longest source

--- a/chainselection/candidate_fragment.go
+++ b/chainselection/candidate_fragment.go
@@ -58,7 +58,7 @@ func (f CandidateFragment) Anchor() ocommon.Point {
 	if len(f.entries) == 0 {
 		return ocommon.Point{}
 	}
-	return f.entries[0].Point
+	return clonePoint(f.entries[0].Point)
 }
 
 // HeadPoint returns the fragment's most recently delivered point, or the
@@ -67,7 +67,7 @@ func (f CandidateFragment) HeadPoint() ocommon.Point {
 	if len(f.entries) == 0 {
 		return ocommon.Point{}
 	}
-	return f.entries[len(f.entries)-1].Point
+	return clonePoint(f.entries[len(f.entries)-1].Point)
 }
 
 // Points returns the fragment's retained points, including the anchor, in
@@ -141,10 +141,21 @@ func (p *PeerChainTip) CandidateFragment() CandidateFragment {
 }
 
 // CandidateFragments returns a snapshot of the candidate chain fragment
-// maintained for every currently tracked (chainsync-eligible) peer. This is
-// the Dingo equivalent of the upstream readCandidateChains query: a fragment
-// exists only while its peer's connection is tracked, and RemovePeer drops it
-// along with the rest of that peer's state.
+// maintained for every currently tracked peer. This is the Dingo equivalent
+// of the upstream readCandidateChains query: a fragment exists only while its
+// peer's connection is tracked (i.e. chainsync-eligible per peer governance,
+// the sole gate on entry into peerTips — see ouroboros/chainsync.go), and
+// RemovePeer drops it along with the rest of that peer's state.
+//
+// This intentionally does not consult the eligible map (SetConnectionEligible
+// / isConnectionEligible): that flag disqualifies a peer from being chosen as
+// best peer or counted as a corroboration witness, but it is not a disconnect
+// and does not stop the peer from chainsyncing or being tracked here, so
+// filtering on it would hide a still-connected candidate's fragment and would
+// make this accessor inconsistent with its sibling GetAllPeerTips, which does
+// not filter on it either. A future consumer that needs only
+// selection-eligible fragments can intersect this result with
+// isConnectionEligible/GetPeerTip itself.
 func (cs *ChainSelector) CandidateFragments() map[ouroboros.ConnectionId]CandidateFragment {
 	cs.mutex.RLock()
 	defer cs.mutex.RUnlock()

--- a/chainselection/candidate_fragment.go
+++ b/chainselection/candidate_fragment.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"bytes"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// CandidateFragment is a bounded, immutable snapshot of the chain fragment a
+// chainsync-eligible peer has actually delivered, ordered from its anchor
+// (the oldest retained point) to its most recently delivered point.
+//
+// This is Dingo's analogue of the upstream consensus interface
+// readCandidateChains :: STM m (Map peer (AnchoredFragment header)); see
+// ARCHITECTURE.md's "Ouroboros Genesis trust model" section. As with the
+// upstream contract, entries are derived only from headers that have already
+// passed chain-selection observation (see
+// LedgerState.ValidateChainSelectionHeaderCrypto in ARCHITECTURE.md), the
+// fragment may hold fewer than k+1 points, and its anchor is not required to
+// intersect the primary chain or any other peer's fragment.
+//
+// The fragment reuses PeerChainTip's existing delivered-tip history
+// (recordObservedTipHistory), which is already updated once per delivered
+// header and bounded to k+1 entries for rollback restoration, and exposes it
+// as a first-class, independently owned value with an anchor and a pairwise
+// intersection primitive. Entries are kept in strictly ascending slot order.
+type CandidateFragment struct {
+	entries []ochainsync.Tip
+}
+
+// Len returns the number of points retained in the fragment.
+func (f CandidateFragment) Len() int {
+	return len(f.entries)
+}
+
+// Anchor returns the fragment's oldest retained point. Per the upstream
+// AnchoredFragment contract, the anchor is not guaranteed to intersect the
+// primary chain or any other peer's fragment — it is simply the oldest point
+// this snapshot still remembers. Anchor returns the zero Point when the
+// fragment is empty.
+func (f CandidateFragment) Anchor() ocommon.Point {
+	if len(f.entries) == 0 {
+		return ocommon.Point{}
+	}
+	return f.entries[0].Point
+}
+
+// HeadPoint returns the fragment's most recently delivered point, or the
+// zero Point when the fragment is empty.
+func (f CandidateFragment) HeadPoint() ocommon.Point {
+	if len(f.entries) == 0 {
+		return ocommon.Point{}
+	}
+	return f.entries[len(f.entries)-1].Point
+}
+
+// Points returns the fragment's retained points, including the anchor, in
+// ascending slot order. The caller receives an independent copy.
+func (f CandidateFragment) Points() []ocommon.Point {
+	if len(f.entries) == 0 {
+		return nil
+	}
+	out := make([]ocommon.Point, len(f.entries))
+	for i, tip := range f.entries {
+		out[i] = clonePoint(tip.Point)
+	}
+	return out
+}
+
+// Intersect returns the highest point present in both fragments, comparing
+// by (slot, hash). Both fragments must already be in ascending slot order,
+// which recordObservedTipHistory guarantees. This is the primitive the Limit
+// on Eagerness and the Genesis Density Disconnector need to compute the
+// intersection across candidate fragments (see ARCHITECTURE.md); it does not
+// itself implement either.
+func (f CandidateFragment) Intersect(
+	other CandidateFragment,
+) (ocommon.Point, bool) {
+	i := len(f.entries) - 1
+	j := len(other.entries) - 1
+	for i >= 0 && j >= 0 {
+		a := f.entries[i].Point
+		b := other.entries[j].Point
+		switch {
+		case a.Slot == b.Slot:
+			if bytes.Equal(a.Hash, b.Hash) {
+				return clonePoint(a), true
+			}
+			// Same slot, different block: the chains have already diverged
+			// by this point, so any common ancestor lies strictly earlier on
+			// both sides.
+			i--
+			j--
+		case a.Slot > b.Slot:
+			i--
+		default:
+			j--
+		}
+	}
+	return ocommon.Point{}, false
+}
+
+// candidateFragmentFromHistory snapshots a peer's delivered-tip history into
+// an independently owned CandidateFragment.
+func candidateFragmentFromHistory(
+	history []ochainsync.Tip,
+) CandidateFragment {
+	if len(history) == 0 {
+		return CandidateFragment{}
+	}
+	entries := make([]ochainsync.Tip, len(history))
+	for i, tip := range history {
+		entries[i] = cloneObservedTip(tip)
+	}
+	return CandidateFragment{entries: entries}
+}
+
+// CandidateFragment returns a snapshot of this peer's candidate chain
+// fragment. The caller receives an independent copy.
+func (p *PeerChainTip) CandidateFragment() CandidateFragment {
+	if p == nil {
+		return CandidateFragment{}
+	}
+	return candidateFragmentFromHistory(p.observedTipHistory)
+}
+
+// CandidateFragments returns a snapshot of the candidate chain fragment
+// maintained for every currently tracked (chainsync-eligible) peer. This is
+// the Dingo equivalent of the upstream readCandidateChains query: a fragment
+// exists only while its peer's connection is tracked, and RemovePeer drops it
+// along with the rest of that peer's state.
+func (cs *ChainSelector) CandidateFragments() map[ouroboros.ConnectionId]CandidateFragment {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	result := make(
+		map[ouroboros.ConnectionId]CandidateFragment,
+		len(cs.peerTips),
+	)
+	for connId, peerTip := range cs.peerTips {
+		result[connId] = candidateFragmentFromHistory(
+			peerTip.observedTipHistory,
+		)
+	}
+	return result
+}
+
+// GetCandidateFragment returns the candidate chain fragment for a specific
+// peer. The second return value is false when the peer is not tracked (never
+// observed, or removed on disconnect).
+func (cs *ChainSelector) GetCandidateFragment(
+	connId ouroboros.ConnectionId,
+) (CandidateFragment, bool) {
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	peerTip, ok := cs.peerTips[connId]
+	if !ok {
+		return CandidateFragment{}, false
+	}
+	return candidateFragmentFromHistory(peerTip.observedTipHistory), true
+}

--- a/chainselection/candidate_fragment_test.go
+++ b/chainselection/candidate_fragment_test.go
@@ -34,6 +34,40 @@ func TestCandidateFragment_EmptyFragmentIsZeroValue(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestCandidateFragment_AnchorAndHeadPointReturnDefensiveCopies ensures a
+// caller mutating the Hash returned by Anchor or HeadPoint cannot corrupt the
+// fragment's own backing bytes, which would otherwise change later Points()
+// and Intersect() results.
+func TestCandidateFragment_AnchorAndHeadPointReturnDefensiveCopies(
+	t *testing.T,
+) {
+	fragment := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("anchor-hash")}},
+		{Point: ocommon.Point{Slot: 200, Hash: []byte("head-hash")}},
+	}}
+
+	anchor := fragment.Anchor()
+	for i := range anchor.Hash {
+		anchor.Hash[i] = 0xff
+	}
+	head := fragment.HeadPoint()
+	for i := range head.Hash {
+		head.Hash[i] = 0xff
+	}
+
+	points := fragment.Points()
+	require.Len(t, points, 2)
+	assert.Equal(t, "anchor-hash", string(points[0].Hash))
+	assert.Equal(t, "head-hash", string(points[1].Hash))
+
+	other := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("anchor-hash")}},
+	}}
+	point, ok := fragment.Intersect(other)
+	require.True(t, ok)
+	assert.Equal(t, "anchor-hash", string(point.Hash))
+}
+
 func TestCandidateFragment_AnchorAndHeadPoint(t *testing.T) {
 	cs := NewChainSelector(ChainSelectorConfig{SecurityParam: 10})
 	connId := newTestConnectionId(1)

--- a/chainselection/candidate_fragment_test.go
+++ b/chainselection/candidate_fragment_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"fmt"
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCandidateFragment_EmptyFragmentIsZeroValue(t *testing.T) {
+	var f CandidateFragment
+	assert.Equal(t, 0, f.Len())
+	assert.Equal(t, ocommon.Point{}, f.Anchor())
+	assert.Equal(t, ocommon.Point{}, f.HeadPoint())
+	assert.Nil(t, f.Points())
+	_, ok := f.Intersect(CandidateFragment{})
+	assert.False(t, ok)
+}
+
+func TestCandidateFragment_AnchorAndHeadPoint(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{SecurityParam: 10})
+	connId := newTestConnectionId(1)
+
+	for i, slot := range []uint64{100, 200, 300} {
+		cs.UpdatePeerTip(connId, ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: slot,
+				Hash: []byte(fmt.Sprintf("h%d", i)),
+			},
+			BlockNumber: uint64(i + 1),
+		}, nil)
+	}
+
+	fragment, ok := cs.GetCandidateFragment(connId)
+	require.True(t, ok)
+	require.Equal(t, 3, fragment.Len())
+	assert.Equal(t, uint64(100), fragment.Anchor().Slot)
+	assert.Equal(t, uint64(300), fragment.HeadPoint().Slot)
+
+	points := fragment.Points()
+	require.Len(t, points, 3)
+	assert.Equal(t, []uint64{100, 200, 300}, []uint64{
+		points[0].Slot, points[1].Slot, points[2].Slot,
+	})
+}
+
+func TestCandidateFragment_IntersectFindsHighestCommonPoint(t *testing.T) {
+	shared := ocommon.Point{Slot: 200, Hash: []byte("shared")}
+	a := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("a100")}},
+		{Point: shared},
+		{Point: ocommon.Point{Slot: 300, Hash: []byte("a300")}},
+	}}
+	b := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: shared},
+		{Point: ocommon.Point{Slot: 250, Hash: []byte("b250")}},
+	}}
+
+	point, ok := a.Intersect(b)
+	require.True(t, ok)
+	assert.Equal(t, shared.Slot, point.Slot)
+	assert.Equal(t, shared.Hash, point.Hash)
+
+	// Intersection is symmetric.
+	point, ok = b.Intersect(a)
+	require.True(t, ok)
+	assert.Equal(t, shared.Slot, point.Slot)
+}
+
+func TestCandidateFragment_IntersectSameSlotDifferentHashIsNotAMatch(
+	t *testing.T,
+) {
+	a := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("shared")}},
+		{Point: ocommon.Point{Slot: 200, Hash: []byte("a-fork")}},
+	}}
+	b := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("shared")}},
+		{Point: ocommon.Point{Slot: 200, Hash: []byte("b-fork")}},
+	}}
+
+	point, ok := a.Intersect(b)
+	require.True(t, ok)
+	assert.Equal(t, uint64(100), point.Slot)
+	assert.Equal(t, "shared", string(point.Hash))
+}
+
+func TestCandidateFragment_IntersectNoCommonPointReturnsFalse(t *testing.T) {
+	a := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 100, Hash: []byte("a100")}},
+	}}
+	b := CandidateFragment{entries: []ochainsync.Tip{
+		{Point: ocommon.Point{Slot: 200, Hash: []byte("b200")}},
+	}}
+
+	_, ok := a.Intersect(b)
+	assert.False(t, ok)
+}
+
+// TestCandidateFragment_BoundedByK asserts the fragment length is bounded to
+// k+1 entries, the same bound recordObservedTipHistory documents: enough to
+// resolve any valid rollback within k, but never unbounded.
+func TestCandidateFragment_BoundedByK(t *testing.T) {
+	const k = 5
+	cs := NewChainSelector(ChainSelectorConfig{SecurityParam: k})
+	connId := newTestConnectionId(1)
+
+	for slot := uint64(1); slot <= 3*k; slot++ {
+		cs.UpdatePeerTip(connId, ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: slot,
+				Hash: []byte(fmt.Sprintf("h%d", slot)),
+			},
+			BlockNumber: slot,
+		}, nil)
+	}
+
+	fragment, ok := cs.GetCandidateFragment(connId)
+	require.True(t, ok)
+	assert.Equal(t, k+1, fragment.Len())
+	// The retained suffix is the most recent k+1 delivered points.
+	assert.Equal(t, uint64(3*k-k), fragment.Anchor().Slot)
+	assert.Equal(t, uint64(3*k), fragment.HeadPoint().Slot)
+}
+
+// TestCandidateFragment_RemovedOnDisconnect covers the acceptance criterion
+// that a candidate fragment's lifetime is bound to its connection's lifetime.
+func TestCandidateFragment_RemovedOnDisconnect(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{SecurityParam: 10})
+	connId := newTestConnectionId(1)
+
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("h1")},
+		BlockNumber: 1,
+	}, nil)
+
+	fragment, ok := cs.GetCandidateFragment(connId)
+	require.True(t, ok)
+	require.Equal(t, 1, fragment.Len())
+	require.Contains(t, cs.CandidateFragments(), connId)
+
+	cs.RemovePeer(connId)
+
+	_, ok = cs.GetCandidateFragment(connId)
+	assert.False(t, ok, "fragment must be gone once its connection is removed")
+	assert.NotContains(t, cs.CandidateFragments(), connId)
+}
+
+// TestCandidateFragment_ReconnectStartsEmpty ensures a fragment does not leak
+// stale history across a disconnect/reconnect on a reused connection ID.
+func TestCandidateFragment_ReconnectStartsEmpty(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{SecurityParam: 10})
+	connId := newTestConnectionId(1)
+
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("h1")},
+		BlockNumber: 1,
+	}, nil)
+	cs.RemovePeer(connId)
+
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 500, Hash: []byte("h2")},
+		BlockNumber: 5,
+	}, nil)
+
+	fragment, ok := cs.GetCandidateFragment(connId)
+	require.True(t, ok)
+	require.Equal(t, 1, fragment.Len())
+	assert.Equal(t, uint64(500), fragment.Anchor().Slot)
+}


### PR DESCRIPTION
## Summary

Materializes a per-peer candidate chain fragment as a first-class value,
Dingo's analogue of the upstream consensus interface
`readCandidateChains :: STM m (Map peer (AnchoredFragment header))`.

`PeerChainTip` already records one delivered point per header
(`recordObservedTipHistory`), bounded to `k+1` entries and trimmed on
rollback. `chainselection.CandidateFragment` snapshots that history into an
anchored, independently owned value with a pairwise-intersection primitive.
`ChainSelector.CandidateFragments()`/`GetCandidateFragment()` expose it,
mirroring `GetAllPeerTips()`/`GetPeerTip()`.

## Acceptance criteria (issue #3269)

- [x] A candidate fragment is maintained per chainsync-eligible peer,
      anchored so pairwise intersection is computable (`CandidateFragment.Anchor`/`Intersect`).
- [x] Fragment lifetime is bound to connection lifetime; removal on
      disconnect is covered by a test (`TestCandidateFragment_RemovedOnDisconnect`,
      `TestCandidateFragment_ReconnectStartsEmpty`).
- [x] Fragment length is bounded and the bound is documented in terms of `k`
      (`k+1` entries, matching `recordObservedTipHistory`;
      `TestCandidateFragment_BoundedByK`).
- [x] `ARCHITECTURE.md` documents the candidate-fragment structure under the
      Genesis trust model section.

This is a prerequisite for #3270 (Limit on Eagerness) and #3271 (Genesis
Density Disconnector); it does not itself implement either.

## Validation

- `go build ./...`
- `go test -race ./chainselection/...`
- `golangci-lint run ./chainselection/...`
- `nilaway ./chainselection/...` (one pre-existing finding in unmodified
  `selector.go:941`, confirmed present on `origin/main` before this change)
- `modernize ./chainselection/...`
- `golines -l` (repo-wide, clean)
- `make import-boundaries`
- `make docs-parity`

Skipped: `make govulncheck` (requires network), DevNet/conformance suites
(not applicable — no consensus/wire-format behavior changed, this only adds
a read-only snapshot type over existing per-peer state).

`DATABASE.md`: checked, not affected (no schema/storage change).

Fixes #3269

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CandidateFragment`, a first-class snapshot of each chainsync-eligible peer's delivered chain fragment, exposed via `CandidateFragments()` and `GetCandidateFragment()`. It materializes Dingo's analogue of the upstream `readCandidateChains` interface, fixes #3269, and is the prerequisite for the Limit on Eagerness and Genesis Density Disconnector work.

**New Features**
- Snapshots `PeerChainTip`'s existing delivered-tip history, bounded to `k+1` entries and trimmed on rollback.
- Fragment lifetime is bound to the connection: `RemovePeer` drops it, and reconnects start empty.
- Provides `Anchor` and `Intersect` primitives for pairwise fragment comparison; `Anchor` and `HeadPoint` return defensive copies.
- Documents the structure in `ARCHITECTURE.md` and adds tests for bounding, disconnect removal, and reconnect behavior.

<sup>Written for commit 4af9f8c604d918630e4dad3e142d72fc05677716. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to per-peer candidate chain fragments, including their anchor, head point, ordered points, and length.
  - Added support for finding the highest common chain point between two candidate fragments.
  - Candidate fragments retain a bounded history and reflect peer connection lifecycle changes.

- **Documentation**
  - Documented the candidate fragment trust-model behavior and available access methods.

- **Tests**
  - Added coverage for fragment creation, bounds, intersections, forks, empty states, and connection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->