### PR TITLE
fix(database): warn only when a transaction loses declared outputs

### DIFF
--- a/database/transaction.go
+++ b/database/transaction.go
@@ -173,6 +173,20 @@ func (d *Database) SetTransaction(
 	)
 }
 
+// producedOutputsDropped reports whether an empty Produced() set means the
+// transaction lost outputs it declared. Producing nothing is a legal shape:
+// a valid transaction can spend its whole input on deposits plus the fee and
+// return no change (issue #3932), and an invalid transaction without a
+// collateral return produces nothing either. Produced() is Outputs() for a
+// valid transaction and the collateral return for an invalid one, so an empty
+// set is unexpected only when the matching declaration is non-empty.
+func producedOutputsDropped(tx lcommon.Transaction) bool {
+	if tx.IsValid() {
+		return len(tx.Outputs()) > 0
+	}
+	return tx.CollateralReturn() != nil
+}
+
 // SetTransactionWithOpts is SetTransaction with control over UTxO ingest
 // behavior via opts. Leios endorser-block application on the Musashi/
 // Haskell-conformant path passes SkipConsumedInputRecovery so a transaction's
@@ -241,10 +255,12 @@ func (d *Database) SetTransactionWithOpts(
 	// transactions (collateral return at index len(Outputs()))
 	// UTxO offsets MUST be available - no fallback to full CBOR storage
 	produced := tx.Produced()
-	if len(produced) == 0 {
+	if len(produced) == 0 && producedOutputsDropped(tx) {
 		d.logger.Warn(
-			"transaction has no produced outputs",
+			"transaction produced no UTxOs despite declaring outputs",
 			"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
+			"valid", tx.IsValid(),
+			"outputs", len(tx.Outputs()),
 			"slot", point.Slot,
 		)
 	}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -250,20 +250,26 @@ func (d *Database) SetTransactionWithOpts(
 	// Each branch reports its own declaration: the two are different fields, so
 	// one shared message would name the wrong one for half the warnings.
 	if len(produced) == 0 {
+		// Each accessor is read once into a local: every era's Outputs()
+		// allocates a fresh slice per call, and reading CollateralReturn()
+		// once closes the gap between the nil test and the dereference.
+		outputs := tx.Outputs()
+		collateralReturn := tx.CollateralReturn()
+		txHashHex := hex.EncodeToString(ledgerHashPrefix(txHash))
 		switch {
-		case tx.IsValid() && len(tx.Outputs()) > 0:
+		case tx.IsValid() && len(outputs) > 0:
 			d.logger.Warn(
 				"valid transaction produced no UTxOs despite declaring outputs",
-				"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
-				"outputs", len(tx.Outputs()),
+				"txHash", txHashHex,
+				"outputs", len(outputs),
 				"slot", point.Slot,
 			)
-		case !tx.IsValid() && tx.CollateralReturn() != nil:
+		case !tx.IsValid() && collateralReturn != nil:
 			d.logger.Warn(
-				"invalid transaction produced no UTxOs despite declaring a collateral return",
-				"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
-				"collateralReturnLovelace",
-				tx.CollateralReturn().Amount().String(),
+				"invalid transaction produced no UTxOs despite "+
+					"declaring a collateral return",
+				"txHash", txHashHex,
+				"collateralReturnLovelace", collateralReturn.Amount().String(),
 				"slot", point.Slot,
 			)
 		}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -173,20 +173,6 @@ func (d *Database) SetTransaction(
 	)
 }
 
-// producedOutputsDropped reports whether an empty Produced() set means the
-// transaction lost outputs it declared. Producing nothing is a legal shape:
-// a valid transaction can spend its whole input on deposits plus the fee and
-// return no change (issue #3932), and an invalid transaction without a
-// collateral return produces nothing either. Produced() is Outputs() for a
-// valid transaction and the collateral return for an invalid one, so an empty
-// set is unexpected only when the matching declaration is non-empty.
-func producedOutputsDropped(tx lcommon.Transaction) bool {
-	if tx.IsValid() {
-		return len(tx.Outputs()) > 0
-	}
-	return tx.CollateralReturn() != nil
-}
-
 // SetTransactionWithOpts is SetTransaction with control over UTxO ingest
 // behavior via opts. Leios endorser-block application on the Musashi/
 // Haskell-conformant path passes SkipConsumedInputRecovery so a transaction's
@@ -255,14 +241,32 @@ func (d *Database) SetTransactionWithOpts(
 	// transactions (collateral return at index len(Outputs()))
 	// UTxO offsets MUST be available - no fallback to full CBOR storage
 	produced := tx.Produced()
-	if len(produced) == 0 && producedOutputsDropped(tx) {
-		d.logger.Warn(
-			"transaction produced no UTxOs despite declaring outputs",
-			"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
-			"valid", tx.IsValid(),
-			"outputs", len(tx.Outputs()),
-			"slot", point.Slot,
-		)
+	// Producing no UTxOs is a legal shape: a valid transaction can spend its
+	// whole input on deposits plus the fee and return no change (issue #3932),
+	// and an invalid transaction without a collateral return produces nothing
+	// either. Produced() is Outputs() for a valid transaction and the
+	// collateral return for an invalid one, so an empty set means outputs were
+	// dropped before storage only when the matching declaration is non-empty.
+	// Each branch reports its own declaration: the two are different fields, so
+	// one shared message would name the wrong one for half the warnings.
+	if len(produced) == 0 {
+		switch {
+		case tx.IsValid() && len(tx.Outputs()) > 0:
+			d.logger.Warn(
+				"valid transaction produced no UTxOs despite declaring outputs",
+				"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
+				"outputs", len(tx.Outputs()),
+				"slot", point.Slot,
+			)
+		case !tx.IsValid() && tx.CollateralReturn() != nil:
+			d.logger.Warn(
+				"invalid transaction produced no UTxOs despite declaring a collateral return",
+				"txHash", hex.EncodeToString(ledgerHashPrefix(txHash)),
+				"collateralReturnLovelace",
+				tx.CollateralReturn().Amount().String(),
+				"slot", point.Slot,
+			)
+		}
 	}
 	for _, utxo := range produced {
 		txId := ledgerInputIDBytes(utxo.Id)

--- a/database/zero_produced_outputs_test.go
+++ b/database/zero_produced_outputs_test.go
@@ -21,9 +21,14 @@ import (
 	"testing"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
+
+// collateralReturnAddress is an arbitrary mainnet payment address; the
+// collateral-return fixtures only need a decodable one.
+const collateralReturnAddress = "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 
 // noOutputsTx is the legal zero-output shape from issue #3932: a valid
 // transaction that declares no outputs, so Produced() is empty too. On chain
@@ -62,6 +67,35 @@ func (t invalidTx) CollateralReturn() lcommon.TransactionOutput {
 }
 
 func (t invalidTx) Produced() []lcommon.Utxo { return nil }
+
+// collateralReturnTx is the shape a real phase-2 failure takes in Babbage and
+// later: invalid, a non-nil collateral return, and a Produced() that carries
+// that return at index len(Outputs()). It is the true negative for the
+// collateral branch of the warning -- the only shape where a non-nil
+// CollateralReturn() coexists with a correctly stored UTxO, so it is the shape
+// that would expose the branch firing on declaration alone rather than on loss.
+type collateralReturnTx struct {
+	lcommon.Transaction
+	collateralReturn lcommon.TransactionOutput
+}
+
+func (t collateralReturnTx) IsValid() bool { return false }
+
+func (t collateralReturnTx) CollateralReturn() lcommon.TransactionOutput {
+	return t.collateralReturn
+}
+
+func (t collateralReturnTx) Produced() []lcommon.Utxo {
+	return []lcommon.Utxo{
+		{
+			Id: shelley.NewShelleyTransactionInput(
+				t.Hash().String(),
+				len(t.Outputs()),
+			),
+			Output: t.collateralReturn,
+		},
+	}
+}
 
 // TestSetTransactionZeroProducedOutputsLogging covers the log emitted when a
 // transaction stores no UTxOs. A zero-output transaction is a legal shape and
@@ -111,9 +145,13 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 		db *Database,
 		logs *bytes.Buffer,
 		tx lcommon.Transaction,
+		withOffsets ...func(*BlockIngestionResult),
 	) string {
 		t.Helper()
 		offsets := mustBlockOffsets(t, candidate.consumerBlock)
+		for _, fn := range withOffsets {
+			fn(offsets)
+		}
 		logs.Reset()
 		require.NoError(t, db.SetTransactionWithOpts(
 			tx,
@@ -183,7 +221,7 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 	t.Run("dropped collateral return warns", func(t *testing.T) {
 		const collateralLovelace = 1_000_000
 		collateralReturn, err := mockledger.NewTransactionOutputBuilder().
-			WithAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd").
+			WithAddress(collateralReturnAddress).
 			WithLovelace(collateralLovelace).
 			Build()
 		require.NoError(t, err)
@@ -211,4 +249,42 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 		require.NotContains(t, out, `"outputs":`)
 		require.NotContains(t, out, "despite declaring outputs")
 	})
+
+	t.Run(
+		"invalid transaction keeping its collateral return does not warn",
+		func(t *testing.T) {
+			collateralReturn, err := mockledger.NewTransactionOutputBuilder().
+				WithAddress(collateralReturnAddress).
+				WithLovelace(1_000_000).
+				Build()
+			require.NoError(t, err)
+			var logs bytes.Buffer
+			db := newStagedDB(t, &logs)
+			var txHash [32]byte
+			copy(txHash[:], ledgerHashBytes(candidate.consumerTx.Hash()))
+			collateralIdx := uint32(len(candidate.consumerTx.Outputs()))
+			out := setTx(
+				t, db, &logs,
+				collateralReturnTx{
+					Transaction:      candidate.consumerTx,
+					collateralReturn: collateralReturn,
+				},
+				func(offsets *BlockIngestionResult) {
+					// The indexer only emits offsets for the outputs the
+					// transaction declares, so the collateral return's index
+					// has none and SetTransactionWithOpts would fail before
+					// reaching the log. Nothing on this path decodes the
+					// offset, so output 0's span stands in for it.
+					offsets.UtxoOffsets[UtxoRef{
+						TxId:      txHash,
+						OutputIdx: collateralIdx,
+					}] = offsets.UtxoOffsets[UtxoRef{
+						TxId:      txHash,
+						OutputIdx: 0,
+					}]
+				},
+			)
+			require.NotContains(t, out, `"level":"WARN"`)
+		},
+	)
 }

--- a/database/zero_produced_outputs_test.go
+++ b/database/zero_produced_outputs_test.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -101,8 +102,19 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 		return db
 	}
 
-	setTx := func(t *testing.T, db *Database, tx lcommon.Transaction) {
+	// setTx discards everything newStagedDB logged before calling the function
+	// under test, so an assertion sees only that call's output. Staging writes
+	// blocks and producer transactions, and a warning from that setup would
+	// otherwise decide a "does not warn" subtest.
+	setTx := func(
+		t *testing.T,
+		db *Database,
+		logs *bytes.Buffer,
+		tx lcommon.Transaction,
+	) string {
 		t.Helper()
+		offsets := mustBlockOffsets(t, candidate.consumerBlock)
+		logs.Reset()
 		require.NoError(t, db.SetTransactionWithOpts(
 			tx,
 			candidate.consumerPoint,
@@ -110,36 +122,49 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 			0,
 			nil,
 			nil,
-			mustBlockOffsets(t, candidate.consumerBlock),
+			offsets,
 			nil,
 			BatchedTxIngestOpts{},
 		))
+		return logs.String()
 	}
 
 	t.Run("zero-output transaction does not warn", func(t *testing.T) {
 		var logs bytes.Buffer
 		db := newStagedDB(t, &logs)
-		setTx(t, db, noOutputsTx{Transaction: candidate.consumerTx})
-		require.NotContains(t, logs.String(), `"level":"WARN"`)
+		out := setTx(
+			t, db, &logs,
+			noOutputsTx{Transaction: candidate.consumerTx},
+		)
+		require.NotContains(t, out, `"level":"WARN"`)
 	})
 
 	t.Run("transaction with outputs does not warn", func(t *testing.T) {
 		var logs bytes.Buffer
 		db := newStagedDB(t, &logs)
-		setTx(t, db, candidate.consumerTx)
-		require.NotContains(t, logs.String(), `"level":"WARN"`)
+		out := setTx(t, db, &logs, candidate.consumerTx)
+		require.NotContains(t, out, `"level":"WARN"`)
 	})
 
 	t.Run("dropped outputs warn", func(t *testing.T) {
 		var logs bytes.Buffer
 		db := newStagedDB(t, &logs)
-		setTx(t, db, droppedOutputsTx{Transaction: candidate.consumerTx})
-		require.Contains(t, logs.String(), `"level":"WARN"`)
+		out := setTx(
+			t, db, &logs,
+			droppedOutputsTx{Transaction: candidate.consumerTx},
+		)
+		require.Contains(t, out, `"level":"WARN"`)
 		require.Contains(
 			t,
-			logs.String(),
-			"transaction produced no UTxOs despite declaring outputs",
+			out,
+			"valid transaction produced no UTxOs despite declaring outputs",
 		)
+		// The count names what was dropped, so it must be the declared
+		// outputs rather than the (empty) produced set.
+		require.Contains(t, out, fmt.Sprintf(
+			`"outputs":%d`,
+			len(candidate.consumerTx.Outputs()),
+		))
 	})
 
 	t.Run(
@@ -147,28 +172,43 @@ func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
 		func(t *testing.T) {
 			var logs bytes.Buffer
 			db := newStagedDB(t, &logs)
-			setTx(t, db, invalidTx{Transaction: candidate.consumerTx})
-			require.NotContains(t, logs.String(), `"level":"WARN"`)
+			out := setTx(
+				t, db, &logs,
+				invalidTx{Transaction: candidate.consumerTx},
+			)
+			require.NotContains(t, out, `"level":"WARN"`)
 		},
 	)
 
 	t.Run("dropped collateral return warns", func(t *testing.T) {
+		const collateralLovelace = 1_000_000
 		collateralReturn, err := mockledger.NewTransactionOutputBuilder().
 			WithAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd").
-			WithLovelace(1_000_000).
+			WithLovelace(collateralLovelace).
 			Build()
 		require.NoError(t, err)
 		var logs bytes.Buffer
 		db := newStagedDB(t, &logs)
-		setTx(t, db, invalidTx{
+		out := setTx(t, db, &logs, invalidTx{
 			Transaction:      candidate.consumerTx,
 			collateralReturn: collateralReturn,
 		})
-		require.Contains(t, logs.String(), `"level":"WARN"`)
+		require.Contains(t, out, `"level":"WARN"`)
+		// The dropped declaration here is the collateral return, so the
+		// message and the attribute must name it. Reporting the transaction's
+		// outputs instead would point an operator at a field that is not what
+		// went missing.
 		require.Contains(
 			t,
-			logs.String(),
-			"transaction produced no UTxOs despite declaring outputs",
+			out,
+			"invalid transaction produced no UTxOs despite declaring "+
+				"a collateral return",
 		)
+		require.Contains(t, out, fmt.Sprintf(
+			`"collateralReturnLovelace":"%d"`,
+			collateralLovelace,
+		))
+		require.NotContains(t, out, `"outputs":`)
+		require.NotContains(t, out, "despite declaring outputs")
 	})
 }

--- a/database/zero_produced_outputs_test.go
+++ b/database/zero_produced_outputs_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// noOutputsTx is the legal zero-output shape from issue #3932: a valid
+// transaction that declares no outputs, so Produced() is empty too. On chain
+// this is e.g. a stake registration that spends its whole input on the deposit
+// plus the fee and returns no change.
+type noOutputsTx struct {
+	lcommon.Transaction
+}
+
+func (t noOutputsTx) Outputs() []lcommon.TransactionOutput { return nil }
+
+func (t noOutputsTx) Produced() []lcommon.Utxo { return nil }
+
+// droppedOutputsTx is the unexpected shape: a valid transaction that declares
+// outputs but produces no UTxOs. Produced() maps one-to-one onto Outputs() for
+// a valid transaction, so this cannot occur on chain -- it would mean outputs
+// were dropped before storage.
+type droppedOutputsTx struct {
+	lcommon.Transaction
+}
+
+func (t droppedOutputsTx) Produced() []lcommon.Utxo { return nil }
+
+// invalidTx is the phase-2 failure shape, where Produced() is the collateral
+// return alone. A nil collateralReturn is the legal zero-output case; a
+// non-nil one that still produces nothing has lost the collateral return.
+type invalidTx struct {
+	lcommon.Transaction
+	collateralReturn lcommon.TransactionOutput
+}
+
+func (t invalidTx) IsValid() bool { return false }
+
+func (t invalidTx) CollateralReturn() lcommon.TransactionOutput {
+	return t.collateralReturn
+}
+
+func (t invalidTx) Produced() []lcommon.Utxo { return nil }
+
+// TestSetTransactionZeroProducedOutputsLogging covers the log emitted when a
+// transaction stores no UTxOs. A zero-output transaction is a legal shape and
+// must not warn; only losing declared outputs is worth an operator's
+// attention.
+func TestSetTransactionZeroProducedOutputsLogging(t *testing.T) {
+	candidate := findGapConsumeCandidateWithoutCertificates(t)
+
+	// newStagedDB stages the consumer's producers so the consumed inputs
+	// resolve, leaving the produced-side logging as the only thing under test.
+	newStagedDB := func(t *testing.T, logs *bytes.Buffer) *Database {
+		t.Helper()
+		db, err := newTestDatabase(t, &Config{
+			DataDir: t.TempDir(),
+			Logger: slog.New(slog.NewJSONHandler(
+				logs,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			)),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		for _, p := range candidate.producers {
+			storeBlockOffsetsOnly(t, db, p.block)
+			metaTxn := db.MetadataTxn(true)
+			producer := p
+			require.NoError(t, metaTxn.Do(func(txn *Txn) error {
+				return db.Metadata().SetGapBlockTransaction(
+					producer.tx,
+					producer.point,
+					0,
+					txn.Metadata(),
+				)
+			}))
+			metaTxn.Release()
+		}
+		storeBlockOffsetsOnly(t, db, candidate.consumerBlock)
+		return db
+	}
+
+	setTx := func(t *testing.T, db *Database, tx lcommon.Transaction) {
+		t.Helper()
+		require.NoError(t, db.SetTransactionWithOpts(
+			tx,
+			candidate.consumerPoint,
+			0,
+			0,
+			nil,
+			nil,
+			mustBlockOffsets(t, candidate.consumerBlock),
+			nil,
+			BatchedTxIngestOpts{},
+		))
+	}
+
+	t.Run("zero-output transaction does not warn", func(t *testing.T) {
+		var logs bytes.Buffer
+		db := newStagedDB(t, &logs)
+		setTx(t, db, noOutputsTx{Transaction: candidate.consumerTx})
+		require.NotContains(t, logs.String(), `"level":"WARN"`)
+	})
+
+	t.Run("transaction with outputs does not warn", func(t *testing.T) {
+		var logs bytes.Buffer
+		db := newStagedDB(t, &logs)
+		setTx(t, db, candidate.consumerTx)
+		require.NotContains(t, logs.String(), `"level":"WARN"`)
+	})
+
+	t.Run("dropped outputs warn", func(t *testing.T) {
+		var logs bytes.Buffer
+		db := newStagedDB(t, &logs)
+		setTx(t, db, droppedOutputsTx{Transaction: candidate.consumerTx})
+		require.Contains(t, logs.String(), `"level":"WARN"`)
+		require.Contains(
+			t,
+			logs.String(),
+			"transaction produced no UTxOs despite declaring outputs",
+		)
+	})
+
+	t.Run(
+		"invalid transaction without collateral return does not warn",
+		func(t *testing.T) {
+			var logs bytes.Buffer
+			db := newStagedDB(t, &logs)
+			setTx(t, db, invalidTx{Transaction: candidate.consumerTx})
+			require.NotContains(t, logs.String(), `"level":"WARN"`)
+		},
+	)
+
+	t.Run("dropped collateral return warns", func(t *testing.T) {
+		collateralReturn, err := mockledger.NewTransactionOutputBuilder().
+			WithAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd").
+			WithLovelace(1_000_000).
+			Build()
+		require.NoError(t, err)
+		var logs bytes.Buffer
+		db := newStagedDB(t, &logs)
+		setTx(t, db, invalidTx{
+			Transaction:      candidate.consumerTx,
+			collateralReturn: collateralReturn,
+		})
+		require.Contains(t, logs.String(), `"level":"WARN"`)
+		require.Contains(
+			t,
+			logs.String(),
+			"transaction produced no UTxOs despite declaring outputs",
+		)
+	})
+}


### PR DESCRIPTION
## Why

`database.SetTransactionWithOpts` warned whenever `tx.Produced()` was empty.
Producing no UTxOs is a legal transaction shape, so the warning fired during
ordinary sync with no remedy attached, and "transaction has no produced
outputs" on a `valid = 1` transaction reads as lost UTxOs.

Fixes #3932.

## Evidence

Fourteen occurrences in one Preview replay. Taking the first
(`7ad44ff9eaa54b34`, slot 32983570): one input worth 3126383, zero outputs, a
stake-registration certificate, deposit 2000000, fee 1126383. `3126383 =
2000000 + 1126383` — the transaction spends its whole input on the deposit plus
the fee and returns no change. Value is conserved and Dingo stores it
correctly.

## What changed

Narrowed the condition rather than lowering the level, so the "outputs went
missing" signal survives instead of being demoted to DEBUG where nobody would
see it.

Value-conservation accounting was rejected as the narrowing rule: it needs every
consumed input resolved from the UTxO store in the ingest hot path, and it
restates a ledger rule (`UtxoValidateValueNotConservedUtxo`) inside the storage
layer. The storage layer's own invariant is cheaper and exact — `Produced()` is
`Outputs()` for a valid transaction and the collateral return for an invalid
one, so an empty produced set means outputs were dropped before storage only
when the matching declaration is non-empty.

Those are two different fields, so the warning has two branches and each names
its own:

| transaction | declaration lost | message | attribute |
| --- | --- | --- | --- |
| valid | `Outputs()` | `valid transaction produced no UTxOs despite declaring outputs` | `outputs` |
| invalid | `CollateralReturn()` | `invalid transaction produced no UTxOs despite declaring a collateral return` | `collateralReturnLovelace` |

Each accessor is read once into a local before the branch (`Outputs()`
allocates a fresh slice per call in every era, and one read of
`CollateralReturn()` leaves no window between the nil test and `.Amount()`),
and the invalid branch's message literal is split so the file stays stable
under `golines --max-len=80` as `origin/main`'s copy is.

No other code, test, or doc referenced the old message.

### Behaviour note

One signal is dropped that the summary above does not imply. A Byron
transaction with zero outputs is malformed per the Byron CDDL (`txouts` is
`[+ txout]`), but `ByronTransactionBody.UnmarshalCBOR` is a plain `cbor.Decode`
with no non-emptiness check and `ByronTransaction.IsValid()` is `return true`,
so that shape lands in the legal-zero-output case and is now silent where it
used to warn. Accepted: the warning was never a CDDL check, and a
body-hash-valid block carrying a malformed Byron body is a consensus problem
that a storage-layer "outputs went missing" line would mislabel.

## Tests

`TestSetTransactionZeroProducedOutputsLogging` in
`database/zero_produced_outputs_test.go` drives real `SetTransactionWithOpts`
calls against a staged database and asserts on captured `slog` JSON. The capture
buffer is reset after staging and immediately before the call under test, so a
warning from `BlockCreate` or `SetGapBlockTransaction` cannot decide a subtest.

The immutable testdata contains no zero-output transaction (21299 transactions
scanned, 0 with zero outputs), so each shape is a thin wrapper embedding a real
fixture transaction and overriding only `Outputs()`, `Produced()`, `IsValid()`,
or `CollateralReturn()`.

| sub-test | shape | expected |
| --- | --- | --- |
| zero-output transaction does not warn | valid, no outputs, no produced | no WARN |
| transaction with outputs does not warn | unmodified fixture | no WARN (control) |
| dropped outputs warn | valid, declares outputs, produces none | WARN naming `outputs` |
| invalid transaction without collateral return does not warn | invalid, no collateral return | no WARN |
| dropped collateral return warns | invalid, collateral return declared, produces none | WARN naming `collateralReturnLovelace` |
| invalid transaction keeping its collateral return does not warn | invalid, collateral return declared *and* produced at index `len(Outputs())` | no WARN |

The two warning sub-tests assert the message text and the attribute, and the
collateral case additionally asserts the *absence* of `"outputs":` and of
`despite declaring outputs`, so a warning that named the wrong field would fail.

The last sub-test is the true negative for the collateral branch: the real
Babbage+ shape, where a non-nil `CollateralReturn()` coexists with a correctly
stored UTxO. The block indexer only emits offsets for declared outputs, so the
collateral return's index `len(Outputs())` has none and the call would fail on
`missing UTxO offset` before reaching the log; `setTx` therefore takes an
optional `func(*BlockIngestionResult)` and the sub-test copies output 0's span
to that index. Nothing on this path decodes the offset, so a borrowed span is
sufficient and the assertion is on the log alone.

Discrimination, re-verified at the current head:

- with `database/transaction.go` reverted to `origin/main`, 4 of the original 5
  sub-tests fail — the two legal shapes on the WARN that should not be there,
  the two dropped-output shapes on the message that should be;
- with the earlier single-shared-message version of the file, the two warning
  sub-tests fail on the wording and attributes;
- with the guard widened to `len(produced) == 0 || !tx.IsValid()`, so the
  collateral branch fires on declaration rather than on loss, the new true
  negative is the *only* one of the six to fail — it is not redundant with the
  existing controls;
- the two controls (unmodified fixture, kept collateral return) pass against
  `origin/main` as they should, so the assertions are not simply matching
  everything.

## Validation

Re-run at the current head:

- `go test ./database/... -count=1` — all packages ok
- `go test ./database/ -run TestSetTransactionZeroProducedOutputsLogging` — 6/6
- `golangci-lint run ./...` in all three module dirs, plus `GOOS=windows
  golangci-lint run ./...` — 0 issues in each. (`run.tests: false`, so the new
  test file is out of scope by configuration, not by omission.)
- `go test ./internal/architecture` (import boundaries) — ok
- `make docs-parity` — ok
- `gofmt -s`, `gofumpt`, and `golines -w --ignore-generated --chain-split-dots
  --max-len=80 --reformat-tags` over copies of both changed files — no diff

Not run: `nilaway` and `modernize`. Both are installed but built against go1.26
and cannot analyse this go1.27.1 toolchain — `nilaway` emits only
`failed prerequisites:` lines and `modernize` only
`analysis skipped due to errors in package`, so neither analysed any code and
neither result can be read as clean. Neither is pinned by the Makefile or run
in CI. An earlier `nilaway` run on this branch, while it still worked, reported
0 findings in either changed file.

## Docs

No update needed. `DATABASE.md` and `ARCHITECTURE.md` document the produced-UTxO
write path and the Leios closure semantics, neither of which changes; the log
level and text of this line are not documented in either file, and neither keeps
an inventory of logged warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction warnings when no UTxOs are produced.
  - Warnings now distinguish between dropped outputs and dropped collateral returns.
  - Diagnostic messages include the relevant output count or collateral-return amount, along with transaction details.

- **Tests**
  - Added coverage for valid, invalid, zero-output, and collateral-return transaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->