### PR TITLE
fix(ledger): enforce inbound block execution budgets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2440,6 +2440,17 @@ The experimental N2N Leios protocols (`Config.experimentalLeiosNetworkingEnabled
 
 For the current respun prototype, the notify vote dialect is specifically the three-field `(announcing_rb_hash, voter_id, signature)` form. The selected-chain `chain.update` path records an announcement only after its ranking block is adopted; merely observing an eligible ChainSync header cannot make a local vote eligible. A bounded TTL queue holds votes that race ahead of adoption and retains a bounded set of alternate signatures per voter, so an invalid first candidate cannot suppress a later valid vote. Local votes use that same LeiosNotify stream; each outbound response reserves its log entry and commits the per-peer cursor only after gouroboros reports a successful send. Failed or aborted sends release the reservation into a counted retry set retained across reconnects; a reconnect advances through every pending retry on its stream rather than clearing only the first failed entry. The transitional offered-ID and four-field forms remain decode-compatible only.
 
+Before header cryptography or body deltas run, the inbound consensus-envelope
+validator enforces the era's block body/header limits and, for Alonzo and later,
+the aggregate `MaxBlockExUnits` budget. The aggregate contains every declared
+redeemer budget in every transaction, including both the outer Dijkstra witness
+set and all Dijkstra subtransaction witness sets; phase-2-invalid transactions
+remain included because the block budget constrains declared execution, not the
+UTxO outcome. Negative values and checked-add overflow fail closed. The forging
+selector uses the same transaction-wide declared-budget helper, so it cannot
+construct a candidate that inbound envelope validation would reject on that
+block-wide budget.
+
 During accepted block replay, Alonzo-and-newer validation runs the UTXO/Phase 1 rule set and keeps declared ExUnit limit checks. Plutus Phase 2 execution is skipped only for blocks at or before the immutable tip (`tipBlockNo - securityParam`), where the block producer's `isValid` flag is treated as authoritative until the local Plutus VM is consensus-equivalent. Volatile block replay, local transaction validation for mempool submission, and forging continue to run Plutus execution.
 
 Restrictive Phase 2 validation runs the CEK machine against the protocol's
@@ -4115,6 +4126,15 @@ therefore exposed to forging and relay consumers in admission order. Duplicate
 submission refreshes `LastSeen` without changing position, and oldest entries
 are removed first when watermark eviction is active. FIFO is not a fee-density
 priority queue.
+
+Pending-transaction overlays in both mempool validation and forging apply the
+consensus UTxO outcome exposed by `Transaction.Consumed()` and
+`Transaction.Produced()`. A valid transaction therefore consumes its regular
+inputs and produces its normal outputs; a phase-2-invalid transaction consumes
+collateral instead, leaves its regular inputs available, and produces only its
+collateral return when present. Dependency and double-spend checks use that
+same outcome rather than treating the transaction body's regular input set as
+unconditionally spent.
 
 The DAG provider maintains nodes keyed by transaction hash, a pending-output
 producer index, explicit parent/child edges, and a cached transaction order. An

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -90,7 +91,51 @@ func validateInboundBlockEnvelope(
 	if block.Era().Id == byron.EraIdByron {
 		return nil
 	}
-	return validateBlockSizes(block, pparams)
+	if err := validateBlockSizes(block, pparams); err != nil {
+		return err
+	}
+	return validateBlockExUnits(block, pparams)
+}
+
+// validateBlockExUnits enforces the aggregate execution-unit budget for all
+// transactions in an inbound block. Per-transaction validation checks
+// MaxTxExUnits, but the protocol also bounds the sum at MaxBlockExUnits.
+// This runs before ledger deltas are created or applied.
+func validateBlockExUnits(
+	block gledger.Block,
+	pparams lcommon.ProtocolParameters,
+) error {
+	maxBlockExUnits, ok := protocolBlockExUnitsLimit(pparams)
+	if !ok {
+		// Byron through Mary have no Plutus execution-unit budget.
+		return nil
+	}
+	var total lcommon.ExUnits
+	for index, tx := range block.Transactions() {
+		declared, err := eras.DeclaredExUnits(tx)
+		if err != nil {
+			return fmt.Errorf(
+				"transaction %d declared execution units: %w",
+				index,
+				err,
+			)
+		}
+		total, err = eras.SafeAddExUnits(total, declared)
+		if err != nil {
+			return fmt.Errorf("block declared execution units: %w", err)
+		}
+		if total.Memory > maxBlockExUnits.Memory ||
+			total.Steps > maxBlockExUnits.Steps {
+			return fmt.Errorf(
+				"block declared execution units %d memory/%d steps exceed maxBlockExUnits %d memory/%d steps",
+				total.Memory,
+				total.Steps,
+				maxBlockExUnits.Memory,
+				maxBlockExUnits.Steps,
+			)
+		}
+	}
+	return nil
 }
 
 func isNilBlockHeader(header lcommon.BlockHeader) bool {
@@ -298,5 +343,34 @@ func protocolBlockSizeLimits(
 		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
 	default:
 		return 0, 0, false
+	}
+}
+
+func protocolBlockExUnitsLimit(
+	pparams lcommon.ProtocolParameters,
+) (lcommon.ExUnits, bool) {
+	switch pp := pparams.(type) {
+	case *alonzo.AlonzoProtocolParameters:
+		if pp == nil {
+			return lcommon.ExUnits{}, false
+		}
+		return pp.MaxBlockExUnits, true
+	case *babbage.BabbageProtocolParameters:
+		if pp == nil {
+			return lcommon.ExUnits{}, false
+		}
+		return pp.MaxBlockExUnits, true
+	case *conway.ConwayProtocolParameters:
+		if pp == nil {
+			return lcommon.ExUnits{}, false
+		}
+		return pp.MaxBlockExUnits, true
+	case *dijkstra.DijkstraProtocolParameters:
+		if pp == nil {
+			return lcommon.ExUnits{}, false
+		}
+		return pp.MaxBlockExUnits, true
+	default:
+		return lcommon.ExUnits{}, false
 	}
 }

--- a/ledger/envelope_validation.go
+++ b/ledger/envelope_validation.go
@@ -105,9 +105,12 @@ func validateBlockExUnits(
 	block gledger.Block,
 	pparams lcommon.ProtocolParameters,
 ) error {
-	maxBlockExUnits, ok := protocolBlockExUnitsLimit(pparams)
+	limits, ok := protocolBlockLimits(pparams)
 	if !ok {
 		// Byron through Mary have no Plutus execution-unit budget.
+		return nil
+	}
+	if !limits.hasMaxBlockExUnits {
 		return nil
 	}
 	var total lcommon.ExUnits
@@ -124,14 +127,14 @@ func validateBlockExUnits(
 		if err != nil {
 			return fmt.Errorf("block declared execution units: %w", err)
 		}
-		if total.Memory > maxBlockExUnits.Memory ||
-			total.Steps > maxBlockExUnits.Steps {
+		if total.Memory > limits.maxBlockExUnits.Memory ||
+			total.Steps > limits.maxBlockExUnits.Steps {
 			return fmt.Errorf(
 				"block declared execution units %d memory/%d steps exceed maxBlockExUnits %d memory/%d steps",
 				total.Memory,
 				total.Steps,
-				maxBlockExUnits.Memory,
-				maxBlockExUnits.Steps,
+				limits.maxBlockExUnits.Memory,
+				limits.maxBlockExUnits.Steps,
 			)
 		}
 	}
@@ -235,7 +238,7 @@ func validateBlockSizes(
 	block gledger.Block,
 	pparams lcommon.ProtocolParameters,
 ) error {
-	maxBodySize, maxHeaderSize, ok := protocolBlockSizeLimits(pparams)
+	limits, ok := protocolBlockLimits(pparams)
 	if !ok {
 		return fmt.Errorf(
 			"block size validation unsupported for protocol parameters %T",
@@ -243,11 +246,11 @@ func validateBlockSizes(
 		)
 	}
 	headerCbor := block.Header().Cbor()
-	if uint64(len(headerCbor)) > maxHeaderSize {
+	if uint64(len(headerCbor)) > limits.maxHeaderSize {
 		return fmt.Errorf(
 			"block header size %d exceeds maxBlockHeaderSize %d",
 			len(headerCbor),
-			maxHeaderSize,
+			limits.maxHeaderSize,
 		)
 	}
 	actualBodySize, err := serializedBlockBodySize(block)
@@ -262,11 +265,11 @@ func validateBlockSizes(
 			actualBodySize,
 		)
 	}
-	if actualBodySize > maxBodySize {
+	if actualBodySize > limits.maxBodySize {
 		return fmt.Errorf(
 			"block body size %d exceeds maxBlockBodySize %d",
 			actualBodySize,
-			maxBodySize,
+			limits.maxBodySize,
 		)
 	}
 	return nil
@@ -305,72 +308,75 @@ func serializedBlockBodySize(block gledger.Block) (uint64, error) {
 	return size, nil
 }
 
-// protocolBlockSizeLimits extracts max block body/header size protocol
-// parameters from eras whose inbound block sizes can be validated here.
-func protocolBlockSizeLimits(
-	pparams lcommon.ProtocolParameters,
-) (maxBodySize, maxHeaderSize uint64, ok bool) {
+type blockProtocolLimits struct {
+	maxBodySize        uint64
+	maxHeaderSize      uint64
+	maxBlockExUnits    lcommon.ExUnits
+	hasMaxBlockExUnits bool
+}
+
+// protocolBlockLimits extracts the inbound block limits for a protocol era.
+// Keeping the era mapping here ensures size and execution-unit validation use
+// the same protocol-parameter type coverage.
+func protocolBlockLimits(pparams lcommon.ProtocolParameters) (blockProtocolLimits, bool) {
 	switch pp := pparams.(type) {
 	case *shelley.ShelleyProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:   uint64(pp.MaxBlockBodySize),
+			maxHeaderSize: uint64(pp.MaxBlockHeaderSize),
+		}, true
 	case *mary.MaryProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:   uint64(pp.MaxBlockBodySize),
+			maxHeaderSize: uint64(pp.MaxBlockHeaderSize),
+		}, true
 	case *alonzo.AlonzoProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:        uint64(pp.MaxBlockBodySize),
+			maxHeaderSize:      uint64(pp.MaxBlockHeaderSize),
+			maxBlockExUnits:    pp.MaxBlockExUnits,
+			hasMaxBlockExUnits: true,
+		}, true
 	case *babbage.BabbageProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:        uint64(pp.MaxBlockBodySize),
+			maxHeaderSize:      uint64(pp.MaxBlockHeaderSize),
+			maxBlockExUnits:    pp.MaxBlockExUnits,
+			hasMaxBlockExUnits: true,
+		}, true
 	case *conway.ConwayProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:        uint64(pp.MaxBlockBodySize),
+			maxHeaderSize:      uint64(pp.MaxBlockHeaderSize),
+			maxBlockExUnits:    pp.MaxBlockExUnits,
+			hasMaxBlockExUnits: true,
+		}, true
 	case *dijkstra.DijkstraProtocolParameters:
 		if pp == nil {
-			return 0, 0, false
+			return blockProtocolLimits{}, false
 		}
-		return uint64(pp.MaxBlockBodySize), uint64(pp.MaxBlockHeaderSize), true
+		return blockProtocolLimits{
+			maxBodySize:        uint64(pp.MaxBlockBodySize),
+			maxHeaderSize:      uint64(pp.MaxBlockHeaderSize),
+			maxBlockExUnits:    pp.MaxBlockExUnits,
+			hasMaxBlockExUnits: true,
+		}, true
 	default:
-		return 0, 0, false
-	}
-}
-
-func protocolBlockExUnitsLimit(
-	pparams lcommon.ProtocolParameters,
-) (lcommon.ExUnits, bool) {
-	switch pp := pparams.(type) {
-	case *alonzo.AlonzoProtocolParameters:
-		if pp == nil {
-			return lcommon.ExUnits{}, false
-		}
-		return pp.MaxBlockExUnits, true
-	case *babbage.BabbageProtocolParameters:
-		if pp == nil {
-			return lcommon.ExUnits{}, false
-		}
-		return pp.MaxBlockExUnits, true
-	case *conway.ConwayProtocolParameters:
-		if pp == nil {
-			return lcommon.ExUnits{}, false
-		}
-		return pp.MaxBlockExUnits, true
-	case *dijkstra.DijkstraProtocolParameters:
-		if pp == nil {
-			return lcommon.ExUnits{}, false
-		}
-		return pp.MaxBlockExUnits, true
-	default:
-		return lcommon.ExUnits{}, false
+		return blockProtocolLimits{}, false
 	}
 }

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -15,12 +15,14 @@
 package ledger
 
 import (
+	"math"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
@@ -57,6 +59,7 @@ func (h *envelopeTestHeader) BlockBodyHash() lcommon.Blake2b256 {
 type envelopeTestBlock struct {
 	header *envelopeTestHeader
 	cbor   []byte
+	txs    []lcommon.Transaction
 }
 
 func (b *envelopeTestBlock) Header() lcommon.BlockHeader { return b.header }
@@ -81,7 +84,62 @@ func (b *envelopeTestBlock) BlockBodyHash() lcommon.Blake2b256 {
 }
 func (b *envelopeTestBlock) Type() int { return 0 }
 func (b *envelopeTestBlock) Transactions() []lcommon.Transaction {
-	return nil
+	return b.txs
+}
+
+func TestValidateInboundBlockExUnitsAggregatesDeclaredBudgets(t *testing.T) {
+	newTx := func(memory, steps int64) lcommon.Transaction {
+		return &mockFeeTx{
+			witnesses: &mockWitnessSet{redeemers: &mockRedeemers{entries: []struct {
+				key lcommon.RedeemerKey
+				val lcommon.RedeemerValue
+			}{
+				{val: lcommon.RedeemerValue{ExUnits: lcommon.ExUnits{
+					Memory: memory,
+					Steps:  steps,
+				}}},
+			}}},
+		}
+	}
+	pparams := &conway.ConwayProtocolParameters{
+		MaxBlockExUnits: lcommon.ExUnits{Memory: 10, Steps: 10},
+	}
+	tests := []struct {
+		name string
+		txs  []lcommon.Transaction
+		want string
+	}{
+		{name: "valid exact aggregate", txs: []lcommon.Transaction{
+			newTx(4, 4), newTx(6, 6),
+		}},
+		{name: "over budget aggregate", txs: []lcommon.Transaction{
+			newTx(5, 5), newTx(6, 5),
+		}, want: "exceed maxBlockExUnits"},
+		{name: "checked overflow", txs: []lcommon.Transaction{
+			newTx(math.MaxInt64, 0), newTx(1, 0),
+		}, want: "overflow"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := &envelopeTestBlock{txs: tt.txs}
+			checkParams := pparams
+			if tt.name == "checked overflow" {
+				checkParams = &conway.ConwayProtocolParameters{
+					MaxBlockExUnits: lcommon.ExUnits{
+						Memory: math.MaxInt64,
+						Steps:  math.MaxInt64,
+					},
+				}
+			}
+			err := validateBlockExUnits(block, checkParams)
+			if tt.want == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
 }
 func (b *envelopeTestBlock) Utxorpc() (*utxorpc.Block, error) {
 	return nil, nil

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
@@ -141,6 +142,78 @@ func TestValidateInboundBlockExUnitsAggregatesDeclaredBudgets(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateInboundBlockExUnitsIncludesDijkstraSubtransactions(
+	t *testing.T,
+) {
+	newWitnessSet := func(memory, steps int64) dijkstra.DijkstraTransactionWitnessSet {
+		return dijkstra.DijkstraTransactionWitnessSet{
+			WsRedeemers: dijkstra.DijkstraRedeemers{
+				Redeemers: map[lcommon.RedeemerKey]lcommon.RedeemerValue{
+					{}: {ExUnits: lcommon.ExUnits{
+						Memory: memory,
+						Steps:  steps,
+					}},
+				},
+			},
+		}
+	}
+	tx := &dijkstra.DijkstraTransaction{
+		Body: dijkstra.DijkstraTransactionBody{
+			TxSubTransactions: cbor.NewSetType(
+				[]dijkstra.DijkstraSubTransaction{{
+					WitnessSet: newWitnessSet(6, 7),
+				}},
+				true,
+			),
+		},
+		WitnessSet: newWitnessSet(5, 4),
+		TxIsValid:  false,
+	}
+	block := &envelopeTestBlock{txs: []lcommon.Transaction{tx}}
+
+	require.NoError(t, validateBlockExUnits(
+		block,
+		&dijkstra.DijkstraProtocolParameters{
+			ConwayProtocolParameters: conway.ConwayProtocolParameters{
+				MaxBlockExUnits: lcommon.ExUnits{Memory: 11, Steps: 11},
+			},
+		},
+	))
+	require.ErrorContains(t, validateBlockExUnits(
+		block,
+		&dijkstra.DijkstraProtocolParameters{
+			ConwayProtocolParameters: conway.ConwayProtocolParameters{
+				MaxBlockExUnits: lcommon.ExUnits{Memory: 10, Steps: 10},
+			},
+		},
+	), "11 memory/11 steps exceed maxBlockExUnits")
+
+	overflowTx := &dijkstra.DijkstraTransaction{
+		Body: dijkstra.DijkstraTransactionBody{
+			TxSubTransactions: cbor.NewSetType(
+				[]dijkstra.DijkstraSubTransaction{{
+					WitnessSet: newWitnessSet(1, 0),
+				}},
+				true,
+			),
+		},
+		WitnessSet: newWitnessSet(math.MaxInt64, 0),
+		TxIsValid:  false,
+	}
+	require.ErrorContains(t, validateBlockExUnits(
+		&envelopeTestBlock{txs: []lcommon.Transaction{overflowTx}},
+		&dijkstra.DijkstraProtocolParameters{
+			ConwayProtocolParameters: conway.ConwayProtocolParameters{
+				MaxBlockExUnits: lcommon.ExUnits{
+					Memory: math.MaxInt64,
+					Steps:  math.MaxInt64,
+				},
+			},
+		},
+	), "overflow")
+}
+
 func (b *envelopeTestBlock) Utxorpc() (*utxorpc.Block, error) {
 	return nil, nil
 }

--- a/ledger/eras/validation.go
+++ b/ledger/eras/validation.go
@@ -970,28 +970,41 @@ func referencedScriptUtxos(
 	return utxos, nil
 }
 
-// DeclaredExUnits returns the total execution units
-// declared across all redeemers in a transaction's
-// witness set. These are the budgets the transaction
-// builder committed to (not the evaluated actuals).
-// Returns an error if the summation would overflow
-// int64.
+// DeclaredExUnits returns the total execution units declared across all
+// redeemers in a transaction, including Dijkstra subtransaction witness sets.
+// These are the budgets the transaction builder committed to (not the
+// evaluated actuals). Returns an error for negative values or if the summation
+// would overflow int64.
 func DeclaredExUnits(
 	tx lcommon.Transaction,
 ) (lcommon.ExUnits, error) {
 	var total lcommon.ExUnits
-	wits := tx.Witnesses()
-	if wits == nil {
-		return total, nil
+	addWitnessSet := func(wits lcommon.TransactionWitnessSet) error {
+		if wits == nil {
+			return nil
+		}
+		redeemers := wits.Redeemers()
+		if redeemers == nil {
+			return nil
+		}
+		for _, val := range redeemers.Iter() {
+			var err error
+			total, err = SafeAddExUnits(total, val.ExUnits)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	}
-	redeemers := wits.Redeemers()
-	if redeemers == nil {
-		return total, nil
+
+	if err := addWitnessSet(tx.Witnesses()); err != nil {
+		return lcommon.ExUnits{}, fmt.Errorf(
+			"summing redeemer execution units: %w",
+			err,
+		)
 	}
-	for _, val := range redeemers.Iter() {
-		var err error
-		total, err = SafeAddExUnits(total, val.ExUnits)
-		if err != nil {
+	for _, wits := range lcommon.SubTransactionWitnessSetsFromTransaction(tx) {
+		if err := addWitnessSet(wits); err != nil {
 			return lcommon.ExUnits{}, fmt.Errorf(
 				"summing redeemer execution units: %w",
 				err,

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -463,28 +463,14 @@ func (b *DefaultBlockBuilder) buildBlock(
 				continue
 			}
 
-			// Pull ExUnits from redeemers in the witness set
-			var estimatedTxExUnits lcommon.ExUnits
-			var exUnitsErr error
-			if witnesses := fullTx.Witnesses(); witnesses != nil {
-				if redeemers := witnesses.Redeemers(); redeemers != nil {
-					for _, redeemer := range redeemers.Iter() {
-						estimatedTxExUnits, exUnitsErr = eras.SafeAddExUnits(
-							estimatedTxExUnits,
-							redeemer.ExUnits,
-						)
-						if exUnitsErr != nil {
-							b.logger.Debug(
-								"skipping transaction - ExUnits overflow",
-								"component", "forging",
-								"error", exUnitsErr,
-							)
-							break
-						}
-					}
-				}
-			}
+			// Pull ExUnits from every transaction-level witness set.
+			estimatedTxExUnits, exUnitsErr := eras.DeclaredExUnits(fullTx)
 			if exUnitsErr != nil {
+				b.logger.Debug(
+					"skipping transaction - invalid ExUnits",
+					"component", "forging",
+					"error", exUnitsErr,
+				)
 				continue
 			}
 

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -436,12 +436,12 @@ func (b *DefaultBlockBuilder) buildBlock(
 				continue
 			}
 
-			// Check for intra-block double-spends: if any input of
-			// this transaction was already consumed by an earlier
-			// transaction in this block candidate, skip it.
-			txInputKeys := make([]string, 0, len(fullTx.Inputs()))
+			// Check for intra-block double-spends using the consensus spent
+			// set. A phase-2-invalid transaction consumes collateral, not
+			// its regular inputs.
+			txInputKeys := make([]string, 0, len(fullTx.Consumed()))
 			doubleSpend := false
-			for _, input := range fullTx.Inputs() {
+			for _, input := range fullTx.Consumed() {
 				key := fmt.Sprintf(
 					"%s:%d",
 					input.Id().String(),

--- a/ledger/validation.go
+++ b/ledger/validation.go
@@ -85,10 +85,10 @@ func CalculateMinFee(
 	)
 }
 
-// DeclaredExUnits returns the total execution units
-// declared across all redeemers in a transaction's
-// witness set. Returns an error if the summation
-// would overflow int64.
+// DeclaredExUnits returns the total execution units declared across all
+// redeemers in a transaction, including Dijkstra subtransaction witness sets.
+// Returns an error for negative values or if the summation would overflow
+// int64.
 func DeclaredExUnits(
 	tx lcommon.Transaction,
 ) (lcommon.ExUnits, error) {

--- a/mempool/backend_contract_test.go
+++ b/mempool/backend_contract_test.go
@@ -70,6 +70,10 @@ func newBackendContractPool(
 func getDependentTestTxBytes(t *testing.T) ([]byte, []byte, string, string) {
 	t.Helper()
 	parentBytes := getTestTxBytes(t)
+	// The shared fixture is phase-2-invalid so validity-outcome tests can use
+	// it. Dependency/removal tests need a regular output to exist, so make
+	// this local copy a declared-valid transaction before deriving the child.
+	parentBytes[len(parentBytes)-2] = 0xf5
 	parent, err := gledger.NewTransactionFromCbor(
 		uint(conway.EraIdConway),
 		parentBytes,
@@ -89,6 +93,10 @@ func getDependentTestTxBytes(t *testing.T) ([]byte, []byte, string, string) {
 
 	childBytes := bytes.Clone(parentBytes)
 	copy(childBytes[inputOffset:], parentOutputHashBytes)
+	// The original fixture spends output 1. A valid parent has its regular
+	// output at index 0, so keep the dependency shape while adapting the local
+	// child input to the valid transaction's produced set.
+	childBytes[inputOffset+len(originalInputHashBytes)] = 0
 	child, err := gledger.NewTransactionFromCbor(
 		uint(conway.EraIdConway),
 		childBytes,

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -358,7 +358,10 @@ func (o *utxoOverlay) applyTx(
 		cbor:    cbor,
 		created: make(map[string]lcommon.Utxo),
 	}
-	for _, input := range tx.Inputs() {
+	// Consumed is the consensus spent set: regular inputs for valid
+	// transactions and collateral for phase-2-invalid transactions. Using
+	// Inputs here would incorrectly reserve an input the ledger does not spend.
+	for _, input := range tx.Consumed() {
 		key := fmt.Sprintf("%s:%d", input.Id().String(), input.Index())
 		o.consumed[key] = struct{}{}
 		at.consumed = append(at.consumed, key)

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -313,6 +313,29 @@ func getTestTxBytes(t *testing.T) []byte {
 	return txBytes
 }
 
+func TestUtxoOverlayUsesConsensusConsumedInputsForInvalidTx(t *testing.T) {
+	tx, err := gledger.NewTransactionFromCbor(
+		uint(conway.EraIdConway),
+		getTestTxBytes(t),
+	)
+	require.NoError(t, err)
+	require.False(t, tx.IsValid())
+	require.NotEmpty(t, tx.Inputs())
+	require.NotEmpty(t, tx.Collateral())
+	overlay := newUtxoOverlay()
+	overlay.applyTx(tx.Hash().String(), uint(conway.EraIdConway), tx.Cbor(), tx)
+	for _, input := range tx.Inputs() {
+		key := fmt.Sprintf("%s:%d", input.Id().String(), input.Index())
+		assert.NotContains(t, overlay.consumed, key,
+			"invalid transaction regular inputs must remain available")
+	}
+	for _, input := range tx.Collateral() {
+		key := fmt.Sprintf("%s:%d", input.Id().String(), input.Index())
+		assert.Contains(t, overlay.consumed, key,
+			"invalid transaction collateral must be consumed")
+	}
+}
+
 // =============================================================================
 // Original Test (preserved)
 // =============================================================================


### PR DESCRIPTION
## Summary

- enforce aggregate declared ExUnits against `MaxBlockExUnits` before inbound block deltas are built
- include outer and Dijkstra subtransaction witness sets in transaction-wide execution budgets
- use `Transaction.Consumed()` for phase-2-invalid mempool and forging overlays
- document the consensus-envelope and pending-UTxO contracts

Closes #3898
