### PR TITLE
fix(chain): propagate ledger reader failures (#3919)

### DIFF
--- a/ledger/read_chain_test.go
+++ b/ledger/read_chain_test.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -91,6 +92,21 @@ func (m *readChainMockBlock) Utxorpc() (*utxorpc_cardano.Block, error) {
 type scriptedLedgerReadIterator struct {
 	ctx     context.Context
 	results []*chain.ChainIteratorResult
+}
+
+type failingLedgerReadIterator struct{}
+
+func (failingLedgerReadIterator) Next(bool) (*chain.ChainIteratorResult, error) {
+	return nil, errors.New("iterator storage failure")
+}
+
+func TestLedgerReadChainIteratorForwardsIteratorError(t *testing.T) {
+	resultCh := make(chan readChainResult, 1)
+	ls := &LedgerState{config: LedgerStateConfig{Logger: testLogger()}}
+	ls.ledgerReadChainIterator(t.Context(), failingLedgerReadIterator{}, resultCh)
+	result := <-resultCh
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "iterator storage failure")
 }
 
 func (s *scriptedLedgerReadIterator) Next(

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -4167,6 +4167,12 @@ func (ls *LedgerState) ledgerReadChain(
 	// Without this, the consumer blocks forever on the channel
 	// read if the reader goroutine exits silently on an error.
 	defer close(resultCh)
+	reportErr := func(err error) {
+		select {
+		case resultCh <- readChainResult{err: err}:
+		case <-ctx.Done():
+		}
+	}
 	const maxReconcileRetries = 3
 	reconcileRetries := 0
 	for {
@@ -4184,6 +4190,7 @@ func (ls *LedgerState) ledgerReadChain(
 					"error", err,
 					"start_slot", startPoint.Slot,
 				)
+				reportErr(fmt.Errorf("create chain iterator from %v: %w", startPoint, err))
 				return
 			}
 			if reconcileRetries >= maxReconcileRetries {
@@ -4200,6 +4207,7 @@ func (ls *LedgerState) ledgerReadChain(
 					"max_retries",
 					maxReconcileRetries,
 				)
+				reportErr(fmt.Errorf("exhausted ledger rollback retries from %v: %w", startPoint, err))
 				return
 			}
 			ls.config.Logger.Warn(
@@ -4218,6 +4226,7 @@ func (ls *LedgerState) ledgerReadChain(
 					"start_slot", startPoint.Slot,
 					"start_hash", hex.EncodeToString(startPoint.Hash),
 				)
+				reportErr(fmt.Errorf("recover missing chain iterator start point: %w", reconcileErr))
 				return
 			}
 			reconcileRetries++
@@ -4233,6 +4242,7 @@ func (ls *LedgerState) ledgerReadChain(
 					"start_hash",
 					hex.EncodeToString(startPoint.Hash),
 				)
+				reportErr(fmt.Errorf("ledger rollback did not change missing chain iterator start point: %v", startPoint))
 				return
 			}
 			continue
@@ -4255,6 +4265,12 @@ func (ls *LedgerState) ledgerReadChainIterator(
 	var err error
 	var shouldBlock bool
 	var result readChainResult
+	reportErr := func(err error) {
+		select {
+		case resultCh <- readChainResult{err: err}:
+		case <-ctx.Done():
+		}
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -4322,6 +4338,7 @@ func (ls *LedgerState) ledgerReadChainIterator(
 							"error", err,
 						)
 						releaseGatherLock()
+						reportErr(fmt.Errorf("get next block from chain iterator: %w", err))
 						return
 					}
 					shouldBlock = true
@@ -4341,6 +4358,7 @@ func (ls *LedgerState) ledgerReadChainIterator(
 			if next == nil {
 				ls.config.Logger.Error("next block from chain iterator is nil")
 				releaseGatherLock()
+				reportErr(errors.New("chain iterator returned nil block"))
 				return
 			}
 			if next.Rollback {


### PR DESCRIPTION
Follow-up to #3611; fixes #3776.

Propagate every non-cancellation ledger reader/iterator failure through `readChainResult` so the existing retry/backoff supervisor remains active instead of treating a silent channel close as clean shutdown. Adds a regression test for iterator storage errors.

Validation: `go test ./ledger -run 'TestLedgerReadChainIteratorForwardsIteratorError|TestLedgerReadChainIteratorForwardsDecodeError|TestLedgerReadChainIteratorWaitsForResultCompletion' -count=1`