### PR TITLE
fix(ledger): align opcert and cached-batch comments with behavior

### DIFF
--- a/ledger/byron_shelley_boundary_test.go
+++ b/ledger/byron_shelley_boundary_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -438,6 +439,15 @@ func TestByronShelleyBoundaryProcessesFirstShelleyBlockWithPParams(
 // firstShelley is ever applied -- previously told the reader goroutine this
 // result was fully consumed while the tip was still at the pre-boundary
 // block, letting it start gathering and decoding the next raw batch early.
+//
+// firstShelley carries no transactions, so the existing
+// beforeTransactionApplyPublish hook (gated on having transaction events to
+// publish) never fires for it and can't be used to pin this timing. Instead
+// this test uses the dedicated beforeReadResultDoneSignal hook, which fires
+// unconditionally once per outer-loop pass, to deterministically pause the
+// pipeline goroutine at each pass boundary and assert on done's state there
+// -- rather than racing a separate observer goroutine against the
+// pipeline's own progress after done closes.
 func TestByronShelleyBoundaryDefersReadResultDoneUntilCachedBatchApplied(
 	t *testing.T,
 ) {
@@ -452,30 +462,149 @@ func TestByronShelleyBoundaryDefersReadResultDoneUntilCachedBatchApplied(
 	}
 	close(results)
 
-	slotAtDone := make(chan uint64, 1)
+	requireDoneNotYetClosed := func(msg string) {
+		t.Helper()
+		select {
+		case <-done:
+			t.Fatal(msg)
+		default:
+		}
+	}
+
+	// passReached/releasePass rendezvous with the pipeline goroutine inside
+	// beforeReadResultDoneSignal: once a receive on passReached completes,
+	// the pipeline goroutine's only next step is to block on releasePass
+	// (see beforeReadResultDoneSignal's body below), so it is guaranteed to
+	// not yet have run completeReadResult() for this pass.
+	passReached := make(chan struct{})
+	releasePass := make(chan struct{})
+	ls.beforeReadResultDoneSignal = func() {
+		passReached <- struct{}{}
+		<-releasePass
+	}
+
+	processDone := make(chan error, 1)
 	go func() {
-		<-done
-		ls.RLock()
-		defer ls.RUnlock()
-		slotAtDone <- ls.currentTip.Point.Slot
+		processDone <- ls.ledgerProcessBlocksFromSource(
+			context.Background(),
+			results,
+		)
 	}()
 
-	require.NoError(t, ls.ledgerProcessBlocksFromSource(
-		context.Background(),
-		results,
-	))
+	// Pass 1: discovers the epoch boundary and defers firstShelley into
+	// cachedNextBatch without applying it.
+	testutil.RequireReceive(
+		t, passReached, 2*time.Second,
+		"pass 1 (boundary discovery) never reached the done-signal hook",
+	)
+	requireDoneNotYetClosed(
+		"done must not fire after only the boundary-discovery pass",
+	)
+	releasePass <- struct{}{}
+
+	// Pass 2: runs the epoch/era rollover and then actually applies
+	// firstShelley.
+	testutil.RequireReceive(
+		t, passReached, 2*time.Second,
+		"pass 2 (cached-batch apply) never reached the done-signal hook",
+	)
+	ls.RLock()
+	appliedSlot := ls.currentTip.Point.Slot
+	ls.RUnlock()
+	require.Equal(
+		t,
+		firstShelley.SlotNumber(),
+		appliedSlot,
+		"firstShelley must already be applied by the time the second "+
+			"pass reaches the done-signal hook",
+	)
+	requireDoneNotYetClosed(
+		"done must not fire until the pass that actually applied the " +
+			"deferred block finishes",
+	)
+	releasePass <- struct{}{}
+
+	require.NoError(t, <-processDone)
 
 	select {
-	case observed := <-slotAtDone:
-		assert.Equal(
-			t,
-			firstShelley.SlotNumber(),
-			observed,
-			"done must not fire until the deferred cached batch "+
-				"(firstShelley) is actually applied, not merely discovered",
-		)
-	case <-time.After(5 * time.Second):
+	case <-done:
+	case <-time.After(2 * time.Second):
 		t.Fatal("readChainResult.done was never closed")
+	}
+}
+
+// TestByronShelleyBoundaryClosesReadResultDoneOnEpochRolloverFailure is a
+// regression test for a deadlock the cachedNextBatch fix above could
+// otherwise introduce: once a boundary-crossing batch defers its remainder
+// to cachedNextBatch, currentReadResultDone is deliberately left open (not
+// closed) across the pass boundary -- see the "cachedNextBatch != nil"
+// branch and the completeReadResult() guard in
+// ledgerProcessBlocksFromSource. If the epoch/era rollover that runs at the
+// top of the next pass then fails, the function returns before that guard
+// ever runs, and would leave the read-chain reader goroutine blocked on
+// <-result.done forever.
+//
+// This forces that exact rollover failure (by clearing CardanoNodeConfig,
+// which processEpochRollover checks first) after firstShelley's boundary
+// crossing has already deferred it to cachedNextBatch, and asserts that
+// ledgerProcessBlocksFromSource still signals done before returning its
+// error.
+func TestByronShelleyBoundaryClosesReadResultDoneOnEpochRolloverFailure(
+	t *testing.T,
+) {
+	ls, _, firstShelley := newByronShelleyBoundaryLedger(t)
+	require.True(t, ls.validationEnabled)
+
+	results := make(chan readChainResult, 1)
+	done := make(chan struct{})
+	results <- readChainResult{
+		blocks: []gledger.Block{firstShelley},
+		done:   done,
+	}
+	close(results)
+
+	passReached := make(chan struct{})
+	releasePass := make(chan struct{})
+	ls.beforeReadResultDoneSignal = func() {
+		passReached <- struct{}{}
+		<-releasePass
+	}
+
+	processDone := make(chan error, 1)
+	go func() {
+		processDone <- ls.ledgerProcessBlocksFromSource(
+			context.Background(),
+			results,
+		)
+	}()
+
+	// Pass 1: discovers the epoch boundary and defers firstShelley into
+	// cachedNextBatch. Break processEpochRollover for the pass that
+	// follows, right before releasing it -- ensureReferencedEndorserBlocks
+	// and the rest of pass 1 don't touch CardanoNodeConfig for this
+	// single-block batch, so clearing it here only affects pass 2.
+	testutil.RequireReceive(
+		t, passReached, 2*time.Second,
+		"pass 1 (boundary discovery) never reached the done-signal hook",
+	)
+	ls.config.CardanoNodeConfig = nil
+	releasePass <- struct{}{}
+
+	err := testutil.RequireReceive(
+		t, processDone, 2*time.Second,
+		"ledgerProcessBlocksFromSource never returned after the forced "+
+			"epoch-rollover failure",
+	)
+	require.ErrorContains(t, err, "process epoch rollover")
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"readChainResult.done was left open after an epoch-rollover " +
+				"failure, which would block the read-chain reader goroutine " +
+				"forever",
+		)
 	}
 }
 

