### PR TITLE
fix(ledger): give GetStakeDistribution its own circulation-based total

### DIFF
--- a/ledger/pool_stake_distribution.go
+++ b/ledger/pool_stake_distribution.go
@@ -60,6 +60,12 @@ type PoolStakeDistribution struct {
 	// because cardano clients decode this as a NonZero value; see its doc
 	// comment. It is the denominator every StakeFraction is taken over.
 	TotalActiveStake uint64
+	// TotalCirculatingSupply is genesis MaxLovelaceSupply minus the live
+	// reserves pot, clamped the same way as TotalActiveStake. It is a
+	// different total from TotalActiveStake -- see totalCirculatingSupply's
+	// doc comment (blinklabs-io/dingo#3824) for why GetStakeDistribution, and
+	// only GetStakeDistribution, needs this one instead.
+	TotalCirculatingSupply uint64
 	// Pools is ordered by PoolKeyHash. Callers that place this in a repeated
 	// protobuf field or any other ordered encoding depend on that: without it
 	// the order is Go map iteration order, so two identical requests against
@@ -163,6 +169,17 @@ func (ls *LedgerState) PoolStakeDistribution(
 	if err != nil {
 		return nil, err
 	}
+	// Read inside the same transaction as everything else here so a caller
+	// combining this with per-pool Stake gets one consistent view, the same
+	// reason totalActiveStake is read from metaTxn rather than a fresh one.
+	totalCirculatingSupply, err := ls.totalCirculatingSupply(
+		snapshotEpoch,
+		true,
+		metaTxn,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	keyHashes := make([]lcommon.PoolKeyHash, 0, len(stakeByPool))
 	for hash := range stakeByPool {
@@ -186,10 +203,11 @@ func (ls *LedgerState) PoolStakeDistribution(
 	}
 
 	dist := &PoolStakeDistribution{
-		Tip:              tip,
-		SnapshotEpoch:    snapshotEpoch,
-		TotalActiveStake: totalActiveStake,
-		Pools:            make([]PoolStakeShare, 0, len(keyHashes)),
+		Tip:                    tip,
+		SnapshotEpoch:          snapshotEpoch,
+		TotalActiveStake:       totalActiveStake,
+		TotalCirculatingSupply: totalCirculatingSupply,
+		Pools:                  make([]PoolStakeShare, 0, len(keyHashes)),
 	}
 	for _, pkh := range keyHashes {
 		stake := stakeByPool[string(pkh.Bytes())]

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -821,6 +821,67 @@ func (ls *LedgerState) totalActiveStake(
 	return total, nil
 }
 
+// totalCirculatingSupply returns the total ADA in circulation, delegated or
+// not: MaxLovelaceSupply minus the live reserves pot, clamped to a minimum of
+// one for the same NonZero-decode reason totalActiveStake is (see its doc
+// comment).
+//
+// This is a genuinely different total from totalActiveStake, not an
+// alternative way to compute the same one. GetPoolDistr2's TotalActiveStake
+// really is the sum of delegated stake -- confirmed against the real
+// cardano-ledger source (calculatePoolDistr/SnapShot.ssTotalActiveStake,
+// IntersectMBO/cardano-ledger) -- and Dingo already gets that right; an
+// earlier attempt at blinklabs-io/dingo#3824 wrongly "fixed" GetPoolDistr2's
+// total to use this instead, which was reverted.
+//
+// GetStakeDistribution is a different, older query, and a real cardano-node
+// answers it with a genuinely different total: captured raw wire bytes
+// (not just the decoded Go value) show cardano-node's GetStakeDistribution
+// reply encoding each pool's StakeFraction as tag(30)[stake, circulation],
+// not tag(30)[stake, sum-of-delegated] -- verified against a live cardano-node
+// on a devnet whose genesis deliberately delegates only half its circulating
+// supply (a staked and an unstaked genesis address per pool; see
+// internal/test/devnet/testnet.yaml), where GetStakeSnapshots independently
+// confirmed both nodes agree exactly on the underlying per-pool and
+// sum-of-delegated numbers, isolating the divergence to this one query.
+//
+// Falls back to totalActiveStake's sum-of-delegated total when genesis
+// config or live network state is unavailable to read circulation from --
+// only true of a LedgerState a test builds by hand rather than one backing a
+// running node, which always has both.
+func (ls *LedgerState) totalCirculatingSupply(
+	epoch uint64,
+	exists bool,
+	txn types.Txn,
+) (uint64, error) {
+	fallback := func() (uint64, error) {
+		return ls.totalActiveStake(epoch, exists, txn)
+	}
+	if ls.config.CardanoNodeConfig == nil {
+		return fallback()
+	}
+	genesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
+	if genesis == nil || genesis.MaxLovelaceSupply == 0 {
+		return fallback()
+	}
+	state, err := ls.db.Metadata().GetNetworkState(txn)
+	if err != nil {
+		return 0, err
+	}
+	if state == nil {
+		return fallback()
+	}
+	reserves := uint64(state.Reserves)
+	if reserves > genesis.MaxLovelaceSupply {
+		return fallback()
+	}
+	circulation := genesis.MaxLovelaceSupply - reserves
+	if circulation == 0 {
+		return 1, nil
+	}
+	return circulation, nil
+}
+
 func (ls *LedgerState) queryShelleyGenesisConfig() (any, error) {
 	shelleyGenesis := ls.config.CardanoNodeConfig.ShelleyGenesis()
 	return []any{shelleyGenesis}, nil

--- a/ledger/queries_stakedistribution.go
+++ b/ledger/queries_stakedistribution.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"math/big"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -36,17 +38,23 @@ type stakeDistributionEntry = struct {
 // snapshot. Unlike GetPoolDistr2 (queryShelleyPoolDistr2), this query has
 // no pool filter on the wire, so every pool that holds stake is reported.
 //
-// Reads from PoolStakeDistribution, the same helper queryShelleyPoolDistr2
-// and the UTxO RPC ReadState handler share, so this query cannot report a
-// different snapshot or VRF key for the same chain than either of those --
-// which is exactly what lets the devnet cross-node ledger-state comparison
-// (internal/test/devnet, blinklabs-io/dingo#1900) trust this leaf as a
-// faithful reflection of Dingo's own leadership-election view.
+// Reads the per-pool stake, pool set, and VRF keys from PoolStakeDistribution,
+// the same helper queryShelleyPoolDistr2 and the UTxO RPC ReadState handler
+// share, so this query cannot report a different snapshot, pool set, or VRF
+// key for the same chain than either of those.
+//
+// It does NOT reuse PoolStakeDistribution's own StakeFraction (taken over
+// TotalActiveStake, the sum of delegated stake): a real cardano-node's
+// GetStakeDistribution reply uses total circulating supply as its
+// denominator instead, confirmed against real cardano-node's raw wire bytes
+// -- see totalCirculatingSupply's doc comment (blinklabs-io/dingo#3824) for
+// the full story and why GetPoolDistr2 must not make the same change.
 func (ls *LedgerState) queryShelleyStakeDistribution() (any, error) {
 	dist, err := ls.PoolStakeDistribution(nil)
 	if err != nil {
 		return nil, err
 	}
+	circulation := new(big.Int).SetUint64(dist.TotalCirculatingSupply)
 	result := olocalstatequery.StakeDistributionResult{
 		Results: make(
 			map[ledger.PoolId]stakeDistributionEntry,
@@ -54,8 +62,12 @@ func (ls *LedgerState) queryShelleyStakeDistribution() (any, error) {
 		),
 	}
 	for _, pool := range dist.Pools {
+		fraction := new(big.Rat).SetFrac(
+			new(big.Int).SetUint64(pool.Stake),
+			circulation,
+		)
 		result.Results[ledger.PoolId(pool.PoolKeyHash)] = stakeDistributionEntry{
-			StakeFraction: pool.StakeFraction,
+			StakeFraction: &cbor.Rat{Rat: fraction},
 			VrfHash:       pool.VrfKeyHash,
 		}
 	}

--- a/ledger/queries_stakedistribution_test.go
+++ b/ledger/queries_stakedistribution_test.go
@@ -15,8 +15,11 @@
 package ledger
 
 import (
+	"math/big"
+	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -174,6 +177,79 @@ func TestQueryShelleyStakeDistribution_ViaGetCBOR(t *testing.T) {
 	require.True(t, ok, "pool missing from the GetCBOR-wrapped distribution")
 	require.NotNil(t, entryA.StakeFraction)
 	assert.Equal(t, vrfA, entryA.VrfHash[:])
+}
+
+// TestQueryShelleyStakeDistribution_UsesCirculationNotGetPoolDistr2sTotal
+// covers blinklabs-io/dingo#3824: a live devnet run against a real
+// cardano-node found GetStakeDistribution's reported fraction inflated 2x,
+// because it shared GetPoolDistr2's denominator (sum of delegated stake).
+// Confirmed with real cardano-node's own raw wire bytes (not just the
+// decoded fraction) that its GetStakeDistribution reply genuinely uses total
+// circulation instead -- a real, deliberate difference between the two
+// queries, not a bug in either one. GetPoolDistr2's own denominator is
+// correct as sum-of-delegated (matching real cardano-ledger's
+// calculatePoolDistr/SnapShot.ssTotalActiveStake) and must not change --
+// this test proves the two queries now correctly disagree on the same
+// underlying data, rather than being kept artificially consistent.
+func TestQueryShelleyStakeDistribution_UsesCirculationNotGetPoolDistr2sTotal(
+	t *testing.T,
+) {
+	db := newTestDB(t)
+
+	const snapshotEpoch = 0
+	pkhA := seedPoolDistr2Fixture(
+		t, db,
+		repeatedBytes(28, 0xAA), repeatedBytes(32, 0x01),
+		1_000_000, snapshotEpoch,
+	)
+	seedPoolDistr2Fixture(
+		t, db,
+		repeatedBytes(28, 0xBB), repeatedBytes(32, 0x02),
+		1_000_000, snapshotEpoch,
+	)
+
+	cfg := &cardano.CardanoNodeConfig{
+		ShelleyGenesisHash: strings.Repeat("11", 32),
+	}
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"activeSlotsCoeff": 0.1,
+		"epochLength": 100,
+		"maxLovelaceSupply": 8000000,
+		"securityParam": 10,
+		"slotLength": 1,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`)))
+	// Half the genesis supply sits in reserves, undelegated: circulation is
+	// 8_000_000 - 4_000_000 = 4_000_000, twice the 2_000_000 the two pools
+	// hold delegated between them.
+	require.NoError(t, db.Metadata().SetNetworkState(0, 4_000_000, 1, nil))
+
+	ls := newPoolDistr2Ledger(t, db)
+	ls.config.CardanoNodeConfig = cfg
+
+	// GetPoolDistr2 must be unaffected: still sum-of-delegated (2_000_000),
+	// so each pool is 1/2.
+	poolDistr2Result, err := ls.Query(poolDistr2Query())
+	require.NoError(t, err)
+	poolDistr2 := decodePoolDistr2Result(t, poolDistr2Result)
+	entryA2, ok := poolDistr2.Pools[lcommon.PoolId(pkhA)]
+	require.True(t, ok)
+	assert.Equal(t, 0, entryA2.StakeFraction.Cmp(big.NewRat(1, 2)),
+		"GetPoolDistr2 must keep using sum-of-delegated stake as its total")
+	assert.Equal(t, uint64(2_000_000), poolDistr2.TotalActiveStake)
+
+	// GetStakeDistribution must use circulation (4_000_000) instead, so each
+	// pool is 1/4 -- not 1/2.
+	stakeDistResult, err := ls.Query(stakeDistributionQuery())
+	require.NoError(t, err)
+	stakeDist := decodeStakeDistributionResult(t, stakeDistResult)
+	entryA, ok := stakeDist.Results[lcommon.PoolId(pkhA)]
+	require.True(t, ok)
+	require.NotNil(t, entryA.StakeFraction)
+	assert.Equal(t, int64(1), entryA.StakeFraction.Num().Int64())
+	assert.Equal(t, int64(4), entryA.StakeFraction.Denom().Int64(),
+		"GetStakeDistribution must use total circulation, not "+
+			"GetPoolDistr2's sum-of-delegated total")
 }
 
 // TestQueryShelleyStakeDistribution_EmptySnapshot covers a chain with no


### PR DESCRIPTION
## Summary

`GetStakeDistribution` reports each pool's stake as a fraction (e.g. "this pool holds 1/4 of the network"). The denominator it used was wrong.

**Note on this PR's history:** the first version of this fix and its description below were incorrect, and stayed open through a real correction rather than being force-pushed away quietly:

1. Original claim: both `GetStakeDistribution` and `GetPoolDistr2` should divide by total circulating supply instead of sum-of-delegated stake.
2. [Cubic caught this](https://github.com/blinklabs-io/dingo/pull/3837#discussion_r3928966455): checked the actual `cardano-ledger` source (`SnapShot.ssTotalActiveStake`, `calculatePoolDistr`) and confirmed `GetPoolDistr2`'s total genuinely is sum-of-delegated stake. That part of the original fix was reverted.
3. That still left the original observation (cardano-node reporting 1/4, Dingo reporting 1/2 for the same pools) unexplained. Captured the *raw CBOR wire bytes* both nodes actually send for `GetStakeDistribution` (not just the decoded fraction): both encode identical pool key hashes and VRF hashes, but Dingo's reply literally contains `tag(30)[1,2]` and cardano-node's literally contains `tag(30)[1,4]`. `GetStakeSnapshots`, queried in the same run, showed the two nodes' underlying per-pool and total mark-snapshot stake numbers are byte-identical. So the two queries genuinely need different denominators on a real cardano-node -- this isn't a client decode bug and isn't the same total GetPoolDistr2 uses.

**The corrected fix**: `GetPoolDistr2` and UTxORPC's `ReadState` are untouched -- still sum-of-delegated stake, matching real cardano-ledger. Only `GetStakeDistribution`'s own handler now computes a separate total: genesis `MaxLovelaceSupply` minus live reserves (total circulation, delegated or not).

This was originally surfaced by `node-parity` (#3806) comparing Dingo against a real cardano-node on a live devnet run: `GetStakeDistribution` reported every pool's fraction inflated 2x, because that devnet's genesis deliberately delegates only half its circulating supply (a staked and an unstaked genesis address per pool -- see `internal/test/devnet/testnet.yaml`).

Fixes blinklabs-io/dingo#3824.

## File-by-file changes

- **`ledger/queries.go`** -- new `totalCirculatingSupply()`: total ADA in circulation, computed as genesis `MaxLovelaceSupply` minus the live reserves pot (the same `MaxLovelaceSupply - Reserves` formula already used for reward calculation). Falls back to the sum-of-delegated-stake total when genesis config or live network state isn't available, which only happens for a `LedgerState` a test constructs by hand -- every real running node always has both.
- **`ledger/pool_stake_distribution.go`** -- `PoolStakeDistribution` gains a new `TotalCirculatingSupply` field, computed alongside (not replacing) the existing `TotalActiveStake`. `TotalActiveStake` itself, and everything that already used it (`GetPoolDistr2`, UTxORPC's `ReadState`), is unchanged.
- **`ledger/queries_stakedistribution.go`** -- `queryShelleyStakeDistribution` now computes each pool's `StakeFraction` from the new `TotalCirculatingSupply` instead of reusing `PoolStakeDistribution`'s shared, `TotalActiveStake`-based fraction.
- **`ledger/queries_stakedistribution_test.go`** -- new regression test, `TestQueryShelleyStakeDistribution_UsesCirculationNotGetPoolDistr2sTotal`: seeds two pools holding all of a genesis's *delegated* supply between them, with half of a larger *circulating* supply left undelegated, then asserts `GetPoolDistr2` still reports the sum-of-delegated fraction (1/2) while `GetStakeDistribution` reports the circulation-based one (1/4) for the exact same underlying data.

## Testing

- New regression test adversarially verified: confirmed it fails when `GetStakeDistribution` is pointed back at the shared `TotalActiveStake`, passes with the fix.
- `go test ./ledger/... ./api/utxorpc/... ./internal/nodeparity/... ./cmd/node-parity/... -race` -- all pass.
- `golangci-lint run`, `nilaway`, `modernize`, `make import-boundaries`, `make docs-parity` -- clean on touched files.
- Live devnet conformance run (`./run-tests.sh --conformance`, `TestLedgerStateConsensus`) against a real `dingo-producer` + `cardano-node` pair, before and after the corrected fix:
  - **Before**: `stake distribution: pool ... fraction differs: 1/2 (a) vs 1/4 (b)` for both pools.
  - **After**: that line does not appear at all. The run still fails, but only on the separate, already-filed blinklabs-io/dingo#3825 (a `plutusV1` cost-model mismatch), which this PR does not touch.

Log evidence for both the raw wire-byte capture and the before/after devnet runs will be attached as a follow-up comment on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GetStakeDistribution` stake fractions, which previously used the sum of delegated stake; it now uses total circulating supply, matching cardano-node and including undelegated ADA. `GetPoolDistr2` and UTxORPC `ReadState` retain the delegated-stake denominator.

- Reads the circulation total in the same metadata transaction and falls back to delegated stake when test-only state is unavailable.
- Adds regression coverage proving the two queries use their intended denominators.

Fixes blinklabs-io/dingo#3824.

<sup>Written for commit 1cc23a1d960e8b4f2357dcc11b5758fb1b09aa72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected stake pool distribution calculations to use total circulating ADA, including undelegated funds.
  - Stake fractions now accurately reflect each pool’s share of circulating supply instead of only delegated stake.
  - Improved handling of supply and reserve data, including safe fallback behavior when network information is unavailable.
  - Updated pool distribution results to remain accurate across previewnet and other configured network states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
