### PR TITLE
fix(ledger): reject execution-unit aggregation overflow (#3912)

### DIFF
--- a/ledger/eras/alonzo.go
+++ b/ledger/eras/alonzo.go
@@ -465,8 +465,10 @@ func EvaluateTxAlonzo(
 			if err != nil {
 				return 0, lcommon.ExUnits{}, nil, err
 			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
+			retTotalExUnits, err = SafeAddExUnits(retTotalExUnits, usedBudget)
+			if err != nil {
+				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("aggregate execution units: %w", err)
+			}
 			retRedeemerExUnits[lcommon.RedeemerKey{
 				Tag:   redeemer.Tag,
 				Index: redeemer.Index,

--- a/ledger/eras/babbage.go
+++ b/ledger/eras/babbage.go
@@ -568,8 +568,10 @@ func EvaluateTxBabbage(
 			if err != nil {
 				return 0, lcommon.ExUnits{}, nil, err
 			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
+			retTotalExUnits, err = SafeAddExUnits(retTotalExUnits, usedBudget)
+			if err != nil {
+				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("aggregate execution units: %w", err)
+			}
 			retRedeemerExUnits[lcommon.RedeemerKey{
 				Tag:   redeemer.Tag,
 				Index: redeemer.Index,
@@ -611,8 +613,10 @@ func EvaluateTxBabbage(
 			if err != nil {
 				return 0, lcommon.ExUnits{}, nil, err
 			}
-			retTotalExUnits.Steps += usedBudget.Steps
-			retTotalExUnits.Memory += usedBudget.Memory
+			retTotalExUnits, err = SafeAddExUnits(retTotalExUnits, usedBudget)
+			if err != nil {
+				return 0, lcommon.ExUnits{}, nil, fmt.Errorf("aggregate execution units: %w", err)
+			}
 			retRedeemerExUnits[lcommon.RedeemerKey{
 				Tag:   redeemer.Tag,
 				Index: redeemer.Index,

--- a/ledger/eras/conway.go
+++ b/ledger/eras/conway.go
@@ -1393,8 +1393,10 @@ func EvaluateTxConway(
 		if execErr != nil {
 			return 0, lcommon.ExUnits{}, nil, execErr
 		}
-		retTotalExUnits.Steps += usedBudget.Steps
-		retTotalExUnits.Memory += usedBudget.Memory
+		retTotalExUnits, err = SafeAddExUnits(retTotalExUnits, usedBudget)
+		if err != nil {
+			return 0, lcommon.ExUnits{}, nil, fmt.Errorf("aggregate execution units: %w", err)
+		}
 		retRedeemerExUnits[lcommon.RedeemerKey{
 			Tag:   redeemer.Tag,
 			Index: redeemer.Index,


### PR DESCRIPTION
Closes #3662

Use checked ExUnits aggregation in Alonzo, Babbage, and Conway EvaluateTx paths so overflow returns an error instead of wrapping. Dijkstra delegates to Conway evaluation.

Validation: GOWORK=off go test ./ledger/eras

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes execution-unit aggregation overflow in the Alonzo, Babbage, and Conway `EvaluateTx` paths so overflow returns an error instead of wrapping. Previously, summing execution unit budgets could silently wrap around. This resolves #3662 and also applies to Conway evaluation used by Dijkstra delegation.

<sup>Written for commit 39c12477f0fd7d48df7902ca90ee68822443eab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

