### PR TITLE
fix(ledger): expose the current epoch to gouroboros ledger rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2774,6 +2774,16 @@ The `LedgerView` interface provides query access to ledger state:
   inclusive. The legacy hash-only `CommitteeMember` and
   `CommitteeMembers` methods omit ambiguous same-hash key/script identities
   instead of selecting one by map iteration.
+- `EpochForSlot` implements the `common.EpochState` capability, mapping a slot
+  to its epoch through the same epoch cache the header path uses. gouroboros
+  expresses several rules relative to the current epoch and obtains it by
+  optional type assertion, so a ledger state that omits this method silently
+  takes the weaker path in each of them rather than failing to build. Two
+  depend on it: the pool-deposit decision cannot otherwise distinguish a
+  retired pool from a registered one, so a re-registration of a retired pool
+  is charged no deposit and then fails value conservation by exactly the
+  deposit; and the Shelley POOL retirement bound can only reject epoch zero
+  without it.
 - The Conway and Dijkstra validation compositions replace the pinned
   hash-only committee certificate and voter rules when that capability is
   present. Cold authorization/resignation certificates and hot committee votes

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -414,6 +414,24 @@ func (lv *LedgerView) PoolCurrentState(
 	return currentReg, pendingEpoch, nil
 }
 
+// EpochForSlot returns the epoch containing the given slot, satisfying
+// gouroboros' optional common.EpochState capability.
+//
+// Several ledger rules are expressed relative to the current epoch and degrade
+// to a weaker check when the ledger state cannot supply one. Without this the
+// pool-deposit decision cannot tell a retired pool from a registered one, so a
+// registration for an already-retired pool is charged no deposit and the
+// transaction fails value conservation by exactly that amount
+// (issue #3908); the retirement-epoch bound on pool retirement certificates is
+// skipped for the same reason.
+func (lv *LedgerView) EpochForSlot(slot uint64) (uint64, error) {
+	epoch, err := lv.ls.epochForSlot(slot)
+	if err != nil {
+		return 0, err
+	}
+	return epoch.EpochId, nil
+}
+
 // IsPoolRegistered checks if a pool is currently registered
 func (lv *LedgerView) IsPoolRegistered(pkh lcommon.PoolKeyHash) bool {
 	reg, _, err := lv.PoolCurrentState(pkh)

--- a/ledger/view_epoch_for_slot_test.go
+++ b/ledger/view_epoch_for_slot_test.go
@@ -1,0 +1,61 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerViewSatisfiesEpochState pins that LedgerView provides gouroboros'
+// optional EpochState capability.
+//
+// Rules that are expressed relative to the current epoch degrade to a weaker
+// check when the ledger state cannot supply one, and they degrade silently. The
+// pool-deposit decision is the case that found this: without an epoch it cannot
+// tell a retired pool from a registered one, charges no deposit for a
+// registration that needs one, and the transaction then fails value
+// conservation by exactly the deposit (issue #3908).
+func TestLedgerViewSatisfiesEpochState(t *testing.T) {
+	var lv any = &LedgerView{}
+	_, ok := lv.(lcommon.EpochState)
+	require.True(t, ok,
+		"LedgerView must satisfy common.EpochState, or every rule that needs "+
+			"the current epoch silently takes its degraded path")
+}
+
+// TestLedgerViewEpochForSlot checks the mapping itself against a known cache.
+func TestLedgerViewEpochForSlot(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{EpochId: 196, StartSlot: 16_934_400, LengthInSlots: 86_400},
+			{EpochId: 197, StartSlot: 17_020_800, LengthInSlots: 86_400},
+		},
+	}
+	ls.publishSnapshotsLocked()
+	lv := &LedgerView{ls: ls}
+
+	for _, tc := range []struct {
+		name string
+		slot uint64
+		want uint64
+	}{
+		{"first slot of an epoch", 17_020_800, 197},
+		// The slot that wedged the replay, ninety slots into epoch 197.
+		{"the slot from issue 3908", 17_020_890, 197},
+		{"last slot of the previous epoch", 17_020_799, 196},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := lv.EpochForSlot(tc.slot)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("a slot outside the cache is an error, not a guess", func(t *testing.T) {
+		_, err := lv.EpochForSlot(99_000_000)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #3908.

## Why

`LedgerView` did not implement gouroboros' `common.EpochState`:

```go
type EpochState interface {
	EpochForSlot(slot uint64) (uint64, error)
}
```

gouroboros obtains the current epoch by optional type assertion, so a ledger
state that omits the method does not fail to build — every rule that needs an
epoch quietly takes its degraded path instead.

Two rules depend on it. The Shelley POOL retirement bound can only reject
epoch zero without it. And the pool-deposit decision cannot tell a retired
pool from a registered one: a registration certificate for an already-retired
pool is charged no deposit, and the transaction then fails value conservation
by exactly the deposit amount.

Preview slot 17020890 wedges the node on the second case.

`LedgerState` already has the mapping — `epochForSlot`, backed by the same
epoch cache the header path uses. This exposes it.

## Relationship to gouroboros#2207

gouroboros#2207 fixes the pool-deposit rule itself. That change alone does
**not** fix Dingo: with no `EpochForSlot`, the `EpochState` assertion there
fails and the helper falls back to the old behavior. Both halves are
required.

## Tests

`TestLedgerViewSatisfiesEpochState` pins the capability itself. It is the
test that matters here, because the failure mode is a silently missing
method rather than a wrong result. Renaming `EpochForSlot` fails the package.

`TestLedgerViewEpochForSlot` covers the mapping against a known epoch cache:
first slot of an epoch, the slot from the issue, the last slot of the
previous epoch, and a slot outside the cache — which must error rather than
guess.

## Validation

Built against gouroboros v0.202.8 plus gouroboros#2207 and restarted on the
data directory already wedged at slot 17020890. The node passed the wedge,
crossed the epoch 197 boundary, and has since replayed through epoch 207 at
~2700 slots/s.

`make lint` reports 0 golangci-lint issues across all modules and the Windows
target. `nilaway` reports one finding in `ouroboros/blockfetch_musashi_test.go`,
a file this branch does not touch; it is present on `main` from #3826.

`ARCHITECTURE.md` updated — it lists the optional gouroboros capabilities
`LedgerView` implements, and `EpochState` was missing. `DATABASE.md` checked
and not affected; no schema, query, or storage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the optional gouroboros `common.EpochState` capability on `LedgerView` so ledger rules that need the current epoch stop silently taking their degraded paths.

- Without an epoch, the pool-deposit rule could not distinguish a retired pool from a registered one; re-registering a retired pool was charged no deposit and failed value conservation by exactly that amount, wedging preview slot 17020890.
- The pool retirement bound could only reject epoch zero.
- `EpochForSlot` delegates to the existing epoch cache lookup used by the header path.
- `ARCHITECTURE.md` now documents the capability and why omitting it is dangerous.
- Requires `gouroboros`#2207; that fix to the pool-deposit rule alone still falls back to the old behavior without `EpochForSlot`, so both changes are needed.
- `TestLedgerViewSatisfiesEpochState` pins the interface; renaming `EpochForSlot` fails the package.
- `TestLedgerViewEpochForSlot` covers first and last slots of an epoch, the slot from issue #3908, and errors on slots outside the cache.
- Validated by replaying past the wedge to epoch 207 at ~2700 slots/s; `make lint` is clean and the `nilaway` finding is pre-existing on `main`.

<sup>Written for commit 176d10be3978abcd90072109e1c0dadcde8b65ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

