### PR TITLE
fix(koiosparity): report the mismatch count that caused the failure

### DIFF
--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -869,20 +869,6 @@ func rationalsEqual(a, b string) bool {
 	return ra.Cmp(&rb) == 0
 }
 
-// DetermineStatus returns PASS, FAIL, or ERROR from a list of mismatches.
-//
-//   - FAIL: any value_mismatch, pool_only_dingo, pool_only_koios,
-//     acct_only_dingo, acct_only_koios, or acct_duplicate entry — a strict
-//     run cannot report PASS while any of these are present (#3097's
-//     acceptance criteria: a single missing, extra, duplicate, or differing
-//     account fails the whole epoch).
-//   - ERROR: only DB-level failures (dingo_db_error, dingo_db_missing),
-//     reference_lag (Koios data may be incomplete for a recent epoch), or
-//     acct_coverage_incomplete (the Koios account-reward fetch for this
-//     epoch never completed across every chunk, so there is no complete
-//     reference set to compare against yet).
-//   - PASS: no mismatches.
-//
 // mismatchSeverity classifies one mismatch category. DetermineStatus and
 // CountSignificant both read it, so a category added to one can never be
 // forgotten by the other — the failure the split invited was a count that did
@@ -937,6 +923,19 @@ func CountSignificant(mismatches []CheckMismatch) int {
 	return n
 }
 
