### PR TITLE
fix(koiosparity): treat a zero-value reward row as agreement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6737,7 +6737,9 @@ never the reverse.
   lag in publishing `/account_reward_history` for a just-closed epoch the
   same way it can lag on any other endpoint) both fall back to
   `reference_lag` within the grace window rather than only the
-  Koios-side direction.
+  Koios-side direction. The zero-value test runs first and wins: a one-sided
+  row worth zero is `acct_zero_reward_row` even inside the grace window,
+  because a zero row is not a value the other side can still publish later.
 - **Strict-mode propagation.** An account-level `FAIL` flows through
   `DetermineStatus` (any `acct_only_dingo`/`acct_only_koios`/`acct_duplicate`
   forces `FAIL`, exactly like the pool-level categories — except a one-sided

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6077,10 +6077,13 @@ at K+1, so its epoch-K block count has no row to live on), plus #3097's
 per-account categories: `acct_only_dingo`,
 `acct_only_koios`, `acct_duplicate` (a genuine duplicate (stake_address,
 reward_type) row within one side — a data-integrity problem, not a value
-disagreement), and `acct_coverage_incomplete` (the per-account Koios fetch for
-this epoch never completed across every chunk — see "Per-account exact parity
-(#3097)" below). Results are stored in `check_mismatches` and summarised in
-`check_epoch_status`.
+disagreement), `acct_zero_reward_row` (informational: a reward row worth zero
+lovelace present on one side only — nothing was credited either way, so the
+two sides agree about every lovelace and the one-sided row is a
+representational difference, not a divergence), and `acct_coverage_incomplete`
+(the per-account Koios fetch for this epoch never completed across every chunk
+— see "Per-account exact parity (#3097)" below). Results are stored in
+`check_mismatches` and summarised in `check_epoch_status`.
 
 Epochs 0-1 predate a valid Shelley "go" stake snapshot (mark→set→go takes 3
 epoch boundaries, so the go snapshot backing epoch E's active_stake needs
@@ -6544,7 +6547,12 @@ never the reverse.
   including the identical-string case, so two identical malformed or
   negative amounts never compare equal-by-accident — never a float/rational,
   so #3097's "no rounding, sampling, or tolerance" requirement holds exactly,
-  including a 1-lovelace difference. `graceHours`/`epochEndTime` apply the
+  including a 1-lovelace difference. `lovelaceEqual` and the
+  `acct_zero_reward_row` presence test share one parse (`parseLovelace`:
+  digits only, no sign, no surrounding whitespace) so that the same string
+  cannot be read as zero by one and malformed by the other — otherwise a
+  spelling like `" 0"` or `"+0"` gets a different verdict depending only on
+  whether the other side happened to have a row. `graceHours`/`epochEndTime` apply the
   identical `reference_lag` treatment `ComparePoolEpoch` already uses for a
   genuinely-too-recent epoch, symmetrically for both presence-mismatch
   directions: `acct_only_koios` (Koios has a row Dingo doesn't yet) and
@@ -6555,7 +6563,9 @@ never the reverse.
   Koios-side direction.
 - **Strict-mode propagation.** An account-level `FAIL` flows through
   `DetermineStatus` (any `acct_only_dingo`/`acct_only_koios`/`acct_duplicate`
-  forces `FAIL`, exactly like the pool-level categories) into
+  forces `FAIL`, exactly like the pool-level categories — except a one-sided
+  row worth zero lovelace, which is classified `acct_zero_reward_row` before
+  the presence categories are reached and is purely informational) into
   `EpochCompareResult.Status`, then into `Observer.processEpoch`'s
   `result.Status != StatusPass` check the same way a pool-level mismatch
   already does — no separate code path, so strict mode stops the node on an
@@ -6760,6 +6770,9 @@ every one of #3097's own tests passes unmodified.
   confirmed-zero-reward address (Koios answered, no reward, so no row is
   ever emitted for it) never enters that comparison at all — this half is
   read from `koios_account_checked` (`Cache.GetZeroRewardAccountsForEpoch`).
+  That is a distinct case from a row Koios *does* emit whose amount is zero,
+  which reaches `CompareAccountEpoch` normally and is reported as
+  `acct_zero_reward_row`; preview publishes zero-earned leader rows.
   Newly-registered/deregistered accounts are diffed from **Dingo's own
   epoch-scoped `reward_account_output` rows** at the current and previous
   stake epoch (`dingo.GetRewardAccountOutputs`, decoded via

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -867,14 +866,50 @@ func lovelaceEqual(a, b string) bool {
 	// string-equality short-circuit would report two identical malformed or
 	// negative strings as "equal" without ever validating them, letting
 	// CompareAccountEpoch pass on invalid account data.
-	var x, y big.Int
-	if _, ok := x.SetString(a, 10); !ok || x.Sign() < 0 {
+	x, ok := parseLovelace(a)
+	if !ok {
 		return false
 	}
-	if _, ok := y.SetString(b, 10); !ok || y.Sign() < 0 {
+	y, ok := parseLovelace(b)
+	if !ok {
 		return false
 	}
-	return x.Cmp(&y) == 0
+	return x.Cmp(y) == 0
+}
+
+// parseLovelace is the single definition of a well-formed lovelace amount:
+// one or more ASCII digits, nothing else. No sign, no surrounding whitespace,
+// no separators.
+//
+// It exists so that lovelaceEqual and isZeroRewardAmount cannot disagree about
+// what a string means. They read the same field from the same two sides, and a
+// string one of them accepts while the other rejects gets two verdicts from the
+// same input: with a divergent parse, " 0" was agreement when the row was
+// one-sided and value_mismatch when both sides had one, and "+0" was the
+// reverse. Whether a given malformed spelling ought to be tolerated is a
+// separate question from whether the two paths answer it the same way; this
+// answers the second, strictly, so a malformed amount is always reported and
+// never waived.
+//
+// Deliberately stricter than big.Int.SetString alone, which accepts a leading
+// sign: "-0" parses to zero with a non-negative sign, so a sign check does not
+// exclude it, and a negative lovelace amount is malformed data rather than a
+// zero reward. Leading zeros are accepted ("00" is zero) because the two sides
+// format independently and a value's spelling is not the comparison's business.
+func parseLovelace(s string) (*big.Int, bool) {
+	if s == "" {
+		return nil, false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return nil, false
+		}
+	}
+	var v big.Int
+	if _, ok := v.SetString(s, 10); !ok {
+		return nil, false
+	}
+	return &v, true
 }
 
 // rationalsEqual reports whether two numeric strings represent the same
@@ -894,11 +929,15 @@ func rationalsEqual(a, b string) bool {
 //
 // Parsed rather than compared to "0": the two sides format independently, and
 // a reward that is genuinely zero must be recognised as zero however it is
-// spelled. An unparseable amount is not zero — it is a real value the
-// comparison must keep reporting rather than quietly waive.
+// spelled, so "00" is zero. An unparseable amount is not zero — it is a real
+// value the comparison must keep reporting rather than quietly waive, so "",
+// "abc", " 0" and "-0" all stay one-sided rows and keep failing the epoch.
+//
+// The parse is parseLovelace, the same one lovelaceEqual uses, so a string
+// cannot be zero here and malformed there.
 func isZeroRewardAmount(amount string) bool {
-	v, err := strconv.ParseUint(strings.TrimSpace(amount), 10, 64)
-	return err == nil && v == 0
+	v, ok := parseLovelace(amount)
+	return ok && v.Sign() == 0
 }
 
 // DetermineStatus returns PASS, FAIL, or ERROR from a list of mismatches.

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -890,6 +890,17 @@ func rationalsEqual(a, b string) bool {
 	return ra.Cmp(&rb) == 0
 }
 
+// isZeroRewardAmount reports whether a lovelace decimal string is zero.
+//
+// Parsed rather than compared to "0": the two sides format independently, and
+// a reward that is genuinely zero must be recognised as zero however it is
+// spelled. An unparseable amount is not zero — it is a real value the
+// comparison must keep reporting rather than quietly waive.
+func isZeroRewardAmount(amount string) bool {
+	v, err := strconv.ParseUint(strings.TrimSpace(amount), 10, 64)
+	return err == nil && v == 0
+}
+
 // DetermineStatus returns PASS, FAIL, or ERROR from a list of mismatches.
 //
 //   - FAIL: any value_mismatch, pool_only_dingo, pool_only_koios,
@@ -903,18 +914,6 @@ func rationalsEqual(a, b string) bool {
 //     epoch never completed across every chunk, so there is no complete
 //     reference set to compare against yet).
 //   - PASS: no mismatches.
-//
-// isZeroRewardAmount reports whether a lovelace decimal string is zero.
-//
-// Parsed rather than compared to "0": the two sides format independently, and
-// a reward that is genuinely zero must be recognised as zero however it is
-// spelled. An unparseable amount is not zero — it is a real value the
-// comparison must keep reporting rather than quietly waive.
-func isZeroRewardAmount(amount string) bool {
-	v, err := strconv.ParseUint(strings.TrimSpace(amount), 10, 64)
-	return err == nil && v == 0
-}
-
 func DetermineStatus(mismatches []CheckMismatch) string {
 	if len(mismatches) == 0 {
 		return StatusPass

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -693,14 +693,26 @@ type accountRewardKey struct {
 // is not masked by the duplicate report.
 //
 // The union of the two (deduplicated) keysets is then walked: present only
-// in Koios -> CategoryAcctOnlyKoios (or CategoryReferenceLag within
-// graceHours of epochEndTime, mirroring ComparePoolEpoch's identical
-// pattern), present only in Dingo -> CategoryAcctOnlyDingo, present on both
-// sides with differing amounts -> CategoryValueMismatch (compared as exact
-// integers via lovelaceEqual, never as floats/rationals), present on both
-// sides with equal amounts -> no mismatch. A zero-reward account present
-// identically on both sides is therefore a pass, exactly like any other
-// equal-amount case.
+// in Koios -> CategoryAcctOnlyKoios, present only in Dingo ->
+// CategoryAcctOnlyDingo, present on both sides with differing amounts ->
+// CategoryValueMismatch (compared as exact integers via lovelaceEqual, never
+// as floats/rationals), present on both sides with equal amounts -> no
+// mismatch. A zero-reward account present identically on both sides is
+// therefore a pass, exactly like any other equal-amount case.
+//
+// Two things reclassify a one-sided row before it is emitted, in this order:
+//
+//   - The row is worth zero. The two sides then agree on what was credited
+//     (nothing) and disagree only about whether to store a row saying so, so
+//     it is CategoryAcctZeroRewardRow — informational — rather than either
+//     acct_only_* category. This takes precedence over the grace window
+//     below, because a zero row is not a value the other side can still
+//     publish later.
+//   - The check is inside graceHours of epochEndTime. Koios can lag in
+//     publishing /account_reward_history for a just-closed epoch, and Dingo
+//     can commit ahead of it, so a nonzero one-sided row is
+//     CategoryReferenceLag until the window closes — mirroring
+//     ComparePoolEpoch's identical pattern.
 //
 // graceHours/epochEndTime/now/network/epoch all mirror ComparePoolEpoch's
 // identical parameters and meaning.

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -19,6 +19,7 @@ import (
 	"math/big"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -64,14 +65,25 @@ const (
 	// (dingo #3099) report the three account dimensions #3097's merged
 	// comparison structurally cannot: CompareAccountEpoch only ever compares
 	// keys present in at least one side's row map, so an address absent from
-	// both (a confirmed-zero-reward account, since Koios never emits a row
-	// for zero reward) never enters that comparison at all, and #3097's
+	// both (a confirmed-zero-reward account, meaning Koios returned no rows
+	// for it at all — distinct from Koios returning a row whose amount is
+	// zero, which it does emit and which CategoryAcctZeroRewardRow covers)
+	// never enters that comparison at all, and #3097's
 	// address universe is a single flat list reused across every epoch in one
 	// run, with no per-epoch persisted snapshot to diff for lifecycle
 	// changes. All three are purely informational — descriptive state, not a
 	// Dingo-vs-Koios discrepancy — and must never affect Status (see
 	// DetermineStatus's dedicated no-op case for these three).
 	CategoryAcctZeroReward = "acct_zero_reward"
+	// CategoryAcctZeroRewardRow marks a reward row worth zero that exists on
+	// only one side. It corrects the premise stated above: Koios does emit a
+	// row for a zero reward — Preview publishes zero-earned leader rows —
+	// while Dingo writes no reward_account_output row at all in that case.
+	// Nothing is credited either way, so the two agree about every lovelace
+	// and the one-sided row is a representational difference, not a
+	// divergence. Purely informational, and reported rather than dropped so
+	// the difference stays visible.
+	CategoryAcctZeroRewardRow = "acct_zero_reward_row"
 	// CategoryAcctNewlyRegistered marks a stake address present in this
 	// stake epoch's Dingo-committed reward_account_output universe but
 	// absent from the previous stake epoch's — see
@@ -769,8 +781,13 @@ func CompareAccountEpoch(
 		switch {
 		case koiosOK && !dingoOK:
 			cat := CategoryAcctOnlyKoios
-			if graceHours > 0 && !epochEndTime.IsZero() &&
-				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour {
+			switch {
+			case isZeroRewardAmount(kr.Earned):
+				// Both sides credited nothing; see
+				// CategoryAcctZeroRewardRow.
+				cat = CategoryAcctZeroRewardRow
+			case graceHours > 0 && !epochEndTime.IsZero() &&
+				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour:
 				cat = CategoryReferenceLag
 			}
 			out = append(out, CheckMismatch{
@@ -795,8 +812,12 @@ func CompareAccountEpoch(
 			// hasn't published yet within graceHours is reference lag, not
 			// a real acct_only_dingo discrepancy.
 			cat := CategoryAcctOnlyDingo
-			if graceHours > 0 && !epochEndTime.IsZero() &&
-				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour {
+			switch {
+			case isZeroRewardAmount(dr.Amount):
+				// Symmetric with the koiosOK && !dingoOK case above.
+				cat = CategoryAcctZeroRewardRow
+			case graceHours > 0 && !epochEndTime.IsZero() &&
+				now.Sub(epochEndTime) < time.Duration(graceHours)*time.Hour:
 				cat = CategoryReferenceLag
 			}
 			out = append(out, CheckMismatch{
@@ -882,6 +903,18 @@ func rationalsEqual(a, b string) bool {
 //     epoch never completed across every chunk, so there is no complete
 //     reference set to compare against yet).
 //   - PASS: no mismatches.
+//
+// isZeroRewardAmount reports whether a lovelace decimal string is zero.
+//
+// Parsed rather than compared to "0": the two sides format independently, and
+// a reward that is genuinely zero must be recognised as zero however it is
+// spelled. An unparseable amount is not zero — it is a real value the
+// comparison must keep reporting rather than quietly waive.
+func isZeroRewardAmount(amount string) bool {
+	v, err := strconv.ParseUint(strings.TrimSpace(amount), 10, 64)
+	return err == nil && v == 0
+}
+
 func DetermineStatus(mismatches []CheckMismatch) string {
 	if len(mismatches) == 0 {
 		return StatusPass
@@ -895,6 +928,7 @@ func DetermineStatus(mismatches []CheckMismatch) string {
 			CategoryAcctCoverageIncomplete:
 			hasError = true
 		case CategoryAcctZeroReward,
+			CategoryAcctZeroRewardRow,
 			CategoryAcctNewlyRegistered,
 			CategoryAcctDeregistered,
 			CategoryPoolDeparted:

--- a/internal/koiosparity/zero_reward_row_test.go
+++ b/internal/koiosparity/zero_reward_row_test.go
@@ -1,0 +1,99 @@
+package koiosparity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const zeroRewardAddr = "stake_test1uzf5lwsf37wsxmq9rdpq0v9tepk0g36vqmxr974lenzwchcszrsss"
+
+// TestZeroEarnedKoiosRowIsNotDivergence pins that a Koios reward row worth
+// zero, with no Dingo counterpart, is agreement rather than acct_only_koios.
+//
+// The category doc comment asserted that "Koios never emits a row for zero
+// reward". Preview disproves it: Koios publishes zero-earned leader rows, and
+// Dingo writes no reward_account_output row at all for a zero reward. Nothing
+// was credited on either side, so no lovelace differs — but the presence test
+// read the row as a reward Dingo had missed and failed epoch 222.
+func TestZeroEarnedKoiosRowIsNotDivergence(t *testing.T) {
+	now := time.Now()
+	out := CompareAccountEpoch(
+		"preview", 222,
+		[]KoiosAccountRewards{
+			{
+				StakeAddress: zeroRewardAddr,
+				RewardType:   "leader",
+				Earned:       "0",
+			},
+		},
+		nil,
+		now, 0, time.Time{},
+	)
+	require.Len(t, out, 1, "the row should still be reported, not dropped")
+	assert.Equal(t, CategoryAcctZeroRewardRow, out[0].Category)
+	assert.Equal(t, StatusPass, DetermineStatus(out),
+		"a zero-earned row must never fail an epoch")
+}
+
+// TestZeroAmountDingoRowIsNotDivergence is the mirror. Dingo emits no
+// zero-amount rows today, but the two presence branches are deliberately
+// symmetric and a future zero row must not fail an epoch for the same reason.
+func TestZeroAmountDingoRowIsNotDivergence(t *testing.T) {
+	now := time.Now()
+	out := CompareAccountEpoch(
+		"preview", 222,
+		nil,
+		[]DingoAccountReward{
+			{
+				StakeAddress: zeroRewardAddr,
+				RewardType:   "leader",
+				Amount:       "0",
+			},
+		},
+		now, 0, time.Time{},
+	)
+	require.Len(t, out, 1)
+	assert.Equal(t, CategoryAcctZeroRewardRow, out[0].Category)
+	assert.Equal(t, StatusPass, DetermineStatus(out))
+}
+
+// TestNonZeroKoiosOnlyRowStillFails is the discrimination check: the change
+// must turn off only the zero case, never one-sided rows generally.
+func TestNonZeroKoiosOnlyRowStillFails(t *testing.T) {
+	now := time.Now()
+	out := CompareAccountEpoch(
+		"preview", 222,
+		[]KoiosAccountRewards{
+			{
+				StakeAddress: zeroRewardAddr,
+				RewardType:   "leader",
+				Earned:       "1",
+			},
+		},
+		nil,
+		now, 0, time.Time{},
+	)
+	require.Len(t, out, 1)
+	assert.Equal(t, CategoryAcctOnlyKoios, out[0].Category)
+	assert.Equal(t, StatusFail, DetermineStatus(out))
+}
+
+// A zero-earned row on both sides is an ordinary match and reports nothing —
+// the zero handling must not start manufacturing rows for agreeing pairs.
+func TestZeroOnBothSidesReportsNothing(t *testing.T) {
+	now := time.Now()
+	out := CompareAccountEpoch(
+		"preview", 222,
+		[]KoiosAccountRewards{
+			{StakeAddress: zeroRewardAddr, RewardType: "leader", Earned: "0"},
+		},
+		[]DingoAccountReward{
+			{StakeAddress: zeroRewardAddr, RewardType: "leader", Amount: "0"},
+		},
+		now, 0, time.Time{},
+	)
+	assert.Empty(t, out)
+}

--- a/internal/koiosparity/zero_reward_row_test.go
+++ b/internal/koiosparity/zero_reward_row_test.go
@@ -97,3 +97,74 @@ func TestZeroOnBothSidesReportsNothing(t *testing.T) {
 	)
 	assert.Empty(t, out)
 }
+
+// TestZeroRewardRowAmountSpellings pins both halves of isZeroRewardAmount's
+// contract at the level that matters — CompareAccountEpoch's verdict on a
+// one-sided row — rather than on the helper in isolation.
+//
+// Without these, replacing the helper's body with
+// `strings.TrimSpace(amount) == "0"` leaves the whole package green: every
+// other case in this file spells the amount "0" or "1", so neither "parsed,
+// not compared to the literal" nor "an unparseable amount is not zero" is
+// pinned. A waived row is the one outcome this category can produce that a
+// parity checker must never produce by accident.
+func TestZeroRewardRowAmountSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		earned   string
+		category string
+		status   string
+	}{
+		// Zero however it is spelled: the two sides format independently.
+		{"zero", "0", CategoryAcctZeroRewardRow, StatusPass},
+		{"leading zeros", "00", CategoryAcctZeroRewardRow, StatusPass},
+		// Not zero, and not waivable: each of these is malformed data, and a
+		// malformed amount is a real value the comparison must keep
+		// reporting.
+		{"empty", "", CategoryAcctOnlyKoios, StatusFail},
+		{"non-numeric", "abc", CategoryAcctOnlyKoios, StatusFail},
+		{"negative zero", "-0", CategoryAcctOnlyKoios, StatusFail},
+		{"signed zero", "+0", CategoryAcctOnlyKoios, StatusFail},
+		{"padded zero", " 0", CategoryAcctOnlyKoios, StatusFail},
+		{"nonzero", "1", CategoryAcctOnlyKoios, StatusFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := CompareAccountEpoch(
+				"preview", 222,
+				[]KoiosAccountRewards{{
+					StakeAddress: zeroRewardAddr,
+					RewardType:   "leader",
+					Earned:       tc.earned,
+				}},
+				nil,
+				time.Now(), 0, time.Time{},
+			)
+			require.Len(t, out, 1)
+			assert.Equal(t, tc.category, out[0].Category)
+			assert.Equal(t, tc.status, DetermineStatus(out))
+		})
+	}
+}
+
+// TestZeroRewardRowAgreesWithValueComparison is the property behind
+// parseLovelace: the presence path and the value path must not read the same
+// string two different ways.
+//
+// A spelling isZeroRewardAmount waives on a one-sided row is a spelling
+// lovelaceEqual must also call zero when both sides carry it, and one it
+// rejects must be rejected there too. Before the shared parse, " 0" was
+// agreement one-sided and value_mismatch two-sided, and "+0" was the reverse
+// — the same input, two verdicts, depending only on whether the other side
+// happened to have a row.
+func TestZeroRewardRowAgreesWithValueComparison(t *testing.T) {
+	for _, amount := range []string{
+		"0", "00", "", "abc", "-0", "+0", " 0", "0 ", "1",
+	} {
+		t.Run(amount, func(t *testing.T) {
+			waivedOneSided := isZeroRewardAmount(amount)
+			agreesWithZero := lovelaceEqual(amount, "0")
+			assert.Equal(t, waivedOneSided, agreesWithZero,
+				"presence and value paths must read %q the same way", amount)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3942

## Why

A Koios reward row worth zero with no Dingo counterpart was reported as
`acct_only_koios` — a FAIL category — and failed Preview epoch 222:

```
acct_only_koios  account_reward_presence
  stake_test1uzf5lwsf37wsxmq9rdpq0v9tepk0g36vqmxr974lenzwchcszrsss
  dingo=""   koios="0 (type=leader)"
```

Nothing was credited on either side. No lovelace differs.

The comparison's own documentation had the premise backwards. `CategoryAcctZeroReward`'s
doc comment states the confirmed-zero case arises "since Koios never emits a
row for zero reward". Koios does:

```sql
SELECT epoch, reward_type, count(*) FROM koios_account_rewards
 WHERE CAST(earned AS INTEGER) = 0 GROUP BY epoch, reward_type;

222|leader|1   155|leader|1   154|leader|1   152|leader|1
150|leader|1   149|leader|1   148|leader|1   147|leader|2   ...
```

Dingo, conversely, writes no `reward_account_output` row at all for a zero
reward — its table holds no zero-amount row in any epoch. So the two sides
represent "credited nothing" differently, and the presence test read that as a
reward Dingo had missed.

This is distinct from the existing zero-reward concept, which keys off
`reward_row_count = 0` — Koios returning *no* rows for an account. Here Koios
returns one row whose amount is zero. I corrected that doc comment too.

## The change

A one-sided reward row worth zero is classified informationally instead of as
a presence divergence, in both directions. It is reported rather than dropped,
so the representational difference stays visible.

The amount is parsed rather than compared against the literal `"0"`: the two
sides format independently, and an unparseable amount is deliberately *not*
treated as zero — that is a real value the comparison must keep reporting.

The Dingo-only direction produces no such rows today. It is handled anyway
because the two presence branches are deliberately symmetric.

## Tests

Zero-earned Koios row is informational and passes; the Dingo mirror likewise;
a one-lovelace Koios-only row still fails, which is the discrimination that
keeps this from silencing one-sided rows generally; and a zero on both sides
reports nothing at all, so the handling cannot start manufacturing rows for
agreeing pairs.

## Validation

Found by a from-genesis Preview replay under the parity observer. `make test`
for `internal/koiosparity` passes; `make lint` reports 0 golangci-lint issues
across all modules and the Windows target; `make docs-parity` passes.

`ARCHITECTURE.md` and `DATABASE.md` checked and not affected — no schema,
query, storage, or component-boundary change. The new category is internal to
the parity checker's mismatch classification, which those documents describe
only at the level this change preserves.

## Merge and CI state

`origin/main` merged in (`4005f91a`), not rebased, to resolve the conflict with #3920's shared severity classification: both `severityOf` and `isZeroRewardAmount` are retained, and `CategoryAcctZeroRewardRow` is registered in `severityOf`'s informational case **and** in `AllCategories` — the guard test caught the second omission.

`go-test` is red, for a reason outside this PR. Three tests in `ledger/eras` — `TestConwayUtxoValidationRuleIndexesArePinned`, `TestValidateTxConwayGenuinelyMissingInputStillRejected` and `TestValidateTxConwayGenuinelyUnbalancedStillRejected` — fail on all four platforms at `main`'s own head (`90504583`), which is the commit merged here, and this branch has no diff against main under `ledger/eras`, `go.mod` or `go.sum`. Tracked in **#3976**. `./bin`'s two entrypoint tests also fail under full-suite load on unmodified `main` (#3930/#3574).

Locally: `go test ./internal/koiosparity/... -count=1` passes, `make lint` reports 0 golangci-lint issues across all four scopes, `make docs-parity` passes. `nilaway` could not run — the pinned binary is go1.26-built and fails prerequisites against the installed go1.27.1 toolchain while still exiting 0, so it is reported as unavailable rather than clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a one-sided reward row worth zero as agreement instead of a presence divergence, so Preview epoch 222 no longer fails on rows where both sides credited nothing.

- Reports zero-earned Koios-only rows (and the symmetric Dingo-only case) as informational `acct_zero_reward_row`; this outranks the grace-window reference-lag fallback, and nonzero one-sided rows still fail.
- Parses amounts through one shared `parseLovelace` for both presence and value checks, so the same string can't be read as zero by one and malformed by the other; unparseable amounts are never treated as zero.
- Registers the category in `AllCategories` and `severityOf`, which the merge with main's shared severity classification required.
- Corrects the `CategoryAcctZeroReward` doc comment and `ARCHITECTURE.md` (Koios does emit zero-reward rows; Dingo writes none) and keeps `DetermineStatus`'s doc block attached after the helper insertion.

<sup>Written for commit d711bfb427dd8742ae047bbe637edabf29546167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Zero-reward account rows are now treated as informational rather than reported as discrepancies.
  - Nonzero account-only rows continue to be reported as divergences.
  - Matching zero-reward rows no longer produce unnecessary comparison results.

- **Tests**
  - Added coverage for zero-reward rows from either source, matching zero rows, and nonzero discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
