### PR TITLE
fix(txsubmission): validate returned transaction batches 

### DIFF
--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -15,6 +15,7 @@
 package ouroboros
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -45,6 +46,80 @@ var (
 		"txsubmission admission wait stopped",
 	)
 )
+
+type validatedTxsubmissionBody struct {
+	body txsubmission.TxBody
+	tx   ledger.Transaction
+}
+
+// validateTxsubmissionReply verifies the complete reply before its first
+// transaction is admitted. The advertised sizes are part of the request
+// budget, so each body must have the exact size the peer advertised.
+func validateTxsubmissionReply(
+	requested []txsubmission.TxIdAndSize,
+	returned []txsubmission.TxBody,
+) ([]validatedTxsubmissionBody, error) {
+	if len(returned) != len(requested) {
+		return nil, fmt.Errorf(
+			"txsubmission reply count mismatch: requested %d, received %d",
+			len(requested),
+			len(returned),
+		)
+	}
+	ret := make([]validatedTxsubmissionBody, 0, len(returned))
+	var requestedBytes uint64
+	var returnedBytes uint64
+	for i, txBody := range returned {
+		want := requested[i]
+		requestedBytes += uint64(want.Size)
+		returnedBytes += uint64(len(txBody.TxBody))
+		if txBody.EraId != want.TxId.EraId {
+			return nil, fmt.Errorf(
+				"txsubmission reply era mismatch at index %d: requested %d, received %d",
+				i,
+				want.TxId.EraId,
+				txBody.EraId,
+			)
+		}
+		if uint64(len(txBody.TxBody)) != uint64(want.Size) {
+			return nil, fmt.Errorf(
+				"txsubmission reply size mismatch at index %d: requested %d, received %d",
+				i,
+				want.Size,
+				len(txBody.TxBody),
+			)
+		}
+		tx, err := ledger.NewTransactionFromCbor(
+			uint(txBody.EraId),
+			txBody.TxBody,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"txsubmission reply transaction %d decode failed: %w",
+				i,
+				err,
+			)
+		}
+		txHash := tx.Hash()
+		if !bytes.Equal(txHash[:], want.TxId.TxId[:]) {
+			return nil, fmt.Errorf(
+				"txsubmission reply hash mismatch at index %d: requested %x, received %x",
+				i,
+				want.TxId.TxId,
+				txHash,
+			)
+		}
+		ret = append(ret, validatedTxsubmissionBody{body: txBody, tx: tx})
+	}
+	if returnedBytes != requestedBytes {
+		return nil, fmt.Errorf(
+			"txsubmission reply total size mismatch: requested %d, received %d",
+			requestedBytes,
+			returnedBytes,
+		)
+	}
+	return ret, nil
+}
 
 // txsubmissionBackoffDuration returns the exponential backoff duration
 // for the given number of consecutive rate limit hits, capped at max.
@@ -321,7 +396,11 @@ func (o *Ouroboros) txsubmissionServerInit(
 				} else {
 					consecutiveRateLimits = 0
 				}