--- a/ledger/byron_shelley_boundary_test.go
+++ b/ledger/byron_shelley_boundary_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
@@ -420,6 +421,62 @@ func TestByronShelleyBoundaryProcessesFirstShelleyBlockWithPParams(
 	require.True(t, ok, "the first Shelley block must install Shelley pparams")
 	assert.Equal(t, uint(2), pparams.ProtocolMajor)
 	assert.Equal(t, firstShelley.SlotNumber(), ls.currentTip.Point.Slot)
+}
+
+// TestByronShelleyBoundaryDefersReadResultDoneUntilCachedBatchApplied is a
+// regression test for issue #3533: ledgerProcessBlocksFromSource must not
+// signal a readChainResult's done channel until the whole result has been
+// applied, including any post-boundary remainder deferred through
+// cachedNextBatch.
+//
+// firstShelley alone crosses the Byron/Shelley epoch boundary (see
+// newByronShelleyBoundaryLedger), so processing this one-block batch takes
+// two outer-loop passes: the first discovers the boundary and defers the
+// entire block to cachedNextBatch without applying it (blocksProcessed stays
+// 0); the second runs the epoch/era rollover and then actually applies
+// firstShelley. Signalling done at the end of the first pass -- before
+// firstShelley is ever applied -- previously told the reader goroutine this
+// result was fully consumed while the tip was still at the pre-boundary
+// block, letting it start gathering and decoding the next raw batch early.
+func TestByronShelleyBoundaryDefersReadResultDoneUntilCachedBatchApplied(
+	t *testing.T,
+) {
+	ls, _, firstShelley := newByronShelleyBoundaryLedger(t)
+	require.True(t, ls.validationEnabled)
+
+	results := make(chan readChainResult, 1)
+	done := make(chan struct{})
+	results <- readChainResult{
+		blocks: []gledger.Block{firstShelley},
+		done:   done,
+	}
+	close(results)
+
+	slotAtDone := make(chan uint64, 1)
+	go func() {
+		<-done
+		ls.RLock()
+		defer ls.RUnlock()
+		slotAtDone <- ls.currentTip.Point.Slot
+	}()
+
+	require.NoError(t, ls.ledgerProcessBlocksFromSource(
+		context.Background(),
+		results,
+	))
+
+	select {
+	case observed := <-slotAtDone:
+		assert.Equal(
+			t,
+			firstShelley.SlotNumber(),
+			observed,
+			"done must not fire until the deferred cached batch "+
+				"(firstShelley) is actually applied, not merely discovered",
+		)
+	case <-time.After(5 * time.Second):
+		t.Fatal("readChainResult.done was never closed")
+	}
 }
 
 // TestByronShelleyBoundarySeedsEpochNonceOnProductionPath pins the fix for

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -5426,8 +5426,10 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 		}
 		if cachedNextBatch != nil {
 			// Use cached block batch — keep the original
-			// currentReadResultDone so the reader goroutine
-			// is signalled when all cached blocks are processed.
+			// currentReadResultDone (do not reset it below) so the reader
+			// goroutine is signalled only once cachedNextBatch is fully
+			// drained, at the completeReadResult() guard at the bottom of
+			// this loop.
 			nextBatch = cachedNextBatch
 			cachedNextBatch = nil
 		} else {
@@ -5997,7 +5999,15 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 			// Periodic sync progress reporting
 			ls.logSyncProgress(tipForLog.Point.Slot)
 		}
