### PR TITLE
feat(database): expose Badger value-log GC metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,11 @@ API Plugins:
 - `mesh` - Mesh (Coinbase Rosetta) REST API
 - `utxorpc` - UTxO RPC gRPC API (serves both v1alpha and v1beta)
 
+Badger value-log GC runs every five minutes at a 0.5 discard ratio by default.
+Operators may set `gc: false` for a controlled bulk load, but should re-enable
+GC for steady-state operation. GC activity and measurement guidance are
+documented in [`docs/badger-gc.md`](docs/badger-gc.md).
+
 ### Plugin Selection
 
 Plugins can be selected via command-line flags, environment variables, or configuration file:

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -265,6 +265,7 @@ type BlobStoreBadger struct {
 	runValueLogGC        func(float64) error
 	dataDir              string
 	gcWg                 sync.WaitGroup
+	gcMetrics            *badgerGCMetrics
 	closeOnce            sync.Once
 	closeDone            chan struct{}
 	closeErr             error
@@ -421,8 +422,25 @@ func (d *BlobStoreBadger) blobGc(
 			default:
 			}
 			for {
+				var beforeLSM, beforeVlog int64
+				if d.gcMetrics != nil {
+					d.gcMetrics.attempts.Inc()
+					beforeLSM, beforeVlog = d.DB().Size()
+				}
+				gcStarted := time.Now()
 				err := d.runValueLogGC(0.5)
+				if d.gcMetrics != nil {
+					d.gcMetrics.duration.Observe(time.Since(gcStarted).Seconds())
+				}
 				if err != nil {
+					if d.gcMetrics != nil {
+						if errors.Is(err, badger.ErrNoRewrite) {
+							d.gcMetrics.noRewrite.Inc()
+						} else {
+							d.gcMetrics.errors.Inc()
+						}
+						d.gcMetrics.consecutive.Set(0)
+					}
 					// Log any actual errors
 					if !errors.Is(err, badger.ErrNoRewrite) {
 						d.logger.Warn(
@@ -431,6 +449,21 @@ func (d *BlobStoreBadger) blobGc(
 						)
 					}
 					break
+				}
+				if d.gcMetrics != nil {
+					d.gcMetrics.successes.Inc()
+					afterLSM, afterVlog := d.DB().Size()
+					d.gcMetrics.lsmBytes.Set(float64(afterLSM))
+					d.gcMetrics.vlogBytes.Set(float64(afterVlog))
+					beforeSize := beforeLSM + beforeVlog
+					afterSize := afterLSM + afterVlog
+					if beforeSize > afterSize {
+						d.gcMetrics.reclaimedBytes.Set(float64(beforeSize - afterSize))
+					} else {
+						d.gcMetrics.reclaimedBytes.Set(0)
+					}
+					d.gcMetrics.consecutive.Inc()
+					d.gcMetrics.lastSuccess.SetToCurrentTime()
 				}
 				// A successful rewrite normally starts another pass. Check the
 				// stop signal first so shutdown bounds the cycle to the rewrite
@@ -486,6 +519,9 @@ func (d *BlobStoreBadger) CloseContext(ctx context.Context) error {
 		}
 		go func() {
 			d.gcWg.Wait()
+			if d.gcMetrics != nil && d.gcMetrics.cleanup != nil {
+				d.gcMetrics.cleanup()
+			}
 			if db := d.DB(); db != nil {
 				d.closeErr = db.Close()
 			}

--- a/database/plugin/blob/badger/gc_benchmark_test.go
+++ b/database/plugin/blob/badger/gc_benchmark_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package badger
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	badgerdb "github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkValueLogGC provides a repeatable synthetic comparison of discard
+// ratios. It deliberately disables the background ticker and churns live keys
+// through rewrites and deletes so the benchmark measures reclaimable data, not
+// only ErrNoRewrite. Use -benchmem and compare each ratio's ns/op, allocations,
+// and reclaimed bytes.
+func BenchmarkValueLogGC(b *testing.B) {
+	for _, ratio := range []float64{0.25, 0.5, 0.75} {
+		b.Run(strconv.FormatFloat(ratio, 'f', 2, 64), func(b *testing.B) {
+			store, err := New(
+				WithDataDir(b.TempDir()),
+				WithGc(false),
+				WithValueThreshold(1),
+				WithValueLogFileSize(1<<20),
+			)
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, store.Close()) })
+
+			for i := 0; i < 256; i++ {
+				txn := store.NewTransaction(true)
+				key := []byte("benchmark-key-" + strconv.Itoa(i%32))
+				require.NoError(b, store.Set(txn, key, make([]byte, 4096)))
+				if i%2 == 1 {
+					require.NoError(b, store.Delete(
+						txn,
+						[]byte("benchmark-key-"+strconv.Itoa((i/2)%32)),
+					))
+				}
+				require.NoError(b, txn.Commit())
+			}
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				for j := 0; j < 64; j++ {
+					txn := store.NewTransaction(true)
+					key := []byte("benchmark-key-" + strconv.Itoa(j))
+					require.NoError(b, store.Set(txn, key, make([]byte, 4096)))
+					require.NoError(b, txn.Commit())
+				}
+				before, err := store.DiskSize()
+				require.NoError(b, err)
+				b.StartTimer()
+				err = store.DB().RunValueLogGC(ratio)
+				b.StopTimer()
+				if errors.Is(err, badgerdb.ErrNoRewrite) {
+					continue
+				}
+				require.NoError(b, err)
+				after, err := store.DiskSize()
+				require.NoError(b, err)
+				if before > after {
+					b.ReportMetric(float64(before-after), "bytes_reclaimed")
+				}
+			}
+		})
+	}
+}

