### PR TITLE
fix(midnight): validate numeric conversions and normalize client errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1561,11 +1561,28 @@ implemented in `midnight/server/service.go`:
   (`SlotTimer.TimeToSlot` + `database.BlockBeforeSlot`) instead of the live
   tip. `GetLatestStableBlock` looks the target block number up via
   `Database.BlockByIndex`, translating 0-based block number to the blob
-  store's 1-based index the same way `api/blockfrost` does.
+  store's 1-based index the same way `api/blockfrost` does. A client-supplied
+  `as_of_timestamp_unix_millis` above `int64` range (`resolveTipBlock`) is
+  rejected with `codes.InvalidArgument` rather than being converted with
+  `int64(v)`, which would silently wrap it into a negative timestamp and
+  resolve against a bogus slot.
 
 With both groups wired, every `MidnightState` RPC is implemented. A handler
 whose backend is nil (e.g. a server started for lifecycle/health only)
-returns a clean `codes.FailedPrecondition` rather than nil-panicking. TLS is
+returns a clean status rather than nil-panicking: the `Config.Database`/
+`Config.SlotTimer`-backed RPCs (`checkDatabase`/`checkBlockBackends` in
+service.go) return `codes.FailedPrecondition`, while the `Config.Metadata`-
+backed UTxO-event RPCs return `codes.Unimplemented` when `Metadata` is nil
+(`GetUtxoEvents` still returns `codes.FailedPrecondition` specifically for a
+missing `BlockNumberByHash` resolver when `end_block_hash` is set).
+Every narrowing conversion onto a wire field fixed at `uint32`/`int64`/
+`uint64` (block numbers, timestamps, tx/epoch counts) is bounds-checked
+before applying it; a stored value that doesn't fit fails the request with
+`codes.Internal` instead of silently wrapping. Every `codes.Internal`
+response is built by `internalError`, which logs the real error (which can
+carry driver-specific SQL text, file paths, or CBOR diagnostics) server-side
+and returns only a stable, generic message naming the failed operation, so
+internal detail never reaches the client. TLS is
 enabled when the shared `tlsCertFilePath`/`tlsKeyFilePath` are set. `Start`
 binds the listener synchronously (so bind/cert errors surface immediately)
 and serves in a goroutine; a context watcher performs a bounded
@@ -6979,7 +6996,14 @@ Once eligible to run, it subscribes to `ledger.block`
 
 - **cNIGHT create**: an output carrying the configured `cnight_policy_id` +
   `cnight_asset_name` token writes a `midnight_asset_creates` row and adds
-  the UTxO to an in-memory tracked set.
+  the UTxO to an in-memory tracked set. The quantity is checked against
+  `uint64` range before writing (`checkedCnightQuantity`, delegating to
+  `models.CheckedUint64FromBigInt`); a quantity that doesn't fit is not a
+  transient failure like the write errors below, so unlike them it does not
+  abort the block or reach `idx.fatal` (the indexer is optional -- see the
+  diagram above -- and the failure would reproduce identically on every
+  restart). Only that output's create is skipped, logged at `Error`, and the
+  rest of the block indexes normally.
 - **cNIGHT spend**: an input consuming a tracked cNIGHT UTxO writes a
   `midnight_asset_spends` row and removes the entry from the tracked set.
 - **Registration**: an output at `mapping_validator_address` carrying a token

--- a/database/models/asset.go
+++ b/database/models/asset.go
@@ -91,11 +91,14 @@ func ConvertMintToAssetMintBurnModels(
 	return rows
 }
 
-// checkedUint64FromBigInt converts amount to a uint64, rejecting negative
+// CheckedUint64FromBigInt converts amount to a uint64, rejecting negative
 // values and values that exceed math.MaxUint64. big.Int.Uint64 silently
 // keeps only the low 64 bits on overflow, which would otherwise let an
