### PR TITLE
ci: require Go 1.26 in Antithesis module

### DIFF
--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/dingo/internal/test/antithesis
 
-go 1.25.8
+go 1.26.0
 
 toolchain go1.26.7
 


### PR DESCRIPTION
Require Go 1.26 for the Antithesis nested module, matching Dingo's root module and CI toolchain.

Validation: `go test ./...`, `actionlint .github/workflows/*.yml`, and `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go version requirement in the Antithesis test module to 1.26.0 so it matches the root module and the CI toolchain.

<sup>Written for commit bc3b19f65e8e720699cad71d0400e900bcaf98e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the module’s declared Go version to 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->