-		completeReadResult()
+		// An epoch/era boundary mid-batch defers the post-boundary remainder
+		// to cachedNextBatch for the next outer-loop pass (see the
+		// "cachedNextBatch != nil" branch above) instead of reading a fresh
+		// result. Only signal the reader goroutine once that remainder is
+		// nil too, so the signal represents the whole original result being
+		// processed, not just the pre-boundary chunk of it.
+		if cachedNextBatch == nil {
+			completeReadResult()
+		}
 	}
 }
 

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1062,6 +1062,14 @@ type LedgerState struct {
 	// production; tests use it to hold the exact post-commit/pre-publication
 	// window without relying on scheduler timing.
 	beforeTransactionApplyPublish func()
+	// beforeReadResultDoneSignal is a test-only hook called once per
+	// ledgerProcessBlocksFromSource outer-loop pass, immediately before that
+	// pass decides whether to signal the current readChainResult's done
+	// channel (see the cachedNextBatch handling there). Nil in production;
+	// tests use it to deterministically observe, at each pass boundary,
+	// that done has not yet been signalled -- without racing a separate
+	// goroutine against the pipeline's own progress.
+	beforeReadResultDoneSignal func()
 
 	// replayMu serializes replayWG.Add with Close's replayWG.Wait to
 	// prevent Add-after-Wait panics from the TOCTOU race between
@@ -5144,6 +5152,14 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				return nil
 			}, true)
 			if err != nil {
+				// This runs on the pass after a boundary-crossing batch
+				// deferred its remainder to cachedNextBatch, which (per the
+				// cachedNextBatch != nil branch below) leaves
+				// currentReadResultDone live rather than already closed.
+				// Without this, a rollover failure here would return
+				// without ever signalling the reader goroutine, which
+				// would then block on <-result.done forever.
+				completeReadResult()
 				return fmt.Errorf("process epoch rollover: %w", err)
 			}
 
@@ -6005,6 +6021,9 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 		// result. Only signal the reader goroutine once that remainder is
 		// nil too, so the signal represents the whole original result being
 		// processed, not just the pre-boundary chunk of it.