--- a/database/plugin/blob/badger/metrics.go
+++ b/database/plugin/blob/badger/metrics.go
@@ -16,27 +16,199 @@ package badger
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+type badgerGCMetrics struct {
+	attempts       prometheus.Counter
+	successes      prometheus.Counter
+	noRewrite      prometheus.Counter
+	errors         prometheus.Counter
+	duration       prometheus.Observer
+	lsmBytes       prometheus.Gauge
+	vlogBytes      prometheus.Gauge
+	reclaimedBytes prometheus.Gauge
+	consecutive    prometheus.Gauge
+	lastSuccess    prometheus.Gauge
+	cleanup        func()
+}
+
+type badgerGCMetricCollectors struct {
+	attempts       *prometheus.CounterVec
+	successes      *prometheus.CounterVec
+	noRewrite      *prometheus.CounterVec
+	errors         *prometheus.CounterVec
+	duration       *prometheus.HistogramVec
+	lsmBytes       *prometheus.GaugeVec
+	vlogBytes      *prometheus.GaugeVec
+	reclaimedBytes *prometheus.GaugeVec
+	consecutive    *prometheus.GaugeVec
+	lastSuccess    *prometheus.GaugeVec
+}
+
+type badgerGCCollectorCacheEntry struct {
+	registerer prometheus.Registerer
+	collectors *badgerGCMetricCollectors
+}
+
+type badgerGCCollectorCache struct {
+	mu            sync.Mutex
+	comparable    map[prometheus.Registerer]*badgerGCMetricCollectors
+	nonComparable []badgerGCCollectorCacheEntry
+}
+
+var (
+	badgerGCCollectors = badgerGCCollectorCache{
+		comparable: make(map[prometheus.Registerer]*badgerGCMetricCollectors),
+	}
+	nextBadgerStoreID atomic.Uint64
 )
 
 const (
 	badgerMetricNamePrefix = "database_blob_"
 )
 