+// DetermineStatus returns PASS, FAIL, or ERROR from a list of mismatches.
+//
+//   - FAIL: any value_mismatch, pool_only_dingo, pool_only_koios,
+//     acct_only_dingo, acct_only_koios, or acct_duplicate entry — a strict
+//     run cannot report PASS while any of these are present (#3097's
+//     acceptance criteria: a single missing, extra, duplicate, or differing
+//     account fails the whole epoch).
+//   - ERROR: only DB-level failures (dingo_db_error, dingo_db_missing),
+//     reference_lag (Koios data may be incomplete for a recent epoch), or
+//     acct_coverage_incomplete (the Koios account-reward fetch for this
+//     epoch never completed across every chunk, so there is no complete
+//     reference set to compare against yet).
+//   - PASS: no mismatches.
 func DetermineStatus(mismatches []CheckMismatch) string {
 	hasError := false
 	for _, m := range mismatches {

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -83,6 +83,31 @@ const (
 	CategoryAcctDeregistered = "acct_deregistered"
 )
 
+// AllCategories is every mismatch category above, in one place.
+//
+// severityOf classifies exactly these values, and the tests that guard the
+// classification iterate this slice rather than restating it. A hand-written
+// second copy is how a category comes to be classified by DetermineStatus and
+// missed by CountSignificant (or the reverse) with every test still green, so
+// the list exists once and TestAllCategoriesCoversEveryConstant pins it to the
+// const block above.
+var AllCategories = []string{
+	CategoryValueMismatch,
+	CategoryPoolOnlyDingo,
+	CategoryPoolOnlyKoios,
+	CategoryReferenceLag,
+	CategoryDBError,
+	CategoryDBMissing,
+	CategoryPoolDeparted,
+	CategoryAcctOnlyDingo,
+	CategoryAcctOnlyKoios,
+	CategoryAcctDuplicate,
+	CategoryAcctCoverageIncomplete,
+	CategoryAcctZeroReward,
+	CategoryAcctNewlyRegistered,
+	CategoryAcctDeregistered,
+}
+
 // Epoch check status values.
 const (
 	StatusPass  = "PASS"

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -882,28 +882,70 @@ func rationalsEqual(a, b string) bool {
 //     epoch never completed across every chunk, so there is no complete
 //     reference set to compare against yet).
 //   - PASS: no mismatches.
-func DetermineStatus(mismatches []CheckMismatch) string {
-	if len(mismatches) == 0 {
-		return StatusPass
+//
+// mismatchSeverity classifies one mismatch category. DetermineStatus and
+// CountSignificant both read it, so a category added to one can never be
+// forgotten by the other — the failure the split invited was a count that did
+// not agree with the status it accompanied.
+type mismatchSeverity int
+
+const (
+	// severityInformational describes state rather than disagreement. These
+	// must never turn an otherwise-clean epoch into ERROR or FAIL, and must
+	// never be counted as a reason for one.
+	severityInformational mismatchSeverity = iota
+	// severityError means the comparison could not be trusted, not that it
+	// disagreed.
+	severityError
+	// severityFail is a real Dingo/Koios disagreement.
+	severityFail
+)
+
+func severityOf(category string) mismatchSeverity {
+	switch category {
+	case CategoryDBError,
+		CategoryDBMissing,
+		CategoryReferenceLag,
+		CategoryAcctCoverageIncomplete:
+		return severityError
+	case CategoryAcctZeroReward,
+		CategoryAcctNewlyRegistered,
+		CategoryAcctDeregistered,
+		CategoryPoolDeparted:
+		// Purely informational — see these categories' doc comments.
+		return severityInformational
+	default:
+		return severityFail
 	}
+}
+
+// CountSignificant returns how many mismatches drove the status DetermineStatus
+// reports — every mismatch that is not purely informational.
+//
+// A caller reporting a failure should use this rather than len(mismatches).
+// An epoch can hold many informational rows and still pass, so including them
+// points the reader at rows that are by definition never the reason: Preview
+// epoch 198 failed on three account mismatches and reported twelve, eight of
+// which were pool departures that DetermineStatus ignores by design.
+func CountSignificant(mismatches []CheckMismatch) int {
+	n := 0
+	for _, m := range mismatches {
+		if severityOf(m.Category) != severityInformational {
+			n++
+		}
+	}
+	return n
+}
+
+func DetermineStatus(mismatches []CheckMismatch) string {
 	hasError := false
 	for _, m := range mismatches {
-		switch m.Category {
-		case CategoryDBError,
-			CategoryDBMissing,
-			CategoryReferenceLag,
-			CategoryAcctCoverageIncomplete:
-			hasError = true
-		case CategoryAcctZeroReward,
-			CategoryAcctNewlyRegistered,
-			CategoryAcctDeregistered,
-			CategoryPoolDeparted:
-			// Purely informational — see these categories' doc comments.
-			// Deliberately not counted toward hasError or default's FAIL: a
-			// zero-reward or lifecycle-change mismatch must never turn an
-			// otherwise-clean epoch into ERROR or FAIL.
-		default:
+		switch severityOf(m.Category) {
+		case severityFail:
 			return StatusFail
+		case severityError:
+			hasError = true
+		case severityInformational:
 		}
 	}
 	if hasError {

--- a/internal/koiosparity/observer.go
+++ b/internal/koiosparity/observer.go
@@ -477,9 +477,10 @@ func (o *Observer) processEpoch(ctx context.Context, epoch uint64) {
 		o.cfg.OnResult(result)
 	}
 	if result.Status != StatusPass {
+		significant := CountSignificant(result.Mismatches)
 		o.fail(epoch, fmt.Errorf(
-			"parity %s at epoch %d (%d mismatch(es))",
-			result.Status, epoch, len(result.Mismatches),
+			"parity %s at epoch %d (%d significant of %d mismatch(es))",
+			result.Status, epoch, significant, len(result.Mismatches),
 		))
 		return
 	}

--- a/internal/koiosparity/observer_test.go
+++ b/internal/koiosparity/observer_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -1237,4 +1238,123 @@ func TestObserverFetchIfNeededSurfacesPermanentErrorImmediately(t *testing.T) {
 
 	err = o.fetchIfNeeded(context.Background(), 9)
 	require.Error(t, err)
+}
+
+// TestObserverFailureReportsSignificantMismatchCount is the user-visible half
+// of the fix: the number an operator reads in the strict-mode fatal error and
+// in the observer's "epoch validation failed" log line.
+//
+// CountSignificant's own unit tests pin the arithmetic but not what
+// processEpoch does with it, and processEpoch is the only place the number
+// ever reaches a human. The epoch below holds one account value mismatch --
+// the reason it fails -- and one acct_newly_registered row, which
+// DetermineStatus ignores by design, so a message quoting len(Mismatches)
+// reports twice the count that caused the failure.
+func TestObserverFailureReportsSignificantMismatchCount(t *testing.T) {
+	db := newTestDatabaseSourceDB(t)
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+
+	const koiosEpoch = uint64(5)
+	const stakeEpoch = koiosEpoch - 1
+
+	stakingKey := testPoolKeyHash(t, 0x55)
+	addr, err := StakeAddressFromCredential(stakingKey, 0)
+	require.NoError(t, err)
+	// A second address in the requested universe that neither side ever pays.
+	// It becomes an acct_zero_reward row: descriptive state, never a reason
+	// for the failure, and exactly the kind of row that inflated the count.
+	quietAddr, err := StakeAddressFromCredential(testPoolKeyHash(t, 0x77), 0)
+	require.NoError(t, err)
+
+	srv := newFakeKoiosServer(t, map[uint64]*fakeEpochRef{
+		koiosEpoch: {
+			activeStake: "1000000",
+			treasury:    "10",
+			reserves:    "20",
+			fees:        "30",
+		},
+	}, fakeKoiosAccountFixtures{
+		addresses: []string{addr, quietAddr},
+		rewardsByEpoch: map[uint64][]KoiosAccountRewardHistoryItem{
+			koiosEpoch: {{
+				StakeAddress: addr,
+				EarnedEpoch:  koiosEpoch,
+				Amount:       "9999999", // deliberately wrong
+				Type:         "member",
+			}},
+		},
+	})
+	withTestKoiosBaseURL(t, srv.URL)
+
+	var mu sync.Mutex
+	var fatalErr error
+	var results []EpochCompareResult
+	o, err := NewObserver(ObserverConfig{
+		Network:         "preview",
+		CachePath:       filepath.Join(t.TempDir(), "cache.db"),
+		Source:          source,
+		Strict:          true,
+		AccountsEnabled: true,
+		Logger:          slog.New(slog.DiscardHandler),
+		OnResult: func(r *EpochCompareResult) {
+			mu.Lock()
+			results = append(results, *r)
+			mu.Unlock()
+		},
+		FatalFunc: func(err error) {
+			mu.Lock()
+			fatalErr = err
+			mu.Unlock()
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = o.Stop(context.Background()) }()
+
+	require.NoError(t, o.Start(context.Background()))
+	eb := event.NewEventBus(nil, nil)
+	defer eb.Stop()
+	eb.SubscribeFunc(
+		event.EpochTransitionEventType,
+		o.HandleEpochTransitionEvent,
+	)
+
+	seedDingoEpochAggregate(t, source, koiosEpoch, 1_000_000, 10, 20, 30)
+	sqlDB := sourceSQLDB(t, source.db)
+	require.NoError(t, sqlDB.Create(&models.RewardAccountOutput{
+		Epoch:       stakeEpoch,
+		StakingKey:  stakingKey,
+		PoolKeyHash: testPoolKeyHash(t, 0x66),
+		RewardType:  "member",
+		Amount:      types.Uint64(1_000_000),
+		Spendable:   true,
+	}).Error)
+
+	publishEpochTransition(eb, koiosEpoch)
+
+	testutil.WaitForCondition(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return fatalErr != nil
+	}, 5*time.Second, "strict mode must report the epoch failure")
+
+	mu.Lock()
+	err = fatalErr
+	got := slices.Clone(results)
+	mu.Unlock()
+
+	// The scenario has to actually contain an informational mismatch, or the
+	// two numbers coincide and the assertion below proves nothing.
+	require.NotEmpty(t, got)
+	result := got[len(got)-1]
+	require.Equal(t, StatusFail, result.Status)
+	require.Greater(t, len(result.Mismatches), CountSignificant(result.Mismatches),
+		"scenario must hold at least one informational mismatch")
+
+	require.ErrorContains(t, err, fmt.Sprintf(
+		"parity FAIL at epoch %d (%d significant of %d mismatch(es))",
+		koiosEpoch,
+		CountSignificant(result.Mismatches),
+		len(result.Mismatches),
+	))
 }

--- a/internal/koiosparity/severity_test.go
+++ b/internal/koiosparity/severity_test.go
@@ -1,6 +1,12 @@
 package koiosparity
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,20 +56,12 @@ func TestCountSignificantCountsErrors(t *testing.T) {
 // cannot coexist, in either direction. The two must read the same
 // classification, or a future category added to one will silently disagree
 // with the other.
+//
+// The loop is AllCategories itself, not a copy of it: a hand-maintained list
+// here would omit exactly the category a contributor also forgot to add to
+// severityOf, and the guard would pass on the case it exists to catch.
 func TestCountSignificantAgreesWithDetermineStatus(t *testing.T) {
-	for _, cat := range []string{
-		CategoryDBError,
-		CategoryDBMissing,
-		CategoryReferenceLag,
-		CategoryAcctCoverageIncomplete,
-		CategoryAcctZeroReward,
-		CategoryAcctNewlyRegistered,
-		CategoryAcctDeregistered,
-		CategoryPoolDeparted,
-		CategoryAcctOnlyDingo,
-		CategoryAcctOnlyKoios,
-		CategoryAcctDuplicate,
-	} {
+	for _, cat := range AllCategories {
 		t.Run(cat, func(t *testing.T) {
 			ms := []CheckMismatch{{Category: cat}}
 			passed := DetermineStatus(ms) == StatusPass
@@ -71,5 +69,70 @@ func TestCountSignificantAgreesWithDetermineStatus(t *testing.T) {
 				"status and significant count must classify %q the same way",
 				cat)
 		})
+	}
+}
+
+// TestAllCategoriesCoversEveryConstant keeps AllCategories honest.
+//
+// AllCategories is what makes the classification guard above load-bearing, so
+// it must not itself be a list that can fall behind. This reads the Category*
+// constants straight out of the package source and requires the two to be the
+// same set: a new category constant that never reaches AllCategories fails
+// here rather than sliding past a guard that simply never sees it.
+func TestAllCategoriesCoversEveryConstant(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+	pkg, ok := pkgs["koiosparity"]
+	require.True(t, ok, "package koiosparity must be parseable from .")
+
+	declared := map[string]string{} // constant name -> literal value
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if !strings.HasPrefix(name.Name, "Category") ||
+						i >= len(vs.Values) {
+						continue
+					}
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					value, err := strconv.Unquote(lit.Value)
+					require.NoError(t, err)
+					declared[name.Name] = value
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, declared, "no Category* constants found to check")
+
+	listed := map[string]bool{}
+	for _, cat := range AllCategories {
+		require.False(t, listed[cat],
+			"AllCategories lists %q more than once", cat)
+		listed[cat] = true
+	}
+	for name, value := range declared {
+		assert.True(t, listed[value],
+			"constant %s (%q) is missing from AllCategories, so severityOf's "+
+				"classification of it is unguarded", name, value)
+		delete(listed, value)
+	}
+	for cat := range listed {
+		assert.Fail(t, "unknown category listed",
+			"AllCategories contains %q, which is not a Category* constant",
+			cat)
 	}
 }

--- a/internal/koiosparity/severity_test.go
+++ b/internal/koiosparity/severity_test.go
@@ -1,0 +1,75 @@
+package koiosparity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountSignificantExcludesInformational pins that the number reported with
+// a parity failure counts the mismatches that caused it.
+//
+// DetermineStatus deliberately treats the lifecycle and pool-departure
+// categories as no-ops, so an epoch can hold many of them and still pass.
+// Counting them in the failure message points the reader at rows that are by
+// definition never the reason. Preview epoch 198 failed on 3 mismatches and
+// reported 12.
+func TestCountSignificantExcludesInformational(t *testing.T) {
+	mismatches := []CheckMismatch{
+		{Category: CategoryAcctOnlyDingo},
+		{Category: CategoryAcctOnlyDingo},
+		{Category: CategoryAcctOnlyDingo},
+		{Category: CategoryAcctZeroReward},
+	}
+	for range 8 {
+		mismatches = append(
+			mismatches,
+			CheckMismatch{Category: CategoryPoolDeparted},
+		)
+	}
+	require.Len(t, mismatches, 12)
+	assert.Equal(t, 3, CountSignificant(mismatches))
+	assert.Equal(t, StatusFail, DetermineStatus(mismatches))
+}
+
+// TestCountSignificantCountsErrors keeps the error categories significant:
+// they drive StatusError, so they are a reason too.
+func TestCountSignificantCountsErrors(t *testing.T) {
+	mismatches := []CheckMismatch{
+		{Category: CategoryDBError},
+		{Category: CategoryReferenceLag},
+		{Category: CategoryPoolDeparted},
+	}
+	assert.Equal(t, 2, CountSignificant(mismatches))
+	assert.Equal(t, StatusError, DetermineStatus(mismatches))
+}
+
+// TestCountSignificantAgreesWithDetermineStatus is the invariant that matters
+// more than either number: a status of PASS and a non-zero significant count
+// cannot coexist, in either direction. The two must read the same
+// classification, or a future category added to one will silently disagree
+// with the other.
+func TestCountSignificantAgreesWithDetermineStatus(t *testing.T) {
+	for _, cat := range []string{
+		CategoryDBError,
+		CategoryDBMissing,
+		CategoryReferenceLag,
+		CategoryAcctCoverageIncomplete,
+		CategoryAcctZeroReward,
+		CategoryAcctNewlyRegistered,
+		CategoryAcctDeregistered,
+		CategoryPoolDeparted,
+		CategoryAcctOnlyDingo,
+		CategoryAcctOnlyKoios,
+		CategoryAcctDuplicate,
+	} {
+		t.Run(cat, func(t *testing.T) {
+			ms := []CheckMismatch{{Category: cat}}
+			passed := DetermineStatus(ms) == StatusPass
+			assert.Equal(t, passed, CountSignificant(ms) == 0,
+				"status and significant count must classify %q the same way",
+				cat)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3917.

## Why

`observer.go` reported `len(result.Mismatches)` with a parity failure, but
`DetermineStatus` reaches `StatusFail` only through its `default` branch —
`acct_zero_reward`, `acct_newly_registered`, `acct_deregistered` and
`pool_departed` are explicitly excluded, with a comment saying a lifecycle
mismatch must never turn an otherwise-clean epoch into ERROR or FAIL.

So the count contradicted the decision it accompanied:

```
parity FAIL at epoch 198 (12 mismatch(es))
```

was 3 account mismatches, 1 zero-reward summary, and 8 pool departures. The
nine informational rows can never cause a failure. Investigating #3915 I
worked through the eight departures before noticing they were not the reason.

## The change

`severityOf` now holds the category classification once. `DetermineStatus` and
the new `CountSignificant` both read it. The message becomes:

```
parity FAIL at epoch 198 (3 significant of 12 mismatch(es))
```

Both numbers are kept: the total still says how much the epoch produced, which
is worth seeing, and the leading number now says how much of it mattered.

The `len(mismatches) == 0` early return in `DetermineStatus` is gone as
redundant, not as a behaviour change — an empty loop leaves `hasError` false
and returns `StatusPass`.

## Tests

`TestCountSignificantExcludesInformational` reconstructs epoch 198's exact
mix and pins 3 rather than 12. `TestCountSignificantCountsErrors` keeps the
error categories significant, since they drive `StatusError`.

`TestCountSignificantAgreesWithDetermineStatus` is the one that matters most:
for every category, a `StatusPass` and a non-zero significant count must not
coexist in either direction. That is the invariant the two copies of the
category list could violate, and it is what makes the shared `severityOf`
load-bearing rather than cosmetic.

## Validation

`make test` for `internal/koiosparity` passes, including the existing
`DetermineStatus` tests. `make lint` reports 0 golangci-lint issues across all
modules and the Windows target; `make docs-parity` passes.

`ARCHITECTURE.md` and `DATABASE.md` checked and not affected — no schema,
query, storage, or component-boundary change, and the category semantics
ARCHITECTURE.md describes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the parity failure message to report only the mismatches that caused the failure, not the total count. The old message said "12 mismatch(es)" even when only 3 were significant; now it says "3 significant of 12 mismatch(es)".

- Introduces a shared `mismatchSeverity` classification and an `AllCategories` list, both guarded by tests so a category can never be classified differently by the status and the count, or omitted from either.
- Removes the redundant empty-slice early return in `DetermineStatus`; behavior is unchanged.
- Adds an observer-level test pinning the message an operator reads, not just the `CountSignificant` arithmetic.

<sup>Written for commit 7b8f22bc91e52ebf4eed024ba43c09ad58ef521d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

