### PR TITLE
fix(koiosparity): fail closed on boundary lookup errors

### DIFF
--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -543,6 +543,9 @@ func ComparePoolEpoch(
 	// the grace window it may simply not be computed yet (reference_lag,
 	// ERROR); past it, it's a genuine gap in Dingo's own computation
 	// (dingo_db_missing, ERROR). Neither case can produce a PASS.
+	// RewardsPending is the chain-position form of the same timing check and
+	// takes precedence over the wall-clock grace window, including during
+	// replay where the epoch's close time may be years in the past.
 	if koiosPool.MemberRewards != "" {
 		switch {
 		case !dingoPool.MemberRewardPresent,
@@ -558,7 +561,9 @@ func ComparePoolEpoch(
 			// is a genuine gap in what Dingo can answer (dingo_db_missing,
 			// ERROR).
 			cat := CategoryDBMissing
-			if graceHours > 0 && !epochEndTime.IsZero() &&
+			if dingoPool.RewardsPending {
+				cat = CategoryReferenceLag
+			} else if graceHours > 0 && !epochEndTime.IsZero() &&
 				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour {
 				cat = CategoryReferenceLag
 			}
@@ -582,6 +587,10 @@ func ComparePoolEpoch(
 				dingoValue = dingoPool.MemberRewardTotal
 			}
 			if dingoValue != koiosPool.MemberRewards {
+				cat := CategoryValueMismatch
+				if dingoPool.RewardsPending {
+					cat = CategoryReferenceLag
+				}
 				out = append(out, CheckMismatch{
 					Network:    network,
 					Epoch:      epoch,
@@ -589,7 +598,7 @@ func ComparePoolEpoch(
 					Field:      "member_rewards",
 					DingoValue: dingoValue,
 					KoiosValue: koiosPool.MemberRewards,
-					Category:   CategoryValueMismatch,
+					Category:   cat,
 					CheckedAt:  now,
 				})
 			}

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -487,7 +487,7 @@ func (d *DingoDB) GetPoolEpochDataMap(
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("tip lookup: %w", err)
 		}
-		if err == nil && slot.Valid && slot.Int64 >= 0 && len(hash) > 0 {
+		if err == nil && slot.Valid && slot.Int64 > 0 && len(hash) > 0 {
 			tipSlot = uint64(slot.Int64)
 			tipKnown = true
 		}

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -176,6 +176,11 @@ type DingoPoolEpochData struct {
 	// Subtracting reward_pool_output.unspendable from member_reward_total
 	// would not be equivalent: that column accumulates unspendable leader
 	// rewards too.
+	// RewardsPending reports that the node has not reached the boundary at
+	// which this stake epoch's rewards are applied. The zero value is
+	// deliberately strict: incomplete boundary metadata must not hide a
+	// divergence.
+	RewardsPending             bool
 	SpendableMemberRewardTotal string
 }
 
@@ -468,9 +473,53 @@ func (d *DingoDB) GetPoolEpochDataMap(
 	}
 	_ = rows.Close() //nolint:sqlclosecheck
 
+	// The tip decides whether this stake epoch's rewards have been applied.
+	// An unreadable or empty tip leaves tipKnown false, which keeps comparison
+	// strict rather than downgrading a real divergence on incomplete metadata.
+	var tipSlot uint64
+	tipKnown := false
+	if tipRow := d.queryRow(
+		ctx, `SELECT slot, hash FROM tip ORDER BY id DESC LIMIT 1`,
+	); tipRow != nil {
+		var slot sql.NullInt64
+		var hash []byte
+		err := tipRow.Scan(&slot, &hash)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("tip lookup: %w", err)
+		}
+		if err == nil && slot.Valid && slot.Int64 >= 0 && len(hash) > 0 {
+			tipSlot = uint64(slot.Int64)
+			tipKnown = true
+		}
+	}
+
+	// Rewards for stake epoch E are applied at the boundary into E+3.
+	epochRewardsPending := false
+	if tipKnown {
+		var startSlot sql.NullInt64
+		err := d.queryRow(
+			ctx, `SELECT start_slot FROM epoch WHERE epoch_id = ?`,
+			stakeEpoch+3,
+		).Scan(&startSlot)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			epochRewardsPending = true
+		case err != nil:
+			return nil, fmt.Errorf(
+				"epoch lookup %d: %w", stakeEpoch+3, err,
+			)
+		case !startSlot.Valid || startSlot.Int64 < 0:
+			return nil, fmt.Errorf(
+				"epoch lookup %d: invalid start slot", stakeEpoch+3,
+			)
+		default:
+			epochRewardsPending = tipSlot < uint64(startSlot.Int64)
+		}
+	}
+
 	rows, err = d.query(
 		ctx,
-		`SELECT pool_key_hash, member_reward_total, unspendable FROM reward_pool_output WHERE epoch = ?`,
+		`SELECT pool_key_hash, member_reward_total, unspendable, boundary_slot FROM reward_pool_output WHERE epoch = ?`,
 		stakeEpoch,
 	)
 	if err != nil {
@@ -485,7 +534,10 @@ func (d *DingoDB) GetPoolEpochDataMap(
 		var poolHash []byte
 		var reward types.Uint64
 		var unspendable types.Uint64
-		if err := rows.Scan(&poolHash, &reward, &unspendable); err != nil {
+		var boundarySlot uint64
+		if err := rows.Scan(
+			&poolHash, &reward, &unspendable, &boundarySlot,
+		); err != nil {
 			return nil, err
 		}
 		key := hex.EncodeToString(poolHash)
@@ -497,9 +549,17 @@ func (d *DingoDB) GetPoolEpochDataMap(
 		data.MemberRewardPresent = true
 		data.MemberRewardTotal = strconv.FormatUint(uint64(reward), 10)
 		data.PoolUnspendable = uint64(unspendable)
+		data.RewardsPending = tipKnown && tipSlot < boundarySlot
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+	if epochRewardsPending {
+		for _, data := range m {
+			if !data.MemberRewardPresent {
+				data.RewardsPending = true
+			}
+		}
 	}
 
 	if err := d.addSpendableMemberRewards(ctx, m, stakeEpoch); err != nil {

--- a/internal/koiosparity/rewards_pending_error_test.go
+++ b/internal/koiosparity/rewards_pending_error_test.go
@@ -139,6 +139,42 @@ func TestPositiveSlotWithoutTipHashIsNotPending(t *testing.T) {
 	})
 }
 
+func TestZeroSlotWithTipHashIsNotPending(t *testing.T) {
+	t.Run("standalone source", func(t *testing.T) {
+		db, gdb := openTestDingoDB(t)
+		pool := testPoolKeyHash(t, 0x47)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO reward_pool_input (pool_key_hash, epoch, delegated_stake, delegator_count)
+			 VALUES (?, ?, ?, ?)`, pool, 9, "1000", 1,
+		).Error)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{0x01}, 0, 1,
+		).Error)
+		m, err := db.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		require.False(t, m[hex.EncodeToString(pool)].RewardsPending)
+	})
+
+	t.Run("in-process source", func(t *testing.T) {
+		db := newTestDatabaseSourceDB(t)
+		sqlDB := sourceSQLDB(t, db)
+		pool := testPoolKeyHash(t, 0x48)
+		require.NoError(t, sqlDB.Create(&models.RewardPoolInput{
+			PoolKeyHash: pool, Epoch: 9, DelegatedStake: types.Uint64(1000), DelegatorCount: 1,
+		}).Error)
+		require.NoError(t, sqlDB.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{0x01}, 0, 1,
+		).Error)
+		source, err := NewDatabaseSource(db)
+		require.NoError(t, err)
+		m, err := source.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		require.False(t, m[hex.EncodeToString(pool)].RewardsPending)
+	})
+}
+
 func TestComparePoolEpochUsesRewardsPending(t *testing.T) {
 	memberRewardMismatch := func(mismatches []CheckMismatch) CheckMismatch {
 		for _, mismatch := range mismatches {

--- a/internal/koiosparity/rewards_pending_error_test.go
+++ b/internal/koiosparity/rewards_pending_error_test.go
@@ -101,6 +101,44 @@ func TestMissingApplyingEpochIsThePendingCase(t *testing.T) {
 	})
 }
 
+func TestPositiveSlotWithoutTipHashIsNotPending(t *testing.T) {
+	t.Run("standalone source", func(t *testing.T) {
+		db, gdb := openTestDingoDB(t)
+		pool := testPoolKeyHash(t, 0x45)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO reward_pool_input (pool_key_hash, epoch, delegated_stake, delegator_count)
+			 VALUES (?, ?, ?, ?)`, pool, 9, "1000", 1,
+		).Error)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{}, 100, 1,
+		).Error)
+
+		m, err := db.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		require.False(t, m[hex.EncodeToString(pool)].RewardsPending)
+	})
+
+	t.Run("in-process source", func(t *testing.T) {
+		db := newTestDatabaseSourceDB(t)
+		sqlDB := sourceSQLDB(t, db)
+		pool := testPoolKeyHash(t, 0x46)
+		require.NoError(t, sqlDB.Create(&models.RewardPoolInput{
+			PoolKeyHash: pool, Epoch: 9, DelegatedStake: types.Uint64(1000), DelegatorCount: 1,
+		}).Error)
+		require.NoError(t, sqlDB.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{}, 100, 1,
+		).Error)
+
+		source, err := NewDatabaseSource(db)
+		require.NoError(t, err)
+		m, err := source.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		require.False(t, m[hex.EncodeToString(pool)].RewardsPending)
+	})
+}
+
 func TestComparePoolEpochUsesRewardsPending(t *testing.T) {
 	memberRewardMismatch := func(mismatches []CheckMismatch) CheckMismatch {
 		for _, mismatch := range mismatches {

--- a/internal/koiosparity/rewards_pending_error_test.go
+++ b/internal/koiosparity/rewards_pending_error_test.go
@@ -1,0 +1,133 @@
+package koiosparity
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDingoDBPropagatesApplyingEpochLookupError prevents a failed E+3 lookup
+// from being treated as evidence that rewards are pending. The pending flag is
+// only valid for a missing epoch row; a database failure must reach the caller.
+func TestDingoDBPropagatesApplyingEpochLookupError(t *testing.T) {
+	db, gdb := openTestDingoDB(t)
+	pool := testPoolKeyHash(t, 0x41)
+	require.NoError(t, gdb.Exec(
+		`INSERT INTO reward_pool_input (pool_key_hash, epoch, delegated_stake, delegator_count)
+		 VALUES (?, ?, ?, ?)`, pool, 9, "1000", 1,
+	).Error)
+	require.NoError(t, gdb.Exec(
+		`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+		[]byte{0x01}, 100, 1,
+	).Error)
+	require.NoError(t, gdb.Exec(`DROP TABLE epoch`).Error)
+
+	_, err := db.GetPoolEpochDataMap(context.Background(), 9, 10)
+	require.ErrorContains(t, err, "epoch lookup")
+}
+
+// TestDatabaseSourcePropagatesApplyingEpochLookupError covers the same
+// contract through the in-process source. Both RewardParitySource
+// implementations must fail closed when their E+3 lookup cannot run.
+func TestDatabaseSourcePropagatesApplyingEpochLookupError(t *testing.T) {
+	db := newTestDatabaseSourceDB(t)
+	sqlDB := sourceSQLDB(t, db)
+	pool := testPoolKeyHash(t, 0x42)
+	require.NoError(t, sqlDB.Create(&models.RewardPoolInput{
+		PoolKeyHash:    pool,
+		Epoch:          9,
+		DelegatedStake: types.Uint64(1000),
+		DelegatorCount: 1,
+	}).Error)
+	require.NoError(t, sqlDB.Exec(
+		`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+		[]byte{0x01}, 100, 1,
+	).Error)
+	require.NoError(t, sqlDB.Exec(`DROP TABLE epoch`).Error)
+
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+	_, err = source.GetPoolEpochDataMap(context.Background(), 9, 10)
+	require.ErrorContains(t, err, "epoch lookup 12")
+}
+
+func TestMissingApplyingEpochIsThePendingCase(t *testing.T) {
+	t.Run("standalone source", func(t *testing.T) {
+		db, gdb := openTestDingoDB(t)
+		pool := testPoolKeyHash(t, 0x43)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO reward_pool_input (pool_key_hash, epoch, delegated_stake, delegator_count)
+			 VALUES (?, ?, ?, ?)`, pool, 9, "1000", 1,
+		).Error)
+		require.NoError(t, gdb.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{0x01}, 100, 1,
+		).Error)
+
+		m, err := db.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		data, ok := m[hex.EncodeToString(pool)]
+		require.True(t, ok)
+		require.True(t, data.RewardsPending)
+	})
+
+	t.Run("in-process source", func(t *testing.T) {
+		db := newTestDatabaseSourceDB(t)
+		sqlDB := sourceSQLDB(t, db)
+		pool := testPoolKeyHash(t, 0x44)
+		require.NoError(t, sqlDB.Create(&models.RewardPoolInput{
+			PoolKeyHash:    pool,
+			Epoch:          9,
+			DelegatedStake: types.Uint64(1000),
+			DelegatorCount: 1,
+		}).Error)
+		require.NoError(t, sqlDB.Exec(
+			`INSERT INTO tip (hash, slot, block_number) VALUES (?, ?, ?)`,
+			[]byte{0x01}, 100, 1,
+		).Error)
+
+		source, err := NewDatabaseSource(db)
+		require.NoError(t, err)
+		m, err := source.GetPoolEpochDataMap(context.Background(), 9, 10)
+		require.NoError(t, err)
+		data, ok := m[hex.EncodeToString(pool)]
+		require.True(t, ok)
+		require.True(t, data.RewardsPending)
+	})
+}
+
+func TestComparePoolEpochUsesRewardsPending(t *testing.T) {
+	memberRewardMismatch := func(mismatches []CheckMismatch) CheckMismatch {
+		for _, mismatch := range mismatches {
+			if mismatch.Field == "member_rewards" {
+				return mismatch
+			}
+		}
+		t.Fatal("member_rewards mismatch not found")
+		return CheckMismatch{}
+	}
+
+	koios := &KoiosPoolEpoch{MemberRewards: "1"}
+	dingo := &DingoPoolEpochData{
+		MemberRewardPresent:          true,
+		SpendableMemberRewardPresent: true,
+		SpendableMemberRewardTotal:   "2",
+	}
+
+	dingo.RewardsPending = true
+	mismatches := ComparePoolEpoch(
+		"preview", 96, koios, dingo, time.Now(), 0, time.Time{}, false,
+	)
+	require.Equal(t, CategoryReferenceLag, memberRewardMismatch(mismatches).Category)
+
+	dingo.RewardsPending = false
+	mismatches = ComparePoolEpoch(
+		"preview", 96, koios, dingo, time.Now(), 0, time.Time{}, false,
+	)
+	require.Equal(t, CategoryValueMismatch, memberRewardMismatch(mismatches).Category)
+}

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -268,6 +268,32 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 	defer txn.Release()
 	meta := s.db.Metadata()
 
+	var tipSlot uint64
+	tipKnown := false
+	tip, tipErr := s.db.GetTip(txn)
+	if tipErr != nil {
+		return nil, fmt.Errorf("tip lookup: %w", tipErr)
+	}
+	if len(tip.Point.Hash) > 0 {
+		tipSlot = tip.Point.Slot
+		tipKnown = true
+	}
+
+	epochRewardsPending := false
+	if tipKnown {
+		applyEpoch, err := meta.GetEpoch(stakeEpoch+3, txn.Metadata())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"epoch lookup %d: %w", stakeEpoch+3, err,
+			)
+		}
+		if applyEpoch == nil {
+			epochRewardsPending = true
+		} else {
+			epochRewardsPending = tipSlot < applyEpoch.StartSlot
+		}
+	}
+
 	stakeInputs, err := meta.GetRewardPoolInputs(stakeEpoch, txn.Metadata())
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -332,6 +358,7 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 			10,
 		)
 		data.PoolUnspendable = uint64(out.Unspendable)
+		data.RewardsPending = tipKnown && tipSlot < out.BoundarySlot
 	}
 
 	// The comparable member-reward quantity, formed the same way DingoDB
@@ -375,6 +402,13 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 			data.SpendableMemberRewardPresent = true
 			if data.SpendableMemberRewardTotal == "" {
 				data.SpendableMemberRewardTotal = "0"
+			}
+		}
+	}
+	if epochRewardsPending {
+		for _, data := range m {
+			if !data.MemberRewardPresent {
+				data.RewardsPending = true
 			}
 		}
 	}

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -274,7 +274,7 @@ func (s *DatabaseSource) GetPoolEpochDataMap(
 	if tipErr != nil {
 		return nil, fmt.Errorf("tip lookup: %w", tipErr)
 	}
-	if len(tip.Point.Hash) > 0 {
+	if len(tip.Point.Hash) > 0 && tip.Point.Slot > 0 {
 		tipSlot = tip.Point.Slot
 		tipKnown = true
 	}

--- a/internal/koiosparity/sql_test_helpers_test.go
+++ b/internal/koiosparity/sql_test_helpers_test.go
@@ -92,6 +92,8 @@ func testSchema(includePools bool) []string {
 		ret = append(
 			ret,
 			`CREATE TABLE reward_pool_input (margin TEXT, pool_key_hash BLOB NOT NULL, reward_account BLOB, blocks_produced INTEGER, total_blocks_in_epoch INTEGER, id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL, pledge TEXT NOT NULL DEFAULT '0', delegated_stake TEXT NOT NULL DEFAULT '0', owner_stake TEXT NOT NULL DEFAULT '0', cost TEXT NOT NULL DEFAULT '0', delegator_count INTEGER NOT NULL DEFAULT 0, reward_account_credential_tag INTEGER NOT NULL DEFAULT 0, captured_slot INTEGER NOT NULL DEFAULT 0, boundary_slot INTEGER NOT NULL DEFAULT 0)`,
+			`CREATE TABLE epoch (id INTEGER PRIMARY KEY AUTOINCREMENT, epoch_id INTEGER, start_slot INTEGER, length_in_slots INTEGER)`,
+			`CREATE TABLE tip (hash BLOB, id INTEGER PRIMARY KEY AUTOINCREMENT, slot INTEGER, block_number INTEGER)`,
 			`CREATE TABLE reward_pool_output (apparent_performance TEXT, pool_key_hash BLOB NOT NULL, id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL, optimal_reward TEXT NOT NULL DEFAULT '0', total_reward TEXT NOT NULL DEFAULT '0', leader_reward TEXT NOT NULL DEFAULT '0', member_reward_total TEXT NOT NULL DEFAULT '0', owner_stake TEXT NOT NULL DEFAULT '0', undistributed TEXT NOT NULL DEFAULT '0', unspendable TEXT NOT NULL DEFAULT '0', captured_slot INTEGER NOT NULL DEFAULT 0, boundary_slot INTEGER NOT NULL DEFAULT 0)`,
 		)
 	}


### PR DESCRIPTION
Koios parity now fails closed when tip or applying-epoch boundary lookups return database errors. Only a genuinely missing applying epoch is classified as pending; incomplete boundary metadata remains strict.

Validation:

- Targeted Koios parity tests, race-targeted tests, vet, golangci-lint, gofmt, import-boundaries, and docs-parity passed.
- Full `go test ./internal/koiosparity` is limited by the sandbox: an unrelated `httptest` case cannot listen on `tcp6 [::1]:0` (`operation not permitted`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Koios parity so boundary lookup errors fail closed. Previously, database errors during tip and applying-epoch lookups were treated as evidence that rewards were pending, downgrading real divergences to reference-lag; now those errors propagate, and only a genuinely missing applying epoch is classed as pending. Incomplete chain tips (missing hash or zero slot) also fail closed rather than downgrading.

**Bug Fixes**
- Adds `RewardsPending` to `DingoPoolEpochData`; comparison uses it over the wall-clock grace window, including during replay.
- Both `DingoDB` and `DatabaseSource` require a complete tip and treat tip or applying-epoch lookup failures as errors, so incomplete boundary metadata never hides a divergence.
- Adds tests that lookup errors propagate, incomplete tips stay strict, and pending classification happens only for a missing applying epoch.

Validation:
- Targeted Koios parity tests, race-targeted tests, vet, golangci-lint, gofmt, import-boundaries, and docs-parity passed.
- Full `go test ./internal/koiosparity` is limited by the sandbox: an unrelated `httptest` case cannot listen on `tcp6 [::1]:0` (`operation not permitted`).

<sup>Written for commit 7f0228626106abc1090106440a599a2481b7413d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

