### PR TITLE
fix(koiosparity): prove pool departure from retirement certificates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6070,11 +6070,17 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   history, through `RewardParitySource.GetPoolsRetiredByEpoch` and
   `MetadataStore.GetPoolKeyHashesRetiredByEpoch` (see DATABASE.md), read once
   per epoch at the K+1 `epoch_summary.boundary_slot`
-  (`DingoEpochData.BoundarySlot`). A retirement effective at or before K+1
+  (`DingoEpochData.BoundarySlot`). A retirement effective at or before K
   that no later registration cancelled is a positive fact about that one
   pool, so it proves departure without any argument about set completeness,
   and `pool_registration`/`pool_retirement` are retained for the life of the
-  database. This route also fails closed: "a retirement certificate exists"
+  database. The effective-epoch bound is K rather than the K+1 boundary the
+  certificates are resolved as of, because `epochBoundarySnapshotSlot`
+  captures the K+1 mark pool set at `boundarySlot - 1`: that slot falls in
+  epoch K, so `GetActivePoolKeyHashesAtSlot` keeps every pool retiring
+  effective K+1 and those pools still get a K+1 `reward_pool_input` row.
+  Reading them as departed would mask a genuinely missing one. This route
+  also fails closed: "a retirement certificate exists"
   is not the predicate, because a later registration cancels a pending
   retirement and a re-registration after one has taken effect puts the pool
   back — such a pool is still in the pool set, and downgrading it would turn

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6059,6 +6059,30 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   stays in the pool set leaves the counts unequal, so membership is unproven
   and the stricter classification stands (issue #3795).
 
+  Both of those routes reconstruct the whole K+1 pool set and read departure
+  as absence from it, so both can be closed at once — and on a from-genesis
+  Preview replay they were. The mark rows were pruned for every epoch the
+  observer reached, and `reward_pool_input` was consistently short of
+  `epoch_summary.total_pool_count` because a degraded active pool is omitted
+  from it, which is precisely the case the exact-match requirement exists to
+  exclude. Every ordinary pool retirement then became a `dingo_db_missing`.
+  `checkEpoch` therefore also resolves departure per pool from certificate
+  history, through `RewardParitySource.GetPoolsRetiredByEpoch` and
+  `MetadataStore.GetPoolKeyHashesRetiredByEpoch` (see DATABASE.md), read once
+  per epoch at the K+1 `epoch_summary.boundary_slot`
+  (`DingoEpochData.BoundarySlot`). A retirement effective at or before K+1
+  that no later registration cancelled is a positive fact about that one
+  pool, so it proves departure without any argument about set completeness,
+  and `pool_registration`/`pool_retirement` are retained for the life of the
+  database. This route also fails closed: "a retirement certificate exists"
+  is not the predicate, because a later registration cancels a pending
+  retirement and a re-registration after one has taken effect puts the pool
+  back — such a pool is still in the pool set, and downgrading it would turn
+  a real `dingo_db_missing` into a pass. Without a K+1 boundary slot there is
+  no point in the chain to resolve each pool's latest certificate as of, so
+  the route stays closed and the stricter classification stands (issue
+  #3925).
+
   The same split applies a third time to `reward_pool_input`'s stake-epoch
   fields (`delegated_stake`/`delegator_count`/`fixed_cost`/`margin`, reported
   together as `reward_pool_input_stake` when absent) via
@@ -6167,8 +6191,9 @@ second sync:
   `epoch_summary`/`reward_ada_pots`/`reward_pool_input`/`reward_pool_output`/
   `reward_account_output` through the existing typed `MetadataStore`
   accessors (`GetEpochSummary`, `GetRewardAdaPots`, `GetRewardPoolInputs`,
-  `GetRewardPoolOutputs`, `GetRewardAccountOutputs`) inside a fresh read-only
-  transaction per call — the same tables `ledger/snapshot/rotation.go`
+  `GetRewardPoolOutputs`, `GetRewardAccountOutputs`, and
+  `GetPoolKeyHashesRetiredByEpoch` for the departure evidence above) inside a
+  fresh read-only transaction per call — the same tables `ledger/snapshot/rotation.go`
   already populates at every epoch boundary, with no new table and no
   metadata export. `GetRewardAccountOutputs` is what #3097's per-account
   exact-parity comparison (`compareEpochAccounts`, "Per-account exact parity

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2535,6 +2535,75 @@ when that account is missing or inactive. Both writes are slot-keyed (the
 `account_reward_delta` journal and the boundary `network_state` row), so a
 rollback past the boundary reverts them and re-application is deterministic.
 
+### `GetPoolKeyHashesRetiredByEpoch`
+
+Key hashes of pools whose effective retirement had already taken effect by a
+given epoch. Same latest-certificate resolution and same cancellation rule as
+`GetPoolsRetiringAtEpoch` — a pool is included only when, as of the boundary
+slot, its latest certificate is a retirement and no later registration
+supersedes it — but the epoch comparison is `<=` rather than `=`, and no
+registration columns are selected because no deposit refund is being applied.
+
+The two queries answer different questions. `GetPoolsRetiringAtEpoch` asks
+which pools leave at one exact boundary, which is what POOLREAP needs. This one
+asks which pools had already left by an epoch, which is what the Koios parity
+checker needs when it reaches an epoch long after the node passed it. The
+distinction matters because a pool that retired effective epoch 243 is still
+departed at 244 and 245, and `= $epoch` matches none of those later epochs.
+
+`pool_registration` and `pool_retirement` are retained for the life of the
+database, while `pool_stake_snapshot` is pruned to `currentEpoch - 3` by
+`Manager.cleanupOldSnapshots`. That is why this query, and not a pool-set
+membership read, is the departure evidence available to an observer running
+behind the node. Backends differ only in identifier quoting (`"transaction"` on
+SQLite/Postgres, `` `transaction` `` on MySQL).
+
+```sql
+WITH latest_reg AS (
+  SELECT pr.pool_id, pr.added_slot,
+    COALESCE(t.block_index, 0) AS blk_idx,
+    COALESCE(c.cert_index, 0)  AS cert_idx,
+    ROW_NUMBER() OVER (
+      PARTITION BY pr.pool_id
+      ORDER BY pr.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+    ) AS rn
+  FROM pool_registration pr
+  LEFT JOIN certs c ON c.id = pr.certificate_id
+  LEFT JOIN "transaction" t ON t.id = c.transaction_id
+  WHERE pr.added_slot < $boundarySlot
+),
+latest_ret AS (
+  SELECT rt.pool_id, rt.added_slot, rt.epoch,
+    COALESCE(t.block_index, 0) AS blk_idx,
+    COALESCE(c.cert_index, 0)  AS cert_idx,
+    ROW_NUMBER() OVER (
+      PARTITION BY rt.pool_id
+      ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+    ) AS rn
+  FROM pool_retirement rt
+  LEFT JOIN certs c ON c.id = rt.certificate_id
+  LEFT JOIN "transaction" t ON t.id = c.transaction_id
+  WHERE rt.added_slot < $boundarySlot
+)
+SELECT p.pool_key_hash
+FROM pool p
+INNER JOIN latest_reg lr  ON lr.pool_id = p.id  AND lr.rn = 1
+INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
+WHERE lrt.epoch <= $epoch
+  AND NOT (
+    lrt.added_slot < lr.added_slot
+    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+  );
+```
+
+The Koios parity checker reaches this through `RewardParitySource`, which has
+two implementations: `DatabaseSource` calls this store method directly, and the
+standalone-CLI `DingoDB` runs the same SQL against a separately synced metadata
+database. Both feed `poolDepartedAtParamEpoch`, which treats membership in this
+result as proof of departure and so downgrades a missing K+1 `reward_pool_input`
+row from `dingo_db_missing` to the informational `pool_departed`.
+
 ### `GetMIRCertsInSlotRange`
 
 MIR certificates for the epoch range `[startSlot, endSlot)`, applied at the epoch boundary as the Shelley INSTANT rule. Distribution certs (`other_pot = 0`) credit registered reward accounts and debit the source pot in `network_state`; pot-to-pot transfer certs (`other_pot > 0`) move that amount between treasury and reserves. Every cert in the range is aggregated before any is applied: distribution totals count only credentials with a registered, active account, transfers are folded into the available pot balances, and the boundary writes a single `network_state` row. If either pot cannot cover its total the boundary is a no-op rather than an error, so an over-budget cert cannot fail the epoch rollover on every retry. The `mir.id` value is retained by the processed effect as the per-MIR reward-credit discriminator so multiple MIR certs can credit the same account at one boundary without collapsing into one `account_reward_delta` row.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2474,16 +2474,33 @@ Pools whose effective retirement takes effect at a given epoch, with the reward
 account and deposit needed to refund their POOLREAP deposit at the epoch
 boundary. A pool is included when, as of the boundary slot, its latest
 retirement certificate names the target epoch and has not been cancelled by a
-later re-registration (same-slot disambiguation uses `block_index` then
-`cert_index`). Unlike `GetActivePoolKeyHashesAtSlot`, this query does not rank
-synthetic reconcile retirements (`certificate_id = 0`) first: those rows carry
-the catch-up tip as `epoch`/`added_slot`, so the `added_slot < $boundarySlot`
-and `epoch = $epoch` filters exclude them from boundary refund processing by
-design — a reconcile-retired pool gets no POOLREAP refund because its real
-retirement (or lack of one) was already settled in the imported snapshot's
-ledger state. The deposit and reward account come from the latest
-registration. Backends differ only in identifier quoting (`"transaction"` on
-SQLite/Postgres, `` `transaction` `` on MySQL).
+later re-registration (same-slot disambiguation ranks synthetic reconcile
+retirements first, then compares `block_index`, then `cert_index`). Like
+`GetActivePoolKeyHashesAtSlot`, this query ranks synthetic reconcile
+retirements (`certificate_id = 0`) ahead of certificate-backed rows at the same
+slot and exempts them from the cancellation clauses. Such a row has no
+`certs`/`transaction` join, so its `COALESCE(..., 0)` indices are the lowest
+possible and it would otherwise lose every same-slot tie-break to a
+certificate-backed row — the opposite of what the ledger state it encodes says,
+and the shape `ledgerstate`'s snapshot import writes routinely (`ImportPool`
+followed by `RetirePools` at one slot). All four latest-retirement resolutions
+in the tree — `GetActivePoolKeyHashesAtSlot`, this query,
+`GetPoolKeyHashesRetiredByEpoch` and `DingoDB.GetPoolsRetiredByEpoch` — now
+share one ordering, so the active pool set, the POOLREAP refund and both Koios
+parity routes cannot disagree about which retirement is a pool's latest.
+
+Ranking those rows does not admit them to boundary refund processing. A
+reconcile row carries the catch-up tip as `epoch`/`added_slot`: the boundary
+into that same epoch has already passed by the time the row is written, so
+`added_slot < $boundarySlot` is false for it, and every later boundary asks for
+a different `$epoch`. A reconcile-retired pool therefore still gets no POOLREAP
+refund, because its real retirement (or lack of one) was already settled in the
+imported snapshot's ledger state — that exclusion now rests on those two
+filters alone rather than on the row losing a tie-break, and
+`TestGetPoolsRetiringAtEpochSameSlotResolution` pins both halves. The deposit
+and reward account come from the latest registration. Backends differ only in
+identifier quoting (`"transaction"` on SQLite/Postgres, `` `transaction` `` on
+MySQL).
 
 ```sql
 WITH latest_reg AS (
@@ -2502,11 +2519,13 @@ WITH latest_reg AS (
 ),
 latest_ret AS (
   SELECT rt.pool_id, rt.added_slot, rt.epoch,
+    CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END AS synthetic_ret,
     COALESCE(t.block_index, 0) AS blk_idx,
     COALESCE(c.cert_index, 0)  AS cert_idx,
     ROW_NUMBER() OVER (
       PARTITION BY rt.pool_id
-      ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+      ORDER BY rt.added_slot DESC, CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+               COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
     ) AS rn
   FROM pool_retirement rt
   LEFT JOIN certs c ON c.id = rt.certificate_id
@@ -2521,8 +2540,9 @@ INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
 WHERE lrt.epoch = $epoch
   AND NOT (
     lrt.added_slot < lr.added_slot
-    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
-    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx < lr.blk_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx = lr.blk_idx
+        AND lrt.cert_idx < lr.cert_idx)
   );
 ```
 
@@ -2541,8 +2561,10 @@ Key hashes of pools whose effective retirement had already taken effect by a
 given epoch. Same latest-certificate resolution and same cancellation rule as
 `GetPoolsRetiringAtEpoch` — a pool is included only when, as of the boundary
 slot, its latest certificate is a retirement and no later registration
-supersedes it — but the epoch comparison is `<=` rather than `=`, and no
-registration columns are selected because no deposit refund is being applied.
+supersedes it, with the same synthetic-reconcile ranking and the same
+`synthetic_ret = 0` exemption on the cancellation clauses — but the epoch
+comparison is `<=` rather than `=`, and no registration columns are selected
+because no deposit refund is being applied.
 
 The two queries answer different questions. `GetPoolsRetiringAtEpoch` asks
 which pools leave at one exact boundary, which is what POOLREAP needs. This one
@@ -2574,11 +2596,13 @@ WITH latest_reg AS (
 ),
 latest_ret AS (
   SELECT rt.pool_id, rt.added_slot, rt.epoch,
+    CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END AS synthetic_ret,
     COALESCE(t.block_index, 0) AS blk_idx,
     COALESCE(c.cert_index, 0)  AS cert_idx,
     ROW_NUMBER() OVER (
       PARTITION BY rt.pool_id
-      ORDER BY rt.added_slot DESC, COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
+      ORDER BY rt.added_slot DESC, CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
+               COALESCE(t.block_index, 0) DESC, COALESCE(c.cert_index, 0) DESC
     ) AS rn
   FROM pool_retirement rt
   LEFT JOIN certs c ON c.id = rt.certificate_id
@@ -2592,8 +2616,9 @@ INNER JOIN latest_ret lrt ON lrt.pool_id = p.id AND lrt.rn = 1
 WHERE lrt.epoch <= $epoch
   AND NOT (
     lrt.added_slot < lr.added_slot
-    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx < lr.blk_idx)
-    OR (lrt.added_slot = lr.added_slot AND lrt.blk_idx = lr.blk_idx AND lrt.cert_idx < lr.cert_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx < lr.blk_idx)
+    OR (lrt.added_slot = lr.added_slot AND lrt.synthetic_ret = 0 AND lrt.blk_idx = lr.blk_idx
+        AND lrt.cert_idx < lr.cert_idx)
   );
 ```
 

--- a/database/plugin/metadata/sqlstore/pool.go
+++ b/database/plugin/metadata/sqlstore/pool.go
@@ -1851,11 +1851,13 @@ WITH latest_reg AS (
 ),
 latest_ret AS (
     SELECT rt.pool_id, rt.added_slot, rt.epoch,
+           CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END synthetic_ret,
            COALESCE(t.block_index, 0) block_index,
            COALESCE(c.cert_index, 0) cert_index,
            ROW_NUMBER() OVER (
                PARTITION BY rt.pool_id
                ORDER BY rt.added_slot DESC,
+                        CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
                         COALESCE(t.block_index, 0) DESC,
                         COALESCE(c.cert_index, 0) DESC
            ) rn
@@ -1872,9 +1874,9 @@ JOIN latest_ret ret ON ret.pool_id = p.id AND ret.rn = 1
 WHERE ret.epoch = ?
   AND NOT (
       ret.added_slot < reg.added_slot
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index < reg.block_index)
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index = reg.block_index
           AND ret.cert_index < reg.cert_index)
   )`,

--- a/database/plugin/metadata/sqlstore/pool.go
+++ b/database/plugin/metadata/sqlstore/pool.go
@@ -1911,6 +1911,90 @@ WHERE ret.epoch = ?
 	return ret, rows.Err()
 }
 