-// indexed asset amount wrap into an unrelated, much smaller value.
-func checkedUint64FromBigInt(amount *big.Int) (uint64, error) {
+// indexed asset amount wrap into an unrelated, much smaller value. Exported
+// so other packages indexing arbitrary-precision on-chain quantities (e.g.
+// midnight/indexer's cNIGHT amounts) share this one check rather than each
+// reimplementing it.
+func CheckedUint64FromBigInt(amount *big.Int) (uint64, error) {
 	if amount == nil {
 		return 0, errors.New("asset amount is nil")
 	}
@@ -130,7 +133,7 @@ func ConvertMultiAssetToModels(
 		// Get asset names for this policy
 		assetNames := multiAsset.Assets(policyId)
 		for _, assetNameBytes := range assetNames {
-			amount, err := checkedUint64FromBigInt(
+			amount, err := CheckedUint64FromBigInt(
 				multiAsset.Asset(policyId, assetNameBytes),
 			)
 			if err != nil {

--- a/database/models/asset_test.go
+++ b/database/models/asset_test.go
@@ -45,7 +45,7 @@ func newTestMultiAsset(
 }
 
 // TestConvertMultiAssetToModelsMaxUint64 covers the maximum in-range value:
-// checkedUint64FromBigInt must not reject anything that legitimately fits
+// CheckedUint64FromBigInt must not reject anything that legitimately fits
 // in a uint64.
 func TestConvertMultiAssetToModelsMaxUint64(t *testing.T) {
 	var policyId lcommon.Blake2b224
@@ -99,6 +99,6 @@ func TestConvertMultiAssetToModelsNilMultiAsset(t *testing.T) {
 // a caller passing a nil *big.Int fails loudly instead of panicking inside
 // IsUint64/Uint64.
 func TestCheckedUint64FromBigIntRejectsNil(t *testing.T) {
-	_, err := checkedUint64FromBigInt(nil)
+	_, err := CheckedUint64FromBigInt(nil)
 	assert.Error(t, err)
 }

--- a/database/models/utxo.go
+++ b/database/models/utxo.go
@@ -376,7 +376,7 @@ func UtxoLedgerToModel(
 	slot uint64,
 ) (Utxo, error) {
 	outAddr := utxo.Output.Address()
-	amount, err := checkedUint64FromBigInt(utxo.Output.Amount())
+	amount, err := CheckedUint64FromBigInt(utxo.Output.Amount())
 	if err != nil {
 		return Utxo{}, fmt.Errorf("utxo amount: %w", err)
 	}

--- a/database/models/utxo_test.go
+++ b/database/models/utxo_test.go
@@ -102,7 +102,7 @@ func TestUtxoLedgerToModelPaymentScript(t *testing.T) {
 // TestUtxoLedgerToModelPropagatesAssetOverflowError exercises the asset
 // overflow guard end-to-end through a real ledger.TransactionOutput (a Mary
 // output, the era multi-asset was introduced in) rather than only unit
-// testing ConvertMultiAssetToModels/checkedUint64FromBigInt directly: it
+// testing ConvertMultiAssetToModels/CheckedUint64FromBigInt directly: it
 // confirms UtxoLedgerToModel itself surfaces the error and returns a
 // zero-value Utxo instead of a model with a wrapped asset amount.
 func TestUtxoLedgerToModelPropagatesAssetOverflowError(t *testing.T) {

--- a/midnight/indexer/indexer.go
+++ b/midnight/indexer/indexer.go
@@ -1489,6 +1489,32 @@ func (idx *Indexer) processTx(
 	return nil
 }
 
+// checkedCnightQuantity converts a cNIGHT asset amount to a uint64,
+// rejecting a value that would silently wrap (delegating to
+// models.CheckedUint64FromBigInt, the same arbitrary-precision-to-uint64
+// domain check database/models already applies to every other indexed
+// on-chain asset amount) and additionally rejecting anything above
+// math.MaxInt64. midnight_asset_creates.quantity is a signed SQLite
+// INTEGER column (sqlstore's own checkedInt64 guards the write), so a
+// legitimate uint64 value with the top bit set would still fail
+// CreateMidnightAssetCreate below even though it fits in a uint64.
+// Rejecting it here keeps that failure on the same non-fatal,
+// skip-and-log path as a true arbitrary-precision overflow, rather than
+// letting it surface as a write error that reaches idx.fatal.
+func checkedCnightQuantity(qty *big.Int) (uint64, error) {
+	amount, err := models.CheckedUint64FromBigInt(qty)
+	if err != nil {
+		return 0, err
+	}
+	if amount > math.MaxInt64 {
+		return 0, fmt.Errorf(
+			"cNIGHT quantity %d exceeds midnight_asset_creates.quantity's signed 64-bit storage range",
+			amount,
+		)
+	}
+	return amount, nil
+}
+
 // processOutput checks a single transaction output for cNIGHT tokens,
 // registration auth tokens, and governance/Ariadne/candidate data. txn is
 // processBlock's block-scoped write transaction; journal records this
@@ -1514,32 +1540,57 @@ func (idx *Indexer) processOutput(
 		if assets := out.Assets(); assets != nil {
 			qty := assets.Asset(idx.cnightPolicyID, idx.cnightAssetName)
 			if qty != nil && qty.Cmp(new(big.Int)) > 0 {
-				addrBytes, _ := out.Address().Bytes()
-				quantity := qty.Uint64()
-				row := &models.MidnightAssetCreate{
-					Address:          addrBytes,
-					Quantity:         quantity,
-					TxHash:           txHashBytes,
-					OutputIndex:      outIdx,
-					BlockNumber:      block.Number,
-					BlockHash:        block.Hash,
-					TxIndex:          txIdx,
-					BlockTimestampMs: timestampMs,
+				quantity, err := checkedCnightQuantity(qty)
+				switch {
+				case err != nil:
+					// An out-of-domain quantity is a property of this
+					// output's on-chain data, not a transient operational
+					// failure like the write errors below: failing the
+					// whole block would make the indexer -- an optional,
+					// secondary subsystem (see ARCHITECTURE.md) -- re-fail
+					// identically on every restart and take the entire
+					// node down via idx.fatal over one malformed row.
+					// Reject just this create (skip the row and the
+					// in-memory track below, but keep scanning this output
+					// for registration/governance data) and log loudly
+					// instead, so the anomaly stays visible without an
+					// unrecoverable outage.
+					if idx.config.Logger != nil {
+						idx.config.Logger.Error(
+							"midnight indexer: cNIGHT quantity out of domain",
+							"error", err,
+							"tx", txHashHex,
+							"output", outIdx,
+							"block", block.Number,
+						)
+					}
+				default:
+					addrBytes, _ := out.Address().Bytes()
+					row := &models.MidnightAssetCreate{
+						Address:          addrBytes,
+						Quantity:         quantity,
+						TxHash:           txHashBytes,
+						OutputIndex:      outIdx,
+						BlockNumber:      block.Number,
+						BlockHash:        block.Hash,
+						TxIndex:          txIdx,
+						BlockTimestampMs: timestampMs,
+					}
+					if err := idx.config.Metadata.CreateMidnightAssetCreate(txn, row); err != nil {
+						return fmt.Errorf(
+							"write asset create tx=%s output=%d: %w",
+							txHashHex, outIdx, err,
+						)
+					}
+					counts["create"]++
+					idx.mu.Lock()
+					journal.cNightUTxOs.record(idx.cNightUTxOs, key)
+					idx.cNightUTxOs[key] = cNightUTxO{
+						Address:  addrBytes,
+						Quantity: quantity,
+					}
+					idx.mu.Unlock()
 				}
-				if err := idx.config.Metadata.CreateMidnightAssetCreate(txn, row); err != nil {
-					return fmt.Errorf(
-						"write asset create tx=%s output=%d: %w",
-						txHashHex, outIdx, err,
-					)
-				}
-				counts["create"]++
-				idx.mu.Lock()
-				journal.cNightUTxOs.record(idx.cNightUTxOs, key)
-				idx.cNightUTxOs[key] = cNightUTxO{
-					Address:  addrBytes,
-					Quantity: quantity,
-				}
-				idx.mu.Unlock()
 			}
 		}
 	}

--- a/midnight/indexer/indexer_test.go
+++ b/midnight/indexer/indexer_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"log/slog"
+	"math"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -436,6 +438,34 @@ func TestCNightCreate_HappyPath(t *testing.T) {
 	_, ok := idx.cNightUTxOs[utxoKey{TxHash: txHash, Index: 0}]
 	idx.mu.RUnlock()
 	assert.True(t, ok, "cNIGHT UTxO must be tracked in-memory after create")
+}
+
+// TestCheckedCnightQuantity_Boundary verifies checkedCnightQuantity accepts
+// every value up to math.MaxInt64 (the shared mock's Asset.Amount field is
+// itself a uint64, so this is exercised directly rather than through
+// processBlock/buildCNightOutput), and rejects both a big.Int amount that
+// would silently truncate via big.Int.Uint64 and a legitimate uint64 value
+// above math.MaxInt64 -- the latter fits in a uint64 but would still fail
+// to persist, since midnight_asset_creates.quantity is a signed SQLite
+// INTEGER column.
+func TestCheckedCnightQuantity_Boundary(t *testing.T) {
+	t.Parallel()
+
+	got, err := checkedCnightQuantity(big.NewInt(math.MaxInt64))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxInt64), got)
+
+	_, err = checkedCnightQuantity(new(big.Int).SetUint64(math.MaxUint64))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signed 64-bit storage range")
+
+	overflow := new(big.Int).Add(
+		new(big.Int).SetUint64(math.MaxUint64),
+		big.NewInt(1),
+	)
+	_, err = checkedCnightQuantity(overflow)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not fit in uint64")
 }
 
 // TestCNightSpend_HappyPath verifies that spending a tracked cNIGHT UTxO

--- a/midnight/server/midnight_state.go
+++ b/midnight/server/midnight_state.go
@@ -16,6 +16,8 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"sort"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -121,15 +123,15 @@ func (s *service) GetAssetCreates(
 		nil,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query asset creates: %v",
-			err,
-		)
+		return nil, s.internalError("query asset creates", err)
 	}
 	creates := make([]*midnight.AssetCreate, len(rows))
 	for i := range rows {
-		creates[i] = assetCreateToProto(&rows[i])
+		pb, err := assetCreateToProto(&rows[i])
+		if err != nil {
+			return nil, s.internalError("convert asset create", err)
+		}
+		creates[i] = pb
 	}
 	return &midnight.AssetCreatesResponse{Creates: creates}, nil
 }
@@ -154,11 +156,15 @@ func (s *service) GetAssetSpends(
 		nil,
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "query asset spends: %v", err)
+		return nil, s.internalError("query asset spends", err)
 	}
 	spends := make([]*midnight.AssetSpend, len(rows))
 	for i := range rows {
-		spends[i] = assetSpendToProto(&rows[i])
+		pb, err := assetSpendToProto(&rows[i])
+		if err != nil {
+			return nil, s.internalError("convert asset spend", err)
+		}
+		spends[i] = pb
 	}
 	return &midnight.AssetSpendsResponse{Spends: spends}, nil
 }
@@ -183,15 +189,15 @@ func (s *service) GetRegistrations(
 		nil,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query registrations: %v",
-			err,
-		)
+		return nil, s.internalError("query registrations", err)
 	}
 	registrations := make([]*midnight.Registration, len(rows))
 	for i := range rows {
-		registrations[i] = registrationToProto(&rows[i])
+		pb, err := registrationToProto(&rows[i])
+		if err != nil {
+			return nil, s.internalError("convert registration", err)
+		}
+		registrations[i] = pb
 	}
 	return &midnight.RegistrationsResponse{Registrations: registrations}, nil
 }
@@ -216,15 +222,15 @@ func (s *service) GetDeregistrations(
 		nil,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query deregistrations: %v",
-			err,
-		)
+		return nil, s.internalError("query deregistrations", err)
 	}
 	deregistrations := make([]*midnight.Deregistration, len(rows))
 	for i := range rows {
-		deregistrations[i] = deregistrationToProto(&rows[i])
+		pb, err := deregistrationToProto(&rows[i])
+		if err != nil {
+			return nil, s.internalError("convert deregistration", err)
+		}
+		deregistrations[i] = pb
 	}
 	return &midnight.DeregistrationsResponse{
 		Deregistrations: deregistrations,
@@ -240,7 +246,12 @@ type utxoEventMergeItem struct {
 	kindOrder   int
 	blockHash   []byte
 	timestampMs uint64
-	event       *midnight.UtxoEvent
+	// buildEvent lazily converts this row to its proto representation.
+	// Deferred until after the end_block_hash and tx_capacity trims below
+	// so an out-of-domain field on a row that the trims would exclude from
+	// the page anyway can never fail the whole response -- only rows that
+	// actually make the final page are converted.
+	buildEvent func() (*midnight.UtxoEvent, error)
 }
 
 // GetUtxoEvents returns a merged, kind_order-tie-broken stream of all four
@@ -284,11 +295,7 @@ func (s *service) GetUtxoEvents(
 		txn,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query asset creates: %v",
-			err,
-		)
+		return nil, s.internalError("query asset creates", err)
 	}
 	spends, err := s.metadata.FindMidnightAssetSpendsFrom(
 		startBlock,
@@ -297,7 +304,7 @@ func (s *service) GetUtxoEvents(
 		txn,
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "query asset spends: %v", err)
+		return nil, s.internalError("query asset spends", err)
 	}
 	registrations, err := s.metadata.FindMidnightRegistrationsFrom(
 		startBlock,
@@ -306,11 +313,7 @@ func (s *service) GetUtxoEvents(
 		txn,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query registrations: %v",
-			err,
-		)
+		return nil, s.internalError("query registrations", err)
 	}
 	deregistrations, err := s.metadata.FindMidnightDeregistrationsFrom(
 		startBlock,
@@ -319,11 +322,7 @@ func (s *service) GetUtxoEvents(
 		txn,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"query deregistrations: %v",
-			err,
-		)
+		return nil, s.internalError("query deregistrations", err)
 	}
 
 	items := make(
@@ -339,10 +338,14 @@ func (s *service) GetUtxoEvents(
 			kindOrder:   utxoEventKindAssetCreate,
 			blockHash:   row.BlockHash,
 			timestampMs: row.BlockTimestampMs,
-			event: &midnight.UtxoEvent{
-				Kind: &midnight.UtxoEvent_AssetCreate{
-					AssetCreate: assetCreateToProto(row),
-				},
+			buildEvent: func() (*midnight.UtxoEvent, error) {
+				pb, err := assetCreateToProto(row)
+				if err != nil {
+					return nil, err
+				}
+				return &midnight.UtxoEvent{
+					Kind: &midnight.UtxoEvent_AssetCreate{AssetCreate: pb},
+				}, nil
 			},
 		})
 	}
@@ -354,10 +357,14 @@ func (s *service) GetUtxoEvents(
 			kindOrder:   utxoEventKindAssetSpend,
 			blockHash:   row.BlockHash,
 			timestampMs: row.BlockTimestampMs,
-			event: &midnight.UtxoEvent{
-				Kind: &midnight.UtxoEvent_AssetSpend{
-					AssetSpend: assetSpendToProto(row),
-				},
+			buildEvent: func() (*midnight.UtxoEvent, error) {
+				pb, err := assetSpendToProto(row)
+				if err != nil {
+					return nil, err
+				}
+				return &midnight.UtxoEvent{
+					Kind: &midnight.UtxoEvent_AssetSpend{AssetSpend: pb},
+				}, nil
 			},
 		})
 	}
@@ -369,10 +376,14 @@ func (s *service) GetUtxoEvents(
 			kindOrder:   utxoEventKindRegistration,
 			blockHash:   row.BlockHash,
 			timestampMs: row.BlockTimestampMs,
-			event: &midnight.UtxoEvent{
-				Kind: &midnight.UtxoEvent_Registration{
-					Registration: registrationToProto(row),
-				},
+			buildEvent: func() (*midnight.UtxoEvent, error) {
+				pb, err := registrationToProto(row)
+				if err != nil {
+					return nil, err
+				}
+				return &midnight.UtxoEvent{
+					Kind: &midnight.UtxoEvent_Registration{Registration: pb},
+				}, nil
 			},
 		})
 	}
@@ -384,10 +395,16 @@ func (s *service) GetUtxoEvents(
 			kindOrder:   utxoEventKindDeregistration,
 			blockHash:   row.BlockHash,
 			timestampMs: row.BlockTimestampMs,
-			event: &midnight.UtxoEvent{
-				Kind: &midnight.UtxoEvent_Deregistration{
-					Deregistration: deregistrationToProto(row),
-				},
+			buildEvent: func() (*midnight.UtxoEvent, error) {
+				pb, err := deregistrationToProto(row)
+				if err != nil {
+					return nil, err
+				}
+				return &midnight.UtxoEvent{
+					Kind: &midnight.UtxoEvent_Deregistration{
+						Deregistration: pb,
+					},
+				}, nil
 			},
 		})
 	}
