### PR TITLE
test(ledger): pin Dijkstra required-redeemer validation

### DIFF
--- a/ledger/eras/plutus_validity_outcome_test.go
+++ b/ledger/eras/plutus_validity_outcome_test.go
@@ -25,6 +25,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/lang"
 	"github.com/blinklabs-io/plutigo/syn"
 	"github.com/stretchr/testify/require"
@@ -243,6 +244,109 @@ func TestValidateTxDijkstraDoesNotTreatPhase1FailureAsPhase2Failure(
 		dijkstraValidityOutcomePParams(),
 	)
 	require.ErrorIs(t, err, phase1Sentinel)
+}
+
+// TestValidateTxDijkstraSkipPhase2StillValidatesRequiredRedeemers pins the
+// Dijkstra phase-1 boundary through Dingo's production entry point. Historical
+// replay may skip script execution, but a reference-script spend must still
+// carry its required redeemer.
+func TestValidateTxDijkstraSkipPhase2StillValidatesRequiredRedeemers(
+	t *testing.T,
+) {
+	requiredRedeemerIndex := noUtxoValidationRuleIndex
+	for index, descriptor := range gdijkstra.UtxoValidationRuleDescriptors() {
+		if descriptor.Id == lcommon.UtxoValidationRuleRequiredRedeemers {
+			requiredRedeemerIndex = index
+			break
+		}
+	}
+	require.NotEqual(
+		t,
+		noUtxoValidationRuleIndex,
+		requiredRedeemerIndex,
+		"Dijkstra must declare the required-redeemer rule",
+	)
+
+	var requiredRedeemerRule *indexedUtxoValidationRule
+	for _, rule := range dijkstraPhase1UtxoValidationRules {
+		if rule.index == requiredRedeemerIndex {
+			ruleCopy := rule
+			requiredRedeemerRule = &ruleCopy
+			break
+		}
+	}
+	require.NotNil(
+		t,
+		requiredRedeemerRule,
+		"Dijkstra phase-1 validation must retain the required-redeemer rule",
+	)
+
+	originalPhase1 := dijkstraPhase1UtxoValidationRules
+	dijkstraPhase1UtxoValidationRules = []indexedUtxoValidationRule{
+		*requiredRedeemerRule,
+	}
+	t.Cleanup(func() { dijkstraPhase1UtxoValidationRules = originalPhase1 })
+
+	plutusScript := lcommon.PlutusV1Script{0x01, 0x02, 0x03}
+	scriptAddr := newTestScriptAddress(t, plutusScript)
+	spendInput := shelley.NewShelleyTransactionInput(
+		"6666666666666666666666666666666666666666666666666666666666666666",
+		0,
+	)
+	ls := newMockLedgerState()
+	ls.skipPhase2Validation = true
+	ls.addUtxo(
+		spendInput,
+		testAddressScriptOutput{
+			testOutput: newTestOutput(1_000),
+			addr:       scriptAddr,
+			scriptRef:  plutusScript,
+		},
+	)
+
+	newTx := func() *gdijkstra.DijkstraTransaction {
+		return &gdijkstra.DijkstraTransaction{
+			Body: gdijkstra.DijkstraTransactionBody{
+				TxInputs: conway.NewConwayTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{spendInput},
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+
+	t.Run("missing redeemer", func(t *testing.T) {
+		err := ValidateTxDijkstra(
+			newTx(),
+			0,
+			ls,
+			dijkstraValidityOutcomePParams(),
+		)
+		var missing lcommon.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missing)
+		require.Equal(t, plutusScript.Hash(), missing.ScriptHash)
+		require.Equal(t, lcommon.RedeemerTagSpend, missing.Tag)
+		require.Equal(t, uint32(0), missing.Index)
+	})
+
+	t.Run("matching redeemer", func(t *testing.T) {
+		tx := newTx()
+		tx.WitnessSet = gdijkstra.DijkstraTransactionWitnessSet{
+			WsRedeemers: gdijkstra.DijkstraRedeemers{
+				Redeemers: map[lcommon.RedeemerKey]lcommon.RedeemerValue{
+					{Tag: lcommon.RedeemerTagSpend, Index: 0}: {
+						ExUnits: lcommon.ExUnits{Steps: 1, Memory: 1},
+					},
+				},
+			},
+		}
+		require.NoError(t, ValidateTxDijkstra(
+			tx,
+			0,
+			ls,
+			dijkstraValidityOutcomePParams(),
+		))
+	})
 }
 
 func (t *declaredValidityConwayTx) IsValid() bool {


### PR DESCRIPTION
Fixes #3429

Adds a Dingo entry-point regression proving Dijkstra phase-1 still rejects a reference-script spend without its required redeemer when historical replay skips phase-2 execution. The matching-redeemer control remains accepted.

Checks:

- `go test -race -count=1 ./ledger/eras`
- `go test -tags dingo_extra_plugins -race -count=1 ./ledger/eras`
- `golangci-lint run ./ledger/eras`
- `nilaway -tags dingo_extra_plugins ./ledger/eras`
- `modernize -tags dingo_extra_plugins github.com/blinklabs-io/dingo/ledger/eras`
- `make golines import-boundaries docs-parity`

The full conformance corpus was also attempted; it timed out after 10 minutes in an unchanged SQLite reset while another local corpus run was active.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3429 by adding a regression test that pins Dijkstra phase-1 required-redeemer validation when historical replay skips phase-2 execution. A reference-script spend missing its required redeemer is rejected, and the same spend with a matching redeemer still validates.

This is a test-only change; no production behavior changes.

<sup>Written for commit 4b97170c709b3e2054c7c81744379bfb4e4eed74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical transaction replay now continues validating required redeemers even when phase-2 validation is skipped.
  * Transactions spending through a reference script without a redeemer correctly return an error.
  * Transactions with a matching redeemer continue to validate successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->