### PR TITLE
fix(ledger): preserve same-slot durable order

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1362,16 +1362,18 @@ heal remains idempotent and uses the primary chain index so retained fork blobs
 and synthetic endorser blobs are never folded.
 
 `GetLatestBlockNonce` returns the single highest-slot `block_nonce` row
-(`ORDER BY slot DESC, hash DESC LIMIT 1`). Because a `block_nonce` row is written
-in the same metadata transaction as its block's UTxO/certificate deltas and the
-ledger tip (`ledgerProcessBlocks`) and is trimmed from below by retention pruning
-(and from above, including competing same-slot hashes, when rollback removes an
-abandoned fork), that maximum slot is the authoritative high-water mark of
-durably applied ledger state for the surviving chain. The ledger uses it as the
-"durable applied floor" to detect and repair a slot-based rollback that left the
-in-memory `currentTip` above the applied state, and to anchor replay-recovery
-rollbacks at or below that floor. The row's `nonce` bytes are ignored by that
-path — only `(slot, hash)` are consumed as a rollback point.
+(`ORDER BY slot DESC, id DESC LIMIT 1`). The `id` tie-break preserves the order
+in which same-slot blocks were applied; the block hash is content identity, not
+application order. Because a `block_nonce` row is written in the same metadata
+transaction as its block's UTxO/certificate deltas and the ledger tip
+(`ledgerProcessBlocks`) and is trimmed from below by retention pruning (and from
+above, including competing same-slot hashes, when rollback removes an abandoned
+fork), that latest row is the authoritative high-water mark of durably applied
+ledger state for the surviving chain. The ledger uses it as the "durable applied
+floor" to detect and repair a slot-based rollback that left the in-memory
+`currentTip` above the applied state, and to anchor replay-recovery rollbacks at
+or below that floor. The row's `nonce` bytes are ignored by that path — only
+`(slot, hash)` are consumed as a rollback point.
 
 Whether the decoded endorser transactions are then applied to the ledger is
 selected by `LedgerStateConfig.LeiosApplyEndorserBlockTxs` (see

--- a/database/plugin/metadata/sqlite/block_nonce_test.go
+++ b/database/plugin/metadata/sqlite/block_nonce_test.go
@@ -42,3 +42,28 @@ func TestGetLatestBlockNonce(t *testing.T) {
 	require.Equal(t, uint64(20), row.Slot)
 	require.Equal(t, []byte{0xff}, row.Hash)
 }
+
+func TestGetLatestBlockNonceUsesApplicationOrderForSameSlot(t *testing.T) {
+	store, _ := newSharedSQLStore(t)
+
+	const slot = uint64(20)
+	firstHash := []byte{0xff}
+	secondHash := []byte{0x01}
+	firstNonce := []byte("nonce-first")
+	secondNonce := []byte("nonce-second")
+
+	// The later application has the lower hash. Hash ordering must not make the
+	// earlier row look like the durable floor after a same-slot fork race.
+	require.NoError(t, store.SetBlockNonce(
+		firstHash, slot, firstNonce, false, nil,
+	))
+	require.NoError(t, store.SetBlockNonce(
+		secondHash, slot, secondNonce, false, nil,
+	))
+
+	row, ok, err := store.GetLatestBlockNonce(nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, secondHash, row.Hash)
+	require.Equal(t, secondNonce, row.Nonce)
+}

--- a/database/plugin/metadata/sqlstore/operational.go
+++ b/database/plugin/metadata/sqlstore/operational.go
@@ -658,7 +658,8 @@ func (s *Store) GetLastBlockNonceInRange(
 	return nonce, err
 }
 
-// GetLatestBlockNonce returns the highest-slot nonce row. The nonce is
+// GetLatestBlockNonce returns the highest-slot nonce row, using its ID to
+// preserve application order when multiple blocks share a slot. The nonce is
 // written in the same metadata transaction as the corresponding ledger
 // effects, so this row is the durable ledger-state high-water mark.
 func (s *Store) GetLatestBlockNonce(
@@ -671,7 +672,7 @@ func (s *Store) GetLatestBlockNonce(
 	row := db.QueryRowContext(ctx,
 		`SELECT hash, nonce, id, slot, is_checkpoint
 		 FROM block_nonce
-		 ORDER BY slot DESC, hash DESC
+		 ORDER BY slot DESC, id DESC
 		 LIMIT 1`,
 	)
 	var ret models.BlockNonce

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1945,9 +1945,10 @@ type MetadataStore interface {
 		txn types.Txn,
 	) ([]byte, error)
 
-	// GetLatestBlockNonce returns the block_nonce row with the highest slot.
+	// GetLatestBlockNonce returns the block_nonce row with the highest slot,
+	// using its ID to preserve application order for same-slot rows.
 	// block_nonce is written in the same metadata transaction as a block's
-	// UTxO/certificate effects and the ledger tip, so the maximum slot is the
+	// UTxO/certificate effects and the ledger tip, so the latest row is the
 	// authoritative high-water mark of durably applied ledger state. The bool
 	// is false (with a zero row and nil error) when the table is empty.
 	GetLatestBlockNonce(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8206,9 +8206,10 @@ func (ls *LedgerState) primaryChainContainsBlockID(
 }
 
 // durableAppliedFloor returns the point of the highest block whose ledger
-// effects are durably applied, identified by the highest-slot block_nonce row.
-// The nonce table is written in the same metadata transaction as block effects
-// and the ledger tip, so this is the applied high-water mark used by recovery.
+// effects are durably applied, identified by the highest-slot block_nonce row
+// and its application-order ID for same-slot blocks. The nonce table is
+// written in the same metadata transaction as block effects and the ledger
+// tip, so this is the applied high-water mark used by recovery.
 func (ls *LedgerState) durableAppliedFloor() (ocommon.Point, bool, error) {
 	if ls.db == nil {
 		return ocommon.Point{}, false, nil


### PR DESCRIPTION
Fixes #3832

- Orders same-slot durable nonces by persisted application ID instead of block hash.
- Adds regression coverage for a later-applied nonce with a lower block hash.
- Updates the database and ledger persistence documentation.

Validation:

- The regression test fails with the old hash ordering and passes with the fix.
- Race-enabled SQLite metadata and ledger recovery tests pass.
- Documentation parity and architecture checks pass.