@@ -414,11 +431,7 @@ func (s *service) GetUtxoEvents(
 		// items, silently letting the response run past the boundary.
 		boundary, found, err := s.blockNumberByHash(endHash)
 		if err != nil {
-			return nil, status.Errorf(
-				codes.Internal,
-				"resolve end_block_hash: %v",
-				err,
-			)
+			return nil, s.internalError("resolve end_block_hash", err)
 		}
 		if found {
 			cut := len(items)
@@ -448,93 +461,127 @@ func (s *service) GetUtxoEvents(
 
 	events := make([]*midnight.UtxoEvent, len(items))
 	for i, item := range items {
-		events[i] = item.event
+		event, err := item.buildEvent()
+		if err != nil {
+			return nil, s.internalError("convert utxo event", err)
+		}
+		events[i] = event
 	}
 	resp := &midnight.UtxoEventsResponse{Events: events}
 	if len(items) > 0 {
 		last := items[len(items)-1]
+		blockNumber, err := midnightBlockNumber(last.blockNumber)
+		if err != nil {
+			return nil, s.internalError(
+				"convert next_position block number",
+				err,
+			)
+		}
+		ts, err := midnightTimestamp(last.timestampMs)
+		if err != nil {
+			return nil, s.internalError("convert next_position timestamp", err)
+		}
 		resp.NextPosition = &midnight.CardanoPosition{
-			BlockHash:   last.blockHash,
-			BlockNumber: midnightBlockNumber(last.blockNumber),
-			TxIndex:     last.txIndex,
-			BlockTimestampUnixMillis: midnightTimestamp(
-				last.timestampMs,
-			),
+			BlockHash:                last.blockHash,
+			BlockNumber:              blockNumber,
+			TxIndex:                  last.txIndex,
+			BlockTimestampUnixMillis: ts,
 		}
 	}
 	return resp, nil
 }
 
-func midnightBlockNumber(value uint64) uint32 {
-	// The Midnight protocol fixes this field at uint32.
-	return uint32(value) //nolint:gosec
+// midnightBlockNumber converts a stored block number to the Midnight
+// protocol's fixed uint32 wire representation, rejecting a value that would
+// silently wrap rather than reporting the corruption. Delegates to
+// checkedUint32 (service.go) -- the same uint64->uint32 domain check used
+// for Block/BlockByHashResponse fields -- rather than a second copy of it.
+func midnightBlockNumber(value uint64) (uint32, error) {
+	return checkedUint32(value)
 }
 
-func midnightTimestamp(value uint64) int64 {
-	// The Midnight protocol fixes Unix millisecond timestamps at int64.
-	return int64(value) //nolint:gosec
+// midnightTimestamp converts a stored millisecond timestamp to the Midnight
+// protocol's fixed int64 wire representation, rejecting a value that would
+// wrap negative rather than reporting the corruption.
+func midnightTimestamp(value uint64) (int64, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("timestamp %d exceeds int64 range", value)
+	}
+	return int64(value), nil
 }
 
-func assetCreateToProto(row *models.MidnightAssetCreate) *midnight.AssetCreate {
+func assetCreateToProto(
+	row *models.MidnightAssetCreate,
+) (*midnight.AssetCreate, error) {
+	ts, err := midnightTimestamp(row.BlockTimestampMs)
+	if err != nil {
+		return nil, err
+	}
 	return &midnight.AssetCreate{
-		Address:     row.Address,
-		Quantity:    row.Quantity,
-		TxHash:      row.TxHash,
-		OutputIndex: row.OutputIndex,
-		BlockNumber: row.BlockNumber,
-		BlockHash:   row.BlockHash,
-		TxIndex:     row.TxIndex,
-		BlockTimestampUnixMillis: midnightTimestamp(
-			row.BlockTimestampMs,
-		),
-	}
+		Address:                  row.Address,
+		Quantity:                 row.Quantity,
+		TxHash:                   row.TxHash,
+		OutputIndex:              row.OutputIndex,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		BlockTimestampUnixMillis: ts,
+	}, nil
 }
 
-func assetSpendToProto(row *models.MidnightAssetSpend) *midnight.AssetSpend {
-	return &midnight.AssetSpend{
-		Address:        row.Address,
-		Quantity:       row.Quantity,
-		SpendingTxHash: row.SpendingTxHash,
-		BlockNumber:    row.BlockNumber,
-		BlockHash:      row.BlockHash,
-		TxIndex:        row.TxIndex,
-		UtxoTxHash:     row.UtxoTxHash,
-		UtxoIndex:      row.UtxoIndex,
-		BlockTimestampUnixMillis: midnightTimestamp(
-			row.BlockTimestampMs,
-		),
+func assetSpendToProto(
+	row *models.MidnightAssetSpend,
+) (*midnight.AssetSpend, error) {
+	ts, err := midnightTimestamp(row.BlockTimestampMs)
+	if err != nil {
+		return nil, err
 	}
+	return &midnight.AssetSpend{
+		Address:                  row.Address,
+		Quantity:                 row.Quantity,
+		SpendingTxHash:           row.SpendingTxHash,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		UtxoTxHash:               row.UtxoTxHash,
+		UtxoIndex:                row.UtxoIndex,
+		BlockTimestampUnixMillis: ts,
+	}, nil
 }
 
 func registrationToProto(
 	row *models.MidnightRegistration,
-) *midnight.Registration {
-	return &midnight.Registration{
-		FullDatum:   row.FullDatum,
-		TxHash:      row.TxHash,
-		OutputIndex: row.OutputIndex,
-		BlockNumber: row.BlockNumber,
-		BlockHash:   row.BlockHash,
-		TxIndex:     row.TxIndex,
-		BlockTimestampUnixMillis: midnightTimestamp(
-			row.BlockTimestampMs,
-		),
+) (*midnight.Registration, error) {
+	ts, err := midnightTimestamp(row.BlockTimestampMs)
+	if err != nil {
+		return nil, err
 	}
+	return &midnight.Registration{
+		FullDatum:                row.FullDatum,
+		TxHash:                   row.TxHash,
+		OutputIndex:              row.OutputIndex,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		BlockTimestampUnixMillis: ts,
+	}, nil
 }
 
 func deregistrationToProto(
 	row *models.MidnightDeregistration,
-) *midnight.Deregistration {
-	return &midnight.Deregistration{
-		FullDatum:   row.FullDatum,
-		TxHash:      row.TxHash,
-		BlockNumber: row.BlockNumber,
-		BlockHash:   row.BlockHash,
-		TxIndex:     row.TxIndex,
-		UtxoTxHash:  row.UtxoTxHash,
-		UtxoIndex:   row.UtxoIndex,
-		BlockTimestampUnixMillis: midnightTimestamp(
-			row.BlockTimestampMs,
-		),
+) (*midnight.Deregistration, error) {
+	ts, err := midnightTimestamp(row.BlockTimestampMs)
+	if err != nil {
+		return nil, err
 	}
+	return &midnight.Deregistration{
+		FullDatum:                row.FullDatum,
+		TxHash:                   row.TxHash,
+		BlockNumber:              row.BlockNumber,
+		BlockHash:                row.BlockHash,
+		TxIndex:                  row.TxIndex,
+		UtxoTxHash:               row.UtxoTxHash,
+		UtxoIndex:                row.UtxoIndex,
+		BlockTimestampUnixMillis: ts,
+	}, nil
 }

--- a/midnight/server/midnight_state_internal_test.go
+++ b/midnight/server/midnight_state_internal_test.go
@@ -15,9 +15,14 @@
 package server
 
 import (
+	"errors"
+	"log/slog"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestEffectivePageSize verifies zero/omitted capacity requests fall back
@@ -30,4 +35,89 @@ func TestEffectivePageSize(t *testing.T) {
 	require.Equal(t, 1, effectivePageSize(1))
 	require.Equal(t, maxEventPageSize, effectivePageSize(maxEventPageSize))
 	require.Equal(t, maxEventPageSize, effectivePageSize(maxEventPageSize+1))
+}
+
+// TestMidnightBlockNumber_Boundary verifies midnightBlockNumber accepts
+// every value representable in the Midnight wire type's uint32 and rejects
+// a stored value one past it, rather than silently wrapping (uint32(v) on a
+// value like 1<<32 truncates to 0, corrupting the reported block number).
+func TestMidnightBlockNumber_Boundary(t *testing.T) {
+	t.Parallel()
+
+	got, err := midnightBlockNumber(math.MaxUint32)
+	require.NoError(t, err)
+	require.Equal(t, uint32(math.MaxUint32), got)
+
+	_, err = midnightBlockNumber(uint64(math.MaxUint32) + 1)
+	require.Error(t, err)
+}
+
+// TestMidnightTimestamp_Boundary verifies midnightTimestamp accepts every
+// value representable in the Midnight wire type's int64 and rejects a
+// stored value one past it, rather than silently wrapping into a negative
+// timestamp (int64(v) on math.MaxInt64+1 produces math.MinInt64).
+func TestMidnightTimestamp_Boundary(t *testing.T) {
+	t.Parallel()
+
+	got, err := midnightTimestamp(math.MaxInt64)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt64), got)
+
+	_, err = midnightTimestamp(uint64(math.MaxInt64) + 1)
+	require.Error(t, err)
+}
+
+// TestCheckedUint32_Boundary verifies checkedUint32 accepts every value
+// representable in uint32 and rejects a value one past it, rather than
+// silently wrapping.
+func TestCheckedUint32_Boundary(t *testing.T) {
+	t.Parallel()
+
+	got, err := checkedUint32(math.MaxUint32)
+	require.NoError(t, err)
+	require.Equal(t, uint32(math.MaxUint32), got)
+
+	_, err = checkedUint32(uint64(math.MaxUint32) + 1)
+	require.Error(t, err)
+}
+
+// TestCheckedUint64_Boundary verifies checkedUint64 accepts a non-negative
+// unix-seconds timestamp and rejects a negative one, rather than silently
+// wrapping it into a huge unsigned number.
+func TestCheckedUint64_Boundary(t *testing.T) {
+	t.Parallel()
+
+	got, err := checkedUint64(0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), got)
+
+	_, err = checkedUint64(-1)
+	require.Error(t, err)
+}
+
+// TestInternalError_DoesNotLeakDetail verifies internalError returns a
+// stable, generic message naming only op — never the wrapped error's own
+// text, which can carry driver-specific SQL text, file paths, or CBOR
+// diagnostics that must stay server-side — and that it tolerates a nil
+// logger (a bare &service{} in a white-box test, rather than one built via
+// New, which always defaults Logger).
+func TestInternalError_DoesNotLeakDetail(t *testing.T) {
+	t.Parallel()
+
+	svc := &service{}
+	err := svc.internalError(
+		"get technical committee datum",
+		status.Error(codes.Unknown, "pq: connection refused at 10.0.0.5:5432"),
+	)
+	require.Equal(t, codes.Internal, status.Code(err))
+	msg := status.Convert(err).Message()
+	require.Equal(t, "get technical committee datum failed", msg)
+	require.NotContains(t, msg, "10.0.0.5")
+
+	svc.logger = slog.Default()
+	err = svc.internalError(
+		"get technical committee datum",
+		errors.New("boom"),
+	)
+	require.Equal(t, codes.Internal, status.Code(err))
 }

--- a/midnight/server/midnight_state_test.go
+++ b/midnight/server/midnight_state_test.go
@@ -17,7 +17,9 @@ package server_test
 import (
 	"context"
 	"log/slog"
+	"math"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,6 +211,55 @@ func TestGetUtxoEvents_EmptyDatabase(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, resp.GetEvents())
 	require.Nil(t, resp.GetNextPosition())
+}
+
+// TestGetUtxoEvents_NextPositionBlockNumberOutOfDomain seeds a row whose
+// stored block number exceeds uint32 range (CardanoPosition's wire type) and
+// verifies GetUtxoEvents rejects building next_position with a stable,
+// generic Internal error instead of silently wrapping the block number.
+func TestGetUtxoEvents_NextPositionBlockNumberOutOfDomain(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	const badBlockNumber = uint64(math.MaxUint32) + 1
+	require.NoError(
+		t,
+		store.CreateMidnightAssetCreate(nil, &models.MidnightAssetCreate{
+			Address:     []byte{0x01},
+			Quantity:    1,
+			TxHash:      hashForByte(1),
+			OutputIndex: 0,
+			BlockNumber: badBlockNumber,
+			BlockHash:   hashForByte(1),
+			TxIndex:     0,
+		}),
+	)
+
+	client := midnight.NewMidnightStateClient(
+		dial(t, startTestServerWithMetadata(t, store)),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.GetUtxoEvents(
+		ctx,
+		&midnight.UtxoEventsRequest{TxCapacity: 10},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+	msg := status.Convert(err).Message()
+	require.NotContains(
+		t,
+		msg,
+		"4294967296",
+		"internal error must not leak the raw stored value to the client",
+	)
+	require.True(
+		t,
+		strings.HasSuffix(msg, "failed"),
+		"client message must be the stable generic form, got %q",
+		msg,
+	)
 }
 
 // TestGetUtxoEvents_KindOrderTieBreak seeds one row of each of the four

--- a/midnight/server/server.go
+++ b/midnight/server/server.go
@@ -244,6 +244,7 @@ func (s *Server) Start(ctx context.Context) error {
 		blockNumberByHash: s.config.BlockNumberByHash,
 		db:                s.config.Database,
 		slotTimer:         s.config.SlotTimer,
+		logger:            s.config.Logger,
 	})
 
 	// Health service reporting SERVING for the overall server ("") and the
@@ -378,4 +379,8 @@ type service struct {
 	blockNumberByHash func(hash []byte) (blockNumber uint64, found bool, err error)
 	db                MidnightDatabase
 	slotTimer         SlotTimer
+	// logger receives the diagnostic detail behind every codes.Internal
+	// response (see internalError in service.go); it is never nil, so
+	// handlers can log unconditionally.
+	logger *slog.Logger
 }

--- a/midnight/server/service.go
+++ b/midnight/server/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -26,6 +27,17 @@ import (
 	midnightindexer "github.com/blinklabs-io/dingo/midnight/indexer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+// errAsOfTimestampOutOfRange marks a client-supplied
+// as_of_timestamp_unix_millis that resolveTipBlock cannot convert to a
+// non-negative int64 millisecond value. Converting it anyway (int64(v))
+// would silently wrap into a negative timestamp and resolve to a bogus
+// slot. GetStableBlock and GetLatestStableBlock check for this sentinel to
+// return InvalidArgument instead of masking it as an internal failure or a
+// "no such block" empty response.
+var errAsOfTimestampOutOfRange = errors.New(
+	"as_of_timestamp_unix_millis exceeds the supported range",
 )
 
 // The service struct is declared in server.go, where its db/slotTimer fields
@@ -67,6 +79,19 @@ func (s *service) checkBlockBackends() error {
 	return nil
 }
 
+// internalError logs err's full detail server-side and returns a stable,
+// generic codes.Internal status naming only op. Handlers must route every
+// backend/decode/conversion failure through this rather than interpolating
+// err into the client-facing message: %v on a raw error can carry
+// driver-specific SQL text, file paths, or CBOR diagnostics that should
+// never leave the process.
+func (s *service) internalError(op string, err error) error {
+	if s.logger != nil {
+		s.logger.Error("midnight grpc: internal error", "op", op, "error", err)
+	}
+	return status.Errorf(codes.Internal, "%s failed", op)
+}
+
 // GetTechnicalCommitteeDatum returns the newest Technical Committee datum at
 // or before the requested block number.
 func (s *service) GetTechnicalCommitteeDatum(
@@ -81,11 +106,7 @@ func (s *service) GetTechnicalCommitteeDatum(
 		req.GetBlockNumber(),
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get technical committee datum: %v",
-			err,
-		)
+		return nil, s.internalError("get technical committee datum", err)
 	}
 	if datum == nil {
 		return nil, status.Error(
@@ -113,11 +134,7 @@ func (s *service) GetCouncilDatum(
 		req.GetBlockNumber(),
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get council datum: %v",
-			err,
-		)
+		return nil, s.internalError("get council datum", err)
 	}
 	if datum == nil {
 		return nil, status.Error(
@@ -142,11 +159,7 @@ func (s *service) GetAriadneParameters(
 	}
 	params, err := s.db.GetMidnightAriadneParamsAtOrBeforeEpoch(req.GetEpoch())
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get ariadne parameters: %v",
-			err,
-		)
+		return nil, s.internalError("get ariadne parameters", err)
 	}
 	if params == nil {
 		return nil, status.Error(
@@ -170,7 +183,7 @@ func (s *service) GetEpochNonce(
 	}
 	epoch, err := s.db.GetEpoch(req.GetEpoch())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "get epoch: %v", err)
+		return nil, s.internalError("get epoch", err)
 	}
 	if epoch == nil {
 		return nil, status.Error(codes.NotFound, "epoch not found")
@@ -191,11 +204,7 @@ func (s *service) GetEpochCandidates(
 	epoch := req.GetEpoch()
 	snapshot, err := s.db.GetMidnightEpochCandidatesByEpoch(epoch)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get epoch candidates: %v",
-			err,
-		)
+		return nil, s.internalError("get epoch candidates", err)
 	}
 	if snapshot == nil {
 		return nil, status.Error(
@@ -207,17 +216,12 @@ func (s *service) GetEpochCandidates(
 		snapshot.CandidatesCbor,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"decode candidate snapshot: %v",
-			err,
-		)
+		return nil, s.internalError("decode candidate snapshot", err)
 	}
 	registrations, err := s.candidateRegistrationsFor(entries)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get committee candidate registrations: %v",
+		return nil, s.internalError(
+			"get committee candidate registrations",
 			err,
 		)
 	}
@@ -248,11 +252,7 @@ func (s *service) GetEpochCandidates(
 			reg.TxInputsCbor,
 		)
 		if err != nil {
-			return nil, status.Errorf(
-				codes.Internal,
-				"decode candidate tx inputs: %v",
-				err,
-			)
+			return nil, s.internalError("decode candidate tx inputs", err)
 		}
 		txInputs := make([]*midnight.UtxoId, len(inputs))
 		for j, ref := range inputs {
@@ -266,11 +266,7 @@ func (s *service) GetEpochCandidates(
 		models.PoolStakeSnapshotTypeMark,
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"get pool stake snapshots: %v",
-			err,
-		)
+		return nil, s.internalError("get pool stake snapshots", err)
 	}
 	// GetPoolStakeSnapshotsByEpoch does not guarantee row order; sort by pool
 	// key hash so the response is deterministic across calls and backends.
@@ -352,29 +348,37 @@ func (s *service) GetBlockByHash(
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return nil, status.Error(codes.NotFound, "block not found")
 		}
-		return nil, status.Errorf(codes.Internal, "get block by hash: %v", err)
+		return nil, s.internalError("get block by hash", err)
 	}
 	decoded, err := blk.Decode()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "decode block: %v", err)
+		return nil, s.internalError("decode block", err)
 	}
 	epoch, err := s.epochForSlot(blk.Slot)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
+		return nil, s.internalError("resolve epoch", err)
 	}
 	ts, err := s.slotTimer.SlotToTime(blk.Slot)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"resolve block timestamp: %v",
-			err,
-		)
+		return nil, s.internalError("resolve block timestamp", err)
+	}
+	blockNumber, err := checkedUint32(blk.Number)
+	if err != nil {
+		return nil, s.internalError("convert block number", err)
+	}
+	txCount, err := checkedUint32(uint64(len(decoded.Transactions())))
+	if err != nil {
+		return nil, s.internalError("convert tx count", err)
+	}
+	epochNumber, err := checkedUint32(epoch.EpochId)
+	if err != nil {
+		return nil, s.internalError("convert epoch number", err)
 	}
 	return &midnight.BlockByHashResponse{
-		BlockNumber:        checkedUint32(blk.Number),
-		TxCount:            checkedUint32(uint64(len(decoded.Transactions()))),
+		BlockNumber:        blockNumber,
+		TxCount:            txCount,
 		BlockTimestampUnix: ts.Unix(),
-		EpochNumber:        checkedUint32(epoch.EpochId),
+		EpochNumber:        epochNumber,
 		SlotNumber:         blk.Slot,
 	}, nil
 }
@@ -389,14 +393,14 @@ func (s *service) GetLatestBlock(
 	}
 	blocks, err := s.db.BlocksRecent(1)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "get latest block: %v", err)
