### PR TITLE
fix(txsubmission): retain unacknowledged offered transactions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4120,16 +4120,25 @@ dropping one already advertised would silently omit a transaction the peer
 legitimately requested. A body larger than the consumer's entire byte budget
 is skipped for that consumer because it can never become cacheable; this keeps
 it from permanently blocking the cursor and prevents it from starving later,
-relayable transactions. A non-blocking `NextTx` returns nil once the cache is
-full; a blocking one parks until a slot frees rather than answering empty, since
-the peer's pull loop has no backoff for an empty reply and would spin
-request/reply without pacing. Shutdown or connection cleanup releases a parked
-waiter. Serving a body or the peer acknowledging its ids frees slots and
-reopens the window. The
-protocol request window is far below the default limit, so this bounds an
-aggressive peer rather than affecting normal relay. Explicit cache removal and
-clearing preserve the same per-consumer semantics while preventing an idle
-connection from growing memory without limit.
+relayable transactions. The entry-count bound gates on advertised-but-not-yet-
+acknowledged ids, not on the resident cache alone: serving a body evicts it
+from the cache and frees its bytes immediately, but its id stays counted as
+outstanding until the peer's next RequestTxIds acknowledges it, so a peer that
+keeps fetching bodies without ever acknowledging them cannot force unbounded
+per-connection id tracking. A non-blocking `NextTx` returns nil once that
+count is reached; a blocking one parks until an id is acknowledged rather than
+answering empty, since the peer's pull loop has no backoff for an empty reply
+and would spin request/reply without pacing. Shutdown or connection cleanup
+releases a parked waiter. A peer acknowledgement frees only the acknowledged
+prefix: TxSubmission ids are offered and acknowledged in FIFO order, so the
+consumer tracks that offer order and, on ack, forgets exactly the oldest
+acknowledged count of bodies — never the whole cache — preserving bodies for
+ids offered after that prefix that the peer has not yet acknowledged and may
+still request (issue #3424). The protocol request window is far below the
+default limit, so this bounds an aggressive peer rather than affecting normal
+relay. Explicit cache removal and clearing preserve the same per-consumer
+semantics while preventing an idle connection from growing memory without
+limit.
 
 Mempool shutdown is terminal. `Stop` atomically marks the pool stopped before
 clearing transaction and consumer state; later transaction admission returns

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4138,7 +4138,11 @@ still request (issue #3424). The protocol request window is far below the
 default limit, so this bounds an aggressive peer rather than affecting normal
 relay. Explicit cache removal and clearing preserve the same per-consumer
 semantics while preventing an idle connection from growing memory without
-limit.
+limit. If the underlying pool resurfaces the same hash at a later cursor
+position while an earlier offer of it is still outstanding -- a revalidation
+swap or a remove-then-readmit -- the consumer skips it rather than
+re-advertising it: a second entry for the same hash would create an
+ambiguous, duplicate slot in the peer's FIFO ack window.
 
 Mempool shutdown is terminal. `Stop` atomically marks the pool stopped before
 clearing transaction and consumer state; later transaction admission returns

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -37,7 +37,14 @@ type MempoolConsumer struct {
 	// and not yet acknowledged. TxSubmission acknowledges advertised ids in
 	// the order they were offered, so AcknowledgeOffered must forget exactly
 	// this prefix rather than the whole cache. Guarded by cacheMutex.
-	offered     []string
+	offered []string
+	// offeredSet mirrors offered for O(1) membership checks. A hash can be
+	// evicted from cache (served) while still outstanding in offered; if the
+	// underlying pool then resurfaces the same hash at a later cursor
+	// position (e.g. a revalidation swap or a remove-then-readmit), offered
+	// must not gain a second entry for it, or an ack would consume the
+	// duplicate's slot and evict a different, still-unacknowledged body.
+	offeredSet  map[string]struct{}
 	cacheMutex  sync.Mutex
 	nextTxIdxMu sync.Mutex
 	// onWaitForTx is a test-only hook invoked after a blocking NextTx has
@@ -79,6 +86,7 @@ func newConsumer(
 	return &MempoolConsumer{
 		mempool:         mempool,
 		cache:           make(map[string]*MempoolTransaction),
+		offeredSet:      make(map[string]struct{}),
 		done:            make(chan struct{}),
 		cacheSlot:       make(chan struct{}, 1),
 		cacheLimit:      cacheLimit,
@@ -136,6 +144,19 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 						"tx_size_bytes", size,
 						"cache_limit_bytes", limit,
 					)
+					continue
+				}
+				// The pool can resurface the same hash at a later cursor
+				// position -- a revalidation swap or a remove-then-readmit
+				// -- while an earlier offer of it is still outstanding
+				// (served but not yet acknowledged, or still resident).
+				// Re-offering it would create a second, ambiguous entry in
+				// the peer's FIFO ack window, so advance past it instead of
+				// resending.
+				if m.isOffered(poolTx.Hash) {
+					m.nextTxIdx++
+					m.nextTxIdxMu.Unlock()
+					m.mempool.RUnlock()
 					continue
 				}
 				cached, aggregateChanged := m.cacheTransaction(poolTx)
@@ -213,6 +234,15 @@ func (m *MempoolConsumer) NextTx(blocking bool) *MempoolTransaction {
 	}
 }
 
+// isOffered reports whether hash is already advertised to the peer and
+// outstanding: cached, or served but not yet acknowledged.
+func (m *MempoolConsumer) isOffered(hash string) bool {
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+	_, offered := m.offeredSet[hash]
+	return offered
+}
+
 // cacheTransaction reserves both the per-consumer and aggregate retained-byte
 // budgets before storing an advertised body. Permanently oversized bodies are
 // filtered by NextTx; temporary reservation failures keep the cursor on the
@@ -247,8 +277,14 @@ func (m *MempoolConsumer) cacheTransaction(
 	m.cache[tx.Hash] = cloneMempoolTransaction(tx)
 	m.cacheBytes += size
 	// The tx is now advertised to the peer (returned from the RequestTxIds
-	// callback that drove this NextTx call); track it for AcknowledgeOffered.
-	m.offered = append(m.offered, tx.Hash)
+	// callback that drove this NextTx call); track it for AcknowledgeOffered,
+	// unless it is already outstanding (served but not yet acknowledged) --
+	// the pool resurfacing the same hash at a later cursor position must not
+	// add a second offered slot for it.
+	if _, alreadyOffered := m.offeredSet[tx.Hash]; !alreadyOffered {
+		m.offered = append(m.offered, tx.Hash)
+		m.offeredSet[tx.Hash] = struct{}{}
+	}
 	return true, nil
 }
 
@@ -269,6 +305,7 @@ func (m *MempoolConsumer) ClearCache() {
 		m.cache = make(map[string]*MempoolTransaction)
 		m.cacheBytes = 0
 		m.offered = nil
+		m.offeredSet = make(map[string]struct{})
 		m.mempool.releaseRelayCacheBytes(released)
 		m.signalCacheSlotLocked()
 		m.cacheMutex.Unlock()
@@ -305,6 +342,7 @@ func (m *MempoolConsumer) AcknowledgeOffered(count int) {
 		// already-served hash; freeing an offered slot can unblock a waiter
 		// on its own, so signal below regardless of cache membership.
 		m.removeFromCacheLocked(hash)
+		delete(m.offeredSet, hash)
 	}
 	// Drop the acknowledged prefix; copy the remainder so the backing array
 	// of the retained slice isn't shared with the one about to be discarded.

--- a/mempool/consumer.go
+++ b/mempool/consumer.go
@@ -33,8 +33,13 @@ type MempoolConsumer struct {
 	cacheBytes      int64
 	cacheLimitBytes int64
 	nextTxIdx       int
-	cacheMutex      sync.Mutex
-	nextTxIdxMu     sync.Mutex
+	// offered is the FIFO of tx hashes advertised to the peer via ReplyTxIds
+	// and not yet acknowledged. TxSubmission acknowledges advertised ids in
+	// the order they were offered, so AcknowledgeOffered must forget exactly
+	// this prefix rather than the whole cache. Guarded by cacheMutex.
+	offered     []string
+	cacheMutex  sync.Mutex
+	nextTxIdxMu sync.Mutex
 	// onWaitForTx is a test-only hook invoked after a blocking NextTx has
 	// subscribed for additions and is ready to be cancelled.
 	onWaitForTx func()
@@ -226,7 +231,12 @@ func (m *MempoolConsumer) cacheTransaction(
 	if _, exists := m.cache[tx.Hash]; exists {
 		return true, nil
 	}
-	if len(m.cache) >= m.cacheLimit ||
+	// Gate on the offered count, not the resident cache count: a served body
+	// is evicted from cache immediately (freeing its bytes) but its hash
+	// stays in offered until the peer acknowledges it. Gating on the cache
+	// count alone would let a peer that keeps fetching bodies without ever
+	// acknowledging them grow offered without bound.
+	if len(m.offered) >= m.cacheLimit ||
 		size > m.cacheLimitBytes-m.cacheBytes {
 		return false, nil
 	}
@@ -236,6 +246,9 @@ func (m *MempoolConsumer) cacheTransaction(
 	}
 	m.cache[tx.Hash] = cloneMempoolTransaction(tx)
 	m.cacheBytes += size
+	// The tx is now advertised to the peer (returned from the RequestTxIds
+	// callback that drove this NextTx call); track it for AcknowledgeOffered.
+	m.offered = append(m.offered, tx.Hash)
 	return true, nil
 }
 
@@ -255,6 +268,7 @@ func (m *MempoolConsumer) ClearCache() {
 		released := m.cacheBytes
 		m.cache = make(map[string]*MempoolTransaction)
 		m.cacheBytes = 0
+		m.offered = nil
 		m.mempool.releaseRelayCacheBytes(released)
 		m.signalCacheSlotLocked()
 		m.cacheMutex.Unlock()
@@ -268,13 +282,47 @@ func (m *MempoolConsumer) RemoveTxFromCache(hash string) {
 	if m != nil {
 		m.cacheMutex.Lock()
 		defer m.cacheMutex.Unlock()
-		if tx, existed := m.cache[hash]; existed {
-			delete(m.cache, hash)
-			size := int64(len(tx.Cbor))
-			m.cacheBytes -= size
-			m.mempool.releaseRelayCacheBytes(size)
-			m.signalCacheSlotLocked()
-		}
+		m.removeFromCacheLocked(hash)
+	}
+}
+
+// AcknowledgeOffered forgets exactly the oldest count previously offered
+// transaction bodies, in the order they were advertised. TxSubmission acks
+// only the consumed prefix of the offered-id window; bodies for ids offered
+// after that prefix are still eligible for the peer to request and must be
+// preserved, so this must never clear the whole cache.
+func (m *MempoolConsumer) AcknowledgeOffered(count int) {
+	if m == nil || count <= 0 {
+		return
+	}
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+	if count > len(m.offered) {
+		count = len(m.offered)
+	}
+	for _, hash := range m.offered[:count] {
+		// removeFromCacheLocked no-ops (and so does not signal) for an
+		// already-served hash; freeing an offered slot can unblock a waiter
+		// on its own, so signal below regardless of cache membership.
+		m.removeFromCacheLocked(hash)
+	}
+	// Drop the acknowledged prefix; copy the remainder so the backing array
+	// of the retained slice isn't shared with the one about to be discarded.
+	remaining := make([]string, len(m.offered)-count)
+	copy(remaining, m.offered[count:])
+	m.offered = remaining
+	m.signalCacheSlotLocked()
+}
+
+// removeFromCacheLocked evicts a single cached tx body, if present, and
+// releases its reserved bytes. Caller must hold cacheMutex.
+func (m *MempoolConsumer) removeFromCacheLocked(hash string) {
+	if tx, existed := m.cache[hash]; existed {
+		delete(m.cache, hash)
+		size := int64(len(tx.Cbor))
+		m.cacheBytes -= size
+		m.mempool.releaseRelayCacheBytes(size)
+		m.signalCacheSlotLocked()
 	}
 }
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -89,6 +89,7 @@ type Consumer interface {
 	GetTxFromCache(string) *MempoolTransaction
 	ClearCache()
 	RemoveTxFromCache(string)
+	AcknowledgeOffered(count int)
 }
 
 // Service is the domain-owned mempool capability consumed by node wiring,

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1377,11 +1377,13 @@ func TestMempoolConsumer_ResurfacedHashNotDuplicateOffered(t *testing.T) {
 	assert.Equal(t, []string{"dup-hash", "other-hash"}, consumer.offered,
 		"the resurfaced duplicate must not add a second offered slot")
 
-	// Acknowledging both real slots must not evict "other-hash" ahead of its
-	// own acknowledgement -- there is no third, phantom slot to consume
-	// first.
+	// The phantom-slot guard is the offered-length assertion above; this
+	// final check only confirms FIFO order: acknowledging a single (the
+	// oldest) slot evicts "dup-hash" and leaves "other-hash" -- offered
+	// second -- untouched.
 	consumer.AcknowledgeOffered(1)
 	assert.NotNil(t, consumer.GetTxFromCache("other-hash"))
+	assert.Nil(t, consumer.GetTxFromCache("dup-hash"))
 }
 
 // TestMempoolConsumer_CacheIsBoundedByRetainedBytes verifies that temporary

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1263,14 +1263,79 @@ func TestMempoolConsumer_CacheIsBounded(t *testing.T) {
 	assert.NotNil(t, consumer.GetTxFromCache(txs[0].Hash))
 	assert.NotNil(t, consumer.GetTxFromCache(txs[1].Hash))
 
-	// Serving (or the peer acknowledging) frees a slot and the window reopens,
-	// so the third tx is advertised rather than lost.
+	// Serving frees the body's bytes but not its offered slot: the id stays
+	// outstanding until the peer acknowledges it, so the window stays closed
+	// and the third tx is still declined.
 	consumer.RemoveTxFromCache(txs[0].Hash)
+	assert.Nil(
+		t,
+		consumer.NextTx(false),
+		"serving a body must not reopen the window on its own",
+	)
+
+	// Acknowledging the served tx frees its offered slot and the window
+	// reopens, so the third tx is advertised rather than lost.
+	consumer.AcknowledgeOffered(1)
 	third := consumer.NextTx(false)
 	require.NotNil(t, third)
 	assert.Equal(t, txs[2].Hash, third.Hash)
 	assert.NotNil(t, consumer.GetTxFromCache(txs[2].Hash))
 	assert.Len(t, consumer.cache, 2)
+}
+
+// TestMempoolConsumer_UnackedServedTxsCountTowardCacheLimit verifies that
+// serving a body does not, by itself, reopen its offered slot: a peer that
+// keeps fetching bodies without ever acknowledging them cannot grow the
+// per-connection offered-id tracking without bound.
+func TestMempoolConsumer_UnackedServedTxsCountTowardCacheLimit(t *testing.T) {
+	m, err := NewMempool(MempoolConfig{
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EventBus:          event.NewEventBus(nil, nil),
+		PromRegistry:      prometheus.NewRegistry(),
+		Validator:         newMockValidator(),
+		MempoolCapacity:   1024 * 1024,
+		ConsumerCacheSize: 2,
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(context.Background()))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		require.NoError(t, m.Stop(stopCtx))
+	})
+
+	txs := addMockTransactions(t, m, 3)
+	consumer := m.AddConsumer(newTestConnectionId(0))
+	require.NotNil(t, consumer)
+
+	// Offer and immediately serve both slots' worth of bodies, without ever
+	// acknowledging either.
+	first := consumer.NextTx(false)
+	require.NotNil(t, first)
+	consumer.RemoveTxFromCache(first.Hash)
+	second := consumer.NextTx(false)
+	require.NotNil(t, second)
+	consumer.RemoveTxFromCache(second.Hash)
+
+	// A third offer is still declined: both ids remain outstanding until
+	// acknowledged, even though their bodies were already served and freed
+	// from the resident cache.
+	assert.Nil(
+		t,
+		consumer.NextTx(false),
+		"unacknowledged served ids must still count toward the limit",
+	)
+	assert.Len(t, consumer.offered, 2)
+	assert.Empty(t, consumer.cache, "served bodies are not retained")
+
+	// Acknowledging both frees the tracking and the third tx is advertised.
+	consumer.AcknowledgeOffered(2)
+	third := consumer.NextTx(false)
+	require.NotNil(t, third)
+	assert.Equal(t, txs[2].Hash, third.Hash)
 }
 
 // TestMempoolConsumer_CacheIsBoundedByRetainedBytes verifies that temporary
@@ -1542,6 +1607,7 @@ func TestMempoolConsumer_NilReceiver(t *testing.T) {
 	// These should not panic
 	consumer.ClearCache()
 	consumer.RemoveTxFromCache("any")
+	consumer.AcknowledgeOffered(1)
 }
 
 func TestMempool_ConsumerAfterStop(t *testing.T) {
@@ -4184,10 +4250,19 @@ func TestMempoolConsumer_BlockingNextTxWaitsForCacheSlot(t *testing.T) {
 		"blocking NextTx must not answer while the cache is full",
 	)
 
-	// Serving the cached body frees the slot and releases the waiter.
+	// Serving the cached body frees its bytes but not its offered slot, so
+	// the waiter must stay parked: the id is still outstanding until acked.
 	consumer.RemoveTxFromCache(txs[0].Hash)
+	dingotestutil.RequireNoReceive(
+		t, got, 100*time.Millisecond,
+		"serving a body must not release a waiter on its own",
+	)
+
+	// Acknowledging the served tx frees its offered slot and releases the
+	// waiter.
+	consumer.AcknowledgeOffered(1)
 	second := dingotestutil.RequireReceive(
-		t, got, 2*time.Second, "blocking NextTx after a slot freed",
+		t, got, 2*time.Second, "blocking NextTx after an ack freed a slot",
 	)
 	require.NotNil(t, second)
 	assert.Equal(t, txs[1].Hash, second.Hash)

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1338,6 +1338,52 @@ func TestMempoolConsumer_UnackedServedTxsCountTowardCacheLimit(t *testing.T) {
 	assert.Equal(t, txs[2].Hash, third.Hash)
 }
 
+// TestMempoolConsumer_ResurfacedHashNotDuplicateOffered verifies
+// that if a hash the consumer already offered (served but not yet
+// acknowledged) reappears at a later cursor position -- as a revalidation
+// swap or a remove-then-readmit could transiently produce -- the consumer
+// does not record a second offered slot for it. A duplicate slot would let a
+// later ack consume it and evict a different, still-unacknowledged body.
+func TestMempoolConsumer_ResurfacedHashNotDuplicateOffered(t *testing.T) {
+	m := newTestMempool(t)
+	defer m.Stop(context.Background())
+
+	dup := &MempoolTransaction{Hash: "dup-hash", Cbor: []byte("dup-body")}
+	other := &MempoolTransaction{Hash: "other-hash", Cbor: []byte("other")}
+	// Plant the same hash at two positions in the underlying FIFO order,
+	// as production code elsewhere guards against for the same reason (see
+	// the revalidation cursor-translation comment in mempool.go).
+	m.transactions = append(m.transactions, dup, other, dup)
+	consumer := mustAddConsumer(t, m, newTestConnectionId(0))
+
+	first := consumer.NextTx(false)
+	require.NotNil(t, first)
+	require.Equal(t, "dup-hash", first.Hash)
+	// Served but not yet acknowledged.
+	consumer.RemoveTxFromCache("dup-hash")
+
+	second := consumer.NextTx(false)
+	require.NotNil(t, second)
+	require.Equal(t, "other-hash", second.Hash)
+
+	// The resurfaced duplicate is skipped rather than re-offered: it is
+	// still outstanding, and resending it would create a second, ambiguous
+	// entry in the peer's FIFO ack window.
+	assert.Nil(
+		t,
+		consumer.NextTx(false),
+		"a resurfaced, still-outstanding hash must not be re-offered",
+	)
+	assert.Equal(t, []string{"dup-hash", "other-hash"}, consumer.offered,
+		"the resurfaced duplicate must not add a second offered slot")
+
+	// Acknowledging both real slots must not evict "other-hash" ahead of its
+	// own acknowledgement -- there is no third, phantom slot to consume
+	// first.
+	consumer.AcknowledgeOffered(1)
+	assert.NotNil(t, consumer.GetTxFromCache("other-hash"))
+}
+
 // TestMempoolConsumer_CacheIsBoundedByRetainedBytes verifies that temporary
 // per-consumer byte pressure preserves the cursor until retained bytes are
 // released, while keeping every advertised body available for retransmission.

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -1377,13 +1377,14 @@ func TestMempoolConsumer_ResurfacedHashNotDuplicateOffered(t *testing.T) {
 	assert.Equal(t, []string{"dup-hash", "other-hash"}, consumer.offered,
 		"the resurfaced duplicate must not add a second offered slot")
 
-	// The phantom-slot guard is the offered-length assertion above; this
+	// The phantom-slot guard is the offered-length assertion above. This
 	// final check only confirms FIFO order: acknowledging a single (the
-	// oldest) slot evicts "dup-hash" and leaves "other-hash" -- offered
-	// second -- untouched.
+	// oldest) slot leaves "other-hash" -- offered second -- untouched.
+	// "dup-hash" was already evicted by RemoveTxFromCache above, so it
+	// cannot show ack-driven eviction; that path is covered separately by
+	// TestTxSubmissionClientRequestTxIdsClearsConsumerCacheOnAck.
 	consumer.AcknowledgeOffered(1)
 	assert.NotNil(t, consumer.GetTxFromCache("other-hash"))
-	assert.Nil(t, consumer.GetTxFromCache("dup-hash"))
 }
 
 // TestMempoolConsumer_CacheIsBoundedByRetainedBytes verifies that temporary

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -510,9 +510,13 @@ func (o *Ouroboros) txsubmissionClientRequestTxIds(
 			connId.String(),
 		)
 	}
-	// Clear TX cache
+	// Forget only the acknowledged prefix of previously offered transaction
+	// bodies. TxSubmission acknowledges the offered-id window in FIFO order;
+	// clearing the whole cache here would also drop bodies for ids offered
+	// after that prefix that the peer has not acknowledged and may still
+	// request.
 	if ack > 0 {
-		consumer.ClearCache()
+		consumer.AcknowledgeOffered(int(ack))
 	}
 	// Get available TXs
 	var tmpTxs []*mempool.MempoolTransaction

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -316,6 +316,100 @@ func TestTxSubmissionClientRequestTxIdsClearsConsumerCacheOnAck(t *testing.T) {
 	require.Empty(t, bodies)
 }
 
+// TestTxSubmissionClientRequestTxIdsPartialAck verifies that acknowledging
+// part of a batch of offered transactions discards only the acknowledged
+// prefix, in the order the ids were offered, and preserves the bodies of ids
+// the peer has not yet acknowledged so they remain available to retry.
+// Regression test for
+// https://github.com/blinklabs-io/dingo/issues/3424, where any nonzero ack
+// cleared the entire offered cache and silently dropped unacknowledged
+// bodies.
+func TestTxSubmissionClientRequestTxIdsPartialAck(t *testing.T) {
+	// Arrange two cached transactions for a peer consumer.
+	fixtures := txsubmissionTestFixtures(t)[:2]
+	o, connId := newTxSubmissionTestOuroboros(t)
+	o.mempool.NewConsumer(connId)
+	addTxSubmissionTestFixtures(t, o.mempool, fixtures...)
+	ctx := txsubmission.CallbackContext{ConnectionId: connId}
+
+	// Advertise both transactions so both are stored in the consumer cache.
+	ids, err := o.txsubmissionClientRequestTxIds(ctx, false, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	// Acknowledge only the first (oldest) offered transaction; request no
+	// additional ids in the same call to isolate the ack's effect.
+	ids, err = o.txsubmissionClientRequestTxIds(ctx, false, 1, 0)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	// The acknowledged transaction body can no longer be served.
+	bodies, err := o.txsubmissionClientRequestTxs(ctx, []txsubmission.TxId{
+		fixtures[0].txId,
+	})
+	require.NoError(t, err)
+	require.Empty(t, bodies)
+
+	// The unacknowledged transaction body is still cached and can be served.
+	bodies, err = o.txsubmissionClientRequestTxs(ctx, []txsubmission.TxId{
+		fixtures[1].txId,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []txsubmission.TxBody{
+		{
+			EraId:  txsubmissionRelayTestEraId,
+			TxBody: fixtures[1].body,
+		},
+	}, bodies)
+}
+
+// TestTxSubmissionClientRequestTxIdsAckAcrossMixedBatches verifies that
+// acknowledgements accumulate correctly across multiple RequestTxIds calls
+// that mix acknowledging older offers with advertising new ones in the same
+// call, matching the sliding FIFO window the TxSubmission protocol uses.
+func TestTxSubmissionClientRequestTxIdsAckAcrossMixedBatches(t *testing.T) {
+	// Arrange three cached transactions for a peer consumer.
+	fixtures := txsubmissionTestFixtures(t)
+	o, connId := newTxSubmissionTestOuroboros(t)
+	o.mempool.NewConsumer(connId)
+	addTxSubmissionTestFixtures(t, o.mempool, fixtures...)
+	ctx := txsubmission.CallbackContext{ConnectionId: connId}
+
+	// Offer the first two transactions.
+	ids, err := o.txsubmissionClientRequestTxIds(ctx, false, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	// Acknowledge the first offer while requesting the third in the same
+	// call, mirroring a peer that both confirms and asks for more at once.
+	ids, err = o.txsubmissionClientRequestTxIds(ctx, false, 1, 1)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.Equal(
+		t,
+		fixtures[2].hash,
+		hex.EncodeToString(ids[0].TxId.TxId[:]),
+	)
+
+	// The first offer was acknowledged and its body is gone.
+	bodies, err := o.txsubmissionClientRequestTxs(ctx, []txsubmission.TxId{
+		fixtures[0].txId,
+	})
+	require.NoError(t, err)
+	require.Empty(t, bodies)
+
+	// The second and third offers are still unacknowledged and servable.
+	bodies, err = o.txsubmissionClientRequestTxs(ctx, []txsubmission.TxId{
+		fixtures[1].txId,
+		fixtures[2].txId,
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []txsubmission.TxBody{
+		{EraId: txsubmissionRelayTestEraId, TxBody: fixtures[1].body},
+		{EraId: txsubmissionRelayTestEraId, TxBody: fixtures[2].body},
+	}, bodies)
+}
+
 // TestTxSubmissionClientRequestTxs verifies that known cached TxIds return
 // bodies while unknown or already-served TxIds are ignored.
 func TestTxSubmissionClientRequestTxs(t *testing.T) {


### PR DESCRIPTION
## Problem

`ouroboros/txsubmission.go`'s `txsubmissionClientRequestTxIds` cleared the
entire per-consumer offered-body cache on any nonzero peer acknowledgement,
dropping bodies for ids the peer had not yet acknowledged and could not
retry.

## Changes

- `MempoolConsumer` now tracks advertised tx hashes in FIFO offer order
  (`offered`). `AcknowledgeOffered(count)` forgets only that acknowledged
  prefix instead of the whole cache.
- The offered-count bound (`ConsumerCacheSize`) now gates on outstanding
  advertised ids rather than the resident cache count: serving a body frees
  its bytes immediately, but the id stays counted until acknowledged, so a
  peer that keeps fetching bodies without ever acknowledging them cannot
  grow per-connection tracking without bound.
- `mempool.Consumer` gains `AcknowledgeOffered(count int)`.

## Tests

- `TestTxSubmissionClientRequestTxIdsPartialAck` and
  `TestTxSubmissionClientRequestTxIdsAckAcrossMixedBatches` (ouroboros):
  verify a partial ack discards only the acknowledged prefix and preserves
  later unacknowledged bodies. Both fail against the prior `ClearCache()`
  call.
- `TestMempoolConsumer_UnackedServedTxsCountTowardCacheLimit` (mempool):
  verifies the new outstanding-id bound. Fails when the count gate uses the
  resident cache instead of the offered list.
- Updated `TestMempoolConsumer_CacheIsBounded` and
  `TestMempoolConsumer_BlockingNextTxWaitsForCacheSlot` to reflect that
  serving alone no longer reopens the offer window (only acknowledgement
  does).

## Validation

- `go build ./...`
- `go test -race ./mempool/... ./ouroboros/...` (also full `go test -race
  ./...`, green aside from `internal/test/conformance` timing out under
  parallel resource contention in this sandbox; it passes standalone in 45s
  non-race, confirming it's unrelated to this change)
- `golangci-lint run`, `nilaway` (pre-existing unrelated finding in
  `blockfetch_musashi_test.go`), `modernize`, `make golines`,
  `make import-boundaries`, `make docs-parity`

Fixes #3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes txsubmission so a partial acknowledgement no longer drops offered transaction bodies the peer hasn't yet acknowledged and may still request (issue #3424).

- `MempoolConsumer` tracks advertised tx hashes in FIFO order and forgets only the acknowledged prefix on ack, instead of clearing the whole cache.
- The per-consumer cache bound now counts outstanding advertised ids rather than resident cache entries, so a peer that fetches bodies without acknowledging them can't grow tracking without bound.
- A hash that resurfaces at a later cursor position while still outstanding (served but unacked) is skipped rather than re-advertised, so it can't create a duplicate slot in the peer's FIFO ack window.
- Adds regression tests for partial acks, acks across mixed batches, the outstanding-id bound, and the resurfaced-hash case; updates `ARCHITECTURE.md` to match.

<sup>Written for commit 9b3ab65088b0f3d55b9815d65c56b3297df2e451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction submission flow control by accurately tracking offered transactions until peer acknowledgment.
  - Preserved unacknowledged transaction bodies when acknowledgments cover only part of an offered batch.
  - Prevented transaction delivery from exceeding the outstanding offer limit.
  - Blocking transaction requests now resume only when the peer acknowledges previously offered transaction IDs.
  - Improved handling of acknowledgments across multiple transaction-submission exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->