-// safeRegister registers a collector, silently ignoring duplicates.
-func safeRegister(reg prometheus.Registerer, c prometheus.Collector) {
+func registerExistingOrNew(
+	reg prometheus.Registerer,
+	c prometheus.Collector,
+) prometheus.Collector {
 	if err := reg.Register(c); err != nil {
-		// Ignore AlreadyRegisteredError — a second blob store instance
-		// (e.g. chain-manager store) shares the same default registry.
-		if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); !ok {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegistered) {
 			panic(err)
 		}
+		return alreadyRegistered.ExistingCollector
 	}
+	return c
+}
+
+func registerCollector[T prometheus.Collector](
+	reg prometheus.Registerer,
+	c prometheus.Collector,
+) T {
+	registered := registerExistingOrNew(reg, c)
+	collector, ok := registered.(T)
+	if !ok {
+		panic(fmt.Sprintf("registered collector has unexpected type %T", registered))
+	}
+	return collector
+}
+
+func safeRegister(reg prometheus.Registerer, c prometheus.Collector) {
+	_ = registerExistingOrNew(reg, c)
+}
+
+func (c *badgerGCCollectorCache) get(
+	reg prometheus.Registerer,
+) *badgerGCMetricCollectors {
+	value := reflect.ValueOf(reg)
+	if value.IsValid() && value.Type().Comparable() {
+		return c.comparable[reg]
+	}
+	for _, entry := range c.nonComparable {
+		if reflect.DeepEqual(entry.registerer, reg) {
+			return entry.collectors
+		}
+	}
+	return nil
+}
+
+func (c *badgerGCCollectorCache) put(
+	reg prometheus.Registerer,
+	collectors *badgerGCMetricCollectors,
+) {
+	value := reflect.ValueOf(reg)
+	if value.IsValid() && value.Type().Comparable() {
+		c.comparable[reg] = collectors
+		return
+	}
+	c.nonComparable = append(c.nonComparable, badgerGCCollectorCacheEntry{
+		registerer: reg,
+		collectors: collectors,
+	})
 }
 
 func (d *BlobStoreBadger) registerBlobMetrics() {
+	badgerGCCollectors.mu.Lock()
+	defer badgerGCCollectors.mu.Unlock()
+	storeID := fmt.Sprintf("store-%d", nextBadgerStoreID.Add(1))
+	labels := []string{"store"}
+	gcCollectors := badgerGCCollectors.get(d.promRegistry)
+	if gcCollectors == nil {
+		gcCollectors = &badgerGCMetricCollectors{}
+		gcCollectors.attempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: badgerMetricNamePrefix + "gc_attempts_total", Help: "Total Badger value-log GC attempts.",
+		}, labels)
+		gcCollectors.successes = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: badgerMetricNamePrefix + "gc_successes_total", Help: "Total successful Badger value-log GC rewrites.",
+		}, labels)
+		gcCollectors.noRewrite = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: badgerMetricNamePrefix + "gc_no_rewrite_total", Help: "Total Badger value-log GC attempts with no rewrite.",
+		}, labels)
+		gcCollectors.errors = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: badgerMetricNamePrefix + "gc_errors_total", Help: "Total Badger value-log GC errors.",
+		}, labels)
+		gcCollectors.duration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: badgerMetricNamePrefix + "gc_duration_seconds", Help: "Duration of Badger value-log GC attempts in seconds.",
+		}, labels)
+		gcCollectors.lsmBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "gc_lsm_bytes", Help: "Badger LSM size after the last successful value-log GC rewrite.",
+		}, labels)
+		gcCollectors.vlogBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "gc_vlog_bytes", Help: "Badger value-log size after the last successful GC rewrite.",
+		}, labels)
+		gcCollectors.reclaimedBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "gc_reclaimed_bytes", Help: "Bytes reclaimed by the last successful Badger GC rewrite.",
+		}, labels)
+		gcCollectors.consecutive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "gc_consecutive_successes", Help: "Successful value-log GC rewrites in the current GC cycle.",
+		}, labels)
+		gcCollectors.lastSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: badgerMetricNamePrefix + "gc_last_success_timestamp_seconds", Help: "Unix timestamp of the last successful value-log GC rewrite.",
+		}, labels)
+		gcCollectors.attempts = registerCollector[*prometheus.CounterVec](d.promRegistry, gcCollectors.attempts)
+		gcCollectors.successes = registerCollector[*prometheus.CounterVec](d.promRegistry, gcCollectors.successes)
+		gcCollectors.noRewrite = registerCollector[*prometheus.CounterVec](d.promRegistry, gcCollectors.noRewrite)
+		gcCollectors.errors = registerCollector[*prometheus.CounterVec](d.promRegistry, gcCollectors.errors)
+		gcCollectors.duration = registerCollector[*prometheus.HistogramVec](d.promRegistry, gcCollectors.duration)
+		gcCollectors.lsmBytes = registerCollector[*prometheus.GaugeVec](d.promRegistry, gcCollectors.lsmBytes)
+		gcCollectors.vlogBytes = registerCollector[*prometheus.GaugeVec](d.promRegistry, gcCollectors.vlogBytes)
+		gcCollectors.reclaimedBytes = registerCollector[*prometheus.GaugeVec](d.promRegistry, gcCollectors.reclaimedBytes)
+		gcCollectors.consecutive = registerCollector[*prometheus.GaugeVec](d.promRegistry, gcCollectors.consecutive)
+		gcCollectors.lastSuccess = registerCollector[*prometheus.GaugeVec](d.promRegistry, gcCollectors.lastSuccess)
+		badgerGCCollectors.put(d.promRegistry, gcCollectors)
+	}
+	d.gcMetrics = &badgerGCMetrics{
+		attempts:       gcCollectors.attempts.WithLabelValues(storeID),
+		successes:      gcCollectors.successes.WithLabelValues(storeID),
+		noRewrite:      gcCollectors.noRewrite.WithLabelValues(storeID),
+		errors:         gcCollectors.errors.WithLabelValues(storeID),
+		duration:       gcCollectors.duration.WithLabelValues(storeID),
+		lsmBytes:       gcCollectors.lsmBytes.WithLabelValues(storeID),
+		vlogBytes:      gcCollectors.vlogBytes.WithLabelValues(storeID),
+		reclaimedBytes: gcCollectors.reclaimedBytes.WithLabelValues(storeID),
+		consecutive:    gcCollectors.consecutive.WithLabelValues(storeID),
+		lastSuccess:    gcCollectors.lastSuccess.WithLabelValues(storeID),
+		cleanup: func() {
+			gcCollectors.attempts.DeleteLabelValues(storeID)
+			gcCollectors.successes.DeleteLabelValues(storeID)
+			gcCollectors.noRewrite.DeleteLabelValues(storeID)
+			gcCollectors.errors.DeleteLabelValues(storeID)
+			gcCollectors.duration.DeleteLabelValues(storeID)
+			gcCollectors.lsmBytes.DeleteLabelValues(storeID)
+			gcCollectors.vlogBytes.DeleteLabelValues(storeID)
+			gcCollectors.reclaimedBytes.DeleteLabelValues(storeID)
+			gcCollectors.consecutive.DeleteLabelValues(storeID)
+			gcCollectors.lastSuccess.DeleteLabelValues(storeID)
+		},
+	}
+
 	// Badger exposes metrics via expvar, so we need to set up some translation
 	collector := collectors.NewExpvarCollector(
 		map[string]*prometheus.Desc{
@@ -116,8 +288,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total block cache hits",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				return float64(m.Hits())
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					return float64(m.Hits())
+				}
 			}
 			return 0
 		},