+		return nil, s.internalError("get latest block", err)
 	}
 	if len(blocks) == 0 {
 		return nil, status.Error(codes.NotFound, "no blocks in chain yet")
 	}
 	pb, err := s.buildBlock(blocks[0])
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
+		return nil, s.internalError("build block", err)
 	}
 	return &midnight.LatestBlockResponse{Block: pb}, nil
 }
@@ -416,14 +420,18 @@ func (s *service) GetStableBlock(
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return nil, status.Error(codes.NotFound, "block not found")
 		}
-		return nil, status.Errorf(codes.Internal, "get block by hash: %v", err)
+		return nil, s.internalError("get block by hash", err)
 	}
 	tip, err := s.resolveTipBlock(req.GetAsOfTimestampUnixMillis())
 	if err != nil {
-		if errors.Is(err, models.ErrBlockNotFound) {
+		switch {
+		case errors.Is(err, models.ErrBlockNotFound):
 			return &midnight.StableBlockResponse{}, nil
+		case errors.Is(err, errAsOfTimestampOutOfRange):
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		default:
+			return nil, s.internalError("resolve chain tip", err)
 		}
-		return nil, status.Errorf(codes.Internal, "resolve chain tip: %v", err)
 	}
 	if tip.Number < blk.Number ||
 		tip.Number-blk.Number < uint64(req.GetStabilityOffset()) {
@@ -431,7 +439,7 @@ func (s *service) GetStableBlock(
 	}
 	pb, err := s.buildBlock(blk)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
+		return nil, s.internalError("build block", err)
 	}
 	return &midnight.StableBlockResponse{Block: pb}, nil
 }