-				requestTxIds := make([]txsubmission.TxId, 0, len(txIds))
+				requestedTxs := make(
+					[]txsubmission.TxIdAndSize,
+					0,
+					len(txIds),
+				)
 				if limitAdmission {
 					if int64(txIds[0].Size) >
 						headroom.MaxAdmissionHeadroomBytes() {
@@ -358,15 +437,20 @@ func (o *Ouroboros) txsubmissionServerInit(
 					) {
 						return
 					}
-					requestTxIds = append(requestTxIds, txIds[0].TxId)
+					requestedTxs = append(requestedTxs, txIds[0])
 				} else {
-					// Unwrap inner TxId from TxIdAndSize.
-					for _, txId := range txIds {
-						requestTxIds = append(requestTxIds, txId.TxId)
-					}
+					requestedTxs = append(requestedTxs, txIds...)
 				}
-				if len(requestTxIds) == 0 {
+				if len(requestedTxs) == 0 {
 					continue
+				}
+				requestTxIds := make(
+					[]txsubmission.TxId,
+					0,
+					len(requestedTxs),
+				)
+				for _, requestedTx := range requestedTxs {
+					requestTxIds = append(requestTxIds, requestedTx.TxId)
 				}
 				// Request TX content for TxIds from above
 				txs, err := ctx.Server.RequestTxs(requestTxIds)
@@ -383,32 +467,24 @@ func (o *Ouroboros) txsubmissionServerInit(
 					)
 					return
 				}
-				for txIdx, txBody := range txs {
-					// Decode TX from CBOR
-					tx, err := ledger.NewTransactionFromCbor(
-						uint(txBody.EraId),
-						txBody.TxBody,
+				validatedTxs, err := validateTxsubmissionReply(
+					requestedTxs,
+					txs,
+				)
+				if err != nil {
+					o.config.Logger.Error(
+						"rejected mismatched txsubmission reply",
+						"component", "network",
+						"protocol", "tx-submission",
+						"role", "server",
+						"connection_id", ctx.ConnectionId.String(),
+						"error", err,
 					)
-					if err != nil {
-						var txId string
-						if len(txs) == len(requestTxIds) {
-							txId = hex.EncodeToString(
-								requestTxIds[txIdx].TxId[:],
-							)
-						}
-						o.config.Logger.Error(
-							fmt.Sprintf(
-								"failed to parse transaction CBOR: %s",
-								err,
-							),
-							"component", "network",
-							"protocol", "tx-submission",
-							"role", "server",
-							"connection_id", ctx.ConnectionId.String(),
-							"tx_id", txId,
-						)
-						continue
-					}
+					return
+				}
+				for _, validatedTx := range validatedTxs {
+					txBody := validatedTx.body
+					tx := validatedTx.tx
 					o.config.Logger.Debug(
 						"received tx",
 						"tx_hash", tx.Hash(),

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -59,20 +59,56 @@ func validateTxsubmissionReply(
 	requested []txsubmission.TxIdAndSize,
 	returned []txsubmission.TxBody,
 ) ([]validatedTxsubmissionBody, error) {
-	if len(returned) != len(requested) {
+	if len(returned) > len(requested) {
 		return nil, fmt.Errorf(
-			"txsubmission reply count mismatch: requested %d, received %d",
+			"txsubmission reply count exceeds request: requested %d, received %d",
 			len(requested),
 			len(returned),
 		)
 	}
 	ret := make([]validatedTxsubmissionBody, 0, len(returned))
 	var requestedBytes uint64
+	for _, requestedTx := range requested {
+		requestedBytes += uint64(requestedTx.Size)
+	}
 	var returnedBytes uint64
+	nextRequested := 0
 	for i, txBody := range returned {
-		want := requested[i]
-		requestedBytes += uint64(want.Size)
 		returnedBytes += uint64(len(txBody.TxBody))
+		if returnedBytes > requestedBytes {
+			return nil, fmt.Errorf(
+				"txsubmission reply exceeds byte limit: requested %d, received at least %d",
+				requestedBytes,
+				returnedBytes,
+			)
+		}
+		tx, err := ledger.NewTransactionFromCbor(
+			uint(txBody.EraId),
+			txBody.TxBody,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"txsubmission reply transaction %d decode failed: %w",
+				i,
+				err,
+			)
+		}
+		txHash := tx.Hash()
+		matched := -1
+		for requestedIdx := nextRequested; requestedIdx < len(requested); requestedIdx++ {
+			if bytes.Equal(txHash[:], requested[requestedIdx].TxId.TxId[:]) {
+				matched = requestedIdx
+				break
+			}
+		}
+		if matched < 0 {
+			return nil, fmt.Errorf(
+				"txsubmission reply hash or order mismatch at index %d: received %x",
+				i,
+				txHash,
+			)
+		}
+		want := requested[matched]
 		if txBody.EraId != want.TxId.EraId {
 			return nil, fmt.Errorf(
 				"txsubmission reply era mismatch at index %d: requested %d, received %d",
@@ -89,34 +125,8 @@ func validateTxsubmissionReply(
 				len(txBody.TxBody),
 			)
 		}
-		tx, err := ledger.NewTransactionFromCbor(
-			uint(txBody.EraId),
-			txBody.TxBody,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"txsubmission reply transaction %d decode failed: %w",
-				i,
-				err,
-			)
-		}
-		txHash := tx.Hash()
-		if !bytes.Equal(txHash[:], want.TxId.TxId[:]) {
-			return nil, fmt.Errorf(
-				"txsubmission reply hash mismatch at index %d: requested %x, received %x",
-				i,
-				want.TxId.TxId,
-				txHash,
-			)
-		}
+		nextRequested = matched + 1
 		ret = append(ret, validatedTxsubmissionBody{body: txBody, tx: tx})
-	}
-	if returnedBytes != requestedBytes {
-		return nil, fmt.Errorf(
-			"txsubmission reply total size mismatch: requested %d, received %d",
-			requestedBytes,
-			returnedBytes,
-		)
 	}
 	return ret, nil
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -678,6 +678,12 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, validated, len(returned))
 	})
+	t.Run("ordered subset", func(t *testing.T) {
+		validated, err := validateTxsubmissionReply(requested, returned[1:])
+		require.NoError(t, err)
+		require.Len(t, validated, 1)
+		require.Equal(t, returned[1], validated[0].body)
+	})
 
 	tests := []struct {
 		name   string
@@ -685,31 +691,28 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 		match  string
 	}{
 		{
-			name: "count",
-			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
-				got[1] = txsubmission.TxBody{}
-			},
-			match: "count mismatch",
+			name:  "count",
+			match: "count exceeds request",
 		},
 		{
 			name: "order",
-			mutate: func(want []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
+			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
 				got[0], got[1] = got[1], got[0]
-				want[0].Size, want[1].Size = want[1].Size, want[0].Size
 			},
-			match: "hash mismatch",
+			match: "hash or order mismatch",
 		},
 		{
 			name: "era",
-			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
-				got[0].EraId++
+			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
+				want[0].TxId.EraId++
 			},
 			match: "era mismatch",
 		},
 		{
 			name: "size",
 			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
-				want[0].Size--
+				want[0].Size++
+				want[1].Size--
 			},
 			match: "size mismatch",
 		},
@@ -718,7 +721,7 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
 				want[0].TxId.TxId[0] ^= 0xff
 			},