@@ -128,8 +302,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total block cache misses",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				return float64(m.Misses())
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					return float64(m.Misses())
+				}
 			}
 			return 0
 		},
@@ -140,8 +316,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Block cache hit ratio (0.0-1.0)",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				return m.Ratio()
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					return m.Ratio()
+				}
 			}
 			return 0
 		},
@@ -152,13 +330,15 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Current block cache cost in bytes (added - evicted)",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				added := m.CostAdded()
-				evicted := m.CostEvicted()
-				if added >= evicted {
-					return float64(added - evicted)
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					added := m.CostAdded()
+					evicted := m.CostEvicted()
+					if added >= evicted {
+						return float64(added - evicted)
+					}
+					return 0
 				}
-				return 0
 			}
 			return 0
 		},
@@ -169,8 +349,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total keys added to block cache",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				return float64(m.KeysAdded())
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					return float64(m.KeysAdded())
+				}
 			}
 			return 0
 		},
@@ -181,8 +363,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total keys evicted from block cache",
 		},
 		func() float64 {
-			if m := d.DB().BlockCacheMetrics(); m != nil {
-				return float64(m.KeysEvicted())
+			if db := d.DB(); db != nil {
+				if m := db.BlockCacheMetrics(); m != nil {
+					return float64(m.KeysEvicted())
+				}
 			}
 			return 0
 		},
@@ -193,8 +377,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total index cache hits",
 		},
 		func() float64 {
-			if m := d.DB().IndexCacheMetrics(); m != nil {
-				return float64(m.Hits())
+			if db := d.DB(); db != nil {
+				if m := db.IndexCacheMetrics(); m != nil {
+					return float64(m.Hits())
+				}
 			}
 			return 0
 		},
@@ -205,8 +391,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Total index cache misses",
 		},
 		func() float64 {
-			if m := d.DB().IndexCacheMetrics(); m != nil {
-				return float64(m.Misses())
+			if db := d.DB(); db != nil {
+				if m := db.IndexCacheMetrics(); m != nil {
+					return float64(m.Misses())
+				}
 			}
 			return 0
 		},
@@ -217,8 +405,10 @@ func (d *BlobStoreBadger) registerBlobMetrics() {
 			Help: "Index cache hit ratio (0.0-1.0)",
 		},
 		func() float64 {
-			if m := d.DB().IndexCacheMetrics(); m != nil {
-				return m.Ratio()
+			if db := d.DB(); db != nil {
+				if m := db.IndexCacheMetrics(); m != nil {
+					return m.Ratio()
+				}
 			}
 			return 0
 		},

--- a/database/plugin/blob/badger/metrics_test.go
+++ b/database/plugin/blob/badger/metrics_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package badger
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type nonComparableRegisterer struct {
+	prometheus.Registerer
+	labels []string
+}
+
+func TestRegisterBlobMetricsReusesSharedGCCollectors(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	first := &BlobStoreBadger{promRegistry: registry}
+	second := &BlobStoreBadger{promRegistry: registry}
+
+	first.registerBlobMetrics()
+	second.registerBlobMetrics()
+
+	first.gcMetrics.attempts.Inc()
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(first.gcMetrics.attempts),
+	)
+	second.gcMetrics.attempts.Inc()
+	require.Equal(t, float64(1), testutil.ToFloat64(second.gcMetrics.attempts))
+}
+
+func TestRegisterBlobMetricsAllowsLabelWrappedReuse(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	registerer := prometheus.WrapRegistererWith(
+		prometheus.Labels{"network": "preview"},
+		registry,
+	)
+	first := &BlobStoreBadger{promRegistry: registerer}
+	second := &BlobStoreBadger{promRegistry: registerer}
+
+	first.registerBlobMetrics()
+	require.NotPanics(t, second.registerBlobMetrics)
+	second.gcMetrics.attempts.Inc()
+	count, err := testutil.GatherAndCount(registry,
+		"database_blob_gc_attempts_total")
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	require.Equal(t, float64(1), testutil.ToFloat64(second.gcMetrics.attempts))
+}
+
+func TestRegisterBlobMetricsRemovesClosedStoreSeries(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	store := &BlobStoreBadger{promRegistry: registry}
+	store.registerBlobMetrics()
+	store.gcMetrics.attempts.Inc()
+	count, err := testutil.GatherAndCount(registry,
+		"database_blob_gc_attempts_total")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.NoError(t, store.Close())
+	count, err = testutil.GatherAndCount(registry,
+		"database_blob_gc_attempts_total")
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}
+
+func TestRegisterBlobMetricsAllowsNonComparableRegisterer(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	registerer := nonComparableRegisterer{
+		Registerer: registry,
+		labels:     []string{"network"},
+	}
+	store := &BlobStoreBadger{promRegistry: registerer}
+	require.NotPanics(t, store.registerBlobMetrics)
+	second := &BlobStoreBadger{promRegistry: registerer}
+	require.NotPanics(t, second.registerBlobMetrics)
+	second.gcMetrics.attempts.Inc()
+	count, err := testutil.GatherAndCount(registry,
+		"database_blob_gc_attempts_total")
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	require.Equal(t, float64(1), testutil.ToFloat64(second.gcMetrics.attempts))
+}

--- a/database/plugin/blob/badger/provider_test.go
+++ b/database/plugin/blob/badger/provider_test.go
@@ -229,13 +229,24 @@ func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
 		50*time.Millisecond,
 	)
 	defer cancel()
