### PR TITLE
fix(forging): preserve sigma snapshot consistency

### DIFF
--- a/node_forging.go
+++ b/node_forging.go
@@ -504,6 +504,9 @@ func (b *blockBroadcaster) AddBlock(
 // snapshot rotation semantics as other ledger queries.
 type stakeDistributionAdapter struct {
 	ledgerState *ledger.LedgerState
+	// afterPoolStakeReadFn is a test-only hook for coordinating a concurrent
+	// snapshot recapture after the transaction has read the numerator.
+	afterPoolStakeReadFn func()
 }
 
 func (a *stakeDistributionAdapter) getStakeDistribution(
@@ -597,6 +600,12 @@ func (a *stakeDistributionAdapter) GetPoolAndTotalActiveStake(
 			poolKey,
 			err,
 		)
+	}
+	// Test-only synchronization seam. The transaction has already observed
+	// the numerator, so a concurrent recapture can commit before the
+	// denominator query without changing this transaction's snapshot.
+	if a.afterPoolStakeReadFn != nil {
+		a.afterPoolStakeReadFn()
 	}
 	totalActiveStake, err = view.GetTotalActiveStake(epoch)
 	if err != nil {

--- a/node_forging_sigma_denominator_test.go
+++ b/node_forging_sigma_denominator_test.go
@@ -17,7 +17,9 @@ package dingo
 import (
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -306,4 +308,134 @@ func TestStakeDistributionProviderForbidsTornSigmaRead(t *testing.T) {
 				"(dingo #3815)",
 		)
 	}
+}
+
+func replaceSigmaSnapshotAtomically(
+	t *testing.T,
+	db *database.Database,
+	poolKeyHash []byte,
+	poolStake, totalStake uint64,
+	capturedSlot uint64,
+) {
+	t.Helper()
+	txn := db.Transaction(true)
+	defer func() { require.NoError(t, txn.Rollback()) }()
+
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshots(
+		[]*models.PoolStakeSnapshot{{
+			Epoch:          sigmaDenomEpoch,
+			SnapshotType:   models.PoolStakeSnapshotTypeMark,
+			PoolKeyHash:    poolKeyHash,
+			TotalStake:     dbtypes.Uint64(poolStake),
+			DelegatorCount: 1,
+			CapturedSlot:   capturedSlot,
+		}},
+		txn.Metadata(),
+	))
+	require.NoError(t, db.Metadata().SaveEpochSummary(
+		&models.EpochSummary{
+			Epoch:            sigmaDenomEpoch,
+			TotalActiveStake: dbtypes.Uint64(totalStake),
+			TotalPoolCount:   2,
+			TotalDelegators:  2,
+			BoundarySlot:     capturedSlot,
+			SnapshotReady:    true,
+		},
+		txn.Metadata(),
+	))
+	require.NoError(t, txn.Commit())
+}
+
+// TestStakeDistributionAdapterKeepsSigmaConsistentAcrossRecapture proves the
+// reader's transaction is the consistency boundary for the sigma pair.
+//
+// The hook releases an atomic recapture after the numerator query has fixed the
+// read transaction's snapshot but before the denominator query. A reader that
+// opens one transaction per half can combine generation one and generation two;
+// the paired accessor must return generation one in full.
+func TestStakeDistributionAdapterKeepsSigmaConsistentAcrossRecapture(
+	t *testing.T,
+) {
+	ledgerState, db := newSigmaDenominatorLedger(t)
+	poolA := sigmaDenomPoolKeyHash(0x41)
+	poolB := sigmaDenomPoolKeyHash(0x42)
+	replaceSigmaSnapshotAtomically(
+		t, db, poolA,
+		sigmaDenomPoolAStake, sigmaDenomSummaryTotal, 1,
+	)
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshots(
+		[]*models.PoolStakeSnapshot{{
+			Epoch:          sigmaDenomEpoch,
+			SnapshotType:   models.PoolStakeSnapshotTypeMark,
+			PoolKeyHash:    poolB,
+			TotalStake:     dbtypes.Uint64(sigmaDenomPoolBStake),
+			DelegatorCount: 1,
+			CapturedSlot:   1,
+		}},
+		nil,
+	))
+
+	readStarted := make(chan struct{})
+	releaseRead := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRead) }) }
+	defer release()
+	result := make(chan struct {
+		poolStake  uint64
+		totalStake uint64
+		err        error
+	}, 1)
+	adapter := &stakeDistributionAdapter{
+		ledgerState: ledgerState,
+		afterPoolStakeReadFn: func() {
+			close(readStarted)
+			<-releaseRead
+		},
+	}
+	go func() {
+		poolStake, totalStake, err := adapter.GetPoolAndTotalActiveStake(
+			sigmaDenomEpoch,
+			poolA,
+		)
+		result <- struct {
+			poolStake  uint64
+			totalStake uint64
+			err        error
+		}{poolStake, totalStake, err}
+	}()
+
+	select {
+	case <-readStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sigma reader did not reach the coordinated recapture point")
+	}
+	// Generation two changes both halves while the reader is paused between
+	// its two SQL statements. The write is one transaction, matching the
+	// snapshot publication path in ledger/snapshot/rotation.go.
+	replaceSigmaSnapshotAtomically(
+		t, db, poolA,
+		sigmaDenomPoolAStake*2, sigmaDenomSummaryTotal*2, 2,
+	)
+	release()
+
+	var got struct {
+		poolStake  uint64
+		totalStake uint64
+		err        error
+	}
+	select {
+	case got = <-result:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sigma reader did not finish after recapture")
+	}
+	require.NoError(t, got.err)
+	require.Equal(t, sigmaDenomPoolAStake, got.poolStake,
+		"the numerator must remain from the reader's snapshot generation")
+	require.Equal(t, sigmaDenomSummaryTotal, got.totalStake,
+		"the denominator must not come from the recaptured generation")
+	require.Equal(t,
+		got.poolStake*sigmaDenomSummaryTotal,
+		got.totalStake*sigmaDenomPoolAStake,
+		"a sigma read must use one committed snapshot generation",
+	)
 }


### PR DESCRIPTION
Fixes #3815.

Adds a deterministic concurrent regression at the forging adapter boundary. The test coordinates an atomic snapshot recapture between the numerator and denominator reads and verifies that both values come from one committed snapshot generation. A nil-by-default test hook provides only the required sequencing point; production behavior is unchanged.

Validation:

- Concurrent regression passes under `go test -race`.
- Root and `ledger/leader` packages pass under `go test -race`.
- Regression repeated five times under `go test -race`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3815 by keeping the forging sigma numerator and denominator on the same committed snapshot generation when a recapture occurs between the two reads.

Adds a test-only hook to `stakeDistributionAdapter` and a concurrent regression test that replaces the snapshot while the reader is paused between queries. Production behavior is unchanged because the hook is nil by default.

Validation:
- New regression and `ledger/leader` tests pass under `go test -race`.

<sup>Written for commit ff22728867d9f65f7bd0006207403bd67e997c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