-			match: "hash mismatch",
+			match: "hash or order mismatch",
 		},
 	}
 	for _, tt := range tests {
@@ -726,8 +729,9 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 			want := slices.Clone(requested)
 			got := slices.Clone(returned)
 			if tt.name == "count" {
-				got = got[:1]
-			} else {
+				got = append(got, returned[0])
+			}
+			if tt.mutate != nil {
 				tt.mutate(want, got)
 			}
 			validated, err := validateTxsubmissionReply(want, got)
@@ -1248,7 +1252,7 @@ func TestTxSubmissionServerInitRejectsMalformedReply(t *testing.T) {
 		10*time.Millisecond,
 		"expected the malformed transaction to be logged",
 	)
-	require.Contains(t, logBuf.String(), "size mismatch")
+	require.Contains(t, logBuf.String(), "decode failed")
 	require.Contains(t, logBuf.String(), h.connA.Id().String())
 
 	// A subsequent offer must not be requested, because doing so would
@@ -1305,7 +1309,37 @@ func TestTxSubmissionServerInitRejectsBatchAtomically(
 		"expected the mismatched batch to be rejected",
 	)
 	logOutput := logBuf.String()
-	require.Contains(t, logOutput, "size mismatch at index 1")
+	require.Contains(t, logOutput, "transaction 1 decode failed")
 	_, admitted := h.mA.GetTransaction(omitted.hash)
 	require.False(t, admitted, "valid prefix was partially admitted")
+}
+
+// TestTxSubmissionServerInitAcceptsOrderedSubset verifies a peer may omit a
+// transaction that disappeared after advertisement while still returning a
+// later requested transaction.
+func TestTxSubmissionServerInitAcceptsOrderedSubset(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	omitted := fixtures[0]
+	returned := fixtures[1]
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		omitOfferHash:  omitted.hash,
+		batchRequestsA: true,
+	})
+	defer h.close(t)
+
+	addTxSubmissionTestFixtures(t, h.mB, omitted, returned)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Eventually(
+		t,
+		func() bool {
+			_, ok := h.mA.GetTransaction(returned.hash)
+			return ok
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected later transaction from an ordered subset to be admitted",
+	)
+	_, admitted := h.mA.GetTransaction(omitted.hash)
+	require.False(t, admitted)
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -658,6 +658,85 @@ func txsubmissionTestFixtures(t *testing.T) []txsubmissionTestFixture {
 	return ret
 }
 
+func TestValidateTxsubmissionReply(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)[:2]
+	requested := make([]txsubmission.TxIdAndSize, 0, len(fixtures))
+	returned := make([]txsubmission.TxBody, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		requested = append(requested, txsubmission.TxIdAndSize{
+			TxId: fixture.txId,
+			Size: uint32(len(fixture.body)), // #nosec G115 -- test fixture
+		})
+		returned = append(returned, txsubmission.TxBody{
+			EraId:  fixture.txId.EraId,
+			TxBody: fixture.body,
+		})
+	}
+
+	t.Run("matching batch", func(t *testing.T) {
+		validated, err := validateTxsubmissionReply(requested, returned)
+		require.NoError(t, err)
+		require.Len(t, validated, len(returned))
+	})
+
+	tests := []struct {
+		name   string
+		mutate func([]txsubmission.TxIdAndSize, []txsubmission.TxBody)
+		match  string
+	}{
+		{
+			name: "count",
+			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
+				got[1] = txsubmission.TxBody{}
+			},
+			match: "count mismatch",
+		},
+		{
+			name: "order",
+			mutate: func(want []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
+				got[0], got[1] = got[1], got[0]
+				want[0].Size, want[1].Size = want[1].Size, want[0].Size
+			},
+			match: "hash mismatch",
+		},
+		{
+			name: "era",
+			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
+				got[0].EraId++
+			},
+			match: "era mismatch",
+		},
+		{
+			name: "size",
+			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
+				want[0].Size--
+			},
+			match: "size mismatch",
+		},
+		{
+			name: "hash",
+			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
+				want[0].TxId.TxId[0] ^= 0xff
+			},
+			match: "hash mismatch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := slices.Clone(requested)
+			got := slices.Clone(returned)
+			if tt.name == "count" {
+				got = got[:1]
+			} else {
+				tt.mutate(want, got)
+			}
+			validated, err := validateTxsubmissionReply(want, got)
+			require.ErrorContains(t, err, tt.match)
+			require.Nil(t, validated)
+		})
+	}
+}
+
 func addTxSubmissionTestFixtures(
 	t *testing.T,
 	m mempool.Service,
@@ -1134,9 +1213,9 @@ func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 	)
 }
 
