### PR TITLE
fix(database): preserve failed ledger close results

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,10 @@ continues after that rewrite drains; direct close calls join the same cleanup.
 Live restore and truncate classify that deadline as an unconfirmed storage
 drain and request a supervised restart; they never resolve a replacement store
 against the same data directory while the prior close may still own it.
+`LedgerState.Close` retains the first close result until all later callers have
+observed it, so the normal shutdown triggered by that cancellation cannot
+mistake an earlier unconfirmed drain for a successful second close and close
+the database underneath the outstanding worker.
 API providers are resolved for lifecycle only because node composition has no
 in-process consumer of their concrete server values. Each API provider's
 TLS/authentication policy goes through a merged-config handoff, not a

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -19,7 +19,9 @@ provider returns the stop context error at its deadline. A later direct
 `Close` waits for that same cleanup instead of starting a competing close.
 Live restore and truncate treat this deadline as an unconfirmed drain and
 request a supervised restart instead of reopening the same data directory
-while the background close may still own it.
+while the background close may still own it. `LedgerState.Close` preserves an
+unconfirmed result across the subsequent normal shutdown call, which then
+skips database and provider teardown until the supervised process exit.
 
 Standalone command/bootstrap composition owns these stores through
 `internal/plugins.DatabaseRuntime`. `OpenDatabase` returns either a live

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -969,6 +969,9 @@ type LedgerState struct {
 	deferredHeaderValidationMu sync.Mutex
 	checkpointWrittenForEpoch  bool
 	closed                     atomic.Bool
+	closeMu                    sync.Mutex
+	closeDone                  chan struct{}
+	closeErr                   error
 	inRecovery                 bool // guards against recursive recovery in SubmitAsyncDBTxn
 	lastAtTipRecovery          *atTipRecoveryAttempt
 	// At-tip recovery non-convergence tracking (issue #2939). A descending
@@ -2088,14 +2091,45 @@ var (
 	BlockPipelineRollbackDrainTimeout = 5 * time.Second
 )
 
-func (ls *LedgerState) Close() error {
+func (ls *LedgerState) Close() (retErr error) {
+	// Close can be called once by the live lifecycle operation and again by
+	// the node's normal shutdown after that operation cancels the node. Keep
+	// the first result visible to every caller: returning nil from the second
+	// call would make shutdown close storage after the first call reported an
+	// unconfirmed drain.
+	ls.closeMu.Lock()
+	if ls.closeDone != nil {
+		done := ls.closeDone
+		ls.closeMu.Unlock()
+		<-done
+		ls.closeMu.Lock()
+		retErr = ls.closeErr
+		ls.closeMu.Unlock()
+		return retErr
+	}
+	ls.closeDone = make(chan struct{})
+	done := ls.closeDone
+	if ls.closed.Load() {
+		// A few low-level tests mark closed directly to model a lifecycle
+		// state that has already begun closing. There is no close result to
+		// replay in that case, so publish the completed no-op explicitly.
+		close(done)
+		ls.closeMu.Unlock()
+		return nil
+	}
+	ls.closed.Store(true)
+	ls.closeMu.Unlock()
+	defer func() {
+		ls.closeMu.Lock()
+		ls.closeErr = retErr
+		close(done)
+		ls.closeMu.Unlock()
+	}()
+
 	// Release any ledger.tx publish parked on a full ordered lane before
 	// waiting on the goroutines that might be doing the publishing.
 	if ls.publishCancel != nil {
 		ls.publishCancel()
-	}
-	if !ls.closed.CompareAndSwap(false, true) {
-		return nil
 	}
 
 	// Accumulates errors from the two bounded waits below (rollback

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2080,6 +2080,7 @@ var (
 	CloseProcessBlocksDrainTimeout = 20 * time.Second
 	CloseBlockPipelineDrainTimeout = 10 * time.Second
 	CloseBlockfetchDrainTimeout    = 10 * time.Second
+	CloseResultReplayTimeout       = 10 * time.Second
 	// BlockPipelineRollbackDrainTimeout bounds how long an asynchronous
 	// rollback (chainsync fork resolution or a peer-reported rollback --
 	// see rollbackChainAndStateDeferred) waits for ls.blockPipeline to drain
@@ -2101,7 +2102,11 @@ func (ls *LedgerState) Close() (retErr error) {
 	if ls.closeDone != nil {
 		done := ls.closeDone
 		ls.closeMu.Unlock()
-		<-done
+		select {
+		case <-done:
+		case <-time.After(CloseResultReplayTimeout):
+			return errors.New("previous ledger state close still in progress")
+		}
 		ls.closeMu.Lock()
 		retErr = ls.closeErr
 		ls.closeMu.Unlock()

--- a/ledger/state_test.go
+++ b/ledger/state_test.go
@@ -5080,6 +5080,17 @@ func TestCloseWaitsForBlockProcessingPipelineToActuallyStop(t *testing.T) {
 	}
 }
 
+func TestCloseReplayReturnsWhenPreviousCloseIsStillRunning(t *testing.T) {
+	origTimeout := CloseResultReplayTimeout
+	CloseResultReplayTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { CloseResultReplayTimeout = origTimeout })
+
+	ls := &LedgerState{closeDone: make(chan struct{})}
+	err := ls.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "previous ledger state close still in progress")
+}
+
 // TestCloseStopsDecodePipelineBeforeWaitingForBlockProcessing covers the
 // shutdown ordering required when block processing is draining the decode
 // pipeline's Results channel. That drain has no context select after a batch

--- a/node_lifecycle_test.go
+++ b/node_lifecycle_test.go
@@ -1008,6 +1008,18 @@ func TestLiveTruncateCancelsInsteadOfResumingWhenStorageDrainUnconfirmed(
 	require.ErrorContains(t, err, "close storage")
 	require.ErrorContains(t, err, "could not confirm")
 
+	// A cancelled live operation is followed by the node's normal shutdown
+	// path. That path must preserve the failed LedgerState.Close result;
+	// otherwise its idempotent second Close reports success and shutdown
+	// closes storage underneath the still-running worker above.
+	shutdownErr := n.Stop()
+	require.Error(t, shutdownErr)
+	require.ErrorContains(
+		t,
+		shutdownErr,
+		"database close skipped: ledger state drain unconfirmed",
+	)
+
 	// The node must have been brought down for a supervised restart, not
 	// resumed against the same data directory the still-running worker
 	// above may still be using.


### PR DESCRIPTION
Refs #3823

- Preserve the first `LedgerState.Close` result when live truncate cannot confirm storage drain, so follow-up shutdown does not close storage underneath a running worker.
- Add regression coverage for cancelled truncate followed by normal shutdown.

Validation:

- Regression test passed with `go test -race -count=5`.
- Focused lifecycle and ledger shutdown tests passed with `-race`.
- `go vet ./ledger .` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses #3823 by preserving the first `LedgerState.Close` result across repeated calls, so the normal shutdown after a cancelled live truncate no longer reports success and closes storage underneath a still-running worker.

- `LedgerState.Close` replays the first error (or nil) to every caller instead of returning nil on a second call.
- Replay waits up to `CloseResultReplayTimeout` for an in-progress close, then returns an error instead of blocking indefinitely.
- Adds regression coverage for a cancelled live truncate followed by normal shutdown.

<sup>Written for commit 35b65a9f22fc9082d7943ae3c1ad0a8d4383ba81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


