### PR TITLE
fix(ledger): gate Musashi behavior by current era

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7513,6 +7513,11 @@ The flag also scopes acceptance through
 and trusts a Dijkstra validation disagreement. Standard Leios profiles run the
 Dijkstra rules and reject invalid transactions.
 
+Ledger-era gates use the active era derived from protocol parameters
+(`currentEra`) as their sole authority. Musashi type-7 blocks can decode
+through the Conway wire type while carrying Dijkstra protocol state; block and
+header-derived era values are not used for ledger-era gates.
+
 Because these two settings make a node accept blocks and transactions a
 validating ledger would reject, the profile boundary is enforced and
 documented here.

--- a/ledger/musashi_trust_scope_test.go
+++ b/ledger/musashi_trust_scope_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -27,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSkipDijkstraTxValidationScope documents the accepted non-validating
@@ -127,6 +129,10 @@ func TestDijkstraTxValidationErrorsArePrototypeOnly(t *testing.T) {
 }
 
 func TestDijkstraEraGateUsesCurrentEra(t *testing.T) {
-	assert.True(t, dijkstraEraGate(eras.DijkstraEraDesc))
+	raw := newTestDijkstraBlockCbor(t, 100, 1, 1, 0, []byte{1})
+	block, err := gledger.NewBlockFromCbor(gledger.BlockTypeDijkstra, raw)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(dijkstra.EraIdDijkstra), block.Era().Id)
 	assert.False(t, dijkstraEraGate(eras.ConwayEraDesc))
+	assert.True(t, dijkstraEraGate(eras.DijkstraEraDesc))
 }

--- a/ledger/musashi_trust_scope_test.go
+++ b/ledger/musashi_trust_scope_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"testing"
 
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -123,4 +124,9 @@ func TestDijkstraTxValidationErrorsArePrototypeOnly(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestDijkstraEraGateUsesCurrentEra(t *testing.T) {
+	assert.True(t, dijkstraEraGate(eras.DijkstraEraDesc))
+	assert.False(t, dijkstraEraGate(eras.ConwayEraDesc))
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -6057,6 +6057,13 @@ func (ls *LedgerState) trustDijkstraTxValidationError(eraId uint) bool {
 		ls.config.SkipDijkstraTxValidation
 }
 
+// dijkstraEraGate uses the pparams-derived active era. A Musashi block may
+// decode through the Conway wire type while carrying a Dijkstra header; block
+// and header era values are not authoritative for ledger-era gates.
+func dijkstraEraGate(currentEra eras.EraDesc) bool {
+	return currentEra.Id == dijkstra.EraIdDijkstra
+}
+
 func (ls *LedgerState) ledgerProcessBlock(
 	txn *database.Txn,
 	point ocommon.Point,
@@ -6173,7 +6180,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 	// resolution, availability, decode, and apply failures abort the block.
 	// Storage-phase failures always abort the DB transaction so a partial
 	// endorser-block application cannot be committed.
-	if currentEra.Id == dijkstra.EraIdDijkstra {
+	if dijkstraEraGate(currentEra) {
 		if ls.config.EndorserBlockProvider == nil {
 			if certifier, ok := block.Header().(leiosEndorserBlockCertifier); ok {
 				if certified, present := certifier.LeiosCertified(); present &&


### PR DESCRIPTION
Use pparams-derived `currentEra` for Musashi era gates.

Closes #3828

Tests: `go test ./ledger -run 'Test(DijkstraTxValidation|DijkstraEraGate)' -count=1`