### PR TITLE
fix(ledger): guard stake deposit state

### DIFF
--- a/ledger/view.go
+++ b/ledger/view.go
@@ -118,6 +118,16 @@ var _ lcommon.DRepDelegationState = (*LedgerView)(nil)
 // witnesses rather than fail to build.
 var _ eras.ByronProtocolMagicProvider = (*LedgerView)(nil)
 
+// UtxoValidateValueNotConservedUtxo discovers this capability with a runtime
+// type assertion and, unlike the assertions above, degrades rather than fails
+// when it misses: a failed assertion silently refunds a legacy stake
+// deregistration at the current KeyDeposit instead of the deposit actually
+// recorded at registration. Value conservation then passes on the wrong
+// number for every credential registered under a different KeyDeposit, with
+// no error anywhere. A missed assertion is therefore invisible at runtime,
+// which is exactly why it has to be a compile error here.
+var _ lcommon.StakeCredentialDepositState = (*LedgerView)(nil)
+
 func (lv *LedgerView) NetworkId() uint {
 	genesis := lv.ls.config.CardanoNodeConfig.ShelleyGenesis()
 	if genesis == nil {


### PR DESCRIPTION
Add a compile-time assertion that `*ledger.LedgerView` implements `common.StakeCredentialDepositState`. This prevents interface drift from silently disabling recorded stake-deposit lookups during Conway certificate validation.

Fixes #3830

Race validation:

- `TestLedgerViewStakeCredentialDeposit` with `dingo_extra_plugins`
- `TestLedgerViewStakeCredentialDeposit` without optional build tags


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compile-time assertion that `*ledger.LedgerView` implements `common.StakeCredentialDepositState`. Without this guard, a runtime assertion failure would silently refund legacy stake deregistrations at the wrong KeyDeposit value and still pass value conservation checks.

Fixes #3830.

<sup>Written for commit ab07470ad5db1bf28eed15d35f873ecb5e9512c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