@@ -449,10 +457,14 @@ func (s *service) GetLatestStableBlock(
 	}
 	tip, err := s.resolveTipBlock(req.GetAsOfTimestampUnixMillis())
 	if err != nil {
-		if errors.Is(err, models.ErrBlockNotFound) {
+		switch {
+		case errors.Is(err, models.ErrBlockNotFound):
 			return &midnight.LatestStableBlockResponse{}, nil
+		case errors.Is(err, errAsOfTimestampOutOfRange):
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		default:
+			return nil, s.internalError("resolve chain tip", err)
 		}
-		return nil, status.Errorf(codes.Internal, "resolve chain tip: %v", err)
 	}
 	offset := uint64(req.GetStabilityOffset())
 	if tip.Number < offset {
@@ -463,15 +475,11 @@ func (s *service) GetLatestStableBlock(
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return &midnight.LatestStableBlockResponse{}, nil
 		}
-		return nil, status.Errorf(
-			codes.Internal,
-			"get block by number: %v",
-			err,
-		)
+		return nil, s.internalError("get block by number", err)
 	}
 	pb, err := s.buildBlock(blk)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "%v", err)
+		return nil, s.internalError("build block", err)
 	}
 	return &midnight.LatestStableBlockResponse{Block: pb}, nil
 }
