### PR TITLE
fix(mesh): bound request body completion time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5647,6 +5647,17 @@ TLS and token authentication are configured through
 
 Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.
 
+Request bodies are bounded in two dimensions, because either bound alone
+leaves a handler goroutine reachable indefinitely. `maxRequestBody` (1 MiB)
+caps how many bytes a client may send; `defaultRequestBodyTimeout` (30s),
+applied as a read deadline in `decodeRequest` and cleared once the body is
+read, caps how long it may take to send them. A request that breaches either
+bound fails as the existing `ErrInvalidRequest`, so callers see no new error.
+`listenerReadTimeout` (60s, the listener's `http.Server.ReadTimeout`) is the
+backstop for a request whose body no handler reads — an unknown route, or one
+rejected by authentication before the handler runs — which the per-request
+deadline never sees.
+
 The server depends on four narrow interfaces (`api/mesh/node_interface.go`) —
 `MeshChain`, `MeshDatabase`, `MeshLedgerState`, and `MeshMempool` — rather than
 on the concrete chain, database, ledger, and mempool types, so the handlers stay

--- a/api/mesh/listener_test.go
+++ b/api/mesh/listener_test.go
@@ -502,6 +502,8 @@ func TestRequestBodyAtLimitIsAccepted(t *testing.T) {
 
 // TestServerTimeoutsAreConfigured pins the listener timeouts, which
 // bound how long a slow or idle client can hold a connection.
+// ReadTimeout is the backstop for a request whose body no handler
+// reads, which the per-request deadline in decodeRequest never sees.
 func TestServerTimeoutsAreConfigured(t *testing.T) {
 	srv, _ := startTestServer(t, newTestDeps())
 
@@ -511,8 +513,23 @@ func TestServerTimeoutsAreConfigured(t *testing.T) {
 	require.Equal(
 		t, 60*time.Second, httpServer.ReadHeaderTimeout,
 	)
+	require.Equal(
+		t, listenerReadTimeout, httpServer.ReadTimeout,
+	)
+	require.Positive(t, httpServer.ReadTimeout)
 	require.Equal(t, 30*time.Second, httpServer.WriteTimeout)
 	require.Equal(t, 120*time.Second, httpServer.IdleTimeout)
+}
+
+// TestDefaultRequestBodyTimeoutIsApplied asserts a server built
+// without an explicit body deadline still gets one, so the bound
+// cannot be lost by composition code that never sets it.
+func TestDefaultRequestBodyTimeoutIsApplied(t *testing.T) {
+	srv := newTestServer(t, newTestDeps())
+
+	require.Equal(
+		t, defaultRequestBodyTimeout, srv.config.requestBodyTimeout,
+	)
 }
 
 // --- routing ------------------------------------------------------------

--- a/api/mesh/mesh.go
+++ b/api/mesh/mesh.go
@@ -44,6 +44,21 @@ const (
 	defaultListenAddr = ":8080"
 	maxRequestBody    = 1 << 20 // 1 MB
 
+	// defaultRequestBodyTimeout bounds how long a single request may
+	// take to deliver its body. maxRequestBody caps how many bytes a
+	// client may send, but nothing caps how slowly it may send them, so
+	// without this a client that stops partway through a declared body
+	// holds its handler goroutine for as long as it keeps the
+	// connection open.
+	defaultRequestBodyTimeout = 30 * time.Second
+
+	// listenerReadTimeout bounds the whole request read at the
+	// connection, covering the requests whose body no handler reads --
+	// an unknown route, or one rejected by authentication before the
+	// handler runs -- which the per-request deadline above never sees.
+	// api/utxorpc's listener carries the same bound.
+	listenerReadTimeout = 60 * time.Second
+
 	// mainnetMagic is the network magic for Cardano
 	// mainnet, used to determine the address network.
 	mainnetMagic = 764824073
@@ -73,6 +88,12 @@ type ServerConfig struct {
 	// ARCHITECTURE.md's "API security" section.
 	TLS  apiconfig.EffectiveTLS
 	Auth apiconfig.EffectiveAuth
+	// requestBodyTimeout bounds a single request's body read. It is
+	// unexported deliberately: operators get the constant above, not a
+	// knob whose only supported values are "the default" and "short
+	// enough for a test". NewServer substitutes
+	// defaultRequestBodyTimeout when it is not positive.
+	requestBodyTimeout time.Duration
 }
 
 // Server is the Mesh-compatible REST API server.
@@ -146,6 +167,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.ListenAddress == "" {
 		cfg.ListenAddress = defaultListenAddr
 	}
+	if cfg.requestBodyTimeout <= 0 {
+		cfg.requestBodyTimeout = defaultRequestBodyTimeout
+	}
 
 	var addrNetID uint8 = lcommon.AddressNetworkTestnet
 	if cfg.NetworkMagic == mainnetMagic {
@@ -207,6 +231,7 @@ func (s *Server) Start(ctx context.Context) error {
 				},
 			),
 			ReadHeaderTimeout: 60 * time.Second,
+			ReadTimeout:       listenerReadTimeout,
 			WriteTimeout:      30 * time.Second,
 			IdleTimeout:       120 * time.Second,
 		}
@@ -369,7 +394,7 @@ func (s *Server) decodeAndValidate(
 	r *http.Request,
 	dst networkRequest,
 ) *Error {
-	if err := decodeRequest(w, r, dst); err != nil {
+	if err := s.decodeRequest(w, r, dst); err != nil {
 		return wrapErr(ErrInvalidRequest, err)
 	}
 	id := dst.networkID()
@@ -449,14 +474,47 @@ func writeError(w http.ResponseWriter, meshErr *Error) {
 	writeJSON(w, status, meshErr)
 }
 
-// decodeRequest decodes a JSON request body into dst.
-func decodeRequest(
+// decodeRequest decodes a JSON request body into dst under both
+// request bounds: maxRequestBody caps how many bytes a client may send,
+// and requestBodyTimeout caps how long it may take to send them. A
+// client that stalls partway through a declared body fails the read,
+// and its caller reports the same invalid-request error a malformed
+// body already produces.
+func (s *Server) decodeRequest(
 	w http.ResponseWriter,
 	r *http.Request,
 	dst any,
 ) error {
+	rc := http.NewResponseController(w)
+	s.setBodyReadDeadline(
+		rc, time.Now().Add(s.config.requestBodyTimeout),
+	)
+	// Clear it on the way out: the deadline covers the body read only,
+	// and must not outlive it into the response write, the drain
+	// net/http performs to reuse the connection, or the next request
+	// on a kept-alive one.
+	defer s.setBodyReadDeadline(rc, time.Time{})
+
 	body := http.MaxBytesReader(w, r.Body, maxRequestBody)
 	defer body.Close()
 	decoder := json.NewDecoder(body)
 	return decoder.Decode(dst)
+}
+
+// setBodyReadDeadline applies a read deadline to the connection behind
+// a response writer. An httptest recorder, which the handler-level
+// tests use, does not carry one; the served path always does, and the
+// listenerReadTimeout still bounds a request there either way,
+// so a missing deadline is reported rather than raised.
+func (s *Server) setBodyReadDeadline(
+	rc *http.ResponseController,
+	deadline time.Time,
+) {
+	if err := rc.SetReadDeadline(deadline); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		s.logger.Debug(
+			"could not bound request body read",
+			"error", err,
+		)
+	}
 }

--- a/api/mesh/network.go
+++ b/api/mesh/network.go
@@ -24,7 +24,7 @@ func (s *Server) handleNetworkList(
 	r *http.Request,
 ) {
 	var req MetadataRequest
-	if err := decodeRequest(w, r, &req); err != nil {
+	if err := s.decodeRequest(w, r, &req); err != nil {
 		writeError(w, ErrInvalidRequest)
 		return
 	}

--- a/api/mesh/request_body_test.go
+++ b/api/mesh/request_body_test.go
@@ -39,6 +39,15 @@ import (
 // while staying far above the loopback round trip it measures against.
 const testBodyTimeout = 250 * time.Millisecond
 
+// respondWithin bounds how long a bounded handler may take to answer.
+// It has to clear loopback and CI scheduling noise, but it also has to
+// stay well under both listenerReadTimeout and any plausible
+// regression of the body deadline: an allowance of tens of seconds
+// would pass a deadline that had grown to seconds, or been dropped
+// onto the listener backstop, which is the regression these cases
+// exist to catch.
+const respondWithin = 20 * testBodyTimeout
+
 // withRequestBodyTimeout sets the per-request body deadline so a test
 // need not wait out the production default.
 func withRequestBodyTimeout(d time.Duration) serverOption {
@@ -134,14 +143,21 @@ func TestRequestBodyStalledClientIsBounded(t *testing.T) {
 	conn := dialTestServer(t, baseURL)
 	// Declares far more body than it sends, then goes quiet without
 	// closing: the connection stays open and silent indefinitely.
+	start := time.Now()
 	writePartialRequest(
 		t, conn, "/network/list", 4096,
 		`{"network_identifier":{"blockchain":"cardano"`,
 	)
 
-	resp, body := readMeshResponse(t, conn, 30*time.Second)
+	resp, body := readMeshResponse(t, conn, respondWithin)
+	elapsed := time.Since(start)
 
 	requireInvalidRequest(t, resp, body)
+	// The deadline is what ended this read. An answer arriving before
+	// it could not have come from waiting on the body, so it would
+	// mean the request failed for some other reason and the case was
+	// no longer exercising the bound it names.
+	require.GreaterOrEqual(t, elapsed, testBodyTimeout)
 }
 
 // TestRequestBodyTruncatedIsRejected covers a body shorter than its
@@ -162,7 +178,7 @@ func TestRequestBodyTruncatedIsRejected(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, tcpConn.CloseWrite())
 
-	resp, body := readMeshResponse(t, conn, 30*time.Second)
+	resp, body := readMeshResponse(t, conn, respondWithin)
 
 	requireInvalidRequest(t, resp, body)
 }

--- a/api/mesh/request_body_test.go
+++ b/api/mesh/request_body_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The oversized half of the request bounds is covered at the handler by
+// TestRequestBodyLimit and TestRequestBodyAtLimitIsAccepted. The cases
+// here need a real socket, because a stalled or truncated body cannot
+// be expressed through net/http's client or an httptest recorder: both
+// always deliver a complete body.
+
+// testBodyTimeout is short enough to keep the stalled-client case fast
+// while staying far above the loopback round trip it measures against.
+const testBodyTimeout = 250 * time.Millisecond
+
+// withRequestBodyTimeout sets the per-request body deadline so a test
+// need not wait out the production default.
+func withRequestBodyTimeout(d time.Duration) serverOption {
+	return func(c *ServerConfig) { c.requestBodyTimeout = d }
+}
+
+// dialTestServer opens a raw connection to a running test server, so a
+// test can control exactly how much of a request body reaches it.
+func dialTestServer(t *testing.T, baseURL string) net.Conn {
+	t.Helper()
+	addr := strings.TrimPrefix(baseURL, "http://")
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// writePartialRequest sends a complete request head declaring
+// contentLength, followed by only the supplied prefix of the body.
+func writePartialRequest(
+	t *testing.T,
+	conn net.Conn,
+	path string,
+	contentLength int,
+	bodyPrefix string,
+) {
+	t.Helper()
+	head := fmt.Sprintf(
+		"POST %s HTTP/1.1\r\n"+
+			"Host: mesh.test\r\n"+
+			"Content-Type: application/json\r\n"+
+			"Content-Length: %d\r\n"+
+			"\r\n",
+		path, contentLength,
+	)
+	_, err := io.WriteString(conn, head+bodyPrefix)
+	require.NoError(t, err)
+}
+
+// readMeshResponse reads one HTTP response from conn, failing the test
+// if none arrives within limit. A handler still waiting on the body
+// therefore fails as a read timeout here rather than hanging the test
+// binary until the package deadline.
+func readMeshResponse(
+	t *testing.T,
+	conn net.Conn,
+	limit time.Duration,
+) (*http.Response, []byte) {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(limit)))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(
+		t, err,
+		"no response within %s: the handler is still waiting on the body",
+		limit,
+	)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, body
+}
+
+// requireInvalidRequest asserts the wire response is the existing Mesh
+// invalid-request error, so a bounded body read reports the error
+// callers already handle rather than a new one.
+func requireInvalidRequest(
+	t *testing.T,
+	resp *http.Response,
+	body []byte,
+) {
+	t.Helper()
+	require.Equal(
+		t, http.StatusBadRequest, resp.StatusCode,
+		"unexpected status, body: %s", body,
+	)
+	var got Error
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, ErrInvalidRequest.Code, got.Code)
+	require.Equal(t, ErrInvalidRequest.Message, got.Message)
+	require.Equal(t, ErrInvalidRequest.Retriable, got.Retriable)
+}
+
+// TestRequestBodyStalledClientIsBounded covers the slow-client case: a
+// client that sends a complete request head and then stops partway
+// through the declared body must not hold the handler indefinitely.
+// The byte cap cannot fire here, because the client never sends enough
+// bytes to reach it.
+func TestRequestBodyStalledClientIsBounded(t *testing.T) {
+	_, baseURL := startTestServer(
+		t, newTestDeps(), withRequestBodyTimeout(testBodyTimeout),
+	)
+
+	conn := dialTestServer(t, baseURL)
+	// Declares far more body than it sends, then goes quiet without
+	// closing: the connection stays open and silent indefinitely.
+	writePartialRequest(
+		t, conn, "/network/list", 4096,
+		`{"network_identifier":{"blockchain":"cardano"`,
+	)
+
+	resp, body := readMeshResponse(t, conn, 30*time.Second)
+
+	requireInvalidRequest(t, resp, body)
+}
+
+// TestRequestBodyTruncatedIsRejected covers a body shorter than its
+// declared Content-Length, where the client half-closes instead of
+// stalling. The read ends in an unexpected EOF rather than a deadline,
+// and must produce the same invalid-request error.
+func TestRequestBodyTruncatedIsRejected(t *testing.T) {
+	_, baseURL := startTestServer(
+		t, newTestDeps(), withRequestBodyTimeout(testBodyTimeout),
+	)
+
+	conn := dialTestServer(t, baseURL)
+	writePartialRequest(
+		t, conn, "/network/list", 4096,
+		`{"network_identifier":{"blockchain":"cardano"`,
+	)
+	tcpConn, ok := conn.(*net.TCPConn)
+	require.True(t, ok)
+	require.NoError(t, tcpConn.CloseWrite())
+
+	resp, body := readMeshResponse(t, conn, 30*time.Second)
+
+	requireInvalidRequest(t, resp, body)
+}
+
+// TestRequestBodyNormalRequestUnaffected is the control: a well-formed
+// request served under the same short deadline must still succeed, so
+// the bound cannot be satisfied by rejecting everything.
+func TestRequestBodyNormalRequestUnaffected(t *testing.T) {
+	_, baseURL := startTestServer(
+		t, newTestDeps(), withRequestBodyTimeout(testBodyTimeout),
+	)
+
+	raw, err := json.Marshal(MetadataRequest{})
+	require.NoError(t, err)
+	resp, err := http.Post(
+		baseURL+"/network/list",
+		"application/json",
+		bytes.NewReader(raw),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var decoded NetworkListResponse
+	require.NoError(
+		t, json.NewDecoder(resp.Body).Decode(&decoded),
+	)
+	require.Len(t, decoded.NetworkIdentifiers, 1)
+}


### PR DESCRIPTION
Fixes #3943

## Problem

`maxRequestBody` (1 MiB) caps how many bytes a Mesh client may send, but nothing capped how slowly it may send them. `api/mesh/mesh.go`'s `http.Server` set `ReadHeaderTimeout`, `WriteTimeout`, and `IdleTimeout` but no `ReadTimeout`, so a client that completed its headers and then stopped partway through a declared body held its handler goroutine for as long as it kept the connection open.

Reproduced before the fix: a raw connection sending a complete request head with `Content-Length: 4096` followed by 44 body bytes, then going quiet, received no response for the test's full 30s read limit.

## Change

- `decodeRequest` becomes a `*Server` method and applies a read deadline for the body read (`defaultRequestBodyTimeout`, 30s), clearing it on the way out so the deadline cannot outlive the body into the response write, the drain net/http performs to reuse the connection, or the next request on a kept-alive one. An exceeded deadline fails the decode, and the caller reports the existing `ErrInvalidRequest` — no new error reaches clients.
- The listener gains `http.Server.ReadTimeout` (60s), matching `api/utxorpc`, as the backstop for a request whose body no handler reads: an unknown route, or one rejected by authentication before the handler runs. The per-request deadline never sees those.
- The deadline is set through `http.NewResponseController`. Both middlewares in the chain (`httpcors.Handler`, `apiauth.Middleware`) pass the `ResponseWriter` through unwrapped, so the served path always supports it; an `httptest` recorder does not, and `http.ErrNotSupported` is tolerated so the existing handler-level tests keep working.
- `requestBodyTimeout` is an unexported `ServerConfig` field so tests can shorten it without adding an operator-facing knob or any config/flag/env plumbing. `NewServer` substitutes the default when it is not positive.

## Acceptance criteria

| Criterion | Coverage |
|---|---|
| Enforce a complete-body or inactivity timeout | `TestRequestBodyStalledClientIsBounded` — fails without the fix (no response in 30s), passes in 0.25s with it |
| Return the existing request error for incomplete bodies | Both new wire-level cases assert the `ErrInvalidRequest` code, message, and retriable flag |
| Cover slow | `TestRequestBodyStalledClientIsBounded` |
| Cover truncated | `TestRequestBodyTruncatedIsRejected` |
| Cover oversized | Existing `TestRequestBodyLimit` / `TestRequestBodyAtLimitIsAccepted` |
| Cover normal | `TestRequestBodyNormalRequestUnaffected` (control, under the same short deadline) |

The new cases use a raw socket because neither net/http's client nor an `httptest` recorder can express a stalled or truncated body — both always deliver a complete one.

`TestRequestBodyTruncatedIsRejected` passed before this change: the half-close path already returned `ErrInvalidRequest` via unexpected EOF. It is included as a regression guard, not as evidence of the fix.

Each new assertion was verified to fail without its corresponding change:
- Removing the body deadline: `TestRequestBodyStalledClientIsBounded` fails after 30.01s with "the handler is still waiting on the body".
- Removing `ReadTimeout`: `TestServerTimeoutsAreConfigured` fails with `expected: 1m0s, actual: 0s`.

## Validation

- `go test ./api/mesh/ -race` — ok
- `go test ./api/... -race` — ok
- `make test` (full suite, `-race`) — 84 packages ok. Two `bin` entrypoint tests (`TestEntrypointForwardsSignalsDuringMithrilBootstrap`, `TestEntrypointSignalHandlingSurvivesBootstrapToServeHandoff`) failed on "child did not become ready" under full parallel load; both pass in isolation on this branch and on clean `origin/main`, and they are unrelated to `api/mesh`.
- `golangci-lint run ./...` (0 issues), `GOOS=windows golangci-lint run ./api/mesh/...` (0 issues), `nilaway ./...` (only the pre-existing `ouroboros/blockfetch_musashi_test.go` finding), `modernize`, `golines`, `gofumpt`, `make import-boundaries`, `make docs-parity` — all clean.

Not run: DevNet, conformance, and Antithesis suites — this change touches no consensus, block production, chain selection, mempool, or protocol path.

## Documentation

`ARCHITECTURE.md`'s Mesh API section gains a paragraph on the two request bounds and the listener backstop, parallel to the existing UTxO RPC request-bound note. `DATABASE.md` checked and not affected.

## Follow-up (not in this PR)

`api/blockfrost`'s listener has the same missing `ReadTimeout` (`api/blockfrost/blockfrost.go:318-320`). Left out to keep this change scoped to the issue; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZiMQEmkN34LqZz6UdipSt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the Mesh API request body read time so a client that stalls partway through a declared body can no longer hold a handler goroutine indefinitely. Previously only the byte cap (`maxRequestBody`) was enforced; now `decodeRequest` applies a 30s read deadline that is cleared once the body is read, and the listener gains a 60s `ReadTimeout` as a backstop for requests no handler reads. A deadline breach returns the existing `ErrInvalidRequest`, so clients see no new error.

- `requestBodyTimeout` is an unexported `ServerConfig` field so tests can shorten it without adding operator-facing configuration.
- Added wire-level tests for stalled, truncated, and normal bodies; oversized coverage is unchanged.
- The stalled-body test now ties its response allowance to the configured deadline, so a deadline that grew to seconds or fell back to the listener backstop would fail.
- The `ReadTimeout` matches `api/utxorpc`; `api/blockfrost` has the same gap and is left as follow-up.

<sup>Written for commit dd1e1ace1ee7eb495e4bdbb324d8a7487c8ed2e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards that limit request bodies to 1 MiB.
  - Requests taking longer than 30 seconds to send their body are rejected as invalid.
  - Requests whose bodies are not read by a handler are protected by a 60-second timeout.

- **Documentation**
  - Documented request-body size and timeout limits in the architecture guide.

- **Bug Fixes**
  - Prevented stalled or incomplete client requests from occupying server resources indefinitely.
  - Confirmed that normally completed requests continue to work under these safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->