+		if ls.beforeReadResultDoneSignal != nil {
+			ls.beforeReadResultDoneSignal()
+		}
 		if cachedNextBatch == nil {
 			completeReadResult()
 		}

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -15,8 +15,6 @@
 package ledger
 
 import (
-	"crypto/ed25519"
-	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -245,15 +243,6 @@ func (ls *LedgerState) leiosAnnouncementOCINStaleness(
 	return LeiosAnnouncementFreshOCIN, nil
 }
 
-const (
-	// opCertKesVkeySize is the length of the KES (hot) verification key carried
-	// in an operational certificate.
-	opCertKesVkeySize = 32
-	// opCertSignableSize is the length of the cardano-ledger OCertSignable
-	// representation: KES vkey || counter (uint64 BE) || KES period (uint64 BE).
-	opCertSignableSize = opCertKesVkeySize + 8 + 8
-)
-
 // verifyOpCertColdSignature verifies the pool cold-key signature over the
 // operational certificate.
 //
@@ -261,49 +250,18 @@ const (
 // raw concatenation of the KES (hot) verification key, the issue counter as a
 // big-endian uint64, and the KES period as a big-endian uint64 — NOT a CBOR
 // encoding. This matches what cardano-node signs (verified byte-for-byte
-// against a real cardano-cli NodeOperationalCertificate) and the forging-side
-// check in ledger/forging/keys.go ValidateOpCert.
+// against a real cardano-cli NodeOperationalCertificate; see
+// TestVerifyOpCertColdSignature_RealCardanoCliCert) and the forging-side check
+// in ledger/forging/keys.go ValidateOpCert.
 //
-// gouroboros' ledger.VerifyOpCertSignature is intentionally NOT used here: it
-// hashes a CBOR array ([kes_vkey, issue_number, kes_period]) instead of this
-// raw representation, which does not match real opcerts and would reject every
-// inbound block.
+// gouroboros' ledger.VerifyOpCertSignature builds this same raw
+// representation (via ledger/common.OpCertSignableBytes), so this delegates
+// to it directly instead of re-deriving the byte layout locally. That was not
+// always true: gouroboros previously hashed a CBOR array
+// ([kes_vkey, issue_number, kes_period]) here, which does not match real
+// opcerts and would have rejected every inbound block.
 func verifyOpCertColdSignature(opCert *ledger.OpCert, coldVkey []byte) error {
-	if len(coldVkey) != ed25519.PublicKeySize {
-		return fmt.Errorf(
-			"cold vkey must be %d bytes, got %d",
-			ed25519.PublicKeySize,
-			len(coldVkey),
-		)
-	}
-	if len(opCert.KesVkey) != opCertKesVkeySize {
-		return fmt.Errorf(
-			"KES vkey must be %d bytes, got %d",
-			opCertKesVkeySize,
-			len(opCert.KesVkey),
-		)
-	}
-	if len(opCert.ColdSignature) != ed25519.SignatureSize {
-		return fmt.Errorf(
-			"cold signature must be %d bytes, got %d",
-			ed25519.SignatureSize,
-			len(opCert.ColdSignature),
-		)
-	}
-	var signable [opCertSignableSize]byte
-	copy(signable[:opCertKesVkeySize], opCert.KesVkey)
-	binary.BigEndian.PutUint64(
-		signable[opCertKesVkeySize:opCertKesVkeySize+8],
-		opCert.IssueNumber,
-	)
-	binary.BigEndian.PutUint64(
-		signable[opCertKesVkeySize+8:],
-		opCert.KesPeriod,
-	)
-	if !ed25519.Verify(coldVkey, signable[:], opCert.ColdSignature) {
-		return errors.New("signature verification failed")
-	}
-	return nil
+	return ledger.VerifyOpCertSignature(opCert, coldVkey)
 }
 
 // verifyOpCertHeaderCrypto performs the stateless inbound operational

--- a/ledger/verify_opcert_test.go
+++ b/ledger/verify_opcert_test.go
@@ -109,11 +109,11 @@ func TestOpCertFromHeader_NonPraosReturnsFalse(t *testing.T) {
 // pins the opcert signable representation to real cardano output. The values
 // are taken from a real cardano-cli NodeOperationalCertificate
 // (config/cardano/devnet/keys/opcert.cert). The signature verifies only under
-// the raw 48-byte OCertSignable representation (KES vkey || counter || period);
-// gouroboros' CBOR-based VerifyOpCertSignature rejects it, which is exactly why
-// verifyOpCertColdSignature does not call that function. If this test ever
-// fails, the inbound check has drifted from real cardano and would stall the
-// chain by rejecting valid blocks.
+// the raw 48-byte OCertSignable representation (KES vkey || counter || period),
+// which is what verifyOpCertColdSignature now verifies by delegating directly
+// to gouroboros' ledger.VerifyOpCertSignature. If this test ever fails, either
+// the inbound check or its upstream dependency has drifted from real cardano
+// and would stall the chain by rejecting valid blocks.
 func TestVerifyOpCertColdSignature_RealCardanoCliCert(t *testing.T) {
 	mustHex := func(s string) []byte {
 		b, err := hex.DecodeString(s)


### PR DESCRIPTION
## Summary

Two comments described behavior the code no longer has; this
updates each comment to match the current contract, and fixes the one place
where the underlying behavior itself had actually drifted from what was
intended.

- **Operational-certificate verification** (`ledger/verify_opcert.go`,
  `ledger/verify_opcert_test.go`): the comment claimed gouroboros'
  `ledger.VerifyOpCertSignature` hashes a CBOR array and would reject real
  opcerts. That's no longer true — it now signs the same raw `OCertSignable`
  representation via `ledger/common.OpCertSignableBytes`, confirmed against
  the real cardano-cli certificate already pinned by
  `TestVerifyOpCertColdSignature_RealCardanoCliCert`. `verifyOpCertColdSignature`
  now delegates to it directly instead of re-deriving the byte layout
  locally, removing the duplicate implementation that let the comment go
  stale in the first place.

- **Cached-batch completion signal** (`ledger/state.go`): the comment on
  `ledgerProcessBlocksFromSource`'s `cachedNextBatch` handling claimed the
  read-chain reader's `done` channel is signalled once all cached blocks are
  processed. In practice it closed at the end of the loop pass that merely
  *discovered* an epoch/era boundary, before the deferred post-boundary
  remainder was ever applied — telling the reader goroutine to start
  gathering the next raw batch before this one had actually finished.
  Gated the signal on `cachedNextBatch == nil` so it fires only once the
  whole original batch is processed, matching the comment's (corrected)
  claim.

## Changes by file

- **`ledger/verify_opcert.go`** — Removed the hand-rolled OCertSignable
  byte-layout construction (and its now-unused `crypto/ed25519` /
  `encoding/binary` imports and size constants) and delegated to
  gouroboros' `ledger.VerifyOpCertSignature`. Rewrote the doc comment to
  describe the current, verified state instead of a stale warning.
- **`ledger/verify_opcert_test.go`** — Corrected the doc comment on
  `TestVerifyOpCertColdSignature_RealCardanoCliCert`, which repeated the
  same stale claim about gouroboros' behavior.
- **`ledger/state.go`** — Guarded `completeReadResult()` with
  `cachedNextBatch == nil` so the reader's done-signal fires only after the
  full batch (including any epoch/era-boundary remainder) is applied.
  Corrected the two related comments.
- **`ledger/byron_shelley_boundary_test.go`** — Added
  `TestByronShelleyBoundaryDefersReadResultDoneUntilCachedBatchApplied`, a
  regression test that races a watcher goroutine against the `done` close
  and asserts the tip has already advanced to the deferred block by then.

Closes #3533 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3533. The cached-batch comment in `ledgerProcessBlocksFromSource` no longer matched behavior: the reader's `done` channel closed when an epoch/era boundary was discovered, before the deferred post-boundary remainder was applied. The signal now fires only when the whole original batch is processed, and opcert cold-signature verification delegates to gouroboros instead of re-deriving the byte layout locally.

**Bug Fixes**
- `done` is also closed on the epoch-rollover failure path, so a mid-batch error can't leave the reader goroutine blocked forever.
- Regression tests use a pass-boundary hook to deterministically assert `done`'s state instead of racing it.

**Refactors**
- `verifyOpCertColdSignature` delegates to `ledger.VerifyOpCertSignature`, which signs the same raw `OCertSignable` bytes already pinned against a real cardano-cli certificate, removing the duplicated local construction.

<sup>Written for commit b79ce7eff5decf953cdb17139ed56692aecd6adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block processing so completion is reported only after all deferred blocks have been applied, including blocks spanning the Byron–Shelley boundary.
  * Improved operational certificate signature verification consistency by using the shared verification process.
* **Tests**
  * Added regression coverage for deferred block processing and updated certificate verification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->