+// GetPoolKeyHashesRetiredByEpoch is GetPoolsRetiringAtEpoch's "at or before"
+// sibling: same latest-certificate resolution and same cancellation rule, but
+// it matches every retirement effective up to and including epoch rather than
+// only the one landing on it, and returns bare key hashes because no deposit
+// refund is being applied. See MetadataStore's doc comment for why the parity
+// checker needs the wider comparison (dingo #3925).
+func (s *Store) GetPoolKeyHashesRetiredByEpoch(
+	epoch uint64,
+	boundarySlot uint64,
+	txn types.Txn,
+) ([][]byte, error) {
+	db, ctx, err := s.readDBFromTxn(txn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetPoolKeyHashesRetiredByEpoch: resolve db: %w",
+			err,
+		)
+	}
+	rows, err := db.QueryContext(ctx, `
+WITH latest_reg AS (
+    SELECT pr.pool_id, pr.added_slot,
+           COALESCE(t.block_index, 0) block_index,
+           COALESCE(c.cert_index, 0) cert_index,
+           ROW_NUMBER() OVER (
+               PARTITION BY pr.pool_id
+               ORDER BY pr.added_slot DESC,
+                        COALESCE(t.block_index, 0) DESC,
+                        COALESCE(c.cert_index, 0) DESC
+           ) rn
+    FROM pool_registration pr
+    LEFT JOIN certs c ON c.id = pr.certificate_id
+    LEFT JOIN "transaction" t ON t.id = c.transaction_id
+    WHERE pr.added_slot < ?
+),
+latest_ret AS (
+    SELECT rt.pool_id, rt.added_slot, rt.epoch,
+           COALESCE(t.block_index, 0) block_index,
+           COALESCE(c.cert_index, 0) cert_index,
+           ROW_NUMBER() OVER (
+               PARTITION BY rt.pool_id
+               ORDER BY rt.added_slot DESC,
+                        COALESCE(t.block_index, 0) DESC,
+                        COALESCE(c.cert_index, 0) DESC
+           ) rn
+    FROM pool_retirement rt
+    LEFT JOIN certs c ON c.id = rt.certificate_id
+    LEFT JOIN "transaction" t ON t.id = c.transaction_id
+    WHERE rt.added_slot < ?
+)
+SELECT p.pool_key_hash
+FROM pool p
+JOIN latest_reg reg ON reg.pool_id = p.id AND reg.rn = 1
+JOIN latest_ret ret ON ret.pool_id = p.id AND ret.rn = 1
+WHERE ret.epoch <= ?
+  AND NOT (
+      ret.added_slot < reg.added_slot
+      OR (ret.added_slot = reg.added_slot
+          AND ret.block_index < reg.block_index)
+      OR (ret.added_slot = reg.added_slot
+          AND ret.block_index = reg.block_index
+          AND ret.cert_index < reg.cert_index)
+  )`,
+		boundarySlot,
+		boundarySlot,
+		epoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"GetPoolKeyHashesRetiredByEpoch: query pools: %w",
+			err,
+		)
+	}
+	defer rows.Close()
+	ret := [][]byte{}
+	for rows.Next() {
+		var poolKeyHash []byte
+		if err := rows.Scan(&poolKeyHash); err != nil {
+			return nil, err
+		}
+		ret = append(ret, poolKeyHash)
+	}
+	return ret, rows.Err()
+}
+
 func (s *Store) RestorePoolStateAtSlot(
 	slot uint64,
 	txn types.Txn,

--- a/database/plugin/metadata/sqlstore/pool.go
+++ b/database/plugin/metadata/sqlstore/pool.go
@@ -1919,6 +1919,19 @@ WHERE ret.epoch = ?
 // only the one landing on it, and returns bare key hashes because no deposit
 // refund is being applied. See MetadataStore's doc comment for why the parity
 // checker needs the wider comparison (dingo #3925).
+//
+// "Same resolution" includes the synthetic-retirement key every
+// latest-retirement query in the tree shares. A reconcile retirement
+// (certificate_id = 0) has no certs/transaction join, so its COALESCE'd
+// block_index/cert_index are both zero: without ranking it first and exempting
+// it from the same-slot cancellation clauses it would lose the tie-break to any
+// certificate-backed registration in its own slot, and the pool would be
+// reported as still active. ledgerstate's snapshot import writes exactly that
+// shape — ImportPool followed by RetirePools at one slot — so this is the
+// ordinary bootstrap case, not an edge case. DingoDB.GetPoolsRetiredByEpoch
+// carries the same three elements, and koiosparity's
+// implementations-agree test runs both against one database to pin them
+// against drift.
 func (s *Store) GetPoolKeyHashesRetiredByEpoch(
 	epoch uint64,
 	boundarySlot uint64,
@@ -1949,11 +1962,13 @@ WITH latest_reg AS (
 ),
 latest_ret AS (
     SELECT rt.pool_id, rt.added_slot, rt.epoch,
+           CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END synthetic_ret,
            COALESCE(t.block_index, 0) block_index,
            COALESCE(c.cert_index, 0) cert_index,
            ROW_NUMBER() OVER (
                PARTITION BY rt.pool_id
                ORDER BY rt.added_slot DESC,
+                        CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
                         COALESCE(t.block_index, 0) DESC,
                         COALESCE(c.cert_index, 0) DESC
            ) rn
@@ -1969,9 +1984,9 @@ JOIN latest_ret ret ON ret.pool_id = p.id AND ret.rn = 1
 WHERE ret.epoch <= ?
   AND NOT (
       ret.added_slot < reg.added_slot
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index < reg.block_index)
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index = reg.block_index
           AND ret.cert_index < reg.cert_index)
   )`,

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -1801,6 +1801,24 @@ type MetadataStore interface {
 		txn types.Txn,
 	) ([]models.PoolRetirementRefund, error)
 
+	// GetPoolKeyHashesRetiredByEpoch returns the key hashes of pools whose
+	// effective retirement takes effect at or *before* the given epoch,
+	// under the same cancellation rule GetPoolsRetiringAtEpoch applies: the
+	// pool's latest certificate as of the boundary slot must be a
+	// retirement, so a later re-registration puts the pool back and excludes
+	// it. Where GetPoolsRetiringAtEpoch answers "which pools leave at this
+	// exact boundary" for POOLREAP deposit refunds, this answers "which
+	// pools had already left by this epoch" -- the question the Koios parity
+	// checker asks about an epoch it reaches long after the fact.
+	// pool_registration/pool_retirement are retained for the life of the
+	// database, so this evidence outlives the pool_stake_snapshot retention
+	// window a trailing observer runs behind (dingo #3925).
+	GetPoolKeyHashesRetiredByEpoch(
+		epoch uint64,
+		boundarySlot uint64,
+		txn types.Txn,
+	) ([][]byte, error)
+
 	// GetStakeByPool returns the total delegated stake and delegator count for a pool.
 	// This aggregates all accounts delegated to the pool and sums their UTxO values.
 	GetStakeByPool(

--- a/database/pool_retired_test.go
+++ b/database/pool_retired_test.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// retiredPoolFixture seeds one pool with an explicit certificate history so
+// GetPoolKeyHashesRetiredByEpoch's ordering rules can be exercised directly.
+// Every registration and retirement gets a real transaction/certs row, so
+// added_slot ties are broken by block_index then cert_index exactly the way
+// a same-block registration and retirement would be on chain.
+type retiredPoolFixture struct {
+	keyHash []byte
+	regs    []retiredPoolCert
+	rets    []retiredPoolCert
+}
+
+type retiredPoolCert struct {
+	slot       uint64
+	blockIndex uint64
+	certIndex  uint64
+	epoch      uint64 // retirements only
+}
+
+// retiredPoolCertSeq keeps transaction hashes unique across a single test:
+// "transaction".hash carries a unique index, so two certificates seeded at
+// the same slot need distinct hashes.
+type retiredPoolSeeder struct {
+	raw *sql.DB
+	seq uint64
+}
+
+func (s *retiredPoolSeeder) insertCert(
+	t *testing.T,
+	slot, blockIndex, certIndex uint64,
+) int64 {
+	t.Helper()
+	s.seq++
+	hash := make([]byte, 32)
+	binary.BigEndian.PutUint64(hash, s.seq)
+	res, err := s.raw.Exec(
+		`INSERT INTO "transaction" (hash, slot, block_index) VALUES (?, ?, ?)`,
+		hash, slot, blockIndex,
+	)
+	require.NoError(t, err)
+	txID, err := res.LastInsertId()
+	require.NoError(t, err)
+	res, err = s.raw.Exec(
+		`INSERT INTO certs (transaction_id, slot, cert_index) VALUES (?, ?, ?)`,
+		txID, slot, certIndex,
+	)
+	require.NoError(t, err)
+	certID, err := res.LastInsertId()
+	require.NoError(t, err)
+	return certID
+}
+
+func (s *retiredPoolSeeder) seed(t *testing.T, f retiredPoolFixture) {
+	t.Helper()
+	res, err := s.raw.Exec(
+		`INSERT INTO pool (pool_key_hash) VALUES (?)`,
+		f.keyHash,
+	)
+	require.NoError(t, err)
+	poolID, err := res.LastInsertId()
+	require.NoError(t, err)
+	for _, reg := range f.regs {
+		certID := s.insertCert(t, reg.slot, reg.blockIndex, reg.certIndex)
+		_, err := s.raw.Exec(`
+INSERT INTO pool_registration (
+    pool_id, pool_key_hash, certificate_id, added_slot, deposit_amount
+) VALUES (?, ?, ?, ?, '500')`,
+			poolID, f.keyHash, certID, reg.slot,
+		)
+		require.NoError(t, err)
+	}
+	for _, ret := range f.rets {
+		certID := s.insertCert(t, ret.slot, ret.blockIndex, ret.certIndex)
+		_, err := s.raw.Exec(`
+INSERT INTO pool_retirement (
+    pool_id, pool_key_hash, certificate_id, epoch, added_slot
+) VALUES (?, ?, ?, ?, ?)`,
+			poolID, f.keyHash, certID, ret.epoch, ret.slot,
+		)
+		require.NoError(t, err)
+	}
+}
+
+func retiredPoolKeyHash(seed byte) []byte {
+	return bytes.Repeat([]byte{seed}, 28)
+}
+
+// TestGetPoolKeyHashesRetiredByEpoch pins the predicate the Koios parity
+// checker needs: the pool's latest certificate as of the boundary slot is a
+// retirement effective at or *before* the queried epoch.
+//
+// The two halves that make it different from GetPoolsRetiringAtEpoch are
+// covered explicitly. "At or before" (poolRetiredEarlier) is what lets a
+// trailing observer classify a pool that left several epochs ago, which
+// GetPoolsRetiringAtEpoch's `ret.epoch = ?` would miss. The cancellation
+// rules (poolReregistered, poolReregisteredSameSlot) are what stop "a
+// retirement certificate exists" from being mistaken for the predicate: a
+// later registration puts the pool back, and on this chain seven pools have
+// a registration filed after a retirement certificate.
+func TestGetPoolKeyHashesRetiredByEpoch(t *testing.T) {
+	const (
+		queryEpoch   = uint64(7)
+		boundarySlot = uint64(1_000)
+	)
+	var (
+		poolRetiredEarlier         = retiredPoolKeyHash(0xA1)
+		poolRetiredAtQueryEpoch    = retiredPoolKeyHash(0xA2)
+		poolRetiringLater          = retiredPoolKeyHash(0xA3)
+		poolReregistered           = retiredPoolKeyHash(0xA4)
+		poolReregisteredSameSlot   = retiredPoolKeyHash(0xA5)
+		poolRetiredSameSlotAfter   = retiredPoolKeyHash(0xA6)
+		poolRetiredAfterBoundary   = retiredPoolKeyHash(0xA7)
+		poolNeverRetired           = retiredPoolKeyHash(0xA8)
+		poolRetiredThenReregRetire = retiredPoolKeyHash(0xA9)
+	)
+
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	seeder := &retiredPoolSeeder{raw: rawSQLiteMetadataFixture(t, db)}
+
+	for _, f := range []retiredPoolFixture{
+		// Retired effective epoch 5, still departed at epoch 7 — the
+		// observed dingo #3925 case, where the pool retired at 243 was
+		// still misclassified at param epochs 244 and 245.
+		{
+			keyHash: poolRetiredEarlier,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets:    []retiredPoolCert{{slot: 200, epoch: 5}},
+		},
+		// Retirement effective exactly at the queried epoch is inclusive.
+		{
+			keyHash: poolRetiredAtQueryEpoch,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets:    []retiredPoolCert{{slot: 200, epoch: queryEpoch}},
+		},
+		// Certificate filed, but the retirement has not taken effect yet.
+		{
+			keyHash: poolRetiringLater,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets:    []retiredPoolCert{{slot: 200, epoch: 9}},
+		},
+		// A later registration cancels the pending retirement.
+		{
+			keyHash: poolReregistered,
+			regs:    []retiredPoolCert{{slot: 100}, {slot: 300}},
+			rets:    []retiredPoolCert{{slot: 200, epoch: 5}},
+		},
+		// Same slot, registration ordered after the retirement by
+		// cert_index — still a cancellation.
+		{
+			keyHash: poolReregisteredSameSlot,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 2},
+			},
+			rets: []retiredPoolCert{{slot: 200, certIndex: 1, epoch: 5}},
+		},
+		// Same slot, retirement ordered after the registration — the
+		// retirement stands.
+		{
+			keyHash: poolRetiredSameSlotAfter,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 1},
+			},
+			rets: []retiredPoolCert{{slot: 200, certIndex: 2, epoch: 5}},
+		},
+		// The retirement certificate is not yet visible at the boundary.
+		{
+			keyHash: poolRetiredAfterBoundary,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets:    []retiredPoolCert{{slot: boundarySlot, epoch: 5}},
+		},
+		{
+			keyHash: poolNeverRetired,
+			regs:    []retiredPoolCert{{slot: 100}},
+		},
+		// Retired, re-registered, then filed a fresh retirement that has
+		// taken effect: the latest certificate is the second retirement.
+		{
+			keyHash: poolRetiredThenReregRetire,
+			regs:    []retiredPoolCert{{slot: 100}, {slot: 300}},
+			rets: []retiredPoolCert{
+				{slot: 200, epoch: 5},
+				{slot: 400, epoch: 6},
+			},
+		},
+	} {
+		seeder.seed(t, f)
+	}
+
+	txn := db.Transaction(false)
+	defer txn.Release()
+	got, err := db.Metadata().GetPoolKeyHashesRetiredByEpoch(
+		queryEpoch,
+		boundarySlot,
+		txn.Metadata(),
+	)
+	require.NoError(t, err)
+
+	retired := make(map[string]struct{}, len(got))
+	for _, keyHash := range got {
+		retired[string(keyHash)] = struct{}{}
+	}
+	for _, tc := range []struct {
+		name    string
+		keyHash []byte
+		want    bool
+	}{
+		{"retired at an earlier epoch", poolRetiredEarlier, true},
+		{"retired at the queried epoch", poolRetiredAtQueryEpoch, true},
+		{"retirement takes effect later", poolRetiringLater, false},
+		{"re-registered after retiring", poolReregistered, false},
+		{
+			"re-registered in the retirement's own slot",
+			poolReregisteredSameSlot,
+			false,
+		},
+		{
+			"retired in the registration's own slot",
+			poolRetiredSameSlotAfter,
+			true,
+		},
+		{
+			"retirement filed at or after the boundary",
+			poolRetiredAfterBoundary,
+			false,
+		},
+		{"never retired", poolNeverRetired, false},
+		{
+			"retired again after re-registering",
+			poolRetiredThenReregRetire,
+			true,
+		},
+	} {
+		_, ok := retired[string(tc.keyHash)]
+		require.Equalf(
+			t,
+			tc.want,
+			ok,
+			"pool %x (%s) departure at epoch %d",
+			tc.keyHash,
+			tc.name,
+			queryEpoch,
+		)
+	}
+	require.Len(t, retired, 4, "no other pool may be reported as retired")
+}

--- a/database/pool_retired_test.go
+++ b/database/pool_retired_test.go
@@ -24,10 +24,12 @@ import (
 )
 
 // retiredPoolFixture seeds one pool with an explicit certificate history so
-// GetPoolKeyHashesRetiredByEpoch's ordering rules can be exercised directly.
-// Every registration and retirement gets a real transaction/certs row, so
-// added_slot ties are broken by block_index then cert_index exactly the way
-// a same-block registration and retirement would be on chain.
+// the pool-retirement queries' ordering rules can be exercised directly.
+// Every certificate-backed registration and retirement gets a real
+// transaction/certs row, so added_slot ties are broken by block_index then
+// cert_index exactly the way a same-block registration and retirement would
+// be on chain. A retirement marked synthetic gets neither, matching what
+// Store.RetirePools writes.
 type retiredPoolFixture struct {
 	keyHash []byte
 	regs    []retiredPoolCert

--- a/database/pool_retired_test.go
+++ b/database/pool_retired_test.go
@@ -39,6 +39,11 @@ type retiredPoolCert struct {
 	blockIndex uint64
 	certIndex  uint64
 	epoch      uint64 // retirements only
+	// synthetic writes the row the way Store.RetirePools does, with
+	// certificate_id = 0 and no certs/transaction row behind it. That is how
+	// a ledger-state snapshot import and a reconcile tombstone a pool, so
+	// such a row has no block_index/cert_index of its own to order by.
+	synthetic bool // retirements only
 }
 
 // retiredPoolCertSeq keeps transaction hashes unique across a single test:
@@ -94,7 +99,10 @@ INSERT INTO pool_registration (
 		require.NoError(t, err)
 	}
 	for _, ret := range f.rets {
-		certID := s.insertCert(t, ret.slot, ret.blockIndex, ret.certIndex)
+		var certID int64
+		if !ret.synthetic {
+			certID = s.insertCert(t, ret.slot, ret.blockIndex, ret.certIndex)
+		}
 		_, err := s.raw.Exec(`
 INSERT INTO pool_retirement (
     pool_id, pool_key_hash, certificate_id, epoch, added_slot
@@ -136,6 +144,8 @@ func TestGetPoolKeyHashesRetiredByEpoch(t *testing.T) {
 		poolRetiredAfterBoundary   = retiredPoolKeyHash(0xA7)
 		poolNeverRetired           = retiredPoolKeyHash(0xA8)
 		poolRetiredThenReregRetire = retiredPoolKeyHash(0xA9)
+		poolSyntheticSameSlotAsReg = retiredPoolKeyHash(0xAA)
+		poolSyntheticOverCertRet   = retiredPoolKeyHash(0xAB)
 	)
 
 	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
@@ -209,6 +219,34 @@ func TestGetPoolKeyHashesRetiredByEpoch(t *testing.T) {
 				{slot: 400, epoch: 6},
 			},
 		},
+		// A reconcile retirement sharing its slot with a certificate-backed
+		// registration. It carries no certs row, so its COALESCE'd
+		// block_index/cert_index are both zero and it would lose the
+		// same-slot tie-break to the registration's cert_index 1 — the
+		// synthetic_ret guard is what stops that being read as a
+		// cancellation. This is the shape ledgerstate's snapshot import
+		// writes: ImportPool then RetirePools at one slot.
+		{
+			keyHash: poolSyntheticSameSlotAsReg,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 1},
+			},
+			rets: []retiredPoolCert{{slot: 200, epoch: 5, synthetic: true}},
+		},
+		// A reconcile retirement sharing its slot with a certificate-backed
+		// retirement that has not taken effect yet. The synthetic row is the
+		// ledger state's answer, so it must rank first despite its zero
+		// indices; picking the cert row instead would report epoch 9 and
+		// leave the pool active.
+		{
+			keyHash: poolSyntheticOverCertRet,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets: []retiredPoolCert{
+				{slot: 200, certIndex: 3, epoch: 9},
+				{slot: 200, epoch: 5, synthetic: true},
+			},
+		},
 	} {
 		seeder.seed(t, f)
 	}
