### PR TITLE
fix(ledger): anchor forecast fallback to current epoch

### DIFF
--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -187,6 +187,57 @@ func TestProtocolParamsForSlot_UsesMultiEraEpochs(t *testing.T) {
 		"the first Shelley slot after a Byron prefix must forecast the scheduled fork")
 }
 
+// TestProtocolParamsForSlot_FallbackProjectsFromCurrentEpoch verifies the
+// bounded-summary error path. A slot beyond the forecast horizon still needs
+// an epoch estimate, and that estimate must retain the absolute epoch offset
+// introduced by earlier eras.
+func TestProtocolParamsForSlot_FallbackProjectsFromCurrentEpoch(t *testing.T) {
+	const (
+		byronEpochs      = uint64(2)
+		byronEpochLength = uint64(100)
+		currentEpoch     = uint64(207)
+		shelleyEpochLen  = uint64(432)
+	)
+	currentStart := byronEpochs*byronEpochLength +
+		(currentEpoch-byronEpochs)*shelleyEpochLen
+	targetEpoch := currentEpoch + 100
+	targetSlot := currentStart + (targetEpoch-currentEpoch)*shelleyEpochLen
+	cfg := newMultiEraForecastCfg(t, targetEpoch)
+
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 0, StartSlot: 0, SlotLength: 20_000,
+				LengthInSlots: uint(byronEpochLength), EraId: eras.ByronEraDesc.Id},
+			{EpochId: 1, StartSlot: byronEpochLength, SlotLength: 20_000,
+				LengthInSlots: uint(byronEpochLength), EraId: eras.ByronEraDesc.Id},
+			{EpochId: currentEpoch, StartSlot: currentStart, SlotLength: 1_000,
+				LengthInSlots: uint(shelleyEpochLen), EraId: eras.ShelleyEraDesc.Id},
+		},
+		currentEra: eras.ShelleyEraDesc,
+		currentEpoch: models.Epoch{
+			EpochId: currentEpoch, StartSlot: currentStart,
+			SlotLength: 1_000, LengthInSlots: uint(shelleyEpochLen),
+			EraId: eras.ShelleyEraDesc.Id,
+		},
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(
+			currentStart-1, []byte("tip"),
+		)},
+		currentPParams: &shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+	_, err := ls.SlotToEpoch(targetSlot)
+	require.Error(t, err, "the target must exercise the bounded-summary fallback")
+
+	got, ok := ls.ProtocolParamsForSlot(targetSlot).(*shelley.ShelleyProtocolParameters)
+	require.True(t, ok)
+	require.Equal(t, uint(3), got.ProtocolMajor,
+		"fallback epoch projection must preserve the Byron epoch offset")
+}
+
 func newMultiEraForecastCfg(t *testing.T, forkEpoch uint64) *cardano.CardanoNodeConfig {
 	t.Helper()
 	cfg := &cardano.CardanoNodeConfig{}

--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -230,7 +231,8 @@ func TestProtocolParamsForSlot_FallbackProjectsFromCurrentEpoch(t *testing.T) {
 	}
 	ls.publishSnapshotsLocked()
 	_, err := ls.SlotToEpoch(targetSlot)
-	require.Error(t, err, "the target must exercise the bounded-summary fallback")
+	require.ErrorIs(t, err, hardfork.ErrPastHorizon,
+		"the target must exercise the bounded-summary fallback")
 
 	got, ok := ls.ProtocolParamsForSlot(targetSlot).(*shelley.ShelleyProtocolParameters)
 	require.True(t, ok)

--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,6 +125,86 @@ func TestProtocolParamsForSlot_ForecastsBumpAtBoundarySlot(t *testing.T) {
 			"will produce an Allegra block at it.",
 		got75Major,
 	)
+}
+
+// TestProtocolParamsForSlot_UsesMultiEraEpochs ensures the target epoch is
+// resolved from the complete era history. Dividing an absolute slot by the
+// current era's epoch length loses the epochs occupied by a Byron prefix and
+// can therefore miss a scheduled fork at the first future Shelley boundary.
+func TestProtocolParamsForSlot_UsesMultiEraEpochs(t *testing.T) {
+	const (
+		byronEpochs       = 2
+		byronEpochLength  = uint(100)
+		shelleyEpoch      = uint64(207)
+		shelleyEpochLen   = uint(432)
+		byronEndSlot      = uint64(byronEpochs) * uint64(byronEpochLength)
+		currentEpochStart = byronEndSlot + (shelleyEpoch-2)*uint64(shelleyEpochLen)
+		boundarySlot      = currentEpochStart + uint64(shelleyEpochLen)
+	)
+
+	cfg := newMultiEraForecastCfg(t, shelleyEpoch+1)
+	epochCache := make([]models.Epoch, 0, int(shelleyEpoch)+1)
+	for epoch := uint64(0); epoch < byronEpochs; epoch++ {
+		epochCache = append(epochCache, models.Epoch{
+			EpochId:       epoch,
+			StartSlot:     epoch * uint64(byronEpochLength),
+			SlotLength:    20_000,
+			LengthInSlots: byronEpochLength,
+			EraId:         eras.ByronEraDesc.Id,
+		})
+	}
+	for epoch := uint64(2); epoch <= shelleyEpoch; epoch++ {
+		epochCache = append(epochCache, models.Epoch{
+			EpochId:       epoch,
+			StartSlot:     byronEndSlot + (epoch-2)*uint64(shelleyEpochLen),
+			SlotLength:    1_000,
+			LengthInSlots: shelleyEpochLen,
+			EraId:         eras.ShelleyEraDesc.Id,
+		})
+	}
+
+	ls := &LedgerState{
+		epochCache:   epochCache,
+		currentEra:   eras.ShelleyEraDesc,
+		currentEpoch: epochCache[len(epochCache)-1],
+		currentTip: ochainsync.Tip{Point: ocommon.NewPoint(
+			boundarySlot-1, []byte("tip"),
+		)},
+		currentPParams: &shelley.ShelleyProtocolParameters{
+			ProtocolMajor: 2,
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: cfg,
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	got := ls.ProtocolParamsForSlot(boundarySlot)
+	gotShelley, ok := got.(*shelley.ShelleyProtocolParameters)
+	require.True(t, ok)
+	require.Equal(t, uint(3), gotShelley.ProtocolMajor,
+		"the first Shelley slot after a Byron prefix must forecast the scheduled fork")
+}
+
+func newMultiEraForecastCfg(t *testing.T, forkEpoch uint64) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(t, cfg.LoadByronGenesisFromReader(strings.NewReader(`{
+		"blockVersionData": { "slotDuration": "20000" },
+		"protocolConsts": { "k": 1 }
+	}`)))
+	require.NoError(t, cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"activeSlotsCoeff": 0.4,
+		"securityParam": 1,
+		"slotLength": 1,
+		"epochLength": 432,
+		"systemStart": "2026-01-01T00:00:00Z"
+	}`)))
+	enabled := true
+	cfg.ExperimentalHardForksEnabled = &enabled
+	cfg.TestAllegraHardForkAtEpoch = &forkEpoch
+	return cfg
 }
 
 // TestProtocolParamsForSlot_ForecastsPendingPParamUpdateAtNormalBoundary is

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8817,17 +8817,28 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 	// through the multi-era converter so a Byron prefix does not make a
 	// future Shelley slot appear to belong to an early epoch.
 	slotEpoch := currentEpoch.EpochId
-	if slot >= currentEpoch.StartSlot {
+	// Use the epoch cache from the same immutable snapshot as the other
+	// forecast inputs. Calling ls.SlotToEpoch here would load a second snapshot
+	// and could mix its epoch cache with currentEpoch/currentEra/currentPParams
+	// across a concurrent rollover or rollback.
+	for i := len(snapshot.epochCache) - 1; i >= 0; i-- {
+		epoch := snapshot.epochCache[i]
+		if slot < epoch.StartSlot {
+			continue
+		}
+		slotEpoch = epoch.EpochId
+		if epoch.LengthInSlots != 0 {
+			slotEpoch += (slot - epoch.StartSlot) /
+				uint64(epoch.LengthInSlots)
+		}
+		break
+	}
+	if len(snapshot.epochCache) == 0 && slot >= currentEpoch.StartSlot {
+		// With no cache, project from the captured current epoch. This retains
+		// the absolute epoch offset while preserving the existing bare-state
+		// forecast behavior.
 		slotEpoch += (slot - currentEpoch.StartSlot) /
 			uint64(currentEpoch.LengthInSlots)
-	} else {
-		// A historical slot cannot require forecasting beyond the current
-		// epoch. Keep the old absolute-slot estimate only as a conservative
-		// value for the comparison below.
-		slotEpoch = slot / uint64(currentEpoch.LengthInSlots)
-	}
-	if slotInfo, err := ls.SlotToEpoch(slot); err == nil {
-		slotEpoch = slotInfo.EpochId
 	}
 	if slotEpoch <= currentEpoch.EpochId {
 		return currentPParams

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8813,7 +8813,13 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 	if currentPParams == nil || currentEpoch.LengthInSlots == 0 {
 		return currentPParams
 	}
+	// Epoch lengths can change at an era boundary. Resolve the target slot
+	// through the multi-era converter so a Byron prefix does not make a
+	// future Shelley slot appear to belong to an early epoch.
 	slotEpoch := slot / uint64(currentEpoch.LengthInSlots)
+	if slotInfo, err := ls.SlotToEpoch(slot); err == nil {
+		slotEpoch = slotInfo.EpochId
+	}
 	if slotEpoch <= currentEpoch.EpochId {
 		return currentPParams
 	}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8816,7 +8816,16 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 	// Epoch lengths can change at an era boundary. Resolve the target slot
 	// through the multi-era converter so a Byron prefix does not make a
 	// future Shelley slot appear to belong to an early epoch.
-	slotEpoch := slot / uint64(currentEpoch.LengthInSlots)
+	slotEpoch := currentEpoch.EpochId
+	if slot >= currentEpoch.StartSlot {
+		slotEpoch += (slot - currentEpoch.StartSlot) /
+			uint64(currentEpoch.LengthInSlots)
+	} else {
+		// A historical slot cannot require forecasting beyond the current
+		// epoch. Keep the old absolute-slot estimate only as a conservative
+		// value for the comparison below.
+		slotEpoch = slot / uint64(currentEpoch.LengthInSlots)
+	}
 	if slotInfo, err := ls.SlotToEpoch(slot); err == nil {
 		slotEpoch = slotInfo.EpochId
 	}


### PR DESCRIPTION
## Summary

- Resolve forecast epochs from the multi-era slot converter.
- Anchor the bounded-summary fallback to the current epoch start slot.
- Add coverage for Byron-prefixed multi-era forecasts and fallback projection.

Fixes #3426

## Validation

- `go test -tags dingo_extra_plugins ./ledger -run 'TestProtocolParamsForSlot_(FallbackProjectsFromCurrentEpoch|UsesMultiEraEpochs|ForecastsBumpAtBoundarySlot)$' -count=1 -timeout=5m`
- `go test -race -tags dingo_extra_plugins ./ledger -run 'TestProtocolParamsForSlot_(FallbackProjectsFromCurrentEpoch|UsesMultiEraEpochs|ForecastsBumpAtBoundarySlot)$' -count=1 -timeout=5m`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ProtocolParamsForSlot` forecast resolution so scheduled protocol-parameter forks are detected on multi-era chains with a Byron prefix. Previously the target slot was divided by the current era's epoch length, which loses the epochs occupied by earlier eras and could miss a fork at the first future Shelley boundary; now the target epoch is resolved through the multi-era slot converter, and the bounded-summary fallback projects from the current epoch's start slot. Forecast inputs now come from a single immutable snapshot, so a concurrent rollover or rollback can't mix epoch cache data with the captured current state. Fixes #3426.

**Validation**
- Added tests covering Byron-prefixed multi-era forecasts, the fallback projection, and snapshot consistency.
- Run `go test -tags dingo_extra_plugins ./ledger -run 'TestProtocolParamsForSlot_(FallbackProjectsFromCurrentEpoch|UsesMultiEraEpochs|ForecastsBumpAtBoundarySlot)$' -count=1 -timeout=5m`, with and without `-race`.

<sup>Written for commit 05e26e3f6387372bbc850b20276a4a5897b1c560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