-	stopDone := make(chan error, 1)
+	type stopResult struct {
+		err     error
+		elapsed time.Duration
+	}
+	stopDone := make(chan stopResult, 1)
 	go func() {
-		stopDone <- host.Stop(ctx)
+		stopStarted := time.Now()
+		stopDone <- stopResult{err: host.Stop(ctx), elapsed: time.Since(stopStarted)}
 	}()
-	stopErr := testutil.RequireReceive(
+	result := testutil.RequireReceive(
 		t, stopDone, 5*time.Second,
 		"provider stop exceeded its context",
+	)
+	require.Less(
+		t,
+		result.elapsed,
+		250*time.Millisecond,
+		"provider stop did not honor its deadline promptly",
 	)
 
 	release()
@@ -247,7 +258,7 @@ func TestProviderStopDeadlineDuringValueLogGC(t *testing.T) {
 		"provider-owned close did not finish after value-log GC drained",
 	)
 
-	require.ErrorIs(t, stopErr, context.DeadlineExceeded)
+	require.ErrorIs(t, result.err, context.DeadlineExceeded)
 	require.Equal(t, int32(1), attempts.Load())
 	require.True(t, store.DB().IsClosed())
 	require.ErrorIs(

--- a/docs/badger-gc.md
+++ b/docs/badger-gc.md
@@ -1,0 +1,64 @@
+# Badger value-log GC
+
+Dingo's Badger blob store runs value-log GC every five minutes with a discard
+ratio of `0.5`. This is separate from Badger's automatic LSM compaction. The
+default remains this conservative policy until production measurements show a
+better tradeoff; disabling LSM compaction is not part of the policy options.
+
+## Repeatable measurement procedure
+
+Run the synthetic ratio benchmark from an isolated checkout:
+
+```sh
+GOWORK=off GOCACHE=/tmp/dingo-gc-cache \\
+  go test ./database/plugin/blob/badger \\
+  -run '^$' -bench '^BenchmarkValueLogGC$' -benchmem -count=5
+```
+
+The benchmark compares discard ratios `0.25`, `0.50`, and `0.75` with the
+background ticker disabled. Record `ns/op`, allocations, and the GC metrics
+from a registry-enabled store. For production-shaped evidence, repeat the
+same comparison while loading a fixed dataset for each workload: from-genesis
+sync, Mithril/bootstrap load, API backfill, history expiry/tombstones, and
+steady-state relay/API traffic. Keep the dataset, hardware, Dingo revision,
+Badger options, and workload duration fixed. Record throughput, disk growth,
+LSM/vlog sizes, GC CPU/I/O, query latency, and write-stall/compaction metrics.
+
+Compare these policies:
+
+| Policy | Purpose |
+| --- | --- |
+| `5m / 0.50` | Current default baseline |
+| GC disabled during load, enabled afterward | Bulk-load control |
+| Longer interval | Lower steady-state GC interference |
+| `0.25` or `0.75` discard ratio | Reclaim-efficiency sensitivity |
+| Adaptive interval/ratio | Candidate only if measurements justify its complexity |
+
+The default decision is to retain `5m / 0.50` until every workload has a
+reproducible result showing that another policy improves disk growth and
+throughput without unacceptable latency, CPU, I/O, or shutdown impact. Operators
+can disable GC during controlled bulk loads with the existing `gc: false`
+setting, then re-enable it before steady-state operation.
+
+## Metrics
+
+When Prometheus metrics are configured, inspect:
+
+- `database_blob_gc_attempts_total`, `..._successes_total`,
+  `..._no_rewrite_total`, and `..._errors_total`;
+- `database_blob_gc_duration_seconds` (time spent inside the Badger
+  `RunValueLogGC` call, excluding the pre-GC size snapshot);
+- `database_blob_gc_lsm_bytes`, `..._vlog_bytes`, and
+  `..._reclaimed_bytes`;
+- `database_blob_gc_consecutive_successes` and
+  `database_blob_gc_last_success_timestamp_seconds`.
+
+## Shutdown behavior
+
+Badger cannot cancel an in-flight value-log rewrite. `CloseContext` stops new
+GC passes, waits for the current rewrite, and returns the caller's deadline
+error if that rewrite does not finish in time; the one-time cleanup then closes
+the database after the rewrite drains. The regression test
+`TestProviderStopDeadlineDuringValueLogGC` injects a blocked rewrite and proves
+that the stop call returns promptly at its deadline, then the store closes
+after the rewrite is released.


### PR DESCRIPTION
## Summary

- expose Badger value-log GC attempts, outcomes, duration, cycle depth, and last-success metrics
- reuse registered collectors safely across Badger stores
- add a repeatable value-log GC benchmark and operator guidance
- document the default GC policy and shutdown behavior

Related to #2701

## Validation

- `GOWORK=off GOCACHE=/tmp/dingo-2701-clean-gocache GOMODCACHE=/tmp/dingo-2701-clean-gomodcache go test ./database/plugin/blob/badger -run '^(TestRegisterBlobMetrics|TestProviderStopDeadlineDuringValueLogGC)$' -count=1`
- `git diff --cached --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes Prometheus metrics for Badger value-log GC so operators can track attempts, successes, no-rewrite outcomes, errors, duration, store sizes, reclaimed bytes, and last-success time per store.

**New Features**
- Records GC attempts, successes, no-rewrites, errors, duration, LSM/vlog bytes, reclaimed bytes, consecutive successes, and last-success timestamp with a `store-N` label.
- Reuses registered metric vectors across Badger stores sharing a registry, including label-wrapped and non-comparable registerers, to avoid duplicate registration panics.
- Removes each store's label values on close so series do not linger.
- Adds `BenchmarkValueLogGC` for comparing discard ratios and documents the default 5-minute/0.5 policy and shutdown behavior in `docs/badger-gc.md`.

<sup>Written for commit 2e7622dacb4951139fdcf0c86f43732fc9c3d962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

