### PR TITLE
fix(forging): reject era-incompatible opcert counters before forging

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4341,6 +4341,27 @@ The start, expiry, current-period, and remaining-period gauges use that same
 protocol lifetime; the KES key's `2^depth` cryptographic capacity remains a
 separate upper bound rather than an operational lifetime.
 
+Immediately after that gate, when `ForgerConfig.OpCertLedgerView` is wired
+(`NewBlockForger` requires `EraParams` alongside it), the runtime gate
+pre-flights the opcert's issue-number counter against
+`LedgerView.LatestOpCertSequence` using the same era-scoped rule block
+application enforces at apply time (`validateOpCertCounter` in
+`ledger/verify_opcert.go`, mirrored here as `validateOpCertSequence`): a
+counter behind the last value the ledger observed for this pool is always
+rejected (stale or stolen hot key), and one that skips ahead of it is
+additionally rejected in Praos eras (Babbage onward) but accepted in TPraos
+eras (Shelley-Alonzo). `EraParams.ProtocolParamsForSlot` resolves the era for
+the slot being forged. Startup validation and the KES-lifetime gate above
+cover genesis-derived evolution limits, which are fixed for the life of the
+chain; this covers the era-scoped counter rule and the on-chain observed
+counter, both of which can change after startup as blocks are applied (this
+node's own or a peer's for the same pool) or as the chain crosses an era
+boundary. Catching a rule block application would enforce anyway here, before
+leader selection and the forge-slot fence, means a bad key state costs a
+could-not-forge disposition instead of a burned leader slot and a rejected
+`AddLocalBlock` call. The check is opt-in: a nil `OpCertLedgerView` (dev mode,
+embedders without ledger wiring) skips it entirely, unchanged from before.
+
 Each production forge attempt takes an independently owned snapshot of one
 complete credential generation at the runtime gate. The snapshot deep-copies
 the VRF secret, KES secret, verification keys, opcert, and validated lifetime;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4341,26 +4341,28 @@ The start, expiry, current-period, and remaining-period gauges use that same
 protocol lifetime; the KES key's `2^depth` cryptographic capacity remains a
 separate upper bound rather than an operational lifetime.
 
-Immediately after that gate, when `ForgerConfig.OpCertLedgerView` is wired
-(`NewBlockForger` requires `EraParams` alongside it), the runtime gate
-pre-flights the opcert's issue-number counter against
-`LedgerView.LatestOpCertSequence` using the same era-scoped rule block
-application enforces at apply time (`validateOpCertCounter` in
-`ledger/verify_opcert.go`, mirrored here as `validateOpCertSequence`): a
-counter behind the last value the ledger observed for this pool is always
-rejected (stale or stolen hot key), and one that skips ahead of it is
-additionally rejected in Praos eras (Babbage onward) but accepted in TPraos
-eras (Shelley-Alonzo). `EraParams.ProtocolParamsForSlot` resolves the era for
-the slot being forged. Startup validation and the KES-lifetime gate above
-cover genesis-derived evolution limits, which are fixed for the life of the
-chain; this covers the era-scoped counter rule and the on-chain observed
-counter, both of which can change after startup as blocks are applied (this
-node's own or a peer's for the same pool) or as the chain crosses an era
-boundary. Catching a rule block application would enforce anyway here, before
-leader selection and the forge-slot fence, means a bad key state costs a
-could-not-forge disposition instead of a burned leader slot and a rejected
-`AddLocalBlock` call. The check is opt-in: a nil `OpCertLedgerView` (dev mode,
-embedders without ledger wiring) skips it entirely, unchanged from before.
+When `ForgerConfig.OpCertLedgerView` is wired (`NewBlockForger` requires
+`EraParams` alongside it), the runtime gate pre-flights the opcert's
+issue-number counter against `LedgerView.LatestOpCertSequence` using the
+same era-scoped rule block application enforces at apply time
+(`ledger/eras.ValidateOpCertCounter`, the single implementation shared with
+`validateOpCertCounter` in `ledger/verify_opcert.go` and mirrored here as
+`validateOpCertSequence`): a counter behind the last value the ledger
+observed for this pool is always rejected (stale or stolen hot key), and
+one that skips ahead of it is additionally rejected in Praos eras (Babbage
+onward) but accepted in TPraos eras (Shelley-Alonzo). `EraParams.ProtocolParamsForSlot`
+resolves the era for the slot being forged. Startup validation and the
+KES-lifetime gate above cover genesis-derived evolution limits, which are
+fixed for the life of the chain; this covers the era-scoped counter rule
+and the on-chain observed counter, both of which can change after startup
+as blocks are applied (this node's own or a peer's for the same pool) or
+as the chain crosses an era boundary. The check runs right after leader
+selection -- it costs a real ledger read, so it is skipped for a slot this
+pool does not lead -- but still before the forge-slot fence and any
+VRF/KES/Leios work, so a bad key state costs a could-not-forge disposition
+instead of a burned leader slot and a rejected `AddLocalBlock` call. The
+check is opt-in: a nil `OpCertLedgerView` (dev mode, embedders without
+ledger wiring) skips it entirely, unchanged from before.
 
 Each production forge attempt takes an independently owned snapshot of one
 complete credential generation at the runtime gate. The snapshot deep-copies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4364,6 +4364,33 @@ instead of a burned leader slot and a rejected `AddLocalBlock` call. The
 check is opt-in: a nil `OpCertLedgerView` (dev mode, embedders without
 ledger wiring) skips it entirely, unchanged from before.
 
+`LedgerState.LatestOpCertSequence` -- the `LedgerView` method both this
+gate and startup's `PoolCredentials.ValidateAgainstLedger` read through --
+resolves the "latest observed" counter via the same Mithril-boundary-aware
+path as block application (`latestOpCertCounterForValidation`, both now
+backed by the shared `latestOpCertCounterAfterMithril`), instead of a plain
+`MAX` over the whole table. A Mithril-restored node's per-pool opcert
+history is only trustworthy after the certified boundary; a plain MAX could
+return a stale pre-boundary row that block application itself does not
+trust as a baseline. `LatestOpCertSequence` captures `mithrilLedgerSlot`
+under a read lock before calling the shared resolver, since (unlike
+`latestOpCertCounterForValidation`'s block-application caller) neither
+startup validation nor the forge loop otherwise holds a lock across that
+field.
+
+Startup's `PoolCredentials.ValidateAgainstLedger` applies the identical
+era-scoped counter rule (an `enforceNoGap` parameter, resolved by
+`Node.opCertNoGapRuleForCurrentSlot` via the same exported
+`forging.EnforceOpCertNoGapRule` era classification the forge loop uses),
+not just the staleness half it always checked. Before this, a Praos-era
+opcert that was gapped but not stale would start the node cleanly and only
+be rejected on every subsequent forge attempt; startup now surfaces that
+loudly instead. Era resolution failing at startup (e.g. protocol
+parameters genuinely unavailable yet) is not itself fatal: it logs a
+warning and falls back to the stale-only check rather than adding a new
+startup-failure mode for a condition unrelated to the credential
+cross-check itself.
+
 Each production forge attempt takes an independently owned snapshot of one
 complete credential generation at the runtime gate. The snapshot deep-copies
 the VRF secret, KES secret, verification keys, opcert, and validated lifetime;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4357,12 +4357,13 @@ fixed for the life of the chain; this covers the era-scoped counter rule
 and the on-chain observed counter, both of which can change after startup
 as blocks are applied (this node's own or a peer's for the same pool) or
 as the chain crosses an era boundary. The check runs right after leader
-selection -- it costs a real ledger read, so it is skipped for a slot this
-pool does not lead -- but still before the forge-slot fence and any
-VRF/KES/Leios work, so a bad key state costs a could-not-forge disposition
-instead of a burned leader slot and a rejected `AddLocalBlock` call. The
-check is opt-in: a nil `OpCertLedgerView` (dev mode, embedders without
-ledger wiring) skips it entirely, unchanged from before.
+selection (a Praos leader-VRF check that, together with the KES-lifetime
+gate above, already precedes it) -- it costs a real ledger read, so it is
+skipped for a slot this pool does not lead -- but still before Leios work
+and the forge-slot fence, so a bad key state costs a could-not-forge
+disposition instead of a burned leader slot and a rejected `AddLocalBlock`
+call. The check is opt-in: a nil `OpCertLedgerView` (dev mode, embedders
+without ledger wiring) skips it entirely, unchanged from before.
 
 `LedgerState.LatestOpCertSequence` -- the `LedgerView` method both this
 gate and startup's `PoolCredentials.ValidateAgainstLedger` read through --
@@ -4372,24 +4373,26 @@ backed by the shared `latestOpCertCounterAfterMithril`), instead of a plain
 `MAX` over the whole table. A Mithril-restored node's per-pool opcert
 history is only trustworthy after the certified boundary; a plain MAX could
 return a stale pre-boundary row that block application itself does not
