### PR TITLE
fix(ledger): floor reward expected blocks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8983,7 +8983,13 @@ reward application first, ADA-pot capture last) by
 Reward protocol parameters and block-production counts come from the delayed
 performance epoch, while epoch length comes from the RUPD calculation epoch —
 see "Blockchain State Management" above for the derivation from
-cardano-ledger's `startStep`. TPraos
+cardano-ledger's `startStep`. The global performance factor follows
+`createRUpd`: expected blocks are
+`floor((1-d) * activeSlotCoeff * slotsPerEpoch)` before actual blocks are
+divided by that integer (or performance is fixed at 1 while `d >= 0.8`). The
+floor is consensus-visible through monetary expansion; `rewards.Result` keeps
+the existing rational API field but always returns an integer-valued result.
+TPraos
 overlay slots are excluded while decentralization is non-zero. Pre-Babbage
 calculation resolves the reward prefilter from stake-account certificate
 history immediately before the first reward-update slot, using the RUPD

--- a/ledger/rewards/rewards.go
+++ b/ledger/rewards/rewards.go
@@ -197,9 +197,11 @@ type Result struct {
 	Unspendable      uint64
 	TotalCirculation uint64
 	TotalBlocks      uint64
-	ExpectedBlocks   *big.Rat
-	pendingRewards   []pendingReward
-	poolAccounted    []uint64
+	// ExpectedBlocks is the ledger-specified integer expectation represented
+	// as a rational for compatibility with the existing result contract.
+	ExpectedBlocks *big.Rat
+	pendingRewards []pendingReward
+	poolAccounted  []uint64
 }
 
 type PoolReward struct {
@@ -1201,9 +1203,12 @@ func ApportionFullPot(baseRewards []uint64, availableRewards uint64) []uint64 {
 
 func expectedBlocks(params Parameters) *big.Rat {
 	nonObftSlots := new(big.Rat).Sub(oneRat(), params.Decentralization)
-	return new(big.Rat).Mul(
+	expected := new(big.Rat).Mul(
 		new(big.Rat).Mul(nonObftSlots, params.ActiveSlotsCoeff),
 		uintRat(params.EpochLength),
+	)
+	return new(big.Rat).SetInt(
+		new(big.Int).Quo(expected.Num(), expected.Denom()),
 	)
 }
 

--- a/ledger/rewards/rewards_test.go
+++ b/ledger/rewards/rewards_test.go
@@ -1485,7 +1485,7 @@ func TestCalculateRewardPotMatchesCFCalculatorEtaBoundaryVectors(t *testing.T) {
 	}
 }
 
-func TestCalculateKeepsFractionalExpectedBlocksExact(t *testing.T) {
+func TestCalculateFloorsExpectedBlocksPerShelleySpec(t *testing.T) {
 	params := testParams()
 	params.EpochLength = 10
 	params.ActiveSlotsCoeff = big.NewRat(1, 3)
@@ -1501,9 +1501,18 @@ func TestCalculateKeepsFractionalExpectedBlocksExact(t *testing.T) {
 		}},
 	}, params)
 	require.NoError(t, err)
-	require.Equal(t, big.NewRat(10, 3), result.ExpectedBlocks)
-	require.Equal(t, big.NewRat(3, 10), result.Efficiency)
-	require.Equal(t, uint64(30), result.Incentives)
+	require.Equal(t, big.NewRat(3, 1), result.ExpectedBlocks)
+	require.Equal(t, big.NewRat(1, 3), result.Efficiency)
+	require.Equal(t, uint64(33), result.Incentives)
+}
+
+func TestCalculateRejectsExpectedBlocksThatFloorToZero(t *testing.T) {
+	params := testParams()
+	params.EpochLength = 1
+	params.ActiveSlotsCoeff = big.NewRat(1, 2)
+
+	_, err := Calculate(Pots{Reserves: 100}, Snapshot{}, params)
+	require.ErrorIs(t, err, ErrInvalidParameters)
 }
 
 func TestCalculateRejectsInvalidUnitIntervals(t *testing.T) {


### PR DESCRIPTION
## Summary

- floor expected blocks before calculating reward efficiency, matching Shelley `createRUpd` and `cardano-ledger`
- preserve the exported rational result type while returning the ledger-specified integer value
- cover fractional and zero-after-floor cases and document the consensus rule

Refs #1959

## Validation

- `go test ./ledger/rewards -count=1`
- `go test -race ./ledger/rewards -count=1`
- `go test ./ledger -run '^TestApplyStakeRewardsUsesPrecomputedOutputs$' -count=1 -timeout=5m`
- `go test ./internal/docsparity -count=1`
- `go vet ./ledger/rewards`
- `nilaway ./ledger/rewards`
- `make golines`
- `git diff --check`

The full conformance corpus timed out in Badger filesystem sync during backend reset/close under host I/O contention; no vector assertion failed. Full lint's Linux and Windows golangci passes were clean; nilaway stopped on findings reproduced unchanged on `origin/main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Floors expected blocks before calculating reward efficiency, matching Shelley's `createRUpd` and fixing reward parity (#1959). Previously the fractional rational expectation was used as-is; now the ledger-specified integer value is used, which changes incentive amounts for fractional expectations and rejects expectations that floor to zero.

- Preserves the rational `Result.ExpectedBlocks` field for API compatibility, but it always holds an integer value.
- Documents the consensus-visible floor rule in `ARCHITECTURE.md` and adds tests for fractional and zero-after-floor cases.

<sup>Written for commit 28ed678b3250096354a52b12b57eb5f576f842e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

