### PR TITLE
fix(database): reject invalid chunk offsets with a typed error

### DIFF
--- a/database/immutable/chunk.go
+++ b/database/immutable/chunk.go
@@ -26,6 +26,13 @@ const (
 	chunkFileExtension = ".chunk"
 )
 
+// ErrInvalidChunkOffset reports a secondary-index block offset that cannot be
+// trusted to seek or slice the chunk file it names: it overflows int64,
+// lands beyond the file's size, or does not strictly follow the offset
+// before it. Callers can match it with errors.Is to distinguish a corrupt or
+// tampered index from an ordinary I/O failure.
+var ErrInvalidChunkOffset = errors.New("invalid chunk offset")
+
 type chunk struct {
 	file         entryReader
 	secondary    *secondaryIndex
@@ -75,14 +82,19 @@ func (c *chunk) Next() (*Block, error) {
 	}
 	if c.nextEntry == nil {
 		if c.currentEntry.BlockOffset > math.MaxInt64 {
-			return nil, errors.New("current block offset integer overflow")
+			return nil, fmt.Errorf(
+				"%w: current block offset %d overflows int64",
+				ErrInvalidChunkOffset,
+				c.currentEntry.BlockOffset,
+			)
 		}
 		// This triggers even though we check it above
 		// #nosec G115
 		currOffset := int64(c.currentEntry.BlockOffset)
 		if currOffset > c.fileSize {
 			return nil, fmt.Errorf(
-				"current block offset %d is beyond chunk size %d",
+				"%w: current block offset %d is beyond chunk size %d",
+				ErrInvalidChunkOffset,
 				currOffset,
 				c.fileSize,
 			)
@@ -130,35 +142,46 @@ func (c *chunk) Next() (*Block, error) {
 	} else {
 		// Calculate block size based on the offsets for the current and next entries
 		if c.currentEntry.BlockOffset > math.MaxInt64 {
-			return nil, errors.New("current block offset integer overflow")
+			return nil, fmt.Errorf(
+				"%w: current block offset %d overflows int64",
+				ErrInvalidChunkOffset,
+				c.currentEntry.BlockOffset,
+			)
 		}
 		// This triggers even though we check it above
 		// #nosec G115
 		currOffset := int64(c.currentEntry.BlockOffset)
 
 		if c.nextEntry.BlockOffset > math.MaxInt64 {
-			return nil, errors.New("next block offset integer overflow")
+			return nil, fmt.Errorf(
+				"%w: next block offset %d overflows int64",
+				ErrInvalidChunkOffset,
+				c.nextEntry.BlockOffset,
+			)
 		}
 		// This triggers even though we check it above
 		// #nosec G115
 		nextOffset := int64(c.nextEntry.BlockOffset)
 		if currOffset > c.fileSize {
 			return nil, fmt.Errorf(
-				"current block offset %d is beyond chunk size %d",
+				"%w: current block offset %d is beyond chunk size %d",
+				ErrInvalidChunkOffset,
 				currOffset,
 				c.fileSize,
 			)
 		}
 		if nextOffset > c.fileSize {
 			return nil, fmt.Errorf(
-				"next block offset %d is beyond chunk size %d",
+				"%w: next block offset %d is beyond chunk size %d",
+				ErrInvalidChunkOffset,
 				nextOffset,
 				c.fileSize,
 			)
 		}
 		if nextOffset <= currOffset {
 			return nil, fmt.Errorf(
-				"next block offset %d does not follow current block offset %d",
+				"%w: next block offset %d does not follow current block offset %d",
+				ErrInvalidChunkOffset,
 				nextOffset,
 				currOffset,
 			)

--- a/database/immutable/index_validation_test.go
+++ b/database/immutable/index_validation_test.go
@@ -16,6 +16,7 @@ package immutable_test
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -121,6 +122,39 @@ func requireGetBlockError(
 	}
 }
 
+// requireGetBlockErrorIs is requireGetBlockError plus an errors.Is check
+// against target. Use it for failures chunk.Next wraps in a sentinel, so a
+// dropped %w is caught even though the message would still match wantSubstr.
+func requireGetBlockErrorIs(
+	t *testing.T,
+	fixture immutableIndexFixture,
+	target error,
+	wantSubstr string,
+) {
+	t.Helper()
+	imm, err := immutable.New(fixture.dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	_, err, panicValue := getBlockRecoveringPanic(imm, ocommon.Point{})
+	if panicValue != nil {
+		t.Fatalf(
+			"GetBlock panicked instead of returning an error: %v",
+			panicValue,
+		)
+	}
+	if !errors.Is(err, target) {
+		t.Fatalf("GetBlock error = %v, want errors.Is match for %v", err, target)
+	}
+	if err == nil || !strings.Contains(err.Error(), wantSubstr) {
+		t.Fatalf(
+			"GetBlock error = %v, want an error containing %q",
+			err,
+			wantSubstr,
+		)
+	}
+}
+
 func TestImmutableIndexAcceptsValidSingleAndMultipleBlockChunks(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -202,7 +236,9 @@ func TestImmutableIndexRejectsLastBlockOffsetBeyondChunk(t *testing.T) {
 	fixture := writeImmutableIndexFixture(
 		t, 1, []uint32{0, secondaryIndexEntrySize}, []uint64{1000},
 	)
-	requireGetBlockError(t, fixture, "beyond chunk size")
+	requireGetBlockErrorIs(
+		t, fixture, immutable.ErrInvalidChunkOffset, "beyond chunk size",
+	)
 }
 
 func TestImmutableIndexRejectsDescendingBlockOffsets(t *testing.T) {
@@ -212,7 +248,12 @@ func TestImmutableIndexRejectsDescendingBlockOffsets(t *testing.T) {
 		[]uint32{0, secondaryIndexEntrySize, 2 * secondaryIndexEntrySize},
 		[]uint64{3, 0},
 	)
-	requireGetBlockError(t, fixture, "does not follow current block offset")
+	requireGetBlockErrorIs(
+		t,
+		fixture,
+		immutable.ErrInvalidChunkOffset,
+		"does not follow current block offset",
+	)
 }
 
 func TestImmutableIndexRejectsBlockOffsetOverflow(t *testing.T) {
@@ -242,7 +283,9 @@ func TestImmutableIndexRejectsBlockOffsetOverflow(t *testing.T) {
 			fixture := writeImmutableIndexFixture(
 				t, 1, primaryOffsets, test.blockOffsets,
 			)
-			requireGetBlockError(t, fixture, "overflows int64")
+			requireGetBlockErrorIs(
+				t, fixture, immutable.ErrInvalidChunkOffset, "overflows int64",
+			)
 		})
 	}
 }

--- a/database/immutable/index_validation_test.go
+++ b/database/immutable/index_validation_test.go
@@ -17,6 +17,7 @@ package immutable_test
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,6 +213,38 @@ func TestImmutableIndexRejectsDescendingBlockOffsets(t *testing.T) {
 		[]uint64{3, 0},
 	)
 	requireGetBlockError(t, fixture, "does not follow current block offset")
+}
+
+func TestImmutableIndexRejectsBlockOffsetOverflow(t *testing.T) {
+	tests := []struct {
+		name         string
+		blockOffsets []uint64
+	}{
+		{
+			// Exercises chunk.Next's last-entry branch, which sizes the
+			// block from the current offset and the file size.
+			name:         "last entry",
+			blockOffsets: []uint64{math.MaxUint64},
+		},
+		{
+			// Exercises chunk.Next's two-entry branch, which sizes the
+			// block from the current and next offsets.
+			name:         "next entry",
+			blockOffsets: []uint64{0, math.MaxUint64},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			primaryOffsets := make([]uint32, len(test.blockOffsets)+1)
+			for i := range primaryOffsets {
+				primaryOffsets[i] = uint32(i * secondaryIndexEntrySize)
+			}
+			fixture := writeImmutableIndexFixture(
+				t, 1, primaryOffsets, test.blockOffsets,
+			)
+			requireGetBlockError(t, fixture, "overflows int64")
+		})
+	}
 }
 
 func TestImmutableIndexRejectsMisalignedSecondaryFile(t *testing.T) {


### PR DESCRIPTION
Fixes #3440

## Context

Issue #3447 (closed by #3462) already added the core offset/size/monotonicity
validation this issue asks for in `database/immutable/chunk.go`, along with
most of the required tests. Two gaps remained against #3440's specific
acceptance criteria:

- The validation errors were plain `fmt.Errorf`/`errors.New` strings with no
  way for a caller to distinguish index corruption from an ordinary I/O
  failure via `errors.Is`.
- There was no test for the offset-overflow path in either `chunk.Next`
  branch.

## Changes

- Added an exported `ErrInvalidChunkOffset` sentinel and wrapped all five
  offset-validation failures (both overflow checks, both beyond-file-size
  checks, and the non-monotonic check) with `%w`.
- Added `TestImmutableIndexRejectsBlockOffsetOverflow`, covering both the
  last-entry and two-entry `chunk.Next` code paths.

## Testing

- `go build ./...`
- `go test -race ./...` (full suite, all packages `ok`, no failures or races)
- `golangci-lint run ./...`, `nilaway ./...`, `modernize ./...`
- `make import-boundaries`, `make docs-parity`, `make golines` (no changes)

`DATABASE.md`/`ARCHITECTURE.md` checked: neither documents chunk-offset error
handling, so both are unaffected by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of invalid or corrupted chunk offsets.
  - Block lookups now return clear errors when index offsets exceed supported limits or fall outside valid file boundaries.
  - Error details preserve context for diagnosing malformed immutable indexes.

- **Tests**
  - Added coverage for oversized block offsets, including single-entry and multi-entry indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3440 by making invalid chunk offsets distinguishable from I/O failures. Immutable chunk validation now wraps overflow, out-of-range, and non-monotonic offset errors in the exported `ErrInvalidChunkOffset` sentinel; previously these were plain errors, so callers could not use `errors.Is` to detect index corruption. Valid reads are unaffected. Adds a regression test for the offset-overflow path in both `chunk.Next` branches, and updates existing validation tests to assert the sentinel via `errors.Is` instead of only matching error message substrings.

<sup>Written for commit 96349b0fdc30ec33126000329944e2eacd05d820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