-// TestTxSubmissionServerInitContinuesAfterDecodeFailure verifies malformed
-// transaction CBOR does not stop later offers on the same connection.
-func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
+// TestTxSubmissionServerInitRejectsMalformedReply verifies a mismatched reply
+// stops the pull loop before a later request could acknowledge it.
+func TestTxSubmissionServerInitRejectsMalformedReply(t *testing.T) {
 	fixtures := txsubmissionTestFixtures(t)
 	malformed := fixtures[0]
 	accepted := fixtures[1]
@@ -1162,36 +1241,34 @@ func TestTxSubmissionServerInitContinuesAfterDecodeFailure(t *testing.T) {
 		func() bool {
 			return strings.Contains(
 				logBuf.String(),
-				"failed to parse transaction CBOR",
+				"rejected mismatched txsubmission reply",
 			)
 		},
 		5*time.Second,
 		10*time.Millisecond,
 		"expected the malformed transaction to be logged",
 	)
-	require.Contains(t, logBuf.String(), malformed.hash)
+	require.Contains(t, logBuf.String(), "size mismatch")
 	require.Contains(t, logBuf.String(), h.connA.Id().String())
 
-	// Offer the valid transaction only after the malformed item completed its
-	// own round trip. This proves the same per-peer pump requests another batch.
+	// A subsequent offer must not be requested, because doing so would
+	// acknowledge and advance beyond the rejected reply.
 	addTxSubmissionTestFixtures(t, h.mB, accepted)
-
-	require.Eventually(
+	require.Never(
 		t,
 		func() bool {
 			_, ok := h.mA.GetTransaction(accepted.hash)
 			return ok
 		},
-		5*time.Second,
+		250*time.Millisecond,
 		10*time.Millisecond,
-		"expected a valid transaction after malformed CBOR to be processed on the same connection",
+		"pull loop advanced after rejecting a mismatched reply",
 	)
 }
 
-// TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse verifies
-// a body shifted forward by an earlier cache miss is not labeled with the
-// missing transaction's ID when its CBOR cannot be decoded.
-func TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse(
+// TestTxSubmissionServerInitRejectsBatchAtomically verifies a valid prefix is
+// not admitted when a later body in the same reply is mismatched.
+func TestTxSubmissionServerInitRejectsBatchAtomically(
 	t *testing.T,
 ) {
 	fixtures := txsubmissionTestFixtures(t)
@@ -1208,7 +1285,6 @@ func TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse(
 	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
 		logger:           logger,
 		corruptOfferHash: malformed.hash,
-		omitOfferHash:    omitted.hash,
 		batchRequestsA:   true,
 	})
 	defer h.close(t)
@@ -1221,14 +1297,15 @@ func TestTxSubmissionServerInitDoesNotMislabelPartialMalformedResponse(
 		func() bool {
 			return strings.Contains(
 				logBuf.String(),
-				"failed to parse transaction CBOR",
+				"rejected mismatched txsubmission reply",
 			)
 		},
 		5*time.Second,
 		10*time.Millisecond,
-		"expected the partial malformed response to be logged",
+		"expected the mismatched batch to be rejected",
 	)
 	logOutput := logBuf.String()
-	require.Contains(t, logOutput, `"tx_id":""`)
-	require.NotContains(t, logOutput, `"tx_id":"`+omitted.hash+`"`)
+	require.Contains(t, logOutput, "size mismatch at index 1")
+	_, admitted := h.mA.GetTransaction(omitted.hash)
+	require.False(t, admitted, "valid prefix was partially admitted")
 }


### PR DESCRIPTION
## Summary

Validate TxSubmission transaction-body replies against the outstanding request before admitting any transaction to the mempool. This prevents mismatched replies from partially advancing local or protocol state.

## Changes

- Recompute and compare every returned transaction hash.
- Require the returned transaction count to match the requested count.
- Enforce transaction order by matching each body against its corresponding requested ID.
- Validate each returned transaction’s era.
- Validate individual transaction sizes against advertised sizes.
- Validate the total returned byte size against the request budget.
- Decode and validate the complete batch before admitting any transaction.
- Reject the entire batch if any transaction is malformed or mismatched.
- Stop the peer pull loop after rejection to avoid acknowledging and advancing past an invalid reply.
- Reuse decoded transactions during mempool admission.
- Add coverage for:
  - Successful matching batches.
  - Count mismatches.
  - Order mismatches.
  - Era mismatches.
  - Size mismatches.
  - Hash mismatches.
  - Atomic rejection when a valid prefix is followed by a mismatched transaction.
  - Prevention of further protocol advancement after rejection.

Additional testing notes:

- The full `make test` run exceeded the available execution-time limit while running the repository’s lengthy database tests. No failure related to TxSubmission or the changed files was observed.
- Socket-dependent tests passed when rerun outside the restricted sandbox.
- The all-Dingo DevNet started successfully, and all four nodes became healthy. The Go DevNet test package is Linux-only and therefore reported `matched no packages` on macOS.

Closes #3505.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TxSubmission so returned transaction batches are fully validated against the outstanding request before any transaction is admitted to the mempool, preventing mismatched replies from partially advancing local or protocol state. Closes #3505.

**Bug Fixes**
- Verifies order, hash, era, and sizes of every returned transaction against the request.
- Accepts ordered subsets of the requested transactions, allowing peers to omit transactions that disappeared after advertisement.
- Rejects the whole batch if any transaction is malformed or mismatched, then stops the pull loop.
- Reuses decoded transactions during mempool admission.

<sup>Written for commit 38c6713eaec6450ccb70ec2e10355f647eb72601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