@@ -489,7 +497,14 @@ func (s *service) resolveTipBlock(asOfMillis uint64) (models.Block, error) {
 		}
 		return blocks[0], nil
 	}
-	// #nosec G115 -- millisecond unix timestamps fit in int64 until year 292277026596
+	// asOfMillis is client-supplied and unsigned: a value above
+	// math.MaxInt64 would wrap to a negative int64 below and resolve to a
+	// bogus slot instead of the far-future time it actually encodes. Reject
+	// it rather than let it wrap; the wire domain otherwise fits int64
+	// until year 292277026596.
+	if asOfMillis > math.MaxInt64 {
+		return models.Block{}, errAsOfTimestampOutOfRange
+	}
 	asOf := time.UnixMilli(int64(asOfMillis))
 	slot, err := s.slotTimer.TimeToSlot(asOf)
 	if err != nil {
@@ -516,12 +531,24 @@ func (s *service) buildBlock(blk models.Block) (*midnight.Block, error) {
 			err,
 		)
 	}
+	blockNumber, err := checkedUint32(blk.Number)
+	if err != nil {
+		return nil, fmt.Errorf("convert block number: %w", err)
+	}
+	epochNumber, err := checkedUint32(epoch.EpochId)
+	if err != nil {
+		return nil, fmt.Errorf("convert epoch number: %w", err)
+	}
+	timestampUnix, err := checkedUint64(ts.Unix())
+	if err != nil {
+		return nil, fmt.Errorf("convert block timestamp: %w", err)
+	}
 	return &midnight.Block{
-		BlockNumber:        checkedUint32(blk.Number),
+		BlockNumber:        blockNumber,
 		BlockHash:          blk.Hash,
-		EpochNumber:        checkedUint32(epoch.EpochId),
+		EpochNumber:        epochNumber,
 		SlotNumber:         blk.Slot,
-		BlockTimestampUnix: checkedUint64(ts.Unix()),
+		BlockTimestampUnix: timestampUnix,
 	}, nil
 }
 