-trust as a baseline. `LatestOpCertSequence` captures `mithrilLedgerSlot`
-under a read lock before calling the shared resolver, since (unlike
-`latestOpCertCounterForValidation`'s block-application caller) neither
-startup validation nor the forge loop otherwise holds a lock across that
-field.
+trust as a baseline. Neither caller otherwise holds a lock across
+`mithrilLedgerSlot`, so both resolve it through the existing lock-safe
+`mithrilLedgerSlotSnapshot` accessor before calling the shared resolver,
+rather than reading the field directly.
 
-Startup's `PoolCredentials.ValidateAgainstLedger` applies the identical
-era-scoped counter rule (an `enforceNoGap` parameter, resolved by
-`Node.opCertNoGapRuleForCurrentSlot` via the same exported
-`forging.EnforceOpCertNoGapRule` era classification the forge loop uses),
-not just the staleness half it always checked. Before this, a Praos-era
-opcert that was gapped but not stale would start the node cleanly and only
-be rejected on every subsequent forge attempt; startup now surfaces that
-loudly instead. Era resolution failing at startup (e.g. protocol
-parameters genuinely unavailable yet) is not itself fatal: it logs a
-warning and falls back to the stale-only check rather than adding a new
-startup-failure mode for a condition unrelated to the credential
-cross-check itself.
+Startup's `PoolCredentials.ValidateAgainstLedger` deliberately stays on the
+staleness-only half of this rule and does not apply the era-scoped no-gap
+check the forge loop enforces. Applying it at startup would pair a
+wall-clock-resolved era (`LedgerState.CurrentSlot` is wall-clock and valid
+regardless of sync state) with a baseline that only reflects the applied
+chain (`LatestOpCertSequence`); on a node whose applied tip is behind wall-
+clock time -- an interrupted initial sync, a resume after downtime, a
+restore to an older snapshot -- those two can disagree enough to make a
+pool several opcert rotations into its life look gapped against a baseline
+that has simply not caught up yet, and a fatal startup rejection would
+prevent the node from ever syncing to the point that makes the baseline
+correct. The forge loop's own gate does not have this problem: it runs
+after the upstream-sync skip and the leader check, so both its era and its
+baseline come from near-tip state, and a rejection there costs one slot
+rather than the node's ability to start.
 
 Each production forge attempt takes an independently owned snapshot of one
 complete credential generation at the runtime gate. The snapshot deep-copies

--- a/ledger/eras/opcert.go
+++ b/ledger/eras/opcert.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eras
+
+import "fmt"
+
+// ValidateOpCertCounter enforces the operational-certificate issue-number
+// counter rule shared by block application (ledger/verify_opcert.go) and
+// the forge loop's pre-flight check (ledger/forging/keys.go): the single
+// source of truth for the rule, so the two call sites cannot drift apart.
+//
+// A counter below the last-seen value is always rejected (stale or stolen
+// hot key), in every era. A counter that skips ahead of it is rejected
+// only when enforceNoGap is set: the over-increment (no-gap) rule is
+// Praos-only (Babbage onward); TPraos eras (Shelley-Alonzo) accept any
+// candidate at or above stored. When there is no recorded counter (found
+// is false) there is no baseline to compare against, so the candidate is
+// accepted.
+//
+// The gap comparison checks candidate > stored before subtracting, rather
+// than comparing candidate > stored+1, so a stored value of
+// math.MaxUint64 cannot wrap the addition to zero and misclassify an
+// equal candidate as gapped.
+func ValidateOpCertCounter(
+	stored uint64,
+	found bool,
+	candidate uint64,
+	enforceNoGap bool,
+) error {
+	if !found {
+		return nil
+	}
+	if candidate < stored {
+		return fmt.Errorf(
+			"opcert counter %d is below last seen %d (stale or stolen hot key)",
+			candidate,
+			stored,
+		)
+	}
+	if enforceNoGap && candidate > stored && candidate-stored > 1 {
+		return fmt.Errorf(
+			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
+			candidate,
+			stored,
+		)
+	}
+	return nil
+}

--- a/ledger/forging/eras.go
+++ b/ledger/forging/eras.go
@@ -17,6 +17,7 @@ package forging
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -81,11 +82,19 @@ type pparamsLimits struct {
 }
 
 // extractPParamsLimits returns the BuildBlock-relevant fields from any
-// era's protocol parameters. Returns an error only if pparams is nil
-// or of an unrecognized type.
+// era's protocol parameters. Returns an error if pparams is nil (including
+// a typed-nil pointer of a known era's type stored in the interface, which
+// an `== nil` interface comparison alone would miss and the type switch
+// below would then dereference) or of an unrecognized type.
 func extractPParamsLimits(p lcommon.ProtocolParameters) (pparamsLimits, error) {
 	if p == nil {
 		return pparamsLimits{}, errors.New("protocol parameters are nil")
+	}
+	if v := reflect.ValueOf(p); v.Kind() == reflect.Pointer && v.IsNil() {
+		return pparamsLimits{}, fmt.Errorf(
+			"protocol parameters are a nil %T pointer",
+			p,
+		)
 	}
 	switch pp := p.(type) {
 	case *dijkstra.DijkstraProtocolParameters:

--- a/ledger/forging/eras.go
+++ b/ledger/forging/eras.go
@@ -81,22 +81,6 @@ type pparamsLimits struct {
 	protoMinor   uint64
 }
 
-// EnforceOpCertNoGapRule reports whether the operational-certificate
-// counter's no-gap (over-increment) rule applies for the era described by
-// pparams: Praos eras (Babbage onward) enforce it, TPraos eras
-// (Shelley-Alonzo) do not (see ledger/eras.ValidateOpCertCounter's
-// enforceNoGap parameter). Exported so callers outside this package that
-// need the same era-scoped classification -- e.g. startup credential
-// validation -- do not have to duplicate extractPParamsLimits' era
-// dispatch.
-func EnforceOpCertNoGapRule(pparams lcommon.ProtocolParameters) (bool, error) {
-	limits, err := extractPParamsLimits(pparams)
-	if err != nil {
-		return false, err
-	}
-	return !limits.era.isTPraos(), nil
-}
-
 // extractPParamsLimits returns the BuildBlock-relevant fields from any
 // era's protocol parameters. Returns an error if pparams is nil (including
 // a typed-nil pointer of a known era's type stored in the interface, which

--- a/ledger/forging/eras.go
+++ b/ledger/forging/eras.go
@@ -81,6 +81,22 @@ type pparamsLimits struct {
 	protoMinor   uint64
 }
 
+// EnforceOpCertNoGapRule reports whether the operational-certificate
+// counter's no-gap (over-increment) rule applies for the era described by
+// pparams: Praos eras (Babbage onward) enforce it, TPraos eras
+// (Shelley-Alonzo) do not (see ledger/eras.ValidateOpCertCounter's
+// enforceNoGap parameter). Exported so callers outside this package that
+// need the same era-scoped classification -- e.g. startup credential
+// validation -- do not have to duplicate extractPParamsLimits' era
+// dispatch.
+func EnforceOpCertNoGapRule(pparams lcommon.ProtocolParameters) (bool, error) {
+	limits, err := extractPParamsLimits(pparams)
+	if err != nil {
+		return false, err
+	}
+	return !limits.era.isTPraos(), nil
+}
+
 // extractPParamsLimits returns the BuildBlock-relevant fields from any
 // era's protocol parameters. Returns an error if pparams is nil (including
 // a typed-nil pointer of a known era's type stored in the interface, which

--- a/ledger/forging/eras_test.go
+++ b/ledger/forging/eras_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
@@ -60,4 +61,39 @@ func TestExtractPParamsLimitsRejectsTypedNilPointer(t *testing.T) {
 func TestExtractPParamsLimitsRejectsUnrecognizedType(t *testing.T) {
 	_, err := extractPParamsLimits(unrecognizedProtocolParameters{})
 	require.ErrorContains(t, err, "unsupported")
+}
+
+// TestEnforceOpCertNoGapRule pins the exported era classification callers
+// outside this package (startup credential validation) rely on to match
+// the forge loop's own classification: Praos (Babbage onward) enforces the
+// no-gap rule, TPraos (Shelley-Alonzo) does not.
+func TestEnforceOpCertNoGapRule(t *testing.T) {
+	enforce, err := EnforceOpCertNoGapRule(
+		&babbage.BabbageProtocolParameters{},
+	)
+	require.NoError(t, err)
+	require.True(
+		t,
+		enforce,
+		"Babbage is Praos and must enforce the no-gap rule",
+	)
+
+	enforce, err = EnforceOpCertNoGapRule(
+		&conway.ConwayProtocolParameters{},
+	)
+	require.NoError(t, err)
+	require.True(t, enforce, "Conway is Praos and must enforce the no-gap rule")
+
+	enforce, err = EnforceOpCertNoGapRule(
+		&shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
+	)
+	require.NoError(t, err)
+	require.False(
+		t,
+		enforce,
+		"Shelley is TPraos and must not enforce the no-gap rule",
+	)
+
+	_, err = EnforceOpCertNoGapRule(nil)
+	require.Error(t, err)
 }

--- a/ledger/forging/eras_test.go
+++ b/ledger/forging/eras_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// unrecognizedProtocolParameters satisfies lcommon.ProtocolParameters
+// without matching any case extractPParamsLimits recognizes.
+type unrecognizedProtocolParameters struct{}
+
+func (unrecognizedProtocolParameters) Utxorpc() (*utxorpc_cardano.PParams, error) {
+	return nil, nil
+}
+
+// TestExtractPParamsLimitsRejectsNilInterface covers the ordinary nil case:
+// no concrete type is stored in the interface at all.
+func TestExtractPParamsLimitsRejectsNilInterface(t *testing.T) {
+	_, err := extractPParamsLimits(nil)
+	require.ErrorContains(t, err, "nil")
+}
+
+// TestExtractPParamsLimitsRejectsTypedNilPointer covers a provider
+// returning a non-nil lcommon.ProtocolParameters interface value that
+// wraps a nil pointer of a known era's concrete type -- e.g. a
+// ProtocolParamsForSlot implementation that assigns a typed *T(nil) to an
+// interface-typed field. `p == nil` is false for that value (the
+// interface itself has a concrete type), so without this check the type
+// switch below would match the era's case and panic dereferencing pp.
+func TestExtractPParamsLimitsRejectsTypedNilPointer(t *testing.T) {
+	var nilConway *conway.ConwayProtocolParameters
+	_, err := extractPParamsLimits(nilConway)
+	require.ErrorContains(t, err, "nil")
+
+	var nilBabbage *babbage.BabbageProtocolParameters
+	_, err = extractPParamsLimits(nilBabbage)
+	require.ErrorContains(t, err, "nil")
+}
+
+// TestExtractPParamsLimitsRejectsUnrecognizedType covers a concrete type
+// extractPParamsLimits does not recognize at all.
+func TestExtractPParamsLimitsRejectsUnrecognizedType(t *testing.T) {
+	_, err := extractPParamsLimits(unrecognizedProtocolParameters{})
+	require.ErrorContains(t, err, "unsupported")
+}

--- a/ledger/forging/eras_test.go
+++ b/ledger/forging/eras_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
-	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/require"
 	utxorpc_cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
@@ -61,39 +60,4 @@ func TestExtractPParamsLimitsRejectsTypedNilPointer(t *testing.T) {
 func TestExtractPParamsLimitsRejectsUnrecognizedType(t *testing.T) {
 	_, err := extractPParamsLimits(unrecognizedProtocolParameters{})
 	require.ErrorContains(t, err, "unsupported")
-}
-
-// TestEnforceOpCertNoGapRule pins the exported era classification callers
-// outside this package (startup credential validation) rely on to match
-// the forge loop's own classification: Praos (Babbage onward) enforces the
-// no-gap rule, TPraos (Shelley-Alonzo) does not.
-func TestEnforceOpCertNoGapRule(t *testing.T) {
-	enforce, err := EnforceOpCertNoGapRule(
-		&babbage.BabbageProtocolParameters{},
-	)
-	require.NoError(t, err)
-	require.True(
-		t,
-		enforce,
-		"Babbage is Praos and must enforce the no-gap rule",
-	)
-
-	enforce, err = EnforceOpCertNoGapRule(
-		&conway.ConwayProtocolParameters{},
-	)
-	require.NoError(t, err)
-	require.True(t, enforce, "Conway is Praos and must enforce the no-gap rule")
-
-	enforce, err = EnforceOpCertNoGapRule(
-		&shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
-	)
-	require.NoError(t, err)
-	require.False(
-		t,
-		enforce,
-		"Shelley is TPraos and must not enforce the no-gap rule",
-	)
-
-	_, err = EnforceOpCertNoGapRule(nil)
-	require.Error(t, err)
 }

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -807,6 +806,20 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
+	// Check if we're the leader for this slot only after the KES gate.
+	isLeader := f.checkLeaderSafe(currentSlot)
+	if !isLeader {
+		f.logger.Debug(
+			"forge check: not leader for slot",
+			"current_slot", currentSlot,
+			"tip_slot", tipSlot,
+		)
+		if f.metrics != nil {
+			f.metrics.forgeNotLeader.Inc()
+		}
+		return nil
+	}
+
 	// Pre-flight the OpCert counter against the ledger's observed on-chain
 	// state and the era-scoped rule block application enforces (see
 	// checkOpCertSequence). This covers genesis/era context the KES-lifetime
@@ -814,6 +827,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// applied (this node's own or a peer's for the same pool), so a key
 	// state that was fine at startup or on an earlier slot can become stale,
 	// or -- from Babbage onward -- gapped, by the time a later slot is won.
+	// Checked only for the winning slot -- after the cheap leader check --
+	// rather than on every KES-valid slot, since the check performs a real
+	// ledger read that would otherwise run regardless of whether this pool
+	// is even leader for the slot.
 	if f.opCertLedgerView != nil {
 		if err := f.checkOpCertSequence(currentSlot, generation); err != nil {
 			f.incCouldNotForge()
@@ -828,20 +845,6 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			)
 			return nil
 		}
-	}
-
-	// Check if we're the leader for this slot only after the KES gate.
-	isLeader := f.checkLeaderSafe(currentSlot)
-	if !isLeader {
-		f.logger.Debug(
-			"forge check: not leader for slot",
-			"current_slot", currentSlot,
-			"tip_slot", tipSlot,
-		)
-		if f.metrics != nil {
-			f.metrics.forgeNotLeader.Inc()
-		}
-		return nil
 	}
 
 	// The credential snapshot owns its secret material, so the callback above
@@ -1249,12 +1252,15 @@ func (f *BlockForger) checkOpCertSequence(
 		return fmt.Errorf("opcert sequence lookup: %w", err)
 	}
 	pparams := f.eraParams.ProtocolParamsForSlot(slot)
-	if pparams == nil || (reflect.ValueOf(pparams).Kind() == reflect.Ptr && reflect.ValueOf(pparams).IsNil()) {
+	if pparams == nil {
 		return fmt.Errorf(
 			"protocol parameters unavailable for slot %d",
 			slot,
 		)
 	}
+	// extractPParamsLimits also rejects a typed-nil pointer of a known
+	// era's type stored in this interface, which the plain nil check above
+	// cannot see (see its doc comment in eras.go).
 	limits, err := extractPParamsLimits(pparams)
 	if err != nil {
 		return fmt.Errorf("resolve era for opcert counter rule: %w", err)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -313,10 +313,12 @@ type ForgerConfig struct {
 	// ledger has observed on chain for this pool. When non-nil, the forge
 	// loop pre-flights the candidate counter against it using the same
 	// era-scoped rule block application enforces (see
-	// ledger/verify_opcert.go validateOpCertCounter), before spending a
-	// leader slot on VRF/KES/Leios work a stale or gapped counter would
-	// have the chain discard anyway. Nil disables the check (dev mode,
-	// embedders without ledger wiring). Requires EraParams.
+	// ledger/verify_opcert.go validateOpCertCounter), after leader
+	// selection but before Leios work and the forge-slot fence -- a stale
+	// or gapped counter is rejected there instead of reaching an
+	// `AddLocalBlock` call the chain would discard anyway. Nil disables
+	// the check (dev mode, embedders without ledger wiring). Requires
+	// EraParams.
 	OpCertLedgerView LedgerView
 	// EraParams supplies the era-defining protocol parameters in effect for
 	// the slot being forged, so OpCertLedgerView's counter check applies

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -1248,7 +1249,7 @@ func (f *BlockForger) checkOpCertSequence(
 		return fmt.Errorf("opcert sequence lookup: %w", err)
 	}
 	pparams := f.eraParams.ProtocolParamsForSlot(slot)
-	if pparams == nil {
+	if pparams == nil || (reflect.ValueOf(pparams).Kind() == reflect.Ptr && reflect.ValueOf(pparams).IsNil()) {
 		return fmt.Errorf(
 			"protocol parameters unavailable for slot %d",
 			slot,

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -77,6 +77,8 @@ type BlockForger struct {
 	blockForged      BlockForgedObserver
 	slotClock        SlotClockProvider
 	slotDuration     time.Duration
+	opCertLedgerView LedgerView
+	eraParams        ProtocolParamsProvider
 
 	// Slot battle detection
 	slotTracker *SlotTracker
@@ -307,6 +309,23 @@ type ForgerConfig struct {
 	BlockForged      BlockForgedObserver
 	SlotClock        SlotClockProvider
 
+	// OpCertLedgerView supplies the highest OpCert issue-number counter the
+	// ledger has observed on chain for this pool. When non-nil, the forge
+	// loop pre-flights the candidate counter against it using the same
+	// era-scoped rule block application enforces (see
+	// ledger/verify_opcert.go validateOpCertCounter), before spending a
+	// leader slot on VRF/KES/Leios work a stale or gapped counter would
+	// have the chain discard anyway. Nil disables the check (dev mode,
+	// embedders without ledger wiring). Requires EraParams.
+	OpCertLedgerView LedgerView
+	// EraParams supplies the era-defining protocol parameters in effect for
+	// the slot being forged, so OpCertLedgerView's counter check applies
+	// the correct era-scoped rule: TPraos (Shelley-Alonzo) accepts any
+	// forward counter movement, Praos (Babbage onward) additionally
+	// rejects one that skips ahead of the last-seen value by more than
+	// one. Required whenever OpCertLedgerView is set.
+	EraParams ProtocolParamsProvider
+
 	// ForgeFence persists the last-forged-slot fence so a restart cannot
 	// sign a second block for a slot this node already used. Nil
 	// disables the durable fence, which leaves only the in-memory chain
@@ -378,6 +397,8 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		leiosParent:      cfg.LeiosParentAnnouncementProvider,
 		blockValidator:   cfg.BlockValidator,
 		fenceStore:       cfg.ForgeFence,
+		opCertLedgerView: cfg.OpCertLedgerView,
+		eraParams:        cfg.EraParams,
 	}
 	if cfg.ForgeSyncToleranceSlots == 0 {
 		cfg.ForgeSyncToleranceSlots = forgeSyncToleranceSlots
@@ -435,6 +456,11 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		cfg.LeiosParentAnnouncementProvider == nil {
 		return nil, errors.New(
 			"leios certificate provider requires LeiosParentAnnouncementProvider",
+		)
+	}
+	if cfg.OpCertLedgerView != nil && cfg.EraParams == nil {
+		return nil, errors.New(
+			"OpCertLedgerView requires EraParams to resolve the era-scoped opcert counter rule",
 		)
 	}
 
@@ -778,6 +804,29 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			maxEvolutions,
 		)
 		return nil
+	}
+
+	// Pre-flight the OpCert counter against the ledger's observed on-chain
+	// state and the era-scoped rule block application enforces (see
+	// checkOpCertSequence). This covers genesis/era context the KES-lifetime
+	// gate above does not: LatestOpCertSequence advances as blocks are
+	// applied (this node's own or a peer's for the same pool), so a key
+	// state that was fine at startup or on an earlier slot can become stale,
+	// or -- from Babbage onward -- gapped, by the time a later slot is won.
+	if f.opCertLedgerView != nil {
+		if err := f.checkOpCertSequence(currentSlot, generation); err != nil {
+			f.incCouldNotForge()
+			f.logger.Error(
+				"forge skip: operational certificate counter is not valid for chain state",
+				"slot",
+				currentSlot,
+				"credential_generation",
+				generation.id,
+				"error",
+				err,
+			)
+			return nil
+		}
 	}
 
 	// Check if we're the leader for this slot only after the KES gate.
@@ -1176,6 +1225,45 @@ func (f *BlockForger) incCouldNotForge() {
 	if f.metrics != nil {
 		f.metrics.forgeCouldNot.Inc()
 	}
+}
+
+// checkOpCertSequence resolves the era in effect for slot and validates the
+// generation's OpCert counter against the ledger's on-chain observed value
+// using that era's rule (validateOpCertSequence). Called only when
+// f.opCertLedgerView is set; NewBlockForger guarantees f.eraParams is then
+// also non-nil.
+func (f *BlockForger) checkOpCertSequence(
+	slot uint64,
+	generation *credentialGeneration,
+) error {
+	opCert := generation.opCert()
+	if opCert == nil {
+		return errors.New("operational certificate not loaded")
+	}
+	credsPoolID := f.creds.GetPoolID()
+	var poolID [28]byte
+	copy(poolID[:], credsPoolID[:])
+	stored, found, err := f.opCertLedgerView.LatestOpCertSequence(poolID)
+	if err != nil {
+		return fmt.Errorf("opcert sequence lookup: %w", err)
+	}
+	pparams := f.eraParams.ProtocolParamsForSlot(slot)
+	if pparams == nil {
+		return fmt.Errorf(
+			"protocol parameters unavailable for slot %d",
+			slot,
+		)
+	}
+	limits, err := extractPParamsLimits(pparams)
+	if err != nil {
+		return fmt.Errorf("resolve era for opcert counter rule: %w", err)
+	}
+	return validateOpCertSequence(
+		stored,
+		found,
+		opCert.IssueNumber,
+		!limits.era.isTPraos(),
+	)
 }
 
 // checkLeaderSafe calls the pluggable LeaderChecker, recovering any

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1057,13 +1057,19 @@ type LedgerView interface {
 // registration is not fatal because operators commonly stage their keys
 // before submitting the registration certificate.
 //
-// enforceNoGap applies the same era-scoped counter rule the forge loop's
-// checkOpCertSequence and block application enforce (see
-// ledger/eras.ValidateOpCertCounter): Praos eras (Babbage onward) reject a
-// counter that skips ahead of the last observed value by more than one, in
-// addition to the stale check both eras always apply. Without this, a
-// gapped-but-not-stale opcert would start the node cleanly and only be
-// rejected on every subsequent forge attempt.
+// The opcert counter check here is staleness-only (candidate below the
+// last observed value), not the full era-scoped no-gap rule the forge
+// loop's checkOpCertSequence and block application enforce. Startup
+// cannot apply that rule safely: the era for "now" would have to come
+// from a wall-clock slot, while the observed baseline
+// (LatestOpCertSequence) only reflects the applied chain, and those two
+// can disagree on a node whose applied tip is behind wall-clock time (an
+// interrupted sync, a resume after downtime, a restore to an older
+// snapshot) -- a pool several rotations into its life would look gapped
+// against a baseline that just hasn't caught up yet, and refusing
+// startup for it would prevent the node from ever syncing to the point
+// that makes the baseline correct. The forge loop's own gate does not
+// have this problem, since it runs near the chain tip.
 //
 // Three return values describe the outcome:
 //   - registered: true if the pool registration was found on chain.
@@ -1076,7 +1082,6 @@ type LedgerView interface {
 //     devnet callers may choose to warn on ErrVRFKeyHashMismatch.
 func (pc *PoolCredentials) ValidateAgainstLedger(
 	view LedgerView,
-	enforceNoGap bool,
 ) (registered, vrfMatched bool, err error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
@@ -1118,11 +1123,13 @@ func (pc *PoolCredentials) ValidateAgainstLedger(
 	if err != nil {
 		return true, vrfMatched, fmt.Errorf("opcert sequence lookup: %w", err)
 	}
+	// enforceNoGap is always false here; see the doc comment above for why
+	// startup cannot safely apply the era-scoped no-gap half of this rule.
 	if seqErr := eras.ValidateOpCertCounter(
 		latestSeq,
 		seqFound,
 		pc.opCert.IssueNumber,
-		enforceNoGap,
+		false,
 	); seqErr != nil {
 		return true, vrfMatched, fmt.Errorf(
 			"opcert sequence %d invalid: %w",

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1057,6 +1057,14 @@ type LedgerView interface {
 // registration is not fatal because operators commonly stage their keys
 // before submitting the registration certificate.
 //
+// enforceNoGap applies the same era-scoped counter rule the forge loop's
+// checkOpCertSequence and block application enforce (see
+// ledger/eras.ValidateOpCertCounter): Praos eras (Babbage onward) reject a
+// counter that skips ahead of the last observed value by more than one, in
+// addition to the stale check both eras always apply. Without this, a
+// gapped-but-not-stale opcert would start the node cleanly and only be
+// rejected on every subsequent forge attempt.
+//
 // Three return values describe the outcome:
 //   - registered: true if the pool registration was found on chain.
 //   - vrfMatched: true if registered AND the on-chain VRF key hash
@@ -1068,6 +1076,7 @@ type LedgerView interface {
 //     devnet callers may choose to warn on ErrVRFKeyHashMismatch.
 func (pc *PoolCredentials) ValidateAgainstLedger(
 	view LedgerView,
+	enforceNoGap bool,
 ) (registered, vrfMatched bool, err error) {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
@@ -1109,10 +1118,16 @@ func (pc *PoolCredentials) ValidateAgainstLedger(
 	if err != nil {
 		return true, vrfMatched, fmt.Errorf("opcert sequence lookup: %w", err)
 	}
-	if seqFound && pc.opCert.IssueNumber < latestSeq {
+	if seqErr := eras.ValidateOpCertCounter(
+		latestSeq,
+		seqFound,
+		pc.opCert.IssueNumber,
+		enforceNoGap,
+	); seqErr != nil {
 		return true, vrfMatched, fmt.Errorf(
-			"opcert sequence %d is stale: ledger has observed %d for this pool",
-			pc.opCert.IssueNumber, latestSeq,
+			"opcert sequence %d invalid: %w",
+			pc.opCert.IssueNumber,
+			seqErr,
 		)
 	}
 	return true, vrfMatched, nil

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1149,7 +1149,7 @@ func validateOpCertSequence(
 			stored,
 		)
 	}
-	if enforceNoGap && candidate > stored+1 {
+	if enforceNoGap && candidate > stored && candidate-stored > 1 {
 		return fmt.Errorf(
 			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
 			candidate,

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/dingo/keystore"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/kes"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -1124,37 +1125,13 @@ func (pc *PoolCredentials) ValidateAgainstLedger(
 // VRF/KES/Leios work or committing the duplicate-slot fence. The two must
 // stay in agreement: a candidate this accepts and block application rejects
 // wastes a leader slot; the reverse blocks a slot the chain would have
-// adopted.
-//
-// A counter below the last-seen value is always rejected (stale or stolen
-// hot key). A counter that skips ahead of it is rejected only when
-// enforceNoGap is set: the over-increment rule is Praos-only (Babbage
-// onward), while TPraos eras (Shelley-Alonzo) accept any candidate at or
-// above stored. When the ledger has no recorded counter for this pool
-// (found is false) there is no baseline to compare against, so the
-// candidate is accepted.
+// adopted. The rule itself lives in ledger/eras.ValidateOpCertCounter, the
+// single source both call sites share, so it cannot drift between them.
 func validateOpCertSequence(
 	stored uint64,
 	found bool,
 	candidate uint64,
 	enforceNoGap bool,
 ) error {
-	if !found {
-		return nil
-	}
-	if candidate < stored {
-		return fmt.Errorf(
-			"opcert counter %d is below last seen %d (stale or stolen hot key)",
-			candidate,
-			stored,
-		)
-	}
-	if enforceNoGap && candidate > stored && candidate-stored > 1 {
-		return fmt.Errorf(
-			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
-			candidate,
-			stored,
-		)
-	}
-	return nil
+	return eras.ValidateOpCertCounter(stored, found, candidate, enforceNoGap)
 }

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1116,3 +1116,45 @@ func (pc *PoolCredentials) ValidateAgainstLedger(
 	}
 	return true, vrfMatched, nil
 }
+
+// validateOpCertSequence enforces the same operational-certificate counter
+// rule block application applies (ledger/verify_opcert.go
+// validateOpCertCounter), so the forge loop can decline a leader slot for a
+// key state ledgerProcessBlock would reject, before spending the slot on
+// VRF/KES/Leios work or committing the duplicate-slot fence. The two must
+// stay in agreement: a candidate this accepts and block application rejects
+// wastes a leader slot; the reverse blocks a slot the chain would have
+// adopted.
+//
+// A counter below the last-seen value is always rejected (stale or stolen
+// hot key). A counter that skips ahead of it is rejected only when
+// enforceNoGap is set: the over-increment rule is Praos-only (Babbage
+// onward), while TPraos eras (Shelley-Alonzo) accept any candidate at or
+// above stored. When the ledger has no recorded counter for this pool
+// (found is false) there is no baseline to compare against, so the
+// candidate is accepted.
+func validateOpCertSequence(
+	stored uint64,
+	found bool,
+	candidate uint64,
+	enforceNoGap bool,
+) error {
+	if !found {
+		return nil
+	}
+	if candidate < stored {
+		return fmt.Errorf(
+			"opcert counter %d is below last seen %d (stale or stolen hot key)",
+			candidate,
+			stored,
+		)
+	}
+	if enforceNoGap && candidate > stored+1 {
+		return fmt.Errorf(
+			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
+			candidate,
+			stored,
+		)
+	}
+	return nil
+}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1118,7 +1118,7 @@ func newCredsForLedger(t *testing.T) *PoolCredentials {
 func TestValidateAgainstLedger_PoolNotRegistered(t *testing.T) {
 	pc := newCredsForLedger(t)
 	view := &fakeLedgerView{registered: false}
-	registered, matched, err := pc.ValidateAgainstLedger(view, false)
+	registered, matched, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestValidateAgainstLedger_VRFMatch(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view, false)
+	registered, matched, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
 		t.Fatalf("ValidateAgainstLedger: %v", err)
 	}
@@ -1173,7 +1173,7 @@ func TestValidateAgainstLedger_VRFMismatch(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash(bytes32(0xDD)),
 	}
-	_, _, err := pc.ValidateAgainstLedger(view, false)
+	_, _, err := pc.ValidateAgainstLedger(view)
 	if err == nil {
 		t.Fatal("expected mismatch error")
 	}
@@ -1191,7 +1191,7 @@ func TestValidateAgainstLedger_ZeroVRFHashIsUnknown(t *testing.T) {
 		registered: true,
 		regVRFHash: [32]byte{},
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view, false)
+	registered, matched, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1218,7 +1218,7 @@ func TestValidateAgainstLedger_SeedOnlySkipsCheck(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash([]byte("anything")),
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view, false)
+	registered, matched, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1239,7 +1239,7 @@ func TestValidateAgainstLedger_StaleOpCert(t *testing.T) {
 		seqFound:   true,
 		latestSeq:  5,
 	}
-	_, _, err := pc.ValidateAgainstLedger(view, false)
+	_, _, err := pc.ValidateAgainstLedger(view)
 	if err == nil {
 		t.Fatal("expected stale-counter error")
 	}
@@ -1248,13 +1248,15 @@ func TestValidateAgainstLedger_StaleOpCert(t *testing.T) {
 	}
 }
 
-// TestValidateAgainstLedger_GappedOpCertRejectedUnderNoGap covers startup
-// applying the same era-scoped no-gap rule the forge loop and block
-// application enforce: a counter that skips ahead of the last observed
-// value by more than one is not stale (it is ahead, not behind), so
-// without this check startup would accept it cleanly and only reject it
-// on every subsequent forge attempt.
-func TestValidateAgainstLedger_GappedOpCertRejectedUnderNoGap(t *testing.T) {
+// TestValidateAgainstLedger_GappedOpCertAccepted documents the deliberate
+// startup behavior: a counter that skips ahead of the last observed value
+// by more than one is not stale (it is ahead, not behind), and startup
+// does not apply the era-scoped no-gap rule the forge loop and block
+// application enforce (see ValidateAgainstLedger's doc comment for why:
+// startup's era and its observed baseline can come from different points
+// in time). Only the forge loop's own gate rejects a gapped counter, and
+// it does so near the chain tip where both sides of the check agree.
+func TestValidateAgainstLedger_GappedOpCertAccepted(t *testing.T) {
 	pc := newCredsForLedger(t)
 	pc.opCert.IssueNumber = 7
 	view := &fakeLedgerView{
@@ -1263,33 +1265,9 @@ func TestValidateAgainstLedger_GappedOpCertRejectedUnderNoGap(t *testing.T) {
 		seqFound:   true,
 		latestSeq:  5,
 	}
-	_, _, err := pc.ValidateAgainstLedger(view, true)
-	if err == nil {
-		t.Fatal("expected gapped-counter error under enforceNoGap")
-	}
-	if !strings.Contains(err.Error(), "skips ahead") {
-		t.Errorf("expected 'skips ahead' in error, got: %v", err)
-	}
-}
-
-// TestValidateAgainstLedger_GappedOpCertAcceptedWithoutNoGap covers the
-// TPraos side of the same rule: the identical gapped counter is accepted
-// when enforceNoGap is false, matching a TPraos-era pool.
-func TestValidateAgainstLedger_GappedOpCertAcceptedWithoutNoGap(t *testing.T) {
-	pc := newCredsForLedger(t)
-	pc.opCert.IssueNumber = 7
-	view := &fakeLedgerView{
-		registered: true,
-		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
-		seqFound:   true,
-		latestSeq:  5,
-	}
-	_, _, err := pc.ValidateAgainstLedger(view, false)
+	_, _, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
-		t.Fatalf(
-			"expected gapped counter to be accepted without enforceNoGap: %v",
-			err,
-		)
+		t.Fatalf("expected gapped counter to be accepted at startup: %v", err)
 	}
 }
 
@@ -1314,7 +1292,7 @@ func TestValidateAgainstLedger_OpCertEqualOrAhead(t *testing.T) {
 				seqFound:   true,
 				latestSeq:  tc.ledgerSeq,
 			}
-			if _, _, err := pc.ValidateAgainstLedger(view, false); err != nil {
+			if _, _, err := pc.ValidateAgainstLedger(view); err != nil {
 				t.Errorf("ValidateAgainstLedger: %v", err)
 			}
 		})
@@ -1330,7 +1308,7 @@ func TestValidateAgainstLedger_NoObservedOpCertSequence(t *testing.T) {
 		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
 		seqFound:   false,
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view, false)
+	registered, matched, err := pc.ValidateAgainstLedger(view)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1345,7 +1323,7 @@ func TestValidateAgainstLedger_NoObservedOpCertSequence(t *testing.T) {
 
 func TestValidateAgainstLedger_NilView(t *testing.T) {
 	pc := newCredsForLedger(t)
-	_, _, err := pc.ValidateAgainstLedger(nil, false)
+	_, _, err := pc.ValidateAgainstLedger(nil)
 	if err == nil {
 		t.Fatal("expected nil-view error")
 	}
@@ -1354,7 +1332,7 @@ func TestValidateAgainstLedger_NilView(t *testing.T) {
 func TestValidateAgainstLedger_NoOpCert(t *testing.T) {
 	pc := &PoolCredentials{vrfVKey: bytes32(0xAA)}
 	view := &fakeLedgerView{}
-	_, _, err := pc.ValidateAgainstLedger(view, false)
+	_, _, err := pc.ValidateAgainstLedger(view)
 	if err == nil {
 		t.Fatal("expected error when opcert not loaded")
 	}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1395,6 +1395,13 @@ func TestValidateOpCertSequence(t *testing.T) {
 			candidate:    7,
 			enforceNoGap: false,
 		},
+		{
+			name:         "maximum counter accepted when unchanged",
+			stored:       math.MaxUint64,
+			found:        true,
+			candidate:    math.MaxUint64,
+			enforceNoGap: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1396,7 +1396,7 @@ func TestValidateOpCertSequence(t *testing.T) {
 			enforceNoGap: false,
 		},
 		{
-			name:         "maximum counter accepted when unchanged",
+			name:         "maximum counter accepted when unchanged (boundary)",
 			stored:       math.MaxUint64,
 			found:        true,
 			candidate:    math.MaxUint64,

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1322,3 +1322,110 @@ func bytes32(seed byte) []byte {
 	}
 	return b
 }
+
+// TestValidateOpCertSequence mirrors ledger/verify_opcert_test.go's
+// TestValidateOpCertCounter: the backward (stale) rule applies to every era,
+// while the no-gap (over-increment) rule is Praos-only, so the gapped cases
+// are split by enforceNoGap. The two functions must stay in agreement, since
+// this one pre-flights exactly the rule block application enforces.
+func TestValidateOpCertSequence(t *testing.T) {
+	tests := []struct {
+		name         string
+		stored       uint64
+		found        bool
+		candidate    uint64
+		enforceNoGap bool
+		wantErr      string
+	}{
+		{
+			name:         "first sighting accepts any counter",
+			found:        false,
+			candidate:    7,
+			enforceNoGap: true,
+		},
+		{
+			name:         "equal to last seen",
+			stored:       5,
+			found:        true,
+			candidate:    5,
+			enforceNoGap: true,
+		},
+		{
+			name:         "exactly one greater (boundary, praos)",
+			stored:       5,
+			found:        true,
+			candidate:    6,
+			enforceNoGap: true,
+		},
+		{
+			name:         "exactly one greater (boundary, tpraos)",
+			stored:       5,
+			found:        true,
+			candidate:    6,
+			enforceNoGap: false,
+		},
+		{
+			name:         "backward counter rejected (praos)",
+			stored:       5,
+			found:        true,
+			candidate:    4,
+			enforceNoGap: true,
+			wantErr:      "below last seen",
+		},
+		{
+			name:         "backward counter rejected (tpraos)",
+			stored:       5,
+			found:        true,
+			candidate:    4,
+			enforceNoGap: false,
+			wantErr:      "below last seen",
+		},
+		{
+			name:         "gapped counter rejected under praos (era change)",
+			stored:       5,
+			found:        true,
+			candidate:    7,
+			enforceNoGap: true,
+			wantErr:      "skips ahead",
+		},
+		{
+			name:         "gapped counter accepted under tpraos (era change)",
+			stored:       5,
+			found:        true,
+			candidate:    7,
+			enforceNoGap: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOpCertSequence(
+				tt.stored,
+				tt.found,
+				tt.candidate,
+				tt.enforceNoGap,
+			)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf(
+						"validateOpCertSequence: unexpected error: %v",
+						err,
+					)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf(
+					"validateOpCertSequence: expected error containing %q, got nil",
+					tt.wantErr,
+				)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf(
+					"validateOpCertSequence: error %q does not contain %q",
+					err.Error(),
+					tt.wantErr,
+				)
+			}
+		})
+	}
+}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1118,7 +1118,7 @@ func newCredsForLedger(t *testing.T) *PoolCredentials {
 func TestValidateAgainstLedger_PoolNotRegistered(t *testing.T) {
 	pc := newCredsForLedger(t)
 	view := &fakeLedgerView{registered: false}
-	registered, matched, err := pc.ValidateAgainstLedger(view)
+	registered, matched, err := pc.ValidateAgainstLedger(view, false)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestValidateAgainstLedger_VRFMatch(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view)
+	registered, matched, err := pc.ValidateAgainstLedger(view, false)
 	if err != nil {
 		t.Fatalf("ValidateAgainstLedger: %v", err)
 	}
@@ -1173,7 +1173,7 @@ func TestValidateAgainstLedger_VRFMismatch(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash(bytes32(0xDD)),
 	}
-	_, _, err := pc.ValidateAgainstLedger(view)
+	_, _, err := pc.ValidateAgainstLedger(view, false)
 	if err == nil {
 		t.Fatal("expected mismatch error")
 	}
@@ -1191,7 +1191,7 @@ func TestValidateAgainstLedger_ZeroVRFHashIsUnknown(t *testing.T) {
 		registered: true,
 		regVRFHash: [32]byte{},
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view)
+	registered, matched, err := pc.ValidateAgainstLedger(view, false)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1218,7 +1218,7 @@ func TestValidateAgainstLedger_SeedOnlySkipsCheck(t *testing.T) {
 		registered: true,
 		regVRFHash: lcommon.Blake2b256Hash([]byte("anything")),
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view)
+	registered, matched, err := pc.ValidateAgainstLedger(view, false)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1239,12 +1239,57 @@ func TestValidateAgainstLedger_StaleOpCert(t *testing.T) {
 		seqFound:   true,
 		latestSeq:  5,
 	}
-	_, _, err := pc.ValidateAgainstLedger(view)
+	_, _, err := pc.ValidateAgainstLedger(view, false)
 	if err == nil {
 		t.Fatal("expected stale-counter error")
 	}
 	if !strings.Contains(err.Error(), "stale") {
 		t.Errorf("expected stale in error, got: %v", err)
+	}
+}
+
+// TestValidateAgainstLedger_GappedOpCertRejectedUnderNoGap covers startup
+// applying the same era-scoped no-gap rule the forge loop and block
+// application enforce: a counter that skips ahead of the last observed
+// value by more than one is not stale (it is ahead, not behind), so
+// without this check startup would accept it cleanly and only reject it
+// on every subsequent forge attempt.
+func TestValidateAgainstLedger_GappedOpCertRejectedUnderNoGap(t *testing.T) {
+	pc := newCredsForLedger(t)
+	pc.opCert.IssueNumber = 7
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+		seqFound:   true,
+		latestSeq:  5,
+	}
+	_, _, err := pc.ValidateAgainstLedger(view, true)
+	if err == nil {
+		t.Fatal("expected gapped-counter error under enforceNoGap")
+	}
+	if !strings.Contains(err.Error(), "skips ahead") {
+		t.Errorf("expected 'skips ahead' in error, got: %v", err)
+	}
+}
+
+// TestValidateAgainstLedger_GappedOpCertAcceptedWithoutNoGap covers the
+// TPraos side of the same rule: the identical gapped counter is accepted
+// when enforceNoGap is false, matching a TPraos-era pool.
+func TestValidateAgainstLedger_GappedOpCertAcceptedWithoutNoGap(t *testing.T) {
+	pc := newCredsForLedger(t)
+	pc.opCert.IssueNumber = 7
+	view := &fakeLedgerView{
+		registered: true,
+		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
+		seqFound:   true,
+		latestSeq:  5,
+	}
+	_, _, err := pc.ValidateAgainstLedger(view, false)
+	if err != nil {
+		t.Fatalf(
+			"expected gapped counter to be accepted without enforceNoGap: %v",
+			err,
+		)
 	}
 }
 
@@ -1269,7 +1314,7 @@ func TestValidateAgainstLedger_OpCertEqualOrAhead(t *testing.T) {
 				seqFound:   true,
 				latestSeq:  tc.ledgerSeq,
 			}
-			if _, _, err := pc.ValidateAgainstLedger(view); err != nil {
+			if _, _, err := pc.ValidateAgainstLedger(view, false); err != nil {
 				t.Errorf("ValidateAgainstLedger: %v", err)
 			}
 		})
@@ -1285,7 +1330,7 @@ func TestValidateAgainstLedger_NoObservedOpCertSequence(t *testing.T) {
 		regVRFHash: lcommon.Blake2b256Hash(pc.vrfVKey),
 		seqFound:   false,
 	}
-	registered, matched, err := pc.ValidateAgainstLedger(view)
+	registered, matched, err := pc.ValidateAgainstLedger(view, false)
 	if err != nil {
 		t.Errorf("ValidateAgainstLedger: %v", err)
 	}
@@ -1300,7 +1345,7 @@ func TestValidateAgainstLedger_NoObservedOpCertSequence(t *testing.T) {
 
 func TestValidateAgainstLedger_NilView(t *testing.T) {
 	pc := newCredsForLedger(t)
-	_, _, err := pc.ValidateAgainstLedger(nil)
+	_, _, err := pc.ValidateAgainstLedger(nil, false)
 	if err == nil {
 		t.Fatal("expected nil-view error")
 	}
@@ -1309,7 +1354,7 @@ func TestValidateAgainstLedger_NilView(t *testing.T) {
 func TestValidateAgainstLedger_NoOpCert(t *testing.T) {
 	pc := &PoolCredentials{vrfVKey: bytes32(0xAA)}
 	view := &fakeLedgerView{}
-	_, _, err := pc.ValidateAgainstLedger(view)
+	_, _, err := pc.ValidateAgainstLedger(view, false)
 	if err == nil {
 		t.Fatal("expected error when opcert not loaded")
 	}

--- a/ledger/forging/opcert_sequence_gate_test.go
+++ b/ledger/forging/opcert_sequence_gate_test.go
@@ -17,6 +17,7 @@ package forging
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -181,6 +182,78 @@ func TestCheckAndForgeProductionSkipsWhenEraUnresolvable(t *testing.T) {
 		t,
 		builder.calls,
 		"an unresolvable era must not build a block",
+	)
+	require.Zero(t, broadcaster.calls)
+}
+
+// TestCheckAndForgeProductionSkipsOnTransientLedgerReadError covers a
+// transient database error from LatestOpCertSequence itself (as opposed to
+// a definite stale/gapped counter). A DB hiccup on a leader slot costs a
+// could-not-forge disposition for that slot rather than forging with an
+// unverified key state; the slot is not adopted either way, so failing
+// closed here does not risk a block the chain would reject.
+func TestCheckAndForgeProductionSkipsOnTransientLedgerReadError(t *testing.T) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	leader := &forgerCountingLeader{}
+	var logs bytes.Buffer
+	view := &fakeLedgerView{seqErr: errors.New("transient database error")}
+	eraParams := &mockPParamsProvider{
+		pparams: &babbage.BabbageProtocolParameters{},
+	}
+	forger := opCertSequenceGateForger(
+		t, view, eraParams, leader, builder, broadcaster, &logs,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"leader selection must run before the counter check",
+	)
+	require.Zero(t, builder.calls, "a lookup error must not build a block")
+	require.Zero(t, broadcaster.calls)
+	require.Contains(t, logs.String(), "opcert sequence lookup")
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+// TestCheckAndForgeProductionSkipsOnTypedNilProtocolParameters covers a
+// ProtocolParamsForSlot implementation that returns a typed-nil pointer of
+// a known era's type (e.g. a lookup miss represented as
+// (*babbage.BabbageProtocolParameters)(nil)) rather than a true nil
+// interface. This is the case extractPParamsLimits' reflect-based guard
+// exists for; TestCheckAndForgeProductionSkipsWhenEraUnresolvable above
+// only exercises the plain-nil-interface half of that guard.
+func TestCheckAndForgeProductionSkipsOnTypedNilProtocolParameters(
+	t *testing.T,
+) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	leader := &forgerCountingLeader{}
+	var logs bytes.Buffer
+	view := &fakeLedgerView{seqFound: true, latestSeq: 0}
+	var nilPParams *babbage.BabbageProtocolParameters
+	eraParams := &mockPParamsProvider{pparams: nilPParams}
+	forger := opCertSequenceGateForger(
+		t, view, eraParams, leader, builder, broadcaster, &logs,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"leader selection must run before the counter check",
+	)
+	require.Zero(
+		t,
+		builder.calls,
+		"a typed-nil protocol parameters value must not build a block",
 	)
 	require.Zero(t, broadcaster.calls)
 }

--- a/ledger/forging/opcert_sequence_gate_test.go
+++ b/ledger/forging/opcert_sequence_gate_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// opCertSequenceGateForger builds a production BlockForger whose credentials'
+// OpCert issue number is the fixed value baked into testOpCertJSON (0, see
+// TestValidateOpCertUnsafe_ValidCertificate), wired with the given ledger
+// view / era params so tests can drive the pre-flight counter gate.
+func opCertSequenceGateForger(
+	t *testing.T,
+	view LedgerView,
+	eraParams ProtocolParamsProvider,
+	builder *forgerTestBuilder,
+	broadcaster *forgerTestBroadcaster,
+	logs *bytes.Buffer,
+) *BlockForger {
+	t.Helper()
+	creds := setupTestCredentials(t)
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(logs, nil)),
+		Credentials:      creds,
+		LeaderChecker:    &forgerCountingLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       1,
+			chainTipSlot:      0,
+			slotsPerKESPeriod: 100,
+		},
+		OpCertLedgerView: view,
+		EraParams:        eraParams,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	return forger
+}
+
+func newOpCertSequenceGateTestBuilder() (*forgerTestBuilder, *forgerTestBroadcaster) {
+	block := newForgerTestBlock(0, 1)
+	return &forgerTestBuilder{block: block, cbor: block.cbor},
+		&forgerTestBroadcaster{}
+}
+
+// TestNewBlockForgerRequiresEraParamsWithOpCertLedgerView pins the
+// construction-time contract: the pre-flight counter check cannot resolve
+// the era-scoped rule (no-gap vs. stale-only) without EraParams, so wiring
+// one provider without the other must fail closed at startup rather than at
+// the first forge attempt.
+func TestNewBlockForgerRequiresEraParamsWithOpCertLedgerView(t *testing.T) {
+	creds := setupTestCredentials(t)
+	_, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Credentials:      creds,
+		LeaderChecker:    forgerTestLeader{},
+		BlockBuilder:     &forgerTestBuilder{},
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock:        forgerTestSlotClock{slotsPerKESPeriod: 1},
+		OpCertLedgerView: &fakeLedgerView{},
+	})
+	require.ErrorContains(t, err, "EraParams")
+}
+
+// TestCheckAndForgeProductionSkipsOnStaleOpCertCounter covers a stale
+// counter -- the ledger has observed a higher issue number for this pool
+// than the loaded credentials carry -- which block application would
+// reject regardless of era. It must be caught before the leader check,
+// block build, or forge-slot fence.
+func TestCheckAndForgeProductionSkipsOnStaleOpCertCounter(t *testing.T) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	var logs bytes.Buffer
+	view := &fakeLedgerView{seqFound: true, latestSeq: 1}
+	eraParams := &mockPParamsProvider{
+		pparams: &babbage.BabbageProtocolParameters{},
+	}
+	forger := opCertSequenceGateForger(
+		t, view, eraParams, builder, broadcaster, &logs,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Zero(t, builder.calls, "stale counter must not build a block")
+	require.Zero(
+		t,
+		broadcaster.calls,
+		"stale counter must not adopt a block",
+	)
+	require.Contains(t, logs.String(), "operational certificate counter")
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}
+
+// TestCheckAndForgeProductionAllowsUnobservedOpCertCounter covers the
+// baseline case: the ledger has never observed a counter for this pool
+// (fresh registration, or a Mithril-restored start), so there is nothing to
+// compare against and the candidate is accepted.
+func TestCheckAndForgeProductionAllowsUnobservedOpCertCounter(t *testing.T) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	var logs bytes.Buffer
+	view := &fakeLedgerView{seqFound: false}
+	eraParams := &mockPParamsProvider{
+		pparams: &babbage.BabbageProtocolParameters{},
+	}
+	forger := opCertSequenceGateForger(
+		t, view, eraParams, builder, broadcaster, &logs,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Equal(t, 1, builder.calls)
+	require.Equal(t, 1, broadcaster.calls)
+}
+
+// TestCheckAndForgeProductionSkipsWhenEraUnresolvable covers a provider
+// that cannot yet supply protocol parameters for the slot (e.g. very early
+// startup). The gate fails closed rather than guessing an era-scoped rule.
+func TestCheckAndForgeProductionSkipsWhenEraUnresolvable(t *testing.T) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	var logs bytes.Buffer
+	view := &fakeLedgerView{seqFound: true, latestSeq: 0}
+	eraParams := &mockPParamsProvider{pparams: nil}
+	forger := opCertSequenceGateForger(
+		t, view, eraParams, builder, broadcaster, &logs,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Zero(
+		t,
+		builder.calls,
+		"an unresolvable era must not build a block",
+	)
+}
+
+// TestCheckAndForgeProductionEraScopedOpCertCounterRule covers the era-
+// scoped no-gap rule end to end through the running forger: TPraos
+// (Shelley-Alonzo) accepts a counter that jumps ahead of the last observed
+// value, Praos (Babbage onward) does not. Boundary values (exactly one
+// ahead, exactly equal) are covered for both eras.
+func TestCheckAndForgeProductionEraScopedOpCertCounterRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		pparams    lcommon.ProtocolParameters
+		candidate  uint64
+		stored     uint64
+		wantForged bool
+	}{
+		{
+			name:       "tpraos era equal to last seen",
+			pparams:    &shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
+			candidate:  5,
+			stored:     5,
+			wantForged: true,
+		},
+		{
+			name:       "tpraos era exactly one ahead (boundary)",
+			pparams:    &shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
+			candidate:  6,
+			stored:     5,
+			wantForged: true,
+		},
+		{
+			name:       "tpraos era gap of two accepted (era change from praos)",
+			pparams:    &shelley.ShelleyProtocolParameters{ProtocolMajor: 2},
+			candidate:  7,
+			stored:     5,
+			wantForged: true,
+		},
+		{
+			name:       "praos era exactly one ahead (boundary)",
+			pparams:    &babbage.BabbageProtocolParameters{},
+			candidate:  6,
+			stored:     5,
+			wantForged: true,
+		},
+		{
+			name:       "praos era gap of two rejected (era change from tpraos)",
+			pparams:    &babbage.BabbageProtocolParameters{},
+			candidate:  7,
+			stored:     5,
+			wantForged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, broadcaster := newOpCertSequenceGateTestBuilder()
+			var logs bytes.Buffer
+			view := &fakeLedgerView{seqFound: true, latestSeq: tt.stored}
+			eraParams := &mockPParamsProvider{pparams: tt.pparams}
+			forger := opCertSequenceGateForger(
+				t, view, eraParams, builder, broadcaster, &logs,
+			)
+			forger.creds.mu.Lock()
+			forger.creds.opCert.IssueNumber = tt.candidate
+			forger.creds.mu.Unlock()
+
+			require.NoError(
+				t,
+				forger.checkAndForgeProduction(context.Background()),
+			)
+
+			if tt.wantForged {
+				require.Equal(t, 1, builder.calls)
+				require.Equal(t, 1, broadcaster.calls)
+			} else {
+				require.Zero(t, builder.calls)
+				require.Zero(t, broadcaster.calls)
+				require.Contains(
+					t,
+					logs.String(),
+					"operational certificate counter",
+				)
+			}
+		})
+	}
+}
+
+// TestCheckAndForgeProductionSkipsOpCertSequenceCheckWhenLedgerViewNil
+// confirms the pre-flight counter gate is opt-in: embedders and dev-mode
+// wiring that leave OpCertLedgerView nil (every other forger test in this
+// package) are unaffected by this change.
+func TestCheckAndForgeProductionSkipsOpCertSequenceCheckWhenLedgerViewNil(
+	t *testing.T,
+) {
+	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	var logs bytes.Buffer
+	forger := opCertSequenceGateForger(
+		t, nil, nil, builder, broadcaster, &logs,
+	)
+	// A counter far ahead of any plausible on-chain value would be rejected
+	// under the gate if it were active; with no LedgerView wired it is not
+	// evaluated at all.
+	forger.creds.mu.Lock()
+	forger.creds.opCert.IssueNumber = 1000
+	forger.creds.mu.Unlock()
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Equal(t, 1, builder.calls)
+	require.Equal(t, 1, broadcaster.calls)
+}

--- a/ledger/forging/opcert_sequence_gate_test.go
+++ b/ledger/forging/opcert_sequence_gate_test.go
@@ -31,11 +31,13 @@ import (
 // opCertSequenceGateForger builds a production BlockForger whose credentials'
 // OpCert issue number is the fixed value baked into testOpCertJSON (0, see
 // TestValidateOpCertUnsafe_ValidCertificate), wired with the given ledger
-// view / era params so tests can drive the pre-flight counter gate.
+// view / era params so tests can drive the pre-flight counter gate. The
+// caller retains leader so it can assert whether leader selection ran.
 func opCertSequenceGateForger(
 	t *testing.T,
 	view LedgerView,
 	eraParams ProtocolParamsProvider,
+	leader LeaderChecker,
 	builder *forgerTestBuilder,
 	broadcaster *forgerTestBroadcaster,
 	logs *bytes.Buffer,
@@ -46,7 +48,7 @@ func opCertSequenceGateForger(
 		Mode:             ModeProduction,
 		Logger:           slog.New(slog.NewJSONHandler(logs, nil)),
 		Credentials:      creds,
-		LeaderChecker:    &forgerCountingLeader{},
+		LeaderChecker:    leader,
 		BlockBuilder:     builder,
 		BlockBroadcaster: broadcaster,
 		SlotClock: forgerTestSlotClock{
@@ -90,21 +92,29 @@ func TestNewBlockForgerRequiresEraParamsWithOpCertLedgerView(t *testing.T) {
 // TestCheckAndForgeProductionSkipsOnStaleOpCertCounter covers a stale
 // counter -- the ledger has observed a higher issue number for this pool
 // than the loaded credentials carry -- which block application would
-// reject regardless of era. It must be caught before the leader check,
-// block build, or forge-slot fence.
+// reject regardless of era. It must be caught after leader selection (so
+// the ledger read it performs is skipped for slots this pool does not
+// lead) but before block build or the forge-slot fence.
 func TestCheckAndForgeProductionSkipsOnStaleOpCertCounter(t *testing.T) {
 	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	leader := &forgerCountingLeader{}
 	var logs bytes.Buffer
 	view := &fakeLedgerView{seqFound: true, latestSeq: 1}
 	eraParams := &mockPParamsProvider{
 		pparams: &babbage.BabbageProtocolParameters{},
 	}
 	forger := opCertSequenceGateForger(
-		t, view, eraParams, builder, broadcaster, &logs,
+		t, view, eraParams, leader, builder, broadcaster, &logs,
 	)
 
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
 
+	require.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"leader selection must run before the counter check",
+	)
 	require.Zero(t, builder.calls, "stale counter must not build a block")
 	require.Zero(
 		t,
@@ -131,7 +141,13 @@ func TestCheckAndForgeProductionAllowsUnobservedOpCertCounter(t *testing.T) {
 		pparams: &babbage.BabbageProtocolParameters{},
 	}
 	forger := opCertSequenceGateForger(
-		t, view, eraParams, builder, broadcaster, &logs,
+		t,
+		view,
+		eraParams,
+		&forgerCountingLeader{},
+		builder,
+		broadcaster,
+		&logs,
 	)
 
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
@@ -145,20 +161,28 @@ func TestCheckAndForgeProductionAllowsUnobservedOpCertCounter(t *testing.T) {
 // startup). The gate fails closed rather than guessing an era-scoped rule.
 func TestCheckAndForgeProductionSkipsWhenEraUnresolvable(t *testing.T) {
 	builder, broadcaster := newOpCertSequenceGateTestBuilder()
+	leader := &forgerCountingLeader{}
 	var logs bytes.Buffer
 	view := &fakeLedgerView{seqFound: true, latestSeq: 0}
 	eraParams := &mockPParamsProvider{pparams: nil}
 	forger := opCertSequenceGateForger(
-		t, view, eraParams, builder, broadcaster, &logs,
+		t, view, eraParams, leader, builder, broadcaster, &logs,
 	)
 
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
 
+	require.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"leader selection must run before the counter check",
+	)
 	require.Zero(
 		t,
 		builder.calls,
 		"an unresolvable era must not build a block",
 	)
+	require.Zero(t, broadcaster.calls)
 }
 
 // TestCheckAndForgeProductionEraScopedOpCertCounterRule covers the era-
@@ -213,11 +237,12 @@ func TestCheckAndForgeProductionEraScopedOpCertCounterRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builder, broadcaster := newOpCertSequenceGateTestBuilder()
+			leader := &forgerCountingLeader{}
 			var logs bytes.Buffer
 			view := &fakeLedgerView{seqFound: true, latestSeq: tt.stored}
 			eraParams := &mockPParamsProvider{pparams: tt.pparams}
 			forger := opCertSequenceGateForger(
-				t, view, eraParams, builder, broadcaster, &logs,
+				t, view, eraParams, leader, builder, broadcaster, &logs,
 			)
 			forger.creds.mu.Lock()
 			forger.creds.opCert.IssueNumber = tt.candidate
@@ -228,6 +253,12 @@ func TestCheckAndForgeProductionEraScopedOpCertCounterRule(t *testing.T) {
 				forger.checkAndForgeProduction(context.Background()),
 			)
 
+			require.Equal(
+				t,
+				1,
+				leader.callCount(),
+				"leader selection must run before the counter check",
+			)
 			if tt.wantForged {
 				require.Equal(t, 1, builder.calls)
 				require.Equal(t, 1, broadcaster.calls)
@@ -254,7 +285,7 @@ func TestCheckAndForgeProductionSkipsOpCertSequenceCheckWhenLedgerViewNil(
 	builder, broadcaster := newOpCertSequenceGateTestBuilder()
 	var logs bytes.Buffer
 	forger := opCertSequenceGateForger(
-		t, nil, nil, builder, broadcaster, &logs,
+		t, nil, nil, &forgerCountingLeader{}, builder, broadcaster, &logs,
 	)
 	// A counter far ahead of any plausible on-chain value would be rejected
 	// under the gate if it were active; with no LedgerView wired it is not

--- a/ledger/opcert_mithril_boundary_test.go
+++ b/ledger/opcert_mithril_boundary_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
@@ -90,6 +92,63 @@ func TestMithrilBoundaryOpCertPoolWithoutCertifiedCounterAllowsFirst(
 	require.NoError(t, err)
 	require.False(t, found)
 	require.NoError(t, validateOpCertCounter(stored, found, 490, true))
+}
+
+// TestLatestOpCertSequenceRespectsMithrilBoundary pins that
+// LatestOpCertSequence -- the entry point startup and forge-loop credential
+// checks use through the LedgerView interface -- agrees with what block
+// application itself would compute (latestOpCertCounterForValidation),
+// rather than a plain MAX that would trust a stale pre-boundary row a
+// Mithril import left in the table.
+func TestLatestOpCertSequenceRespectsMithrilBoundary(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+
+	var poolID [28]byte
+	for i := range poolID {
+		poolID[i] = byte(i + 1)
+	}
+	poolKeyHash := lcommon.PoolKeyHash(lcommon.NewBlake2b224(poolID[:]))
+	require.NoError(t, db.Metadata().ImportPool(
+		&models.Pool{
+			PoolKeyHash: poolKeyHash.Bytes(),
+			VrfKeyHash:  make([]byte, 32),
+		},
+		&models.PoolRegistration{
+			PoolKeyHash: poolKeyHash.Bytes(),
+			VrfKeyHash:  make([]byte, 32),
+			AddedSlot:   1,
+			Pledge:      dbtypes.Uint64(1),
+			Cost:        dbtypes.Uint64(1),
+		},
+		nil,
+	))
+
+	const boundarySlot = uint64(100)
+	require.NoError(t, db.UpdatePoolOpCertSequence(
+		poolKeyHash,
+		500,
+		boundarySlot-1,
+		nil,
+	))
+	require.NoError(t, db.UpdatePoolOpCertSequence(
+		poolKeyHash,
+		489,
+		boundarySlot,
+		nil,
+	))
+	ledgerState := &LedgerState{db: db, mithrilLedgerSlot: boundarySlot}
+
+	sequence, found, err := ledgerState.LatestOpCertSequence(poolID)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(
+		t,
+		uint64(489),
+		sequence,
+		"must ignore the pre-boundary row a plain MAX would return",
+	)
 }
 
 func TestMithrilBoundaryOpCertContiguousRotationIsEnforced(t *testing.T) {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2052,10 +2052,11 @@ func (ls *LedgerState) LatestOpCertSequence(
 	if pool == nil {
 		return 0, false, nil
 	}
-	ls.RLock()
-	mithrilLedgerSlot := ls.mithrilLedgerSlot
-	ls.RUnlock()
-	return ls.latestOpCertCounterAfterMithril(pkh, mithrilLedgerSlot, nil)
+	return ls.latestOpCertCounterAfterMithril(
+		pkh,
+		ls.mithrilLedgerSlotSnapshot(),
+		nil,
+	)
 }
 
 // Datum looks up a datum by hash & adding this for implementing query.ReadData #741
@@ -6721,17 +6722,18 @@ func (ls *LedgerState) ledgerProcessBlock(
 // latestOpCertCounterForValidation returns the highest observed counter after
 // the Mithril boundary, or the certified counter at the boundary when no later
 // row exists. Rows before the boundary are not part of the certified state.
-// Called only from block application, which already holds whatever lock
-// guards ls.mithrilLedgerSlot for that path; a caller outside that path must
-// go through LatestOpCertSequence instead, which reads the field under a
-// read lock.
+// Reads mithrilLedgerSlot through the lock-safe mithrilLedgerSlotSnapshot,
+// since the block-apply transaction this runs inside does not itself hold
+// a lock across that field (the snapshot taken before the transaction,
+// e.g. ledgerProcessBlocksFromSource's snapshotMithrilSlot, is not
+// threaded down to this call).
 func (ls *LedgerState) latestOpCertCounterForValidation(
 	poolKeyHash lcommon.PoolKeyHash,
 	txn *database.Txn,
 ) (uint64, bool, error) {
 	return ls.latestOpCertCounterAfterMithril(
 		poolKeyHash,
-		ls.mithrilLedgerSlot,
+		ls.mithrilLedgerSlotSnapshot(),
 		txn,
 	)
 }
@@ -6742,9 +6744,8 @@ func (ls *LedgerState) latestOpCertCounterForValidation(
 // paths agree on which counter is "the latest observed" for a pool instead
 // of one trusting a plain MAX over rows a Mithril import may have left
 // stale relative to the certified boundary. mithrilLedgerSlot is passed in
-// rather than read from ls directly so callers outside block application
-// can capture it under their own lock instead of this function assuming
-// one is already held.
+// rather than read from ls directly so each caller controls how it is
+// obtained (a lock-safe snapshot, or a value already captured under one).
 func (ls *LedgerState) latestOpCertCounterAfterMithril(
 	poolKeyHash lcommon.PoolKeyHash,
 	mithrilLedgerSlot uint64,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -2032,6 +2032,12 @@ func (ls *LedgerState) PoolRegistrationVRFKeyHash(
 	return vrfHash, true, nil
 }
 
+// LatestOpCertSequence returns the highest opcert issue-number counter
+// observed for poolID, honoring the same Mithril trust boundary block
+// application enforces (see latestOpCertCounterAfterMithril): a plain MAX
+// over the whole table would trust rows a Mithril import left below the
+// certified boundary, giving startup and forge-loop credential checks a
+// baseline block application itself does not use.
 func (ls *LedgerState) LatestOpCertSequence(
 	poolID [28]byte,
 ) (sequence uint64, found bool, err error) {
@@ -2046,7 +2052,10 @@ func (ls *LedgerState) LatestOpCertSequence(
 	if pool == nil {
 		return 0, false, nil
 	}
-	return ls.db.LatestPoolOpCertSequence(pkh, nil)
+	ls.RLock()
+	mithrilLedgerSlot := ls.mithrilLedgerSlot
+	ls.RUnlock()
+	return ls.latestOpCertCounterAfterMithril(pkh, mithrilLedgerSlot, nil)
 }
 
 // Datum looks up a datum by hash & adding this for implementing query.ReadData #741
@@ -6712,14 +6721,39 @@ func (ls *LedgerState) ledgerProcessBlock(
 // latestOpCertCounterForValidation returns the highest observed counter after
 // the Mithril boundary, or the certified counter at the boundary when no later
 // row exists. Rows before the boundary are not part of the certified state.
+// Called only from block application, which already holds whatever lock
+// guards ls.mithrilLedgerSlot for that path; a caller outside that path must
+// go through LatestOpCertSequence instead, which reads the field under a
+// read lock.
 func (ls *LedgerState) latestOpCertCounterForValidation(
 	poolKeyHash lcommon.PoolKeyHash,
 	txn *database.Txn,
 ) (uint64, bool, error) {
-	if ls.mithrilLedgerSlot > 0 {
+	return ls.latestOpCertCounterAfterMithril(
+		poolKeyHash,
+		ls.mithrilLedgerSlot,
+		txn,
+	)
+}
+
+// latestOpCertCounterAfterMithril is the Mithril-boundary-aware resolver
+// shared by latestOpCertCounterForValidation (block application) and
+// LatestOpCertSequence (startup and forge-loop credential checks), so both
+// paths agree on which counter is "the latest observed" for a pool instead
+// of one trusting a plain MAX over rows a Mithril import may have left
+// stale relative to the certified boundary. mithrilLedgerSlot is passed in
+// rather than read from ls directly so callers outside block application
+// can capture it under their own lock instead of this function assuming
+// one is already held.
+func (ls *LedgerState) latestOpCertCounterAfterMithril(
+	poolKeyHash lcommon.PoolKeyHash,
+	mithrilLedgerSlot uint64,
+	txn *database.Txn,
+) (uint64, bool, error) {
+	if mithrilLedgerSlot > 0 {
 		sequence, found, err := ls.db.LatestPoolOpCertSequenceAfter(
 			poolKeyHash,
-			ls.mithrilLedgerSlot,
+			mithrilLedgerSlot,
 			txn,
 		)
 		if err != nil || found {
@@ -6727,7 +6761,7 @@ func (ls *LedgerState) latestOpCertCounterForValidation(
 		}
 		return ls.db.LatestPoolOpCertSequenceAfter(
 			poolKeyHash,
-			ls.mithrilLedgerSlot-1,
+			mithrilLedgerSlot-1,
 			txn,
 		)
 	}

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -150,24 +151,7 @@ func validateOpCertCounter(
 	candidate uint64,
 	enforceNoGap bool,
 ) error {
-	if !found {
-		return nil
-	}
-	if candidate < stored {
-		return fmt.Errorf(
-			"opcert counter %d is below last seen %d (stale or stolen hot key)",
-			candidate,
-			stored,
-		)
-	}
-	if enforceNoGap && candidate > stored+1 {
-		return fmt.Errorf(
-			"opcert counter %d skips ahead of last seen %d (gapped rotation)",
-			candidate,
-			stored,
-		)
-	}
-	return nil
+	return eras.ValidateOpCertCounter(stored, found, candidate, enforceNoGap)
 }
 
 // ValidateLeiosAnnouncementHeader validates the announcement's header crypto

--- a/ledger/verify_opcert_test.go
+++ b/ledger/verify_opcert_test.go
@@ -276,6 +276,13 @@ func TestValidateOpCertCounter(t *testing.T) {
 			candidate:    7,
 			enforceNoGap: false,
 		},
+		{
+			name:         "equal counters at max uint64 do not wrap into a gap",
+			stored:       ^uint64(0),
+			found:        true,
+			candidate:    ^uint64(0),
+			enforceNoGap: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/node_forging.go
+++ b/node_forging.go
@@ -163,25 +163,23 @@ func (n *Node) validateBlockProducerLedgerWithView(
 	if creds == nil {
 		return errors.New("nil pool credentials")
 	}
-	enforceNoGap, gapErr := n.opCertNoGapRuleForCurrentSlot()
-	if gapErr != nil {
-		// Era resolution failing here is not itself a reason to refuse
-		// startup: fall back to the stale-only check ValidateAgainstLedger
-		// already applied before this era-scoped rule existed, rather than
-		// adding a new startup-failure mode for an edge case unrelated to
-		// the credential cross-check itself.
-		n.config.logger.Warn(
-			"could not resolve era for opcert no-gap rule; startup will only check for a stale counter",
-			"component",
-			"node",
-			"error",
-			gapErr,
-		)
-	}
-	registered, vrfMatched, err := creds.ValidateAgainstLedger(
-		view,
-		enforceNoGap,
-	)
+	// Startup deliberately checks only for a stale counter, not the
+	// era-scoped no-gap rule the forge loop and block application enforce.
+	// The era for "now" would have to come from LedgerState.CurrentSlot,
+	// which is wall-clock and valid regardless of sync state; the baseline
+	// comes from LatestOpCertSequence, which reflects only the applied
+	// chain. On a node whose applied tip is behind wall-clock time (an
+	// interrupted initial sync, a resume after downtime, a restore to an
+	// older snapshot), those two can disagree: the era resolves to
+	// whatever the wall clock says while the baseline is still the stale,
+	// pre-catch-up counter, so a pool several rotations into its life
+	// would look gapped and fail startup -- unable to then sync to the
+	// point that would make the baseline correct. The forge loop's own
+	// gate does not have this problem: it runs after the upstream-sync
+	// skip and the leader check, so both its era and its baseline come
+	// from near-tip state, and it fails closed per slot rather than
+	// refusing to start the node at all.
+	registered, vrfMatched, err := creds.ValidateAgainstLedger(view)
 	if err != nil {
 		if errors.Is(err, forging.ErrVRFKeyHashMismatch) &&
 			n.config.network == "devnet" {
@@ -222,32 +220,6 @@ func (n *Node) validateBlockProducerLedgerWithView(
 		)
 	}
 	return nil
-}
-
-// opCertNoGapRuleForCurrentSlot resolves whether the era at the ledger's
-// current slot enforces the operational-certificate no-gap rule (Praos,
-// Babbage onward) as opposed to only the stale-counter check (TPraos,
-// Shelley-Alonzo), so ValidateAgainstLedger can apply the same era-scoped
-// rule at startup that the forge loop and block application apply
-// afterward. An error here means the era could not be determined -- the
-// caller falls back to the pre-existing stale-only check rather than
-// refusing startup for it.
-func (n *Node) opCertNoGapRuleForCurrentSlot() (bool, error) {
-	if n.ledgerState == nil {
-		return false, errors.New("ledger state unavailable")
-	}
-	currentSlot, err := n.ledgerState.CurrentSlot()
-	if err != nil {
-		if errors.Is(err, ledger.ErrBeforeGenesis) {
-			return false, nil
-		}
-		return false, fmt.Errorf("compute current slot: %w", err)
-	}
-	pparams := n.ledgerState.ProtocolParamsForSlot(currentSlot)
-	if pparams == nil {
-		return false, errors.New("protocol parameters unavailable")
-	}
-	return forging.EnforceOpCertNoGapRule(pparams)
 }
 
 // handleGenesisSnapshotError returns a fatal error for block producers (which

--- a/node_forging.go
+++ b/node_forging.go
@@ -163,7 +163,25 @@ func (n *Node) validateBlockProducerLedgerWithView(
 	if creds == nil {
 		return errors.New("nil pool credentials")
 	}
-	registered, vrfMatched, err := creds.ValidateAgainstLedger(view)
+	enforceNoGap, gapErr := n.opCertNoGapRuleForCurrentSlot()
+	if gapErr != nil {
+		// Era resolution failing here is not itself a reason to refuse
+		// startup: fall back to the stale-only check ValidateAgainstLedger
+		// already applied before this era-scoped rule existed, rather than
+		// adding a new startup-failure mode for an edge case unrelated to
+		// the credential cross-check itself.
+		n.config.logger.Warn(
+			"could not resolve era for opcert no-gap rule; startup will only check for a stale counter",
+			"component",
+			"node",
+			"error",
+			gapErr,
+		)
+	}
+	registered, vrfMatched, err := creds.ValidateAgainstLedger(
+		view,
+		enforceNoGap,
+	)
 	if err != nil {
 		if errors.Is(err, forging.ErrVRFKeyHashMismatch) &&
 			n.config.network == "devnet" {
@@ -204,6 +222,32 @@ func (n *Node) validateBlockProducerLedgerWithView(
 		)
 	}
 	return nil
+}
+
+// opCertNoGapRuleForCurrentSlot resolves whether the era at the ledger's
+// current slot enforces the operational-certificate no-gap rule (Praos,
+// Babbage onward) as opposed to only the stale-counter check (TPraos,
+// Shelley-Alonzo), so ValidateAgainstLedger can apply the same era-scoped
+// rule at startup that the forge loop and block application apply
+// afterward. An error here means the era could not be determined -- the
+// caller falls back to the pre-existing stale-only check rather than
+// refusing startup for it.
+func (n *Node) opCertNoGapRuleForCurrentSlot() (bool, error) {
+	if n.ledgerState == nil {
+		return false, errors.New("ledger state unavailable")
+	}
+	currentSlot, err := n.ledgerState.CurrentSlot()
+	if err != nil {
+		if errors.Is(err, ledger.ErrBeforeGenesis) {
+			return false, nil
+		}
+		return false, fmt.Errorf("compute current slot: %w", err)
+	}
+	pparams := n.ledgerState.ProtocolParamsForSlot(currentSlot)
+	if pparams == nil {
+		return false, errors.New("protocol parameters unavailable")
+	}
+	return forging.EnforceOpCertNoGapRule(pparams)
 }
 
 // handleGenesisSnapshotError returns a fatal error for block producers (which

--- a/node_forging.go
+++ b/node_forging.go
@@ -373,6 +373,10 @@ func (n *Node) initBlockForger(
 		LeiosTxValidator:                n.ledgerState,
 		LeiosCertificateProvider:        leiosCerts,
 		LeiosParentAnnouncementProvider: leiosParent,
+		OpCertLedgerView: blockProducerLedgerView{
+			ls: n.ledgerState,
+		},
+		EraParams: n.ledgerState,
 	})
 	if err != nil {
 		// Stop election to prevent goroutine leak


### PR DESCRIPTION
Closes #3501.

The forge loop validates the operational certificate's KES evolution
limit on every attempt, but the OpCert issue-number counter was only
checked once, against the ledger, at node startup
(`PoolCredentials.ValidateAgainstLedger`). A counter that went stale or
became gapped after startup — e.g. a peer relays a block from the same
pool with a higher counter, or the chain crosses the Babbage boundary —
was only caught when block application rejected the block the forger
had already built, signed, and fenced against the slot.

## Changes

- **`ledger/forging/keys.go`**: add `validateOpCertSequence`, mirroring
  `validateOpCertCounter` in `ledger/verify_opcert.go`. A counter behind
  the last value the ledger observed for the pool is rejected in every
  era; one that skips ahead of it is rejected only in Praos eras
  (Babbage onward).
- **`ledger/forging/forger.go`**: add optional `ForgerConfig.OpCertLedgerView`
  and `EraParams` fields. `NewBlockForger` requires `EraParams` whenever
  `OpCertLedgerView` is set. `checkAndForgeProduction` runs the new
  `checkOpCertSequence` gate — resolving the counter via
  `LedgerView.LatestOpCertSequence` and the era via
  `ProtocolParamsForSlot` — before leader selection and the forge-slot
  fence. Leaving `OpCertLedgerView` nil skips the check, unchanged from
  before.
- **`node_forging.go`**: wire the new fields to the node's real ledger
  state in `initBlockForger`.
- **`ARCHITECTURE.md`**: document the new pre-flight gate in the Block
  Forging section.
- **`ledger/forging/keys_test.go`**: table-driven tests for
  `validateOpCertSequence` (stale, boundary, and gapped counters, split
  by era).
- **`ledger/forging/opcert_sequence_gate_test.go`**: end-to-end tests
  through `BlockForger.checkAndForgeProduction` — stale counter, no
  prior observed counter, an era-unresolvable slot, the TPraos/Praos
  no-gap rule split (including boundary values), and confirmation the
  gate is a no-op when `OpCertLedgerView` is nil.

## Testing

- `go test -race ./ledger/forging/...`
- `go test ./internal/test/conformance/...`
- `go build ./...`, `go vet ./...`
- `golangci-lint run ./...`, `nilaway ./...`, `modernize ./...` (no new
  findings in touched files)
- `make import-boundaries`, `make docs-parity`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the forge loop so a stale or gapped operational certificate counter is caught on every forge attempt instead of only at startup, preventing a leader slot from being spent on a block the chain would reject.

**Details**
- The counter rule lives in one shared implementation (`eras.ValidateOpCertCounter`) used by block application, the forge gate, and startup validation; it also fixes a max-`uint64` wraparound and rejects typed-nil protocol-parameters pointers.
- Startup validation deliberately stays on the stale-only half; applying the era-scoped gap rule there pairs a wall-clock era with an applied-chain baseline and can falsely reject a pool, preventing the node from ever syncing.
- The gate runs after the leader check, so its ledger read only costs slots this pool leads.
- `LedgerState.LatestOpCertSequence` now resolves the latest counter via the same Mithril-boundary-aware path as block application, instead of a plain `MAX` that could trust stale pre-boundary rows.

Closes #3501.

<sup>Written for commit df5d1c0029aa52e3dc3c143ad56d4e6a26c4b3e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Block forging now checks operational certificate counters against the latest ledger state before attempting to forge.
  - Stale counters are rejected, while counter gaps follow the rules for the active protocol era.
  - Forging safely stops when the applicable era cannot be determined.

- **Reliability**
  - The check is optional and remains skipped when ledger-backed certificate data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->