@@ -256,6 +294,16 @@ func TestGetPoolKeyHashesRetiredByEpoch(t *testing.T) {
 			poolRetiredThenReregRetire,
 			true,
 		},
+		{
+			"reconcile-retired in a registration's own slot",
+			poolSyntheticSameSlotAsReg,
+			true,
+		},
+		{
+			"reconcile retirement outranks a same-slot certificate",
+			poolSyntheticOverCertRet,
+			true,
+		},
 	} {
 		_, ok := retired[string(tc.keyHash)]
 		require.Equalf(
@@ -268,5 +316,189 @@ func TestGetPoolKeyHashesRetiredByEpoch(t *testing.T) {
 			queryEpoch,
 		)
 	}
-	require.Len(t, retired, 4, "no other pool may be reported as retired")
+	require.Len(t, retired, 6, "no other pool may be reported as retired")
+}
+
+// TestGetPoolsRetiringAtEpochSameSlotResolution pins how the POOLREAP
+// deposit-refund query resolves a pool's latest retirement when certificates
+// share an added_slot, which nothing in the tree covered before.
+//
+// Three keys decide it, in order. synthetic_ret ranks reconcile retirements
+// (`certificate_id = 0`, written by Store.RetirePools from ledgerstate's
+// snapshot import and reconcile paths) ahead of certificate-backed rows and
+// exempts them from the cancellation clauses: such a row has no
+// certs/transaction join, so its COALESCE'd block_index and cert_index are
+// both zero — the lowest possible same-slot rank — and without the key it
+// would lose every tie-break to a certificate-backed row, which is the
+// opposite of what the ledger state it encodes says. block_index then orders
+// by transaction within the block, and cert_index by certificate within the
+// transaction.
+//
+// GetActivePoolKeyHashesAtSlot has ranked synthetic rows first since it was
+// written; this query, GetPoolKeyHashesRetiredByEpoch and DingoDB's copy now
+// agree with it, so the active pool set, the POOLREAP refund and both Koios
+// parity routes cannot resolve the same pool's latest retirement differently.
+//
+// poolSyntheticAtBoundry pins the other half: a reconcile row still cannot
+// drive a refund it should not, because RetirePools stamps the catch-up tip as
+// epoch/added_slot and the `added_slot < boundarySlot` cut excludes it. That
+// exclusion is now the only thing keeping reconcile rows out of boundary
+// refund processing, so it is asserted rather than assumed.
+func TestGetPoolsRetiringAtEpochSameSlotResolution(t *testing.T) {
+	const boundarySlot = uint64(1_000)
+	var (
+		poolSyntheticSameSlot  = retiredPoolKeyHash(0xB1)
+		poolSyntheticOverCert  = retiredPoolKeyHash(0xB2)
+		poolCertBackedOnly     = retiredPoolKeyHash(0xB3)
+		poolSyntheticAtBoundry = retiredPoolKeyHash(0xB4)
+		poolRetiredLaterTx     = retiredPoolKeyHash(0xB5)
+		poolReregisteredTx     = retiredPoolKeyHash(0xB6)
+		poolRetiredLaterCert   = retiredPoolKeyHash(0xB7)
+		poolReregisteredCert   = retiredPoolKeyHash(0xB8)
+		poolRetiredTwiceInSlot = retiredPoolKeyHash(0xB9)
+	)
+
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	seeder := &retiredPoolSeeder{raw: rawSQLiteMetadataFixture(t, db)}
+
+	for _, f := range []retiredPoolFixture{
+		// The import shape: a registration and a reconcile retirement in one
+		// slot, with the registration certificate-backed at cert_index 1.
+		{
+			keyHash: poolSyntheticSameSlot,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 1},
+			},
+			rets: []retiredPoolCert{{slot: 200, epoch: 5, synthetic: true}},
+		},
+		// A reconcile retirement and a certificate-backed retirement in one
+		// slot, naming different effective epochs.
+		{
+			keyHash: poolSyntheticOverCert,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets: []retiredPoolCert{
+				{slot: 200, certIndex: 3, epoch: 9},
+				{slot: 200, epoch: 5, synthetic: true},
+			},
+		},
+		// Control: ordinary certificate-backed retirement effective 5.
+		{
+			keyHash: poolCertBackedOnly,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets:    []retiredPoolCert{{slot: 200, certIndex: 1, epoch: 5}},
+		},
+		// A reconcile retirement filed at the boundary itself is not visible
+		// to it, which is what keeps reconcile rows out of refunds.
+		{
+			keyHash: poolSyntheticAtBoundry,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets: []retiredPoolCert{
+				{slot: boundarySlot, epoch: 5, synthetic: true},
+			},
+		},
+		// Same slot, different transactions: the retirement is in the later
+		// transaction, so it stands. cert_index cannot decide this pair —
+		// both are 0 — so only the block_index comparison can.
+		{
+			keyHash: poolRetiredLaterTx,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, blockIndex: 1},
+			},
+			rets: []retiredPoolCert{{slot: 200, blockIndex: 2, epoch: 5}},
+		},
+		// The mirror image: the registration is in the later transaction, so
+		// it cancels. These two pin both directions of block_index.
+		{
+			keyHash: poolReregisteredTx,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, blockIndex: 2},
+			},
+			rets: []retiredPoolCert{{slot: 200, blockIndex: 1, epoch: 5}},
+		},
+		// Same transaction, retirement at the later cert_index: it stands.
+		{
+			keyHash: poolRetiredLaterCert,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 1},
+			},
+			rets: []retiredPoolCert{{slot: 200, certIndex: 2, epoch: 5}},
+		},
+		// Same transaction, registration at the later cert_index: it cancels.
+		{
+			keyHash: poolReregisteredCert,
+			regs: []retiredPoolCert{
+				{slot: 100},
+				{slot: 200, certIndex: 2},
+			},
+			rets: []retiredPoolCert{{slot: 200, certIndex: 1, epoch: 5}},
+		},
+		// Two retirement certificates in one transaction naming different
+		// effective epochs. latest_ret must pick the higher cert_index, so
+		// the pool reaps at 5 rather than 9. The epoch-9 row is seeded first
+		// so insertion order disagrees with cert_index order, which is what
+		// makes latest_ret's own ORDER BY key load-bearing rather than
+		// incidentally satisfied by the scan order.
+		{
+			keyHash: poolRetiredTwiceInSlot,
+			regs:    []retiredPoolCert{{slot: 100}},
+			rets: []retiredPoolCert{
+				{slot: 200, certIndex: 1, epoch: 9},
+				{slot: 200, certIndex: 2, epoch: 5},
+			},
+		},
+	} {
+		seeder.seed(t, f)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		epoch uint64
+		want  [][]byte
+	}{
+		{
+			name:  "the same-slot winners reap at their own epoch",
+			epoch: 5,
+			want: [][]byte{
+				poolSyntheticSameSlot,
+				poolSyntheticOverCert,
+				poolCertBackedOnly,
+				poolRetiredLaterTx,
+				poolRetiredLaterCert,
+				poolRetiredTwiceInSlot,
+			},
+		},
+		{
+			// Every retirement that lost its tie-break named epoch 9, so an
+			// inverted ordering key would move pools into this set and out
+			// of the one above.
+			name:  "the outranked certificates' epoch reaps nothing",
+			epoch: 9,
+			want:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txn := db.Transaction(false)
+			defer txn.Release()
+			refunds, err := db.GetPoolsRetiringAtEpoch(
+				tc.epoch,
+				boundarySlot,
+				txn,
+			)
+			require.NoError(t, err)
+			got := make(map[string]struct{}, len(refunds))
+			for _, refund := range refunds {
+				got[string(refund.PoolKeyHash)] = struct{}{}
+			}
+			want := make(map[string]struct{}, len(tc.want))
+			for _, keyHash := range tc.want {
+				want[string(keyHash)] = struct{}{}
+			}
+			require.Equal(t, want, got)
+		})
+	}
 }

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -650,7 +650,7 @@ func checkEpoch(
 	if paramBoundarySlot > 0 {
 		retired, rErr := dingo.GetPoolsRetiredByEpoch(
 			ctx,
-			paramEpoch,
+			paramEpoch-1,
 			paramBoundarySlot,
 		)
 		if rErr != nil {

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -340,13 +340,30 @@ func koiosStakeEpoch(koiosEpoch uint64) (epoch uint64, ok bool) {
 // at this offset: a mark snapshot records the pool parameters as of its own
 // boundary, so Margin/FixedCost belong with the stake epoch (dingo #3484).
 // See koiosStakeEpoch's doc comment and ARCHITECTURE.md.
-// poolDepartedAtParamEpoch reports whether keyHex is provably absent from the
-// K+1 pool set. It is false whenever membership could not be established, so
-// an unresolved read never downgrades a missing reward-input row from ERROR.
+// poolDepartedAtParamEpoch reports whether keyHex provably left the pool set
+// by K+1, from either of two independent routes.
+//
+// retiredByParamEpoch is per-pool certificate evidence: the pool's latest
+// certificate as of the K+1 boundary is a retirement effective at or before
+// it. That is a positive fact about this pool alone, so unlike the pool-set
+// route it needs no argument that some set was completely recorded, and it
+// survives the snapshot retention window a trailing observer runs behind
+// (dingo #3925).
+//
+// paramEpochPools is the pool-set route: absence from a set already
+// established as complete. It is checked second because absence only means
+// anything once completeness holds.
+//
+// Both are false whenever the evidence could not be established, so an
+// unresolved read never downgrades a missing reward-input row from ERROR.
 func poolDepartedAtParamEpoch(
 	paramEpochPools map[string]struct{},
+	retiredByParamEpoch map[string]struct{},
 	keyHex string,
 ) bool {
+	if _, retired := retiredByParamEpoch[keyHex]; retired {
+		return true
+	}
 	if len(paramEpochPools) == 0 {
 		return false
 	}
@@ -538,6 +555,7 @@ func checkEpoch(
 	// dingo_db_missing classification (dingo #3485).
 	var paramEpochPools map[string]struct{}
 	var declaredParamPools uint64
+	var paramBoundarySlot uint64
 	paramSummary, sErr := dingo.GetEpochData(ctx, paramEpoch)
 	switch {
 	case sErr != nil:
@@ -552,6 +570,7 @@ func checkEpoch(
 		// No ready summary, so no declared count to verify against.
 	default:
 		declaredParamPools = paramSummary.TotalPoolCount
+		paramBoundarySlot = paramSummary.BoundarySlot
 	}
 	members, membersErr := dingo.GetPoolStakeSnapshotMembers(ctx, paramEpoch)
 	switch {
@@ -614,6 +633,39 @@ func checkEpoch(
 			)
 		}
 	}
+	// Both pool-set routes above reconstruct the whole K+1 pool set and read
+	// departure as absence from it, which is why each needs its own
+	// completeness argument and why both can be closed off at once: the mark
+	// rows are pruned to currentEpoch-3, and reward_pool_input is short of
+	// the declared count whenever a degraded active pool was omitted from it.
+	// Certificate history answers the same question per pool instead. A
+	// retirement effective at or before K+1 that no later registration
+	// cancelled is direct evidence this pool left, and
+	// pool_registration/pool_retirement are retained for the life of the
+	// database. Resolved once per epoch, and only against the K+1 summary's
+	// own boundary slot -- without one there is no point in the chain to
+	// resolve each pool's latest certificate as of, so the route stays
+	// closed and the stricter classification stands (dingo #3925).
+	var retiredByParamEpoch map[string]struct{}
+	if paramBoundarySlot > 0 {
+		retired, rErr := dingo.GetPoolsRetiredByEpoch(
+			ctx,
+			paramEpoch,
+			paramBoundarySlot,
+		)
+		if rErr != nil {
+			logger.Debug(
+				"koiosparity: could not resolve param-epoch retirements",
+				"network", network,
+				"epoch", epoch,
+				"param_epoch", paramEpoch,
+				"boundary_slot", paramBoundarySlot,
+				"error", rErr,
+			)
+		} else {
+			retiredByParamEpoch = retired
+		}
+	}
 	if dingoPoolErr != nil {
 		// Record the DB failure and skip all per-pool comparisons.
 		// Continuing with dingoPoolMap == nil would make every Koios pool appear
@@ -670,7 +722,11 @@ func checkEpoch(
 				now,
 				graceHours,
 				epochEndTime,
-				poolDepartedAtParamEpoch(paramEpochPools, keyHex),
+				poolDepartedAtParamEpoch(
+					paramEpochPools,
+					retiredByParamEpoch,
+					keyHex,
+				),
 			)
 			allMismatches = append(allMismatches, poolMismatches...)
 

--- a/internal/koiosparity/check.go
+++ b/internal/koiosparity/check.go
@@ -345,10 +345,17 @@ func koiosStakeEpoch(koiosEpoch uint64) (epoch uint64, ok bool) {
 //
 // retiredByParamEpoch is per-pool certificate evidence: the pool's latest
 // certificate as of the K+1 boundary is a retirement effective at or before
-// it. That is a positive fact about this pool alone, so unlike the pool-set
+// K. That is a positive fact about this pool alone, so unlike the pool-set
 // route it needs no argument that some set was completely recorded, and it
 // survives the snapshot retention window a trailing observer runs behind
 // (dingo #3925).
+//
+// The comparison epoch is K, not the K+1 boundary the certificates are
+// resolved as of. epochBoundarySnapshotSlot captures the K+1 mark pool set at
+// boundarySlot-1, which GetActivePoolKeyHashesAtSlot resolves against epoch K
+// and so keeps every pool whose retirement is effective K+1. Such a pool is
+// still in the K+1 pool set and still has a K+1 reward_pool_input row, so
+// reading it as departed would mask a genuinely missing one.
 //
 // paramEpochPools is the pool-set route: absence from a set already
 // established as complete. It is checked second because absence only means
@@ -639,13 +646,18 @@ func checkEpoch(
 	// rows are pruned to currentEpoch-3, and reward_pool_input is short of
 	// the declared count whenever a degraded active pool was omitted from it.
 	// Certificate history answers the same question per pool instead. A
-	// retirement effective at or before K+1 that no later registration
+	// retirement effective at or before K that no later registration
 	// cancelled is direct evidence this pool left, and
 	// pool_registration/pool_retirement are retained for the life of the
-	// database. Resolved once per epoch, and only against the K+1 summary's
-	// own boundary slot -- without one there is no point in the chain to
-	// resolve each pool's latest certificate as of, so the route stays
-	// closed and the stricter classification stands (dingo #3925).
+	// database. The effective-epoch bound is K rather than the K+1 boundary
+	// the certificates are resolved as of: the K+1 mark pool set is captured
+	// one slot before that boundary, so it still contains every pool
+	// retiring effective K+1, and those pools still have a K+1
+	// reward_pool_input row. Resolved once per epoch, and only against the
+	// K+1 summary's own boundary slot -- without one there is no point in
+	// the chain to resolve each pool's latest certificate as of, so the
+	// route stays closed and the stricter classification stands (dingo
+	// #3925).
 	var retiredByParamEpoch map[string]struct{}
 	if paramBoundarySlot > 0 {
 		retired, rErr := dingo.GetPoolsRetiredByEpoch(

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1262,6 +1262,7 @@ func seedDepartureFixtureWithCount(
 		Epoch:            paramEpoch,
 		TotalActiveStake: types.Uint64(5_000_000),
 		TotalPoolCount:   declaredPools,
+		BoundarySlot:     departureBoundarySlot,
 		SnapshotReady:    true,
 	}).Error)
 	require.NoError(t, gdb.Create(&models.RewardPoolInput{
@@ -1581,4 +1582,197 @@ INSERT INTO reward_pool_input (
 		paramEpoch,
 	).Scan(&snapshots))
 	require.Zero(t, snapshots, "the mark rows must be gone")
+}
+
+// departureBoundarySlot is the slot the departure fixture stamps on the K+1
+// epoch_summary. Every certificate the retirement helpers seed is placed
+// before it, so it is the boundary a real epoch transition would resolve pool
+// state at.
+const departureBoundarySlot = uint64(1_000)
+
+// seedPoolCertificateHistory writes a pool row, its registrations and its
+// retirements straight into the fixture's metadata database, so a departure
+// test can control the certificate history GetPoolsRetiredByEpoch resolves.
+// Slots are given in certificate order; the caller keeps them below
+// departureBoundarySlot for the history to be visible at the boundary.
+func seedPoolCertificateHistory(
+	t *testing.T,
+	dingoDir string,
+	poolHash []byte,
+	regSlots []uint64,
+	retirements map[uint64]uint64, // added_slot -> effective epoch
+) {
+	t.Helper()
+	path := filepath.Join(dingoDir, "metadata.sqlite")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=journal_mode(WAL)")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	res, err := db.Exec(`INSERT INTO pool (pool_key_hash) VALUES (?)`, poolHash)
+	require.NoError(t, err)
+	poolID, err := res.LastInsertId()
+	require.NoError(t, err)
+	for _, slot := range regSlots {
+		_, err := db.Exec(`
+INSERT INTO pool_registration (pool_id, pool_key_hash, added_slot)
+VALUES (?, ?, ?)`,
+			poolID, poolHash, slot,
+		)
+		require.NoError(t, err)
+	}
+	for slot, epoch := range retirements {
+		_, err := db.Exec(`
+INSERT INTO pool_retirement (pool_id, pool_key_hash, epoch, added_slot)
+VALUES (?, ?, ?, ?)`,
+			poolID, poolHash, epoch, slot,
+		)
+		require.NoError(t, err)
+	}
+}
+
+// TestCheckRetiredPoolIsDepartedWithoutAnyPoolSetEvidence is the dingo #3925
+// case, reproduced with both routes to pool-set proof closed off exactly as
+// the Preview replay left them:
+//
+//   - the K+1 mark pool_stake_snapshot rows are pruned (retention keeps only
+//     currentEpoch-3, and the observer trails the node by far more than that);
+//   - the K+1 reward_pool_input set is short of the summary's declared pool
+//     count, because buildRewardStateInputs omits a degraded active pool from
+//     that table while keeping it in the pool set — so #3795's exact-match
+//     fallback cannot fire either.
+//
+// That combination is TestCheckIncompleteRewardInputSetStillErrorsAfterPrune,
+// which is an ERROR and must stay one. The only thing added here is the pool's
+// own retirement certificate, effective at the reporting epoch. Certificate
+// history is retained for the life of the database, and a retirement not
+// cancelled by a later registration is direct per-pool evidence that the pool
+// left, needing no argument about whether some *set* was completely recorded.
+func TestCheckRetiredPoolIsDepartedWithoutAnyPoolSetEvidence(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	dingoDir, cachePath, _ := seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, false, 2,
+	)
+	pruneParamEpochSnapshots(t, dingoDir, koiosEpoch+1)
+	seedPoolCertificateHistory(
+		t,
+		dingoDir,
+		testPoolKeyHash(t, 0x09),
+		[]uint64{100},
+		map[uint64]uint64{200: koiosEpoch},
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		result.ErrorEpochs,
+		"an uncancelled retirement must classify the pool as departed",
+	)
+	require.Empty(t, result.FailEpochs)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, "reward_pool_input_params", mismatches[0].Field)
+	require.Equal(t, CategoryPoolDeparted, mismatches[0].Category)
+}
+
+// TestCheckRetiredPoolStaysDepartedInLaterEpochs is the "at or before" half.
+// The observed pool retired effective epoch 243 and was still misclassified at
+// param epochs 244 and 245, so matching only retirements landing exactly on
+// the param epoch — which is what GetPoolsRetiringAtEpoch does for POOLREAP —
+// would fix the first epoch and leave every later one an ERROR.
+func TestCheckRetiredPoolStaysDepartedInLaterEpochs(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	dingoDir, cachePath, _ := seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, false, 2,
+	)
+	pruneParamEpochSnapshots(t, dingoDir, koiosEpoch+1)
+	// Effective several epochs before the K+1 param epoch this check
+	// resolves departure at.
+	seedPoolCertificateHistory(
+		t,
+		dingoDir,
+		testPoolKeyHash(t, 0x09),
+		[]uint64{100},
+		map[uint64]uint64{200: koiosEpoch - 3},
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		result.ErrorEpochs,
+		"a pool that left several epochs ago is still departed",
+	)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryPoolDeparted, mismatches[0].Category)
+}
+
+// TestCheckReregisteredPoolStillErrors is the fail-closed half, and the reason
+// "a retirement certificate exists" cannot be the predicate. A later
+// registration cancels a pending retirement, and a re-registration after one
+// has taken effect puts the pool back — this chain has seven pools with a
+// registration filed after a retirement certificate. Such a pool is still in
+// the pool set, so its absent K+1 reward-input row is genuine missing input,
+// and downgrading it would turn a real ERROR into a PASS.
+func TestCheckReregisteredPoolStillErrors(t *testing.T) {
+	const network = "preview"
+	const koiosEpoch = uint64(14)
+
+	dingoDir, cachePath, _ := seedDepartureFixtureWithCount(
+		t, network, koiosEpoch, false, 2,
+	)
+	pruneParamEpochSnapshots(t, dingoDir, koiosEpoch+1)
+	// Identical to the departure case above except for the registration at
+	// slot 300, which lands after the retirement certificate at slot 200.
+	seedPoolCertificateHistory(
+		t,
+		dingoDir,
+		testPoolKeyHash(t, 0x09),
+		[]uint64{100, 300},
+		map[uint64]uint64{200: koiosEpoch},
+	)
+
+	result, err := Check(context.Background(), CheckConfig{
+		Network:   network,
+		DingoDB:   DingoDBConfig{Plugin: "sqlite", DataDir: dingoDir},
+		CachePath: cachePath,
+	}, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	require.Contains(
+		t,
+		result.ErrorEpochs,
+		koiosEpoch,
+		"a re-registration cancels the retirement, so the pool is back",
+	)
+
+	cache, err := OpenCache(cachePath, nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+	mismatches, err := cache.GetMismatches(network, koiosEpoch, "")
+	require.NoError(t, err)
+	require.Len(t, mismatches, 1)
+	require.Equal(t, CategoryDBMissing, mismatches[0].Category)
 }

--- a/internal/koiosparity/check_test.go
+++ b/internal/koiosparity/check_test.go
@@ -1733,7 +1733,7 @@ func TestCheckRetiredPoolStaysDepartedInLaterEpochs(t *testing.T) {
 // TestCheckReregisteredPoolStillErrors is the fail-closed half, and the reason
 // "a retirement certificate exists" cannot be the predicate. A later
 // registration cancels a pending retirement, and a re-registration after one
-// has taken effect puts the pool back — this chain has seven pools with a
+// has taken effect puts the pool back — this fixture has one pool with a
 // registration filed after a retirement certificate. Such a pool is still in
 // the pool set, so its absent K+1 reward-input row is genuine missing input,
 // and downgrading it would turn a real ERROR into a PASS.

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -321,15 +321,18 @@ func CompareEpochTotals(
 // epochEndTime is the actual epoch close time (from KoiosEpochInfo.EpochEndTime);
 // zero means unknown. graceHours: if the epoch closed within this many hours and
 // Dingo has no reward_pool_input row, emit reference_lag instead of pool_only_koios.
-// departedAtParamEpoch reports whether this pool is provably absent from the
-// K+1 pool set, established from the mark pool_stake_snapshot rather than from
-// epoch_summary.SnapshotReady. That distinction matters: the snapshot writer
-// commits the epoch summary on every transition regardless of reward-input
-// availability, and deliberately omits a degraded active pool from
-// reward_pool_input while keeping it in the pool-stake snapshot. Both are
-// missing input rather than departure, so only per-pool absence from the K+1
-// pool set may downgrade the finding. False whenever membership could not be
-// established, which keeps the stricter classification (dingo #3485).
+// departedAtParamEpoch reports whether this pool provably left the pool set by
+// K+1 — either because its own retirement certificate had taken effect by the
+// K+1 boundary and no later registration cancelled it, or because it is absent
+// from a K+1 pool set already established as complete. Both are per-pool
+// facts, which is the distinction that matters: epoch_summary.SnapshotReady is
+// not one. The snapshot writer commits the epoch summary on every transition
+// regardless of reward-input availability, and deliberately omits a degraded
+// active pool from reward_pool_input while keeping it in the pool set. Those
+// are missing input rather than departure, and an epoch-level flag would
+// downgrade both. False whenever neither route could establish departure,
+// which keeps the stricter classification (dingo #3485, #3925). See
+// poolDepartedAtParamEpoch in check.go.
 func ComparePoolEpoch(
 	network string,
 	epoch uint64,

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -401,8 +401,12 @@ func quoteTransactionTable(dialect string) string {
 // certificate tables. It is the standalone-CLI twin of
 // MetadataStore.GetPoolKeyHashesRetiredByEpoch and must resolve departure
 // identically: latest registration and latest retirement as of boundarySlot,
-// ordered by (added_slot, block_index, cert_index), with a retirement that a
-// later registration cancelled excluded.
+// ordered by (added_slot, synthetic_ret, block_index, cert_index), with a
+// retirement that a later registration cancelled excluded. synthetic_ret ranks
+// reconcile retirements (certificate_id = 0) ahead of certificate-backed rows
+// at the same slot and exempts them from the cancellation clauses, because
+// they have no certs/transaction join to break the tie with. See the store
+// method's doc comment.
 func (d *DingoDB) GetPoolsRetiredByEpoch(
 	ctx context.Context,
 	epoch uint64,

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -59,7 +59,15 @@ type DingoEpochData struct {
 	// TotalPoolCount, which counts the reduced reward distribution with
 	// degraded pools already excluded.
 	TotalPoolCount uint64
-	Fees           string // lovelace decimal string; empty when reward_ada_pots row absent
+	// BoundarySlot is epoch_summary.boundary_slot: the slot the epoch
+	// transition into this epoch resolved ledger state at. It is the slot
+	// GetPoolsRetiredByEpoch resolves each pool's latest certificate as of,
+	// so the departure question is answered against the same point in the
+	// chain the epoch's own pool set was captured at. Zero when the row
+	// predates the column or was never stamped, which reads as "no boundary
+	// to resolve against" rather than slot 0.
+	BoundarySlot uint64
+	Fees         string // lovelace decimal string; empty when reward_ada_pots row absent
 	// TotalRewards is reward_ada_pots.rewards for this epoch alone: a fresh
 	// per-epoch FLOW value (rewards.Result.TotalRewardPot, overwritten every
 	// epoch — see ledger/reward_calculation.go:389,1955 and
@@ -289,6 +297,7 @@ func (d *DingoDB) GetEpochData(
 			10,
 		),
 		TotalPoolCount: summary.TotalPoolCount,
+		BoundarySlot:   summary.BoundarySlot,
 	}
 
 	var pots models.RewardAdaPots
@@ -373,6 +382,100 @@ func (d *DingoDB) GetPoolStakeSnapshotMembers(
 		members[hex.EncodeToString(poolHash)] = struct{}{}
 	}
 	return members, rows.Err()
+}
+
+// quoteTransactionTable renders the reserved "transaction" identifier for
+// dialect. SQLite and PostgreSQL both accept the double-quoted spelling,
+// while MySQL reads double quotes as string delimiters unless ANSI_QUOTES is
+// enabled — the same split sqlstore handles centrally in
+// translateMySQLReservedIdentifiers. DingoDB's own rebind only rewrites
+// placeholders, so the one query that joins that table spells it itself.
+func quoteTransactionTable(dialect string) string {
+	if dialect == "mysql" {
+		return "`transaction`"
+	}
+	return `"transaction"`
+}
+
+// GetPoolsRetiredByEpoch implements RewardParitySource against the pool
+// certificate tables. It is the standalone-CLI twin of
+// MetadataStore.GetPoolKeyHashesRetiredByEpoch and must resolve departure
+// identically: latest registration and latest retirement as of boundarySlot,
+// ordered by (added_slot, block_index, cert_index), with a retirement that a
+// later registration cancelled excluded.
+func (d *DingoDB) GetPoolsRetiredByEpoch(
+	ctx context.Context,
+	epoch uint64,
+	boundarySlot uint64,
+) (map[string]struct{}, error) {
+	txTable := quoteTransactionTable(d.dialect)
+	rows, err := d.query(
+		ctx,
+		`
+WITH latest_reg AS (
+    SELECT pr.pool_id, pr.added_slot,
+           COALESCE(t.block_index, 0) block_index,
+           COALESCE(c.cert_index, 0) cert_index,
+           ROW_NUMBER() OVER (
+               PARTITION BY pr.pool_id
+               ORDER BY pr.added_slot DESC,
+                        COALESCE(t.block_index, 0) DESC,
+                        COALESCE(c.cert_index, 0) DESC
+           ) rn
+    FROM pool_registration pr
+    LEFT JOIN certs c ON c.id = pr.certificate_id
+    LEFT JOIN `+txTable+` t ON t.id = c.transaction_id
+    WHERE pr.added_slot < ?
+),
+latest_ret AS (
+    SELECT rt.pool_id, rt.added_slot, rt.epoch,
+           COALESCE(t.block_index, 0) block_index,
+           COALESCE(c.cert_index, 0) cert_index,
+           ROW_NUMBER() OVER (
+               PARTITION BY rt.pool_id
+               ORDER BY rt.added_slot DESC,
+                        COALESCE(t.block_index, 0) DESC,
+                        COALESCE(c.cert_index, 0) DESC
+           ) rn
+    FROM pool_retirement rt
+    LEFT JOIN certs c ON c.id = rt.certificate_id
+    LEFT JOIN `+txTable+` t ON t.id = c.transaction_id
+    WHERE rt.added_slot < ?
+)
+SELECT p.pool_key_hash
+FROM pool p
+JOIN latest_reg reg ON reg.pool_id = p.id AND reg.rn = 1
+JOIN latest_ret ret ON ret.pool_id = p.id AND ret.rn = 1
+WHERE ret.epoch <= ?
+  AND NOT (
+      ret.added_slot < reg.added_slot
+      OR (ret.added_slot = reg.added_slot
+          AND ret.block_index < reg.block_index)
+      OR (ret.added_slot = reg.added_slot
+          AND ret.block_index = reg.block_index
+          AND ret.cert_index < reg.cert_index)
+  )`,
+		boundarySlot,
+		boundarySlot,
+		epoch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pool_retirement through epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	defer rows.Close()
+	retired := make(map[string]struct{})
+	for rows.Next() {
+		var poolHash []byte
+		if err := rows.Scan(&poolHash); err != nil {
+			return nil, err
+		}
+		retired[hex.EncodeToString(poolHash)] = struct{}{}
+	}
+	return retired, rows.Err()
 }
 
 func (d *DingoDB) GetPoolEpochDataMap(

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -429,11 +429,13 @@ WITH latest_reg AS (
 ),
 latest_ret AS (
     SELECT rt.pool_id, rt.added_slot, rt.epoch,
+           CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END synthetic_ret,
            COALESCE(t.block_index, 0) block_index,
            COALESCE(c.cert_index, 0) cert_index,
            ROW_NUMBER() OVER (
                PARTITION BY rt.pool_id
                ORDER BY rt.added_slot DESC,
+                        CASE WHEN rt.certificate_id = 0 THEN 1 ELSE 0 END DESC,
                         COALESCE(t.block_index, 0) DESC,
                         COALESCE(c.cert_index, 0) DESC
            ) rn
@@ -449,9 +451,9 @@ JOIN latest_ret ret ON ret.pool_id = p.id AND ret.rn = 1
 WHERE ret.epoch <= ?
   AND NOT (
       ret.added_slot < reg.added_slot
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index < reg.block_index)
-      OR (ret.added_slot = reg.added_slot
+      OR (ret.added_slot = reg.added_slot AND ret.synthetic_ret = 0
           AND ret.block_index = reg.block_index
           AND ret.cert_index < reg.cert_index)
   )`,

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -82,6 +82,26 @@ type RewardParitySource interface {
 		ctx context.Context,
 		epoch uint64,
 	) (map[string]struct{}, error)
+	// GetPoolsRetiredByEpoch returns the set of pool key hashes (hex) whose
+	// effective retirement, resolved as of boundarySlot, takes effect at or
+	// before epoch. It is the second, independent route to the departure
+	// proof GetPoolStakeSnapshotMembers provides: pool_stake_snapshot is
+	// pruned to currentEpoch-3, while pool_registration/pool_retirement are
+	// retained for the life of the database, so an observer trailing the
+	// node has only this one left (dingo #3925).
+	//
+	// Membership in this set is positive per-pool evidence rather than
+	// absence from a set, so it needs no completeness argument. Both
+	// implementations must apply the same cancellation rule
+	// MetadataStore.GetPoolKeyHashesRetiredByEpoch documents: a registration
+	// filed after the retirement puts the pool back, and treating a bare
+	// "retirement certificate exists" as departure would downgrade a real
+	// missing-input ERROR to informational.
+	GetPoolsRetiredByEpoch(
+		ctx context.Context,
+		epoch uint64,
+		boundarySlot uint64,
+	) (map[string]struct{}, error)
 	// GetRewardAccountOutputs returns every per-account reward calculation
 	// output row Dingo committed for epoch. Not yet consumed by any
 	// comparison (that is #3097's scope); exposed now so the source
@@ -198,6 +218,7 @@ func (s *DatabaseSource) GetEpochData(
 			10,
 		),
 		TotalPoolCount: summary.TotalPoolCount,
+		BoundarySlot:   summary.BoundarySlot,
 	}
 
 	pots, err := meta.GetRewardAdaPots(epoch, txn.Metadata())
@@ -252,6 +273,42 @@ func (s *DatabaseSource) GetPoolStakeSnapshotMembers(
 		members[hex.EncodeToString(row.PoolKeyHash)] = struct{}{}
 	}
 	return members, nil
+}
+
+// GetPoolsRetiredByEpoch implements RewardParitySource through the metadata
+// store's own GetPoolKeyHashesRetiredByEpoch, so the in-process observer and
+// the standalone CLI resolve departure from one shared query rather than two
+// copies of the certificate-ordering rules.
+func (s *DatabaseSource) GetPoolsRetiredByEpoch(
+	ctx context.Context,
+	epoch uint64,
+	boundarySlot uint64,
+) (map[string]struct{}, error) {
+	// See GetLatestEpoch's comment: no context-aware transaction/accessor
+	// exists to thread ctx into further, so this only guards against
+	// starting new work after ctx is already done.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	txn := s.db.Transaction(false)
+	defer txn.Release()
+	keyHashes, err := s.db.Metadata().GetPoolKeyHashesRetiredByEpoch(
+		epoch,
+		boundarySlot,
+		txn.Metadata(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pool_retirement through epoch %d: %w",
+			epoch,
+			err,
+		)
+	}
+	retired := make(map[string]struct{}, len(keyHashes))
+	for _, keyHash := range keyHashes {
+		retired[hex.EncodeToString(keyHash)] = struct{}{}
+	}
+	return retired, nil
 }
 
 func (s *DatabaseSource) GetPoolEpochDataMap(

--- a/internal/koiosparity/source_test.go
+++ b/internal/koiosparity/source_test.go
@@ -476,11 +476,28 @@ VALUES (?, ?, ?, ?)`, poolID, keyHash, retEpoch, retSlot).Error)
 	)
 }
 
+// retiredParityCert is one seeded certificate. blockIndex is the
+// transaction's index within its block and certIndex the certificate's index
+// within that transaction, which together break added_slot ties exactly the
+// way a registration and a retirement filed in one block do on chain.
+//
+// reconcile writes the row the way Store.RetirePools does — certificate_id = 0
+// with no certs/transaction row behind it — so such a row has no
+// block_index/cert_index of its own and is ordered by the synthetic_ret key
+// instead. Retirements only.
+type retiredParityCert struct {
+	slot       uint64
+	blockIndex uint64
+	certIndex  uint64
+	epoch      uint64 // retirements only
+	reconcile  bool   // retirements only
+}
+
 // retiredParitySeeder seeds pool certificate histories into the real,
-// migrated metadata schema. Every registration and retirement gets a
-// transaction/certs row so added_slot ties are broken on block_index then
-// cert_index, which is the only way to exercise the same-slot half of the
-// cancellation rule.
+// migrated metadata schema. Every certificate-backed registration and
+// retirement gets a transaction/certs row so added_slot ties are broken on
+// block_index then cert_index, which is the only way to exercise the same-slot
+// half of the cancellation rule.
 type retiredParitySeeder struct {
 	t   *testing.T
 	raw *sql.DB
@@ -509,12 +526,11 @@ func (s *retiredParitySeeder) cert(slot, blockIndex, certIndex uint64) int64 {
 	return certID
 }
 
-// seed writes one pool. regs and rets are (slot, certIndex) pairs; a
-// retirement's effective epoch is its third element.
+// seed writes one pool with the given registration and retirement history.
 func (s *retiredParitySeeder) seed(
 	keyHash []byte,
-	regs [][2]uint64,
-	rets [][3]uint64,
+	regs []retiredParityCert,
+	rets []retiredParityCert,
 ) {
 	s.t.Helper()
 	res, err := s.raw.Exec(
@@ -525,22 +541,25 @@ func (s *retiredParitySeeder) seed(
 	poolID, err := res.LastInsertId()
 	require.NoError(s.t, err)
 	for _, reg := range regs {
-		certID := s.cert(reg[0], 0, reg[1])
+		certID := s.cert(reg.slot, reg.blockIndex, reg.certIndex)
 		_, err := s.raw.Exec(`
 INSERT INTO pool_registration (
     pool_id, pool_key_hash, certificate_id, added_slot, deposit_amount
 ) VALUES (?, ?, ?, ?, '500')`,
-			poolID, keyHash, certID, reg[0],
+			poolID, keyHash, certID, reg.slot,
 		)
 		require.NoError(s.t, err)
 	}
 	for _, ret := range rets {
-		certID := s.cert(ret[0], 0, ret[1])
+		var certID int64
+		if !ret.reconcile {
+			certID = s.cert(ret.slot, ret.blockIndex, ret.certIndex)
+		}
 		_, err := s.raw.Exec(`
 INSERT INTO pool_retirement (
     pool_id, pool_key_hash, certificate_id, epoch, added_slot
 ) VALUES (?, ?, ?, ?, ?)`,
-			poolID, keyHash, certID, ret[2], ret[0],
+			poolID, keyHash, certID, ret.epoch, ret.slot,
 		)
 		require.NoError(s.t, err)
 	}
@@ -562,9 +581,19 @@ INSERT INTO pool_retirement (
 //
 // The fixture is built so that every clause of the predicate is load-bearing
 // for at least one pool: the `<=` comparison, the `added_slot < boundarySlot`
-// visibility cut, the cancellation guard, and both directions of the same-slot
-// cert_index tie-break. Neutralising any one of them in either implementation
-// fails this test.
+// visibility cut, the cancellation guard, both directions of the same-slot
+// block_index and cert_index tie-breaks, latest_ret's own cert_index ordering,
+// and the synthetic_ret key that ranks a reconcile retirement
+// (`certificate_id = 0`) ahead of certificate-backed rows in its own slot and
+// exempts it from cancellation. Neutralising any one of them in either
+// implementation fails this test.
+//
+// The reconcile pools matter because the two implementations diverged on
+// exactly them: DingoDB carried synthetic_ret while the store query did not,
+// so a node bootstrapped from a ledger-state snapshot — where ImportPool and
+// RetirePools write a registration and a certificate_id = 0 retirement in one
+// slot — would have the standalone CLI and the in-process observer classify
+// the same pool differently.
 func TestGetPoolsRetiredByEpochImplementationsAgree(t *testing.T) {
 	const (
 		queryEpoch   = uint64(7)
@@ -587,40 +616,55 @@ func TestGetPoolsRetiredByEpochImplementationsAgree(t *testing.T) {
 		retiredAfterBoundary = testPoolKeyHash(t, 0x37)
 		neverRetired         = testPoolKeyHash(t, 0x38)
 		reregisteredAtBound  = testPoolKeyHash(t, 0x39)
+		retiredLaterTx       = testPoolKeyHash(t, 0x3A)
+		reregisteredLaterTx  = testPoolKeyHash(t, 0x3B)
+		retiredTwiceSameSlot = testPoolKeyHash(t, 0x3C)
+		reconcileSameSlot    = testPoolKeyHash(t, 0x3D)
+		reconcileOverCertRet = testPoolKeyHash(t, 0x3E)
 	)
 	// Retired several epochs ago and still departed — the `<=` clause.
-	seeder.seed(departedEarlier, [][2]uint64{{100, 0}}, [][3]uint64{{200, 0, 5}})
+	seeder.seed(
+		departedEarlier,
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{{slot: 200, epoch: 5}},
+	)
 	seeder.seed(
 		departedAtEpoch,
-		[][2]uint64{{100, 0}},
-		[][3]uint64{{200, 0, queryEpoch}},
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{{slot: 200, epoch: queryEpoch}},
 	)
-	seeder.seed(retiringLater, [][2]uint64{{100, 0}}, [][3]uint64{{200, 0, 9}})
+	seeder.seed(
+		retiringLater,
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{{slot: 200, epoch: 9}},
+	)
 	// The cancellation guard: a later registration puts the pool back.
 	seeder.seed(
 		reregistered,
-		[][2]uint64{{100, 0}, {300, 0}},
-		[][3]uint64{{200, 0, 5}},
+		[]retiredParityCert{{slot: 100}, {slot: 300}},
+		[]retiredParityCert{{slot: 200, epoch: 5}},
 	)
-	// Same slot, registration ordered after the retirement by cert_index.
+	// Same slot and same transaction, registration ordered after the
+	// retirement by cert_index.
 	seeder.seed(
 		reregisteredSameSlot,
-		[][2]uint64{{100, 0}, {200, 2}},
-		[][3]uint64{{200, 1, 5}},
+		[]retiredParityCert{{slot: 100}, {slot: 200, certIndex: 2}},
+		[]retiredParityCert{{slot: 200, certIndex: 1, epoch: 5}},
 	)
-	// Same slot, retirement ordered after the registration.
+	// Same slot and same transaction, retirement ordered after the
+	// registration.
 	seeder.seed(
 		retiredSameSlotAfter,
-		[][2]uint64{{100, 0}, {200, 1}},
-		[][3]uint64{{200, 2, 5}},
+		[]retiredParityCert{{slot: 100}, {slot: 200, certIndex: 1}},
+		[]retiredParityCert{{slot: 200, certIndex: 2, epoch: 5}},
 	)
 	// Not yet visible at the boundary.
 	seeder.seed(
 		retiredAfterBoundary,
-		[][2]uint64{{100, 0}},
-		[][3]uint64{{boundarySlot, 0, 5}},
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{{slot: boundarySlot, epoch: 5}},
 	)
-	seeder.seed(neverRetired, [][2]uint64{{100, 0}}, nil)
+	seeder.seed(neverRetired, []retiredParityCert{{slot: 100}}, nil)
 	// The re-registration lands exactly on the boundary slot, so it is not
 	// yet visible and cannot cancel: the pool is still departed. This is the
 	// only pool for which the registration-side `added_slot < boundarySlot`
@@ -628,8 +672,60 @@ func TestGetPoolsRetiredByEpochImplementationsAgree(t *testing.T) {
 	// ordering guard instead.
 	seeder.seed(
 		reregisteredAtBound,
-		[][2]uint64{{100, 0}, {boundarySlot, 0}},
-		[][3]uint64{{200, 0, 5}},
+		[]retiredParityCert{{slot: 100}, {slot: boundarySlot}},
+		[]retiredParityCert{{slot: 200, epoch: 5}},
+	)
+	// Same slot, different transactions: the retirement is in the later
+	// transaction of the block, so it stands. cert_index cannot decide this
+	// pair — both are 0 — so only the block_index comparison can.
+	seeder.seed(
+		retiredLaterTx,
+		[]retiredParityCert{{slot: 100}, {slot: 200, blockIndex: 1}},
+		[]retiredParityCert{{slot: 200, blockIndex: 2, epoch: 5}},
+	)
+	// The mirror image: the registration is in the later transaction, so it
+	// cancels. Together these two pin both directions of the block_index
+	// comparison, which no other pool here exercises.
+	seeder.seed(
+		reregisteredLaterTx,
+		[]retiredParityCert{{slot: 100}, {slot: 200, blockIndex: 2}},
+		[]retiredParityCert{{slot: 200, blockIndex: 1, epoch: 5}},
+	)
+	// Two retirement certificates in one transaction naming different
+	// effective epochs. latest_ret must pick the higher cert_index, so the
+	// pool is departed by 5 rather than still retiring at 9. The epoch-9 row
+	// is seeded first so insertion order disagrees with cert_index order,
+	// which is what makes latest_ret's ORDER BY key load-bearing rather than
+	// incidentally satisfied by the scan order.
+	seeder.seed(
+		retiredTwiceSameSlot,
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{
+			{slot: 200, certIndex: 1, epoch: 9},
+			{slot: 200, certIndex: 2, epoch: 5},
+		},
+	)
+	// A reconcile retirement (certificate_id = 0) in a certificate-backed
+	// registration's own slot. It has no certs row, so both its indices are
+	// zero and it would lose the tie-break without the synthetic_ret
+	// exemption. This is the shape ledgerstate's snapshot import writes, so
+	// it is on every node bootstrapped from a ledger-state snapshot.
+	seeder.seed(
+		reconcileSameSlot,
+		[]retiredParityCert{{slot: 100}, {slot: 200, certIndex: 1}},
+		[]retiredParityCert{{slot: 200, epoch: 5, reconcile: true}},
+	)
+	// A reconcile retirement sharing a slot with a certificate-backed
+	// retirement effective after the queried epoch. The reconcile row is the
+	// ledger state's answer and must win the ROW_NUMBER ordering despite its
+	// zero indices.
+	seeder.seed(
+		reconcileOverCertRet,
+		[]retiredParityCert{{slot: 100}},
+		[]retiredParityCert{
+			{slot: 200, certIndex: 3, epoch: 9},
+			{slot: 200, epoch: 5, reconcile: true},
+		},
 	)
 
 	want := map[string]struct{}{
@@ -637,6 +733,10 @@ func TestGetPoolsRetiredByEpochImplementationsAgree(t *testing.T) {
 		hex.EncodeToString(departedAtEpoch):      {},
 		hex.EncodeToString(retiredSameSlotAfter): {},
 		hex.EncodeToString(reregisteredAtBound):  {},
+		hex.EncodeToString(retiredLaterTx):       {},
+		hex.EncodeToString(retiredTwiceSameSlot): {},
+		hex.EncodeToString(reconcileSameSlot):    {},
+		hex.EncodeToString(reconcileOverCertRet): {},
 	}
 
 	source, err := NewDatabaseSource(db)

--- a/internal/koiosparity/source_test.go
+++ b/internal/koiosparity/source_test.go
@@ -71,6 +71,7 @@ func TestDatabaseSourceGetEpochData(t *testing.T) {
 	require.NoError(t, sqlDB.Create(&models.EpochSummary{
 		Epoch:            5,
 		TotalActiveStake: types.Uint64(123_456_789),
+		BoundarySlot:     4_320_000,
 		SnapshotReady:    true,
 	}).Error)
 	require.NoError(t, sqlDB.Create(&models.RewardAdaPots{
@@ -93,6 +94,7 @@ func TestDatabaseSourceGetEpochData(t *testing.T) {
 	require.Equal(t, "2000", data.Reserves)
 	require.Equal(t, "3000", data.Fees)
 	require.Equal(t, "4000", data.TotalRewards)
+	require.Equal(t, uint64(4_320_000), data.BoundarySlot)
 }
 
 // TestDatabaseSourceGetEpochDataMissingOrNotReady covers both "no row at
@@ -411,5 +413,63 @@ func TestDatabaseSourceGetPoolEpochDataMapTracksChangingPoolParams(
 		blocksAtParamEpoch,
 		data.BlocksProduced,
 		"blocks_produced still comes from the param epoch",
+	)
+}
+
+// TestDatabaseSourceGetPoolsRetiredByEpoch proves the in-process source
+// resolves departure the same way DingoDB's raw-SQL twin does, including the
+// case that makes "a retirement certificate exists" the wrong predicate: a
+// registration filed after the retirement puts the pool back. Both halves are
+// asserted from one seeding, so a query that simply returned every pool with
+// a retirement row would fail on the re-registered pool.
+func TestDatabaseSourceGetPoolsRetiredByEpoch(t *testing.T) {
+	const (
+		queryEpoch   = uint64(7)
+		boundarySlot = uint64(1_000)
+	)
+	db := newTestDatabaseSourceDB(t)
+	sqlDB := sourceSQLDB(t, db)
+
+	departed := testPoolKeyHash(t, 0x21)
+	reregistered := testPoolKeyHash(t, 0x22)
+	retiringLater := testPoolKeyHash(t, 0x23)
+
+	seed := func(keyHash []byte, regSlots []uint64, retSlot, retEpoch uint64) {
+		t.Helper()
+		raw, err := sqlDB.DB()
+		require.NoError(t, err)
+		res, err := raw.Exec(
+			`INSERT INTO pool (pool_key_hash) VALUES (?)`,
+			keyHash,
+		)
+		require.NoError(t, err)
+		poolID, err := res.LastInsertId()
+		require.NoError(t, err)
+		for _, slot := range regSlots {
+			require.NoError(t, sqlDB.Exec(`
+INSERT INTO pool_registration (pool_id, pool_key_hash, added_slot)
+VALUES (?, ?, ?)`, poolID, keyHash, slot).Error)
+		}
+		require.NoError(t, sqlDB.Exec(`
+INSERT INTO pool_retirement (pool_id, pool_key_hash, epoch, added_slot)
+VALUES (?, ?, ?, ?)`, poolID, keyHash, retEpoch, retSlot).Error)
+	}
+	seed(departed, []uint64{100}, 200, queryEpoch-2)
+	seed(reregistered, []uint64{100, 300}, 200, queryEpoch-2)
+	seed(retiringLater, []uint64{100}, 200, queryEpoch+1)
+
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+
+	retired, err := source.GetPoolsRetiredByEpoch(
+		context.Background(),
+		queryEpoch,
+		boundarySlot,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		map[string]struct{}{hex.EncodeToString(departed): {}},
+		retired,
 	)
 }

--- a/internal/koiosparity/source_test.go
+++ b/internal/koiosparity/source_test.go
@@ -16,6 +16,8 @@ package koiosparity
 
 import (
 	"context"
+	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"math/big"
 	"testing"
@@ -471,5 +473,207 @@ VALUES (?, ?, ?, ?)`, poolID, keyHash, retEpoch, retSlot).Error)
 		t,
 		map[string]struct{}{hex.EncodeToString(departed): {}},
 		retired,
+	)
+}
+
+// retiredParitySeeder seeds pool certificate histories into the real,
+// migrated metadata schema. Every registration and retirement gets a
+// transaction/certs row so added_slot ties are broken on block_index then
+// cert_index, which is the only way to exercise the same-slot half of the
+// cancellation rule.
+type retiredParitySeeder struct {
+	t   *testing.T
+	raw *sql.DB
+	seq uint64
+}
+
+func (s *retiredParitySeeder) cert(slot, blockIndex, certIndex uint64) int64 {
+	s.t.Helper()
+	s.seq++
+	hash := make([]byte, 32)
+	binary.BigEndian.PutUint64(hash, s.seq)
+	res, err := s.raw.Exec(
+		`INSERT INTO "transaction" (hash, slot, block_index) VALUES (?, ?, ?)`,
+		hash, slot, blockIndex,
+	)
+	require.NoError(s.t, err)
+	txID, err := res.LastInsertId()
+	require.NoError(s.t, err)
+	res, err = s.raw.Exec(
+		`INSERT INTO certs (transaction_id, slot, cert_index) VALUES (?, ?, ?)`,
+		txID, slot, certIndex,
+	)
+	require.NoError(s.t, err)
+	certID, err := res.LastInsertId()
+	require.NoError(s.t, err)
+	return certID
+}
+
+// seed writes one pool. regs and rets are (slot, certIndex) pairs; a
+// retirement's effective epoch is its third element.
+func (s *retiredParitySeeder) seed(
+	keyHash []byte,
+	regs [][2]uint64,
+	rets [][3]uint64,
+) {
+	s.t.Helper()
+	res, err := s.raw.Exec(
+		`INSERT INTO pool (pool_key_hash) VALUES (?)`,
+		keyHash,
+	)
+	require.NoError(s.t, err)
+	poolID, err := res.LastInsertId()
+	require.NoError(s.t, err)
+	for _, reg := range regs {
+		certID := s.cert(reg[0], 0, reg[1])
+		_, err := s.raw.Exec(`
+INSERT INTO pool_registration (
+    pool_id, pool_key_hash, certificate_id, added_slot, deposit_amount
+) VALUES (?, ?, ?, ?, '500')`,
+			poolID, keyHash, certID, reg[0],
+		)
+		require.NoError(s.t, err)
+	}
+	for _, ret := range rets {
+		certID := s.cert(ret[0], 0, ret[1])
+		_, err := s.raw.Exec(`
+INSERT INTO pool_retirement (
+    pool_id, pool_key_hash, certificate_id, epoch, added_slot
+) VALUES (?, ?, ?, ?, ?)`,
+			poolID, keyHash, certID, ret[2], ret[0],
+		)
+		require.NoError(s.t, err)
+	}
+}
+
+// TestGetPoolsRetiredByEpochImplementationsAgree runs both RewardParitySource
+// implementations against one physical metadata.sqlite on the real migrated
+// schema: DatabaseSource through MetadataStore.GetPoolKeyHashesRetiredByEpoch,
+// and DingoDB through its own copy of that SQL on a read-only connection to
+// the same file.
+//
+// Two things are asserted, and both are needed. Equality between the
+// implementations is what pins them against drift — nothing else in the tree
+// requires DingoDB's hand-written SQL to keep matching the store query, and
+// the end-to-end checks exercise only DingoDB while
+// TestDatabaseSourceGetPoolsRetiredByEpoch exercises only the store. Equality
+// against an explicit expected set is what stops two identically-broken
+// implementations from agreeing with each other and passing.
+//
+// The fixture is built so that every clause of the predicate is load-bearing
+// for at least one pool: the `<=` comparison, the `added_slot < boundarySlot`
+// visibility cut, the cancellation guard, and both directions of the same-slot
+// cert_index tie-break. Neutralising any one of them in either implementation
+// fails this test.
+func TestGetPoolsRetiredByEpochImplementationsAgree(t *testing.T) {
+	const (
+		queryEpoch   = uint64(7)
+		boundarySlot = uint64(1_000)
+	)
+	dir := t.TempDir()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: dir})
+	require.NoError(t, err)
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	seeder := &retiredParitySeeder{t: t, raw: raw}
+
+	var (
+		departedEarlier      = testPoolKeyHash(t, 0x31)
+		departedAtEpoch      = testPoolKeyHash(t, 0x32)
+		retiringLater        = testPoolKeyHash(t, 0x33)
+		reregistered         = testPoolKeyHash(t, 0x34)
+		reregisteredSameSlot = testPoolKeyHash(t, 0x35)
+		retiredSameSlotAfter = testPoolKeyHash(t, 0x36)
+		retiredAfterBoundary = testPoolKeyHash(t, 0x37)
+		neverRetired         = testPoolKeyHash(t, 0x38)
+		reregisteredAtBound  = testPoolKeyHash(t, 0x39)
+	)
+	// Retired several epochs ago and still departed — the `<=` clause.
+	seeder.seed(departedEarlier, [][2]uint64{{100, 0}}, [][3]uint64{{200, 0, 5}})
+	seeder.seed(
+		departedAtEpoch,
+		[][2]uint64{{100, 0}},
+		[][3]uint64{{200, 0, queryEpoch}},
+	)
+	seeder.seed(retiringLater, [][2]uint64{{100, 0}}, [][3]uint64{{200, 0, 9}})
+	// The cancellation guard: a later registration puts the pool back.
+	seeder.seed(
+		reregistered,
+		[][2]uint64{{100, 0}, {300, 0}},
+		[][3]uint64{{200, 0, 5}},
+	)
+	// Same slot, registration ordered after the retirement by cert_index.
+	seeder.seed(
+		reregisteredSameSlot,
+		[][2]uint64{{100, 0}, {200, 2}},
+		[][3]uint64{{200, 1, 5}},
+	)
+	// Same slot, retirement ordered after the registration.
+	seeder.seed(
+		retiredSameSlotAfter,
+		[][2]uint64{{100, 0}, {200, 1}},
+		[][3]uint64{{200, 2, 5}},
+	)
+	// Not yet visible at the boundary.
+	seeder.seed(
+		retiredAfterBoundary,
+		[][2]uint64{{100, 0}},
+		[][3]uint64{{boundarySlot, 0, 5}},
+	)
+	seeder.seed(neverRetired, [][2]uint64{{100, 0}}, nil)
+	// The re-registration lands exactly on the boundary slot, so it is not
+	// yet visible and cannot cancel: the pool is still departed. This is the
+	// only pool for which the registration-side `added_slot < boundarySlot`
+	// cut is load-bearing — every other cancellation here is decided by the
+	// ordering guard instead.
+	seeder.seed(
+		reregisteredAtBound,
+		[][2]uint64{{100, 0}, {boundarySlot, 0}},
+		[][3]uint64{{200, 0, 5}},
+	)
+
+	want := map[string]struct{}{
+		hex.EncodeToString(departedEarlier):      {},
+		hex.EncodeToString(departedAtEpoch):      {},
+		hex.EncodeToString(retiredSameSlotAfter): {},
+		hex.EncodeToString(reregisteredAtBound):  {},
+	}
+
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+	fromStore, err := source.GetPoolsRetiredByEpoch(
+		context.Background(),
+		queryEpoch,
+		boundarySlot,
+	)
+	require.NoError(t, err)
+
+	dingoDB, err := OpenDingoDB(DingoDBConfig{Plugin: "sqlite", DataDir: dir})
+	require.NoError(t, err)
+	defer dingoDB.Close() //nolint:errcheck
+	fromDingoDB, err := dingoDB.GetPoolsRetiredByEpoch(
+		context.Background(),
+		queryEpoch,
+		boundarySlot,
+	)
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		want,
+		fromStore,
+		"DatabaseSource/MetadataStore resolved the wrong departure set",
+	)
+	require.Equal(
+		t,
+		want,
+		fromDingoDB,
+		"DingoDB resolved the wrong departure set",
+	)
+	require.Equal(
+		t,
+		fromStore,
+		fromDingoDB,
+		"the two RewardParitySource implementations must not drift",
 	)
 }

--- a/internal/koiosparity/sql_test_helpers_test.go
+++ b/internal/koiosparity/sql_test_helpers_test.go
@@ -87,6 +87,16 @@ func testSchema(includePools bool) []string {
 		// pool rows at all, so gating this behind includePools would force
 		// that test to opt into unrelated schema it doesn't use.
 		`CREATE TABLE reward_account_output (staking_key BLOB NOT NULL, pool_key_hash BLOB NOT NULL, reward_type TEXT NOT NULL, id INTEGER PRIMARY KEY, epoch INTEGER NOT NULL, credential_tag INTEGER NOT NULL DEFAULT 0, amount TEXT NOT NULL, spendable BOOLEAN NOT NULL, guarded BOOLEAN NOT NULL DEFAULT FALSE, captured_slot INTEGER NOT NULL, boundary_slot INTEGER NOT NULL, UNIQUE (epoch, credential_tag, staking_key, pool_key_hash, reward_type))`,
+		// The pool certificate tables back DingoDB.GetPoolsRetiredByEpoch.
+		// Created unconditionally for the same reason as
+		// reward_account_output: they are cheap, independent of the reward
+		// tables, and a checkEpoch run reads them for every epoch whether
+		// or not the test seeds pool reward rows.
+		`CREATE TABLE pool (id INTEGER PRIMARY KEY AUTOINCREMENT, pool_key_hash BLOB NOT NULL UNIQUE)`,
+		`CREATE TABLE pool_registration (id INTEGER PRIMARY KEY AUTOINCREMENT, pool_id INTEGER NOT NULL, pool_key_hash BLOB NOT NULL, certificate_id INTEGER, added_slot INTEGER NOT NULL)`,
+		`CREATE TABLE pool_retirement (id INTEGER PRIMARY KEY AUTOINCREMENT, pool_id INTEGER NOT NULL, pool_key_hash BLOB NOT NULL, certificate_id INTEGER, epoch INTEGER NOT NULL, added_slot INTEGER NOT NULL)`,
+		`CREATE TABLE "transaction" (id INTEGER PRIMARY KEY AUTOINCREMENT, hash BLOB, slot INTEGER, block_index INTEGER)`,
+		`CREATE TABLE certs (id INTEGER PRIMARY KEY AUTOINCREMENT, transaction_id INTEGER, slot INTEGER, cert_index INTEGER)`,
 	}
 	if includePools {
 		ret = append(


### PR DESCRIPTION
Fixes #3925

## Why

A pool that retires is classified `dingo_db_missing` — an ERROR that halts
the observer in strict mode — instead of the informational `pool_departed`,
whenever the parity observer runs behind the node.

`ComparePoolEpoch` downgrades to `CategoryPoolDeparted` only when
`dingoPool.StakePresent && departedAtParamEpoch`. `StakePresent` is already
true in the failing case; `departedAtParamEpoch` is the missing half. Both
existing routes to that proof reconstruct the whole K+1 pool set and read
departure as absence from it, so each needs its own completeness argument —
and both were closed at once on a from-genesis Preview replay:

- `pool_stake_snapshot` is pruned to `currentEpoch-3` by
  `Manager.cleanupOldSnapshots`, so it is empty for every epoch a trailing
  observer checks.
- The #3795 reward-input fallback requires
  `len(paramInputs) == declaredParamPools` exactly, and `reward_pool_input`
  is consistently short of `epoch_summary.total_pool_count` because
  `buildRewardStateInputs` deliberately omits a degraded active pool from it
  — precisely the case that exact match exists to exclude. So it never fires.

## Evidence

Verified read-only against the replay's `metadata.sqlite`. The reported pool
`pool18ttg8kwe7w858sdk8rcw08cujytn6vjvpsc9t9c64n6h27wza2u`
(`3ad683d9…aacf575`) registered at slot 20558938 and filed one retirement
effective epoch 243 at slot 20856918. Its `reward_pool_input` rows stop after
epoch 243. `pool_stake_snapshot` has zero rows for epochs 243–249.

Running the shipped query at each param epoch the observer errored on, at
that epoch's real `epoch_summary.boundary_slot`:

```
paramEpoch=244 (boundary 21081600)  retired=55  subject_included=1
paramEpoch=245 (boundary 21168000)  retired=55  subject_included=1
paramEpoch=247 (boundary 21340800)  retired=57  subject_included=1
paramEpoch=248 (boundary 21427200)  retired=57  subject_included=1
```

The cancellation rule is load-bearing, not theoretical. At the epoch-244
boundary the naive predicate "a retirement certificate exists with
`epoch <= 244`" returns 59 pools against the correct 55; seven pools on this
chain have a registration filed after a retirement certificate.

## What changed

- `MetadataStore.GetPoolKeyHashesRetiredByEpoch` (one implementation, in
  `sqlstore/pool.go`): the "at or before" sibling of
  `GetPoolsRetiringAtEpoch`, with that query's latest-certificate resolution
  and cancellation rule preserved exactly — `ret.epoch <= ?` instead of
  `= ?`, returning bare key hashes because no deposit refund is applied.
  `= ?` would fix only the first epoch: the pool retired effective 243 and
  was still misclassified at 244, 245, 247 and 248.
- `DingoEpochData.BoundarySlot` carries `epoch_summary.boundary_slot`,
  populated in both `DingoDB.GetEpochData` (the column was already selected)
  and `DatabaseSource.GetEpochData`, so certificate history is resolved at
  the same point in the chain the epoch's pool set was captured at.
- `RewardParitySource.GetPoolsRetiredByEpoch`, implemented twice: `DingoDB`
  in raw SQL against a separately synced database, `DatabaseSource` through
  the store method.
- `poolDepartedAtParamEpoch` treats membership in that set as proof of
  departure alongside the existing pool-set route. It fails closed the same
  way: no boundary slot, or a read error, leaves the route shut and the
  stricter classification standing.

## Tests

Written first. Every claim below was re-verified by mutating the specific code
it names and confirming the named test fails — separately for each of the two
implementations, since a test naming one does not cover the other.

| Mutation | Where | Caught by |
|---|---|---|
| `ret.epoch <=` → `=` | sqlstore | `TestGetPoolKeyHashesRetiredByEpoch`, `TestGetPoolsRetiredByEpochImplementationsAgree` |
| `ret.epoch <=` → `=` | DingoDB | `TestCheckRetiredPoolStaysDepartedInLaterEpochs`, `TestGetPoolsRetiredByEpochImplementationsAgree` |
| drop `AND NOT ( ... )` cancellation guard | sqlstore | `TestGetPoolKeyHashesRetiredByEpoch`, `TestGetPoolsRetiredByEpochImplementationsAgree` |
| drop `AND NOT ( ... )` cancellation guard | DingoDB | `TestCheckReregisteredPoolStillErrors`, `TestGetPoolsRetiredByEpochImplementationsAgree` |
| retirement cut `rt.added_slot <` → `<=` | sqlstore | `TestGetPoolKeyHashesRetiredByEpoch`, `TestGetPoolsRetiredByEpochImplementationsAgree` |
| retirement cut `rt.added_slot <` → `<=` | DingoDB | `TestGetPoolsRetiredByEpochImplementationsAgree` |
| registration cut `pr.added_slot <` → `<=` | sqlstore | `TestGetPoolsRetiredByEpochImplementationsAgree` |
| registration cut `pr.added_slot <` → `<=` | DingoDB | `TestGetPoolsRetiredByEpochImplementationsAgree` |
| drop `BoundarySlot` from `GetEpochData` | DingoDB | both `TestCheckRetiredPool*` |
| drop `BoundarySlot` from `GetEpochData` | DatabaseSource | `TestDatabaseSourceGetEpochData` |
| `poolDepartedAtParamEpoch` ignores retirement evidence | check.go | both `TestCheckRetiredPool*` |

The tests themselves:

- `TestGetPoolKeyHashesRetiredByEpoch` (`database/pool_retired_test.go`) —
  nine pools with explicit certificate histories, each with a real
  transaction/certs row so `added_slot` ties break on `block_index` then
  `cert_index`. Covers same-slot ordering in both directions.
- `TestGetPoolsRetiredByEpochImplementationsAgree`
  (`internal/koiosparity/source_test.go`) — runs **both** implementations
  against one physical `metadata.sqlite` on the real migrated schema, and
  asserts each against an explicit expected set as well as against each
  other. See "Implementation drift" below.
- `TestCheckRetiredPoolIsDepartedWithoutAnyPoolSetEvidence` — the issue's
  exact shape: `TestCheckIncompleteRewardInputSetStillErrorsAfterPrune`'s
  fixture (mark rows pruned, reward-input set short of the declared count)
  plus the pool's retirement certificate. Was ERROR, now `pool_departed`.
- `TestCheckRetiredPoolStaysDepartedInLaterEpochs` — retirement effective
  several epochs earlier; fails under `= paramEpoch` semantics.
- `TestCheckReregisteredPoolStillErrors` — identical to the first except for
  a registration filed after the retirement. Must stay `dingo_db_missing`.
- `TestDatabaseSourceGetPoolsRetiredByEpoch` — the store path in isolation.

Four pre-existing fail-closed tests (`TestCheckDegradedActivePoolStillErrors`,
`TestCheckMissingRewardBundleStillErrors`,
`TestCheckIncompleteParamEpochPoolSetStillErrors`,
`TestCheckIncompleteRewardInputSetStillErrorsAfterPrune`) all still pass: the
departure fixture now stamps a boundary slot, so the new query runs for them
too and correctly finds no retirement.

## Implementation drift

`RewardParitySource.GetPoolsRetiredByEpoch` is implemented twice, and nothing
required the two to agree. The coverage was split exactly along that seam —
the end-to-end checks drive only `DingoDB`, and
`TestDatabaseSourceGetPoolsRetiredByEpoch` drives only the store — so either
copy could drift without a test naming the other noticing.

`TestGetPoolsRetiredByEpochImplementationsAgree` closes that: one physical
database, both implementations, asserted against an explicit expected set
*and* against each other. Expected-set equality matters on its own — two
identically-broken implementations would otherwise agree and pass.

Auditing the class rather than the reported location also turned up a real
gap: the registration-side `pr.added_slot < boundarySlot` cut had no pool for
which it was load-bearing, because every cancellation in the fixture was
decided by the ordering guard instead. A re-registration landing exactly on
the boundary slot now covers it, in both implementations.

## Validation

- `go test ./internal/koiosparity/... ./database/... -count=1` — all pass.
- `go test ./ledger/... -run 'PoolRetire|Poolreap|PoolReap'` — pass;
  `GetPoolsRetiringAtEpoch` and POOLREAP refunds are untouched.
- `make lint` — golangci-lint 0 issues across every module dir and under
  `GOOS=windows`. `nilaway` is clean on `./internal/koiosparity/...` and
  `./database/plugin/metadata/...`.
- `make docs-parity` — pass.
- `make sql-check` — pass, no drift. No `database/sql` query or `sqlc.yaml`
  change; the new query is hand-written alongside `GetPoolsRetiringAtEpoch`.

## Docs

- `DATABASE.md` — new `GetPoolKeyHashesRetiredByEpoch` section with the full
  SQL, why it differs from `GetPoolsRetiringAtEpoch`, and the retention
  argument.
- `ARCHITECTURE.md` — needed updating too, and is: the Koios Parity Tracker
  section documented both pool-set routes and the #3795 fallback in detail,
  so it now records the third route, why the first two can be closed
  simultaneously, and how this one fails closed.

## Conflict notes

Based on current `origin/main`, not pre-merged with anything. Four open
unreviewed PRs touch these files:

- **#3853** adds a `rewardsPending` 8th parameter to `CompareAccountEpoch`.
  Different function from the `ComparePoolEpoch` call this changes, but both
  live in `compare.go`/`check.go`; expect a textual conflict, not a semantic
  one.
- **#3916, #3920, #3924** also touch `check.go`/`compare.go`. This change's
  edits are confined to `poolDepartedAtParamEpoch`, the evidence-resolution
  block in `checkEpoch`, and one `ComparePoolEpoch` doc comment, so conflicts
  should resolve textually.

Whichever lands last rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A pool that retires was classified `dingo_db_missing` — halting the observer in strict mode — instead of `pool_departed` whenever the parity observer ran behind the node. The pool-set routes to departure evidence were both unavailable (pruned snapshots, short reward-input sets), so the fix resolves departure from pool certificate history instead, which is retained for the life of the database.

**What changed**
- Adds `MetadataStore.GetPoolKeyHashesRetiredByEpoch` and the `RewardParitySource` implementations, resolving departures as "retired at or before a param epoch" under the same cancellation rule as `GetPoolsRetiringAtEpoch`.
- Retirements recorded without a backing certificate now sort ahead of same-slot certificates and skip that ordering's cancellation, in both `GetPoolsRetiringAtEpoch` and the `DingoDB` query, so the store and `DingoDB` cannot disagree; a drift test pins both implementations to each other and an explicit expected set, and a new POOLREAP test pins the same-slot ordering on the refund path.
- Carries `epoch_summary.boundary_slot` through `DingoEpochData`; without one the route stays closed and `dingo_db_missing` stands.
- Addresses #3925; tests cover earlier-epoch retirements, re-registered pools, same-slot tie-breaks, and reconcile retirements.

<sup>Written for commit 45d93ebd8d08966637c76930aa7321f36996e9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pool departure checks now recognize effective retirement certificates, including retirements from earlier epochs.
  * Re-registrations correctly cancel prior retirements.
  * Departure validation uses the K+1 epoch boundary to provide more reliable pool status results.

* **Bug Fixes**
  * Prevents valid retired pools from being incorrectly reported as missing data during parity checks.

* **Tests**
  * Added coverage for retirement timing, certificate ordering, boundary visibility, and re-registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->