### PR TITLE
fix(ledger): skip rewards with incomplete block counts

### DIFF
--- a/ledger/reward_calculation.go
+++ b/ledger/reward_calculation.go
@@ -282,6 +282,24 @@ func (ls *LedgerState) calculateStakeRewardApplication(
 		)
 		return nil, false, nil
 	}
+	// Imported Mithril reward inputs may describe stake and registrations but
+	// cannot carry per-epoch block production counts. Do not interpret those
+	// missing values as zero: that would persist a plausible-looking reward
+	// round with no credits and leave withdrawals inconsistent with the
+	// network state. The round can be retried only when a complete basis is
+	// available; an incomplete one must be skipped before calculation.
+	if !rewardPoolInputsHaveBlockCounts(poolInputs) {
+		ls.config.Logger.Warn(
+			"skipping stake rewards: reward pool inputs have no block production counts",
+			"component",
+			"ledger",
+			"new_epoch",
+			newEpoch,
+			"reward_snapshot_epoch",
+			rewardSnapshotEpoch,
+		)
+		return nil, false, nil
+	}
 
 	pparams, params, performanceDecentralization, err := ls.rewardParameters(
 		txn,
@@ -976,6 +994,18 @@ func precomputedRewardPoolOutputsMatchInputs(
 		delete(expectedOwnerStake, key)
 	}
 	return len(expectedOwnerStake) == 0
+}
+
+func rewardPoolInputsHaveBlockCounts(
+	poolInputs []*models.RewardPoolInput,
+) bool {
+	for _, input := range poolInputs {
+		if input == nil || input.BlocksProduced == nil ||
+			input.TotalBlocksInEpoch == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // precomputedRewardPoolRewardsMatchInputs re-derives each persisted pool's

--- a/ledger/reward_calculation_test.go
+++ b/ledger/reward_calculation_test.go
@@ -306,6 +306,24 @@ func TestApplyStakeRewardsUsesDelayedRewardState(t *testing.T) {
 	require.Equal(t, int64(2), deltas)
 }
 
+func TestRewardPoolInputsHaveBlockCounts(t *testing.T) {
+	t.Parallel()
+
+	blocks, total := uint64(2), uint64(10)
+	complete := &models.RewardPoolInput{
+		BlocksProduced:     &blocks,
+		TotalBlocksInEpoch: &total,
+	}
+	require.True(t, rewardPoolInputsHaveBlockCounts([]*models.RewardPoolInput{complete}))
+	require.False(t, rewardPoolInputsHaveBlockCounts([]*models.RewardPoolInput{{
+		BlocksProduced: &blocks,
+	}}))
+	require.False(t, rewardPoolInputsHaveBlockCounts([]*models.RewardPoolInput{{
+		TotalBlocksInEpoch: &total,
+	}}))
+	require.False(t, rewardPoolInputsHaveBlockCounts([]*models.RewardPoolInput{nil}))
+}
+
 // guardExpiredLeaderResult captures the post-application state a Task 10
 // scenario run produces, so gate-on and gate-off runs can be compared.
 type guardExpiredLeaderResult struct {


### PR DESCRIPTION
## Summary

Skip a stake-reward round when persisted pool inputs do not include complete block-production counts. Missing counts are unavailable data, not zero performance; proceeding would persist an incorrect reward result.

## Validation

- `go test -v ./ledger -run ^TestRewardPoolInputsHaveBlockCounts$ -count=1`
- `go test ./ledger -run TestApplyStakeRewards|TestPrecomputeStakeRewards -count=1`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips stake-reward rounds when persisted pool inputs lack complete block-production counts, instead of treating missing counts as zero and persisting incorrect reward results.

**Bug Fixes**
- The round is skipped with a warning log before reward calculation when counts are missing.
- The round can only be retried once a complete basis is available.
- Adds tests covering nil inputs and missing individual count fields.

<sup>Written for commit cd0bbec96dcdaaed8acf1ecb26f7d3ff5c28be44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