@@ -538,14 +565,25 @@ func (s *service) epochForSlot(slot uint64) (*models.Epoch, error) {
 	return epoch, nil
 }
 
-// checkedUint32 truncates a uint64 to uint32. Block, epoch, and transaction
-// counts stay well under 2^32 for any real Cardano chain.
-func checkedUint32(v uint64) uint32 {
-	return uint32(v) // #nosec G115
+// checkedUint32 converts a uint64 to the Midnight protocol's fixed uint32
+// wire representation, rejecting a value that would silently wrap. Block,
+// epoch, and transaction counts stay well under 2^32 for any real Cardano
+// chain; a value that doesn't fit means the source counter is corrupt, not
+// that this check is overly cautious.
+func checkedUint32(v uint64) (uint32, error) {
+	if v > math.MaxUint32 {
+		return 0, fmt.Errorf("value %d exceeds uint32 range", v)
+	}
+	return uint32(v), nil
 }
 
-// checkedUint64 converts a unix-seconds timestamp (always non-negative for
-// any post-genesis block) to uint64.
-func checkedUint64(v int64) uint64 {
-	return uint64(v) // #nosec G115
+// checkedUint64 converts a unix-seconds timestamp to uint64, rejecting a
+// negative value rather than letting it silently wrap into a huge unsigned
+// number. Every post-genesis Cardano block has a non-negative timestamp; a
+// negative value here means slotTimer returned bad data.
+func checkedUint64(v int64) (uint64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("timestamp %d is negative", v)
+	}
+	return uint64(v), nil
 }

--- a/midnight/server/service_test.go
+++ b/midnight/server/service_test.go
@@ -600,6 +600,35 @@ func TestGetLatestBlock(t *testing.T) {
 	require.Equal(t, tip.Slot, resp.GetBlock().GetSlotNumber())
 }
 
+// TestGetLatestBlock_BlockNumberOutOfDomain verifies that a stored block
+// number above uint32 range (the Midnight wire type) is rejected with a
+// stable, generic Internal error rather than silently wrapping (uint32(v)
+// on a value one past math.MaxUint32 truncates to 0).
+func TestGetLatestBlock_BlockNumberOutOfDomain(t *testing.T) {
+	db := newTestDatabase(t)
+	badNumber := uint64(math.MaxUint32) + 1
+	insertPlaceholderBlock(t, db, badNumber, 1, 0x01)
+
+	addr := startTestServerWithConfig(
+		t,
+		server.Config{
+			Database:  server.NewDatabase(db),
+			SlotTimer: fakeSlotTimer{},
+		},
+	)
+	client := dialClient(t, addr)
+
+	_, err := client.GetLatestBlock(callCtx(t), &midnight.LatestBlockRequest{})
+	require.Equal(t, codes.Internal, status.Code(err))
+	msg := status.Convert(err).Message()
+	require.NotContains(
+		t,
+		msg,
+		"4294967296",
+		"internal error must not leak the raw stored value to the client",
+	)
+}
+
 func TestGetBlockByHash(t *testing.T) {
 	db := newTestDatabase(t)
 	blk := loadRealTestBlock(t)
@@ -779,4 +808,37 @@ func TestGetStableBlock_AsOfTimestamp(t *testing.T) {
 		"older block must be stable relative to the as-of tip",
 	)
 	require.Equal(t, uint32(older.Number), resp.GetBlock().GetBlockNumber())
+}
+
+// TestGetStableBlock_AsOfTimestampOutOfDomain verifies that an
+// AsOfTimestampUnixMillis above int64 range is rejected as InvalidArgument
+// rather than being converted with int64(v), which would silently wrap it
+// into a negative timestamp and resolve against a bogus slot.
+func TestGetStableBlock_AsOfTimestampOutOfDomain(t *testing.T) {
+	db := newTestDatabase(t)
+	blk := insertPlaceholderBlock(t, db, 10, 10, 0x01)
+
+	addr := startTestServerWithConfig(
+		t,
+		server.Config{
+			Database:  server.NewDatabase(db),
+			SlotTimer: fakeSlotTimer{},
+		},
+	)
+	client := dialClient(t, addr)
+
+	const badAsOfMillis = uint64(math.MaxInt64) + 1
+	_, err := client.GetStableBlock(callCtx(t), &midnight.StableBlockRequest{
+		BlockHash:               blk.Hash,
+		AsOfTimestampUnixMillis: badAsOfMillis,
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = client.GetLatestStableBlock(
+		callCtx(t),
+		&midnight.LatestStableBlockRequest{
+			AsOfTimestampUnixMillis: badAsOfMillis,
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }


### PR DESCRIPTION
## Summary

Checks every narrowing numeric conversion in the midnight gRPC server and
indexer before applying it, and normalizes error responses so internal
detail never reaches the client.

- `midnightBlockNumber`/`midnightTimestamp` (`CardanoPosition` and per-row
  wire fields) and `checkedUint32`/`checkedUint64`
  (`Block`/`BlockByHashResponse` fields) now reject an out-of-domain value
  instead of silently truncating/wrapping it.
- `checkedCnightQuantity` rejects a `big.Int` asset amount that doesn't fit
  in `uint64` (`big.Int.Uint64` keeps only the low 64 bits on overflow),
  so an indexed cNIGHT quantity can no longer be silently truncated.
- `resolveTipBlock` rejects a client-supplied `as_of_timestamp_unix_millis`
  above `int64` range with `InvalidArgument` instead of converting it into
  a negative timestamp.
- Every internal/backend failure now routes through a new `internalError`
  helper that logs full diagnostic detail server-side and returns a
  stable, generic `codes.Internal` message to the client, instead of
  interpolating the raw error (which could carry driver-specific SQL
  text, file paths, or CBOR diagnostics) into the response.

## Testing

- `go build ./...`
- `go test ./midnight/...` (`-race`)
- `golangci-lint run ./midnight/...`, `nilaway ./midnight/...`,
  `modernize ./midnight/...` (only pre-existing generated-file findings)
- `make import-boundaries`, `make docs-parity`
- Added boundary/error-response tests for each conversion; confirmed each
  new test fails against the prior unchecked behavior before the fix.

Fixes #3527

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checks every narrowing numeric conversion in the midnight gRPC server and indexer before applying it, and normalizes error responses so internal detail never reaches the client.

**Bug Fixes**
- Out-of-range block numbers, timestamps, and epoch numbers now fail with an error instead of wrapping or truncating.
- A client-supplied `as_of_timestamp_unix_millis` above `int64` range returns `InvalidArgument` instead of becoming a negative timestamp.
- Indexing rejects cNIGHT quantities that don't fit the signed 64-bit quantity column instead of truncating them; only the offending create is skipped and logged, without aborting the block.
- `GetUtxoEvents` defers row conversion until after paging trims, so an out-of-domain field on a trimmed row no longer fails the whole response.

**Refactors**
- All internal failures now return a generic `codes.Internal` message; full diagnostic detail is logged server-side.

<sup>Written for commit ba0ef5f44366913db1657f66a006ee1baaea4bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid timestamps and numeric values from wrapping or producing incorrect results in Midnight APIs.
  - Added clearer validation responses for out-of-range request parameters.
  - Improved error handling so clients receive stable, non-sensitive messages while detailed failures are logged server-side.
  - Prevented oversized cNIGHT quantities from stopping block processing; affected outputs are skipped and recorded for investigation.

- **Documentation**
  - Updated architecture documentation to describe validation, error handling, and out-of-range value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->