### PR TITLE
build: adopt gouroboros v0.202.8 (#3847)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.7
+	github.com/blinklabs-io/gouroboros v0.202.8
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
 	github.com/blinklabs-io/plutigo v0.5.1
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/blinklabs-io/gouroboros v0.202.6 h1:xIJluYjLjmtZp0tVRXviMzuLm7hNkiT7T
 github.com/blinklabs-io/gouroboros v0.202.6/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/gouroboros v0.202.7 h1:XIM5nk5zv/ZQ/ntNIZfQs5JtoDb74IW3CnEK2JIIXu0=
 github.com/blinklabs-io/gouroboros v0.202.7/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.8 h1:dRw7Dpqd2C9d2WvPl8ePgTuhI3mzhu6ZpDy9fytS7bY=
+github.com/blinklabs-io/gouroboros v0.202.8/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.1 h1:cHmv2LII0fZggrOfp6wzW9t644HzTB6s7/vzHVpHJs8=


### PR DESCRIPTION
Updates Dingo's root gouroboros dependency from v0.202.7 to v0.202.8 for the released ledger fix.

Validation:

- Reproduced the pre-fix initialization panic with gouroboros v0.202.6.
- Existing validation-rule ID coverage passed with gouroboros v0.202.6, v0.202.7, and v0.202.8.
- The full `./ledger/eras` suite passed with gouroboros v0.202.8.

Fixes #3847
