### PR TITLE
fix(database): synchronize blob-store replacement with readers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7476,19 +7476,28 @@ releases at `Commit`/`Rollback`/`Release` (through the same `finishLocked` that
 releases the commit barrier), and `Txn.BlobStore()` returns the store it
 pinned: the store and the `types.Txn` handle opened on it therefore always come
 from the same installation, which re-reading `Blob()` mid-transaction would not
-guarantee. Blob work that runs outside a transaction — the tiered CBOR cache's
-cold path, the blob block iterator, the blob-store identity mint, and
-`lifecycle.Snapshot`'s backup call — brackets itself with `Database.PinBlob`
-and the release func it returns.
+guarantee. Blob work that runs outside a transaction — the blob block iterator,
+the blob-store identity mint, `lifecycle.Snapshot`'s backup call, and
+`LedgerState.cleanupOrphanedBlobs` — brackets itself with `Database.PinBlob`
+and the release func it returns. Work that may or may not be handed a
+transaction follows the same rule from one place: the tiered CBOR cache's cold
+path (`ResolveUtxoCbor`, `ResolveTxCbor`) takes the caller's `*database.Txn`
+and resolves through that transaction's store when it has one, pinning the
+installed store only when it does not. That is why those two entry points take
+the transaction rather than its bare `types.Txn` handle — a bare handle does
+not say which store it belongs to.
 
 `SetBlobStore` returns the replaced store and a drain func. New operations get
 the new store immediately, so nothing blocks; drain returns once every
 operation pinned on the replaced store has finished, and that is the point at
 which the replaced store may be closed. `SetBlobStore` never closes anything
 itself, because the two production callers wrap the previous store rather than
-retiring it. `Blob()` deliberately hands back an unpinned reference for callers
-that only identify, wrap, or ask a whole-store question of the current store;
-its result must be used within the call that obtained it.
+retiring it. Drain covers the reference that call retired, so a caller that
+intends to close the replaced store must not install it again before drain
+returns: a second installation of the same store counts its pins separately.
+`Blob()` deliberately hands back an unpinned reference for callers that only
+identify, wrap, or ask a whole-store question of the current store; its result
+must be used within the call that obtained it.
 
 `LedgerState` publishes its read-mostly state through two copy-on-write
 snapshots. The consensus snapshot groups the current epoch, era, current and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1839,7 +1839,14 @@ fallback:
   are accepted only when they are HTTPS, credential-free, and hosted by the
   expected archive hostname or a configured `barkBlockDownloadHosts` allowlist
   entry; redirects are disabled and response bodies are capped before buffering.
-  This wrapper can be used with or without local History Expiry.
+  This wrapper can be used with or without local History Expiry. It is
+  installed by replacing the database's blob-store reference
+  (`Database.SetBlobStore`) after `database.New` has returned, on both the
+  `Run()` startup path and `node_lifecycle.go`'s live reconfigure path where
+  readers are already running — see "Blob-store replacement" under Threading
+  and Concurrency for the rules that make that safe. The wrapper takes the
+  store it replaces as its upstream and forwards `Close` to it, so the
+  replaced store is kept alive rather than retired.
 
 ### Tiered CBOR Cache
 
@@ -7453,6 +7460,35 @@ the continuation drain without holding the scheduling mutex while waiting.
 | Context Cancellation | Graceful shutdown signals |
 | Worker Pools | Database operations and event delivery |
 | sync.Once | Ensure single shutdown execution |
+
+### Blob-store replacement
+
+`Database.blobRef` is guarded by an `RWMutex` (`database/blob_store.go`).
+`Blob()` and the internal pin accessor are its only readers, `SetBlobStore` its
+only writer, so a replacement cannot race a reader — `SetBlobStore` is called
+after `database.New` has returned on both the startup and live-reconfigure
+paths, by which point the size-metrics goroutine `New` started is already
+ticking against the same field.
+
+Replacement swaps a whole reference, not the store inside one, and each
+reference counts the operations pinning it. A `Txn` pins at construction and
+releases at `Commit`/`Rollback`/`Release` (through the same `finishLocked` that
+releases the commit barrier), and `Txn.BlobStore()` returns the store it
+pinned: the store and the `types.Txn` handle opened on it therefore always come
+from the same installation, which re-reading `Blob()` mid-transaction would not
+guarantee. Blob work that runs outside a transaction — the tiered CBOR cache's
+cold path, the blob block iterator, the blob-store identity mint, and
+`lifecycle.Snapshot`'s backup call — brackets itself with `Database.PinBlob`
+and the release func it returns.
+
+`SetBlobStore` returns the replaced store and a drain func. New operations get
+the new store immediately, so nothing blocks; drain returns once every
+operation pinned on the replaced store has finished, and that is the point at
+which the replaced store may be closed. `SetBlobStore` never closes anything
+itself, because the two production callers wrap the previous store rather than
+retiring it. `Blob()` deliberately hands back an unpinned reference for callers
+that only identify, wrap, or ask a whole-store question of the current store;
+its result must be used within the call that obtained it.
 
 `LedgerState` publishes its read-mostly state through two copy-on-write
 snapshots. The consensus snapshot groups the current epoch, era, current and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7476,10 +7476,14 @@ releases at `Commit`/`Rollback`/`Release` (through the same `finishLocked` that
 releases the commit barrier), and `Txn.BlobStore()` returns the store it
 pinned: the store and the `types.Txn` handle opened on it therefore always come
 from the same installation, which re-reading `Blob()` mid-transaction would not
-guarantee. Blob work that runs outside a transaction — the blob block iterator,
-the blob-store identity mint, `lifecycle.Snapshot`'s backup call, and
+guarantee. Blob work that runs outside a transaction — the blob-store identity
+mint, `lifecycle.Snapshot`'s backup call, and
 `LedgerState.cleanupOrphanedBlobs` — brackets itself with `Database.PinBlob`
-and the release func it returns. Work that may or may not be handed a
+and the release func it returns. `BlobBlockIterator` holds its pin for the
+lifetime of a batch rather than a call: it scans a batch of block keys from one
+store and reads each block's CBOR back in a later `NextRaw`, and a replacement
+between the two would make a scanned block look absent, which `NextRaw` skips
+with a warning instead of reporting. Work that may or may not be handed a
 transaction follows the same rule from one place: the tiered CBOR cache's cold
 path (`ResolveUtxoCbor`, `ResolveTxCbor`) takes the caller's `*database.Txn`
 and resolves through that transaction's store when it has one, pinning the
@@ -7498,6 +7502,16 @@ returns: a second installation of the same store counts its pins separately.
 `Blob()` deliberately hands back an unpinned reference for callers that only
 identify, wrap, or ask a whole-store question of the current store; its result
 must be used within the call that obtained it.
+
+"Never closes" also covers partial-commit recovery. When `Txn.Commit` returns
+`types.ErrPartialCommit` the blob transaction has committed and the metadata
+has not, and the transaction releases its pin as it finishes; the recovery that
+trims the blob store back to the metadata tip runs afterwards, from
+`LedgerState.RecoverCommitTimestampConflict`, against the store installed at
+that point. No pin spans that gap on purpose — recovery is caller-scheduled and
+unbounded, so a pin held for it would block drain indefinitely. The replaced
+store staying open, reachable through the wrapper installed over it, is what
+keeps recovery correct.
 
 `LedgerState` publishes its read-mostly state through two copy-on-write
 snapshots. The consensus snapshot groups the current epoch, era, current and

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -11,6 +11,21 @@ behavior, and persisted formats are unchanged. Library callers of Mithril
 `Sync` or `NeedsSync` may leave `SyncConfig.StoragePlugins` unset to select the
 local `badger` blob and `sqlite` metadata providers.
 
+The blob-store reference can be replaced while the database is live.
+`Database.SetBlobStore` installs the new store and returns the one it replaced
+together with a drain func. Operations already in flight keep running against
+the store they pinned: a `Txn` pins the blob store it opened on for its whole
+lifetime and exposes it as `Txn.BlobStore()`, and blob work outside a
+transaction brackets itself with `Database.PinBlob`. The drain func returns
+once every operation pinned on the replaced store has finished, which is the
+point at which that store may be closed — `SetBlobStore` never closes it. The
+two production callers (`node.go` and `node_lifecycle.go`, the latter on the
+live reconfigure path) install a `bark.BlobStoreBark` wrapper over the store
+they were handed and keep it alive inside the wrapper, so they have nothing to
+drain. `Database.Blob()` returns the currently installed store without a pin,
+for callers that only need to identify, wrap, or ask a whole-store question of
+it; it must be used within the call that obtained it.
+
 The Badger provider threads the host's stop context through its close path.
 Stopping periodic value-log GC prevents a successful rewrite from starting a
 second pass. Badger does not expose cancellation for a rewrite already in
@@ -244,8 +259,8 @@ The Go model `models.Block` has `TableName() == "block"`, but it is not migrated
 
 Use the Go APIs when code runs inside Dingo:
 
-- `database.Database` in `database/database.go` owns both stores and exposes `Blob()`, `Metadata()`, `Transaction()`, `BlobTxn()`, `MetadataTxn()`, `StorageMode()`, and `Close()`.
-- `database.Txn` in `database/txn.go` coordinates sibling metadata/blob transactions. Write commits update commit timestamps in both stores, commit the blob transaction first, then commit metadata.
+- `database.Database` in `database/database.go` owns both stores and exposes `Blob()`, `PinBlob()`, `SetBlobStore()`, `Metadata()`, `Transaction()`, `BlobTxn()`, `MetadataTxn()`, `StorageMode()`, and `Close()`. `Blob()`, `PinBlob()`, and `SetBlobStore()` are the only readers and writer of the installed blob store; see "Storage provider ownership" for the pin/drain rules that make replacement safe.
+- `database.Txn` in `database/txn.go` coordinates sibling metadata/blob transactions. Write commits update commit timestamps in both stores, commit the blob transaction first, then commit metadata. `Txn.BlobStore()` returns the blob store the transaction was opened on — the store its `Blob()` handle belongs to, and the one every blob call inside the transaction must use.
 - `metadata.MetadataStore` in `database/plugin/metadata/store.go` is the
   compatibility composition of the SQL-facing capabilities. New components
   should accept the narrowest one they use rather than the composition.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -29,6 +29,16 @@ the currently installed store without a pin, for callers that only need to
 identify, wrap, or ask a whole-store question of it; it must be used within the
 call that obtained it.
 
+Partial-commit recovery depends on the same "never closes" rule. When a commit
+returns `types.ErrPartialCommit` the blob transaction has committed and the
+metadata has not; the transaction releases its pin as it finishes, and the
+recovery that trims the blob store back to the metadata tip runs later, from
+the caller, against the store installed at that point. No pin spans that gap,
+because recovery is caller-scheduled and unbounded and holding one would block
+`drain` indefinitely. The replaced store must therefore stay open and reachable
+until recovery has run, which is what wrapping rather than retiring it
+achieves.
+
 The Badger provider threads the host's stop context through its close path.
 Stopping periodic value-log GC prevents a successful rewrite from starting a
 second pass. Badger does not expose cancellation for a rewrite already in

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -18,13 +18,16 @@ the store they pinned: a `Txn` pins the blob store it opened on for its whole
 lifetime and exposes it as `Txn.BlobStore()`, and blob work outside a
 transaction brackets itself with `Database.PinBlob`. The drain func returns
 once every operation pinned on the replaced store has finished, which is the
-point at which that store may be closed — `SetBlobStore` never closes it. The
-two production callers (`node.go` and `node_lifecycle.go`, the latter on the
-live reconfigure path) install a `bark.BlobStoreBark` wrapper over the store
-they were handed and keep it alive inside the wrapper, so they have nothing to
-drain. `Database.Blob()` returns the currently installed store without a pin,
-for callers that only need to identify, wrap, or ask a whole-store question of
-it; it must be used within the call that obtained it.
+point at which that store may be closed — `SetBlobStore` never closes it, and a
+caller that intends to close the replaced store must not install it again
+before drain returns, because a second installation of the same store counts
+its pins separately. The two production callers (`node.go` and
+`node_lifecycle.go`, the latter on the live reconfigure path) install a
+`bark.BlobStoreBark` wrapper over the store they were handed and keep it alive
+inside the wrapper, so they have nothing to drain. `Database.Blob()` returns
+the currently installed store without a pin, for callers that only need to
+identify, wrap, or ask a whole-store question of it; it must be used within the
+call that obtained it.
 
 The Badger provider threads the host's stop context through its close path.
 Stopping periodic value-log GC prevents a successful rewrite from starting a
@@ -260,6 +263,7 @@ The Go model `models.Block` has `TableName() == "block"`, but it is not migrated
 Use the Go APIs when code runs inside Dingo:
 
 - `database.Database` in `database/database.go` owns both stores and exposes `Blob()`, `PinBlob()`, `SetBlobStore()`, `Metadata()`, `Transaction()`, `BlobTxn()`, `MetadataTxn()`, `StorageMode()`, and `Close()`. `Blob()`, `PinBlob()`, and `SetBlobStore()` are the only readers and writer of the installed blob store; see "Storage provider ownership" for the pin/drain rules that make replacement safe.
+- `database.CborCache()` returns the `TieredCborCache`. Its cold-path entry points `ResolveUtxoCbor(txId, outputIdx, txn ...*Txn)` and `ResolveTxCbor(txn *Txn, txHash)` take the database transaction, not a bare `types.Txn` handle: an optional transaction makes uncommitted writes visible, and the cold read has to run against the store that transaction was opened on rather than whichever store is installed when the resolve happens.
 - `database.Txn` in `database/txn.go` coordinates sibling metadata/blob transactions. Write commits update commit timestamps in both stores, commit the blob transaction first, then commit metadata. `Txn.BlobStore()` returns the blob store the transaction was opened on — the store its `Blob()` handle belongs to, and the one every blob call inside the transaction must use.
 - `metadata.MetadataStore` in `database/plugin/metadata/store.go` is the
   compatibility composition of the SQL-facing capabilities. New components

--- a/database/batch.go
+++ b/database/batch.go
@@ -193,7 +193,7 @@ func (d *Database) SetTransactionBatchedWithOpts(
 		}()
 	}
 
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}

--- a/database/blob_iterator.go
+++ b/database/blob_iterator.go
@@ -178,7 +178,8 @@ func (it *BlobBlockIterator) Close() {
 // fetchBatch retrieves the next batch of block keys from the blob store.
 // Must be called with it.mu held.
 func (it *BlobBlockIterator) fetchBatch() error {
-	blob := it.db.Blob()
+	blob, releaseBlob := it.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -297,7 +298,8 @@ func (it *BlobBlockIterator) fetchBlock(
 	slot uint64,
 	hash []byte,
 ) ([]byte, types.BlockMetadata, error) {
-	blob := it.db.Blob()
+	blob, releaseBlob := it.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return nil, types.BlockMetadata{}, types.ErrBlobStoreUnavailable
 	}

--- a/database/blob_iterator.go
+++ b/database/blob_iterator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -61,6 +62,18 @@ type BlobBlockIterator struct {
 	// resumeKey is the blob key to seek past when fetching the next batch.
 	// nil means start from the beginning (or from startSlot).
 	resumeKey []byte
+
+	// batchStore is the blob store batch's keys were scanned from, and
+	// batchRelease the pin that keeps that store usable until the batch
+	// has been consumed. Every entry in batch is read back through
+	// batchStore, so the scan that found a key and the read that fetches
+	// its CBOR can never land on two different installations: a
+	// SetBlobStore in between would otherwise make a block that exists in
+	// the scanned store look absent in the new one, and NextRaw skips a
+	// missing block with a warning rather than reporting it. Both fields
+	// are set and cleared together, under mu.
+	batchStore   blob.BlobStore
+	batchRelease func()
 }
 
 // BlocksFromSlot returns an iterator that yields blocks starting from
@@ -111,6 +124,9 @@ func (it *BlobBlockIterator) NextRaw() (*BlobBlockResult, error) {
 		// Refill batch if needed
 		if it.batchIdx >= len(it.batch) {
 			if it.exhausted {
+				// Nothing left to read through the batch's
+				// store, so stop holding it open.
+				it.releaseBatchPinLocked()
 				return nil, nil
 			}
 			if err := it.fetchBatch(); err != nil {
@@ -118,6 +134,7 @@ func (it *BlobBlockIterator) NextRaw() (*BlobBlockResult, error) {
 			}
 			if len(it.batch) == 0 {
 				it.exhausted = true
+				it.releaseBatchPinLocked()
 				return nil, nil
 			}
 		}
@@ -173,24 +190,54 @@ func (it *BlobBlockIterator) Close() {
 	it.closed = true
 	it.batch = nil
 	it.resumeKey = nil
+	it.releaseBatchPinLocked()
+}
+
+// releaseBatchPinLocked drops the pin held for the current batch, if any.
+// The fields are cleared before the pin is released, so a repeat call is a
+// no-op rather than an unmatched WaitGroup.Done -- which matters because
+// both Close (idempotent by contract) and the exhaustion paths in NextRaw
+// call it. Callers must hold it.mu.
+func (it *BlobBlockIterator) releaseBatchPinLocked() {
+	if it.batchRelease == nil {
+		return
+	}
+	release := it.batchRelease
+	it.batchRelease = nil
+	it.batchStore = nil
+	release()
 }
 
 // fetchBatch retrieves the next batch of block keys from the blob store.
 // Must be called with it.mu held.
 func (it *BlobBlockIterator) fetchBatch() error {
-	blob, releaseBlob := it.db.PinBlob()
-	defer releaseBlob()
-	if blob == nil {
+	// The previous batch is about to be replaced, so the store it was
+	// scanned from is no longer needed. The new pin is held past this
+	// function, until the batch it scans has been consumed.
+	it.releaseBatchPinLocked()
+	store, releaseBlob := it.db.PinBlob()
+	if store == nil {
+		releaseBlob()
 		return types.ErrBlobStoreUnavailable
 	}
+	it.batchStore = store
+	it.batchRelease = releaseBlob
+	// A batch that is never produced has nothing to read back, so every
+	// error return below drops the pin it just took.
+	scanned := false
+	defer func() {
+		if !scanned {
+			it.releaseBatchPinLocked()
+		}
+	}()
 
-	txn := blob.NewTransaction(false)
+	txn := store.NewTransaction(false)
 	defer txn.Rollback() //nolint:errcheck
 
 	iterOpts := types.BlobIteratorOptions{
 		Prefix: []byte(types.BlockBlobKeyPrefix),
 	}
-	blobIter := blob.NewIterator(txn, iterOpts)
+	blobIter := store.NewIterator(txn, iterOpts)
 	if blobIter == nil {
 		return errors.New("blob iterator is nil")
 	}
@@ -289,6 +336,7 @@ func (it *BlobBlockIterator) fetchBatch() error {
 		it.exhausted = true
 	}
 
+	scanned = true
 	return nil
 }
 
@@ -298,16 +346,17 @@ func (it *BlobBlockIterator) fetchBlock(
 	slot uint64,
 	hash []byte,
 ) ([]byte, types.BlockMetadata, error) {
-	blob, releaseBlob := it.db.PinBlob()
-	defer releaseBlob()
-	if blob == nil {
+	// The store this batch's keys came from, held by the batch's own pin
+	// -- not whichever store is installed now. See batchStore.
+	store := it.batchStore
+	if store == nil {
 		return nil, types.BlockMetadata{}, types.ErrBlobStoreUnavailable
 	}
 
-	txn := blob.NewTransaction(false)
+	txn := store.NewTransaction(false)
 	defer txn.Rollback() //nolint:errcheck
 
-	return blob.GetBlock(txn, slot, hash)
+	return store.GetBlock(txn, slot, hash)
 }
 
 // buildSlotSeekKey constructs a blob key prefix for seeking to a specific slot.

--- a/database/blob_orphan_test.go
+++ b/database/blob_orphan_test.go
@@ -27,7 +27,7 @@ import (
 
 func newBlobOrphanTestDB(store *mockBlobStore) *Database {
 	return &Database{
-		blob: store,
+		blobRef: newBlobStoreRef(store),
 		logger: slog.New(
 			slog.NewJSONHandler(
 				io.Discard,
@@ -114,7 +114,7 @@ func TestDeleteTxBlobsCountsNoOrphansOnSuccess(t *testing.T) {
 // it, so the condition is visible rather than a silent no-op.
 func TestDeleteUtxoBlobsWithoutBlobStoreIsReported(t *testing.T) {
 	db := newBlobOrphanTestDB(nil)
-	db.blob = nil
+	db.SetBlobStore(nil)
 
 	err := deleteUtxoBlobs(db, []models.Utxo{
 		{TxId: []byte{0x04}, OutputIdx: 0},
@@ -131,11 +131,11 @@ func TestDeleteUtxoBlobsWithoutBlobStoreIsReported(t *testing.T) {
 // strands anything.
 func TestBlobOrphansAreNotCountedUntilMetadataCommits(t *testing.T) {
 	db := openTestDB(t)
-	db.blob = &mockBlobStore{
+	db.SetBlobStore(&mockBlobStore{
 		deleteUtxoErrs: map[string]error{
 			"05:0": errors.New("blob store unavailable"),
 		},
-	}
+	})
 	txn := db.Transaction(true)
 	before := BlobOrphanCount()
 
@@ -157,11 +157,11 @@ func TestBlobOrphansAreNotCountedUntilMetadataCommits(t *testing.T) {
 // reachable and must not be counted.
 func TestBlobOrphansAreNotCountedOnRollback(t *testing.T) {
 	db := openTestDB(t)
-	db.blob = &mockBlobStore{
+	db.SetBlobStore(&mockBlobStore{
 		deleteTxErrs: map[string]error{
 			string([]byte{0xDD}): errors.New("blob store unavailable"),
 		},
-	}
+	})
 	txn := db.Transaction(true)
 	before := BlobOrphanCount()
 

--- a/database/blob_store.go
+++ b/database/blob_store.go
@@ -54,6 +54,18 @@ import (
 //     wrap the previous store rather than retiring it, and closing a store
 //     still reachable through a wrapper would break the wrapper.
 //
+//   - One consequence of "never closes" is load-bearing beyond drain.
+//     Txn.Commit's partial-commit path (types.ErrPartialCommit: the blob
+//     transaction committed, the metadata did not) releases the Txn's pin
+//     when the transaction finishes, but the recovery that trims the blob
+//     store back to the metadata tip runs later and from the caller —
+//     LedgerState.RecoverCommitTimestampConflict — against the store
+//     installed at that point. The pin is deliberately not held across that
+//     gap: recovery is caller-scheduled and unbounded, so holding one would
+//     block drain for as long as recovery is pending. What makes the gap
+//     safe is that the replaced store stays open and stays reachable, since
+//     the wrapper installed over it forwards to it.
+//
 // Blob returns the currently installed store without a pin. It is the
 // accessor for callers that only need to identify, wrap, or ask a
 // whole-store question of the current store (bark wrapping it, a DiskSize

--- a/database/blob_store.go
+++ b/database/blob_store.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"sync"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+)
+
+// Blob-store ownership, locking, and replacement.
+//
+// A Database holds a reference to a blob store; the store itself is owned by
+// whoever constructed it (the plugin host — see New's doc comment). The
+// reference can be replaced while the database is live: node.go and
+// node_lifecycle.go wrap the installed store in a bark archive client and
+// install the wrapper with SetBlobStore, the latter on the running-node
+// reconfigure path.
+//
+// One strategy covers every reader in this package:
+//
+//   - blobMu guards Database.blobRef. Nothing reads or writes the field
+//     directly; Blob and pinBlobStore are the only readers, SetBlobStore the
+//     only writer.
+//
+//   - An operation that does blob work pins the store it works on and works
+//     on exactly that store for the whole operation. A Txn pins at
+//     construction and releases when it reaches Commit, Rollback, or
+//     Release, and Txn.BlobStore returns the store it pinned — so a store
+//     and the types.Txn opened on it can never come from two different
+//     installations, which a bare "read the field again later" would allow.
+//     Code that touches the blob store outside a Txn brackets the operation
+//     with PinBlob and the release func it returns.
+//
+//   - SetBlobStore installs the new reference and hands back the replaced
+//     store together with a drain func. The replaced store may be closed
+//     once drain returns: every operation that pinned it has finished, and
+//     no new one can pin it because the reference it would have come from is
+//     already gone. Until then the previous store must stay open, because an
+//     operation that pinned it before the swap is still using it.
+//     SetBlobStore never closes anything itself — the two production callers
+//     wrap the previous store rather than retiring it, and closing a store
+//     still reachable through a wrapper would break the wrapper.
+//
+// Blob returns the currently installed store without a pin. It is the
+// accessor for callers that only need to identify, wrap, or ask a
+// whole-store question of the current store (bark wrapping it, a DiskSize
+// gauge, a Backuper type assertion); its result must be used within the call
+// that obtained it and must not be retained. Callers doing blob work across
+// several calls use a Txn (which pins) or PinBlob, so that drain's guarantee
+// covers them.
+
+// blobStoreRef is one installed blob store plus the set of operations
+// currently pinning it. A replacement retires the whole ref rather than
+// mutating it, so a pin taken before the swap keeps naming the store it was
+// taken on.
+type blobStoreRef struct {
+	store blob.BlobStore
+	// users counts the operations holding a pin on store.
+	//
+	// sync.WaitGroup requires that an Add which raises the counter from
+	// zero happen before a concurrent Wait. That holds here without extra
+	// care: every Add runs under blobMu.RLock, and SetBlobStore takes
+	// blobMu for writing before it can hand this ref's Wait to anyone, so
+	// every Add on a retired ref happened before the swap that retired it,
+	// and no Add can start afterwards.
+	users sync.WaitGroup
+}
+
+// newBlobStoreRef wraps store in a fresh, unpinned ref.
+func newBlobStoreRef(store blob.BlobStore) *blobStoreRef {
+	return &blobStoreRef{store: store}
+}
+
+// blobStore returns the referenced store. It tolerates a nil receiver so
+// callers can pin unconditionally and nil-check the store, matching how the
+// package already treats an absent blob store (types.ErrBlobStoreUnavailable)
+// rather than a missing database.
+func (r *blobStoreRef) blobStore() blob.BlobStore {
+	if r == nil {
+		return nil
+	}
+	return r.store
+}
+
+// release drops one pin taken by pinBlobStore. It must be called exactly
+// once per pin: a second call is an unmatched WaitGroup.Done and panics, the
+// same contract sync.WaitGroup itself has.
+func (r *blobStoreRef) release() {
+	if r == nil {
+		return
+	}
+	r.users.Done()
+}
+
+// pinBlobStore pins the currently installed blob store. The returned ref must
+// be released exactly once, and stays valid (naming the same store) until it
+// is, even across a concurrent SetBlobStore.
+func (d *Database) pinBlobStore() *blobStoreRef {
+	d.blobMu.RLock()
+	defer d.blobMu.RUnlock()
+	ref := d.blobRef
+	if ref != nil {
+		ref.users.Add(1)
+	}
+	return ref
+}
+
+// PinBlob pins the currently installed blob store for the duration of one
+// operation and returns it alongside the func that releases the pin. Call the
+// release func exactly once, normally with defer:
+//
+//	store, release := db.PinBlob()
+//	defer release()
+//	if store == nil {
+//		return types.ErrBlobStoreUnavailable
+//	}
+//
+// A concurrent SetBlobStore's drain does not return while the pin is held, so
+// the store cannot be closed out from under the operation. Work that already
+// runs inside a database Txn does not need this — the Txn holds a pin for its
+// whole lifetime and Txn.BlobStore returns the store it pinned.
+func (d *Database) PinBlob() (blob.BlobStore, func()) {
+	ref := d.pinBlobStore()
+	return ref.blobStore(), ref.release
+}
+
+// Blob returns the currently installed blob store without pinning it. See the
+// ownership notes at the top of this file: use the returned store within the
+// call that obtained it, and use a Txn or PinBlob for anything longer.
+func (d *Database) Blob() blob.BlobStore {
+	d.blobMu.RLock()
+	defer d.blobMu.RUnlock()
+	return d.blobRef.blobStore()
+}
+
+// SetBlobStore installs b as the database's blob store and returns the store
+// it replaced along with a drain func.
+//
+// Operations already in flight keep running against the store they pinned;
+// operations started after this call get b. drain blocks until every
+// operation pinned on the replaced store has finished, which is the point at
+// which prev may be closed — nothing can reach it afterwards. A caller that
+// keeps prev alive (the bark wrapper in node.go and node_lifecycle.go wraps
+// the store it was handed and forwards Close to it) has nothing to drain and
+// may ignore both results; SetBlobStore itself never closes prev.
+//
+// drain is never nil, so it is always safe to call.
+func (d *Database) SetBlobStore(
+	b blob.BlobStore,
+) (prev blob.BlobStore, drain func()) {
+	next := newBlobStoreRef(b)
+	d.blobMu.Lock()
+	old := d.blobRef
+	d.blobRef = next
+	d.blobMu.Unlock()
+	if old == nil {
+		return nil, func() {}
+	}
+	return old.store, old.users.Wait
+}

--- a/database/blob_store.go
+++ b/database/blob_store.go
@@ -137,6 +137,28 @@ func (d *Database) PinBlob() (blob.BlobStore, func()) {
 	return ref.blobStore(), ref.release
 }
 
+// pinBlobForTxn returns the blob store an operation must run against, together
+// with the func that releases whatever pin it took.
+//
+// A transaction that already holds a blob handle pinned its store at
+// construction, and that handle means nothing to any other store. Pinning
+// whichever store is installed now would pair a handle from one installation
+// with a store from another -- the pairing the notes at the top of this file
+// exist to rule out -- so an operation handed such a transaction uses the
+// transaction's store. The transaction's own pin keeps that store alive for as
+// long as its caller holds the transaction open, so no second pin is taken and
+// the returned release func is a no-op. With no transaction, or one that opened
+// no blob handle, the operation is not attached to an installation yet and pins
+// the installed store like any other PinBlob caller.
+func (d *Database) pinBlobForTxn(txn *Txn) (blob.BlobStore, func()) {
+	if txn != nil && txn.Blob() != nil {
+		if store := txn.BlobStore(); store != nil {
+			return store, func() {}
+		}
+	}
+	return d.PinBlob()
+}
+
 // Blob returns the currently installed blob store without pinning it. See the
 // ownership notes at the top of this file: use the returned store within the
 // call that obtained it, and use a Txn or PinBlob for anything longer.
@@ -156,6 +178,15 @@ func (d *Database) Blob() blob.BlobStore {
 // keeps prev alive (the bark wrapper in node.go and node_lifecycle.go wraps
 // the store it was handed and forwards Close to it) has nothing to drain and
 // may ignore both results; SetBlobStore itself never closes prev.
+//
+// drain covers the reference this call retires, which is the only route by
+// which prev can still be reached: the pins taken on it before the swap, and no
+// new ones. Installing prev again before drain returns creates a second
+// reference to the same store whose pins are counted separately, so drain would
+// then report only the first reference as idle while the second is in use. A
+// caller that intends to close prev must therefore not re-install it -- install
+// a fresh store, or drain before re-installing. Neither production caller
+// closes prev at all, so neither can reach that case.
 //
 // drain is never nil, so it is always safe to call.
 func (d *Database) SetBlobStore(

--- a/database/blob_store_id.go
+++ b/database/blob_store_id.go
@@ -34,9 +34,17 @@ var blobStoreIDKey = []byte("nodesettings/storeid")
 // alarms while still missing the case this guards, which is a metadata store
 // paired with a blob store it was never initialised with.
 func (d *Database) blobStoreID() (string, error) {
-	readTxn := d.Blob().NewTransaction(false)
+	// One pin for the whole mint: the read, the write, and the Sync that
+	// makes the write durable all have to hit the same store, and that
+	// store has to stay open until the Sync returns.
+	store, releaseBlob := d.PinBlob()
+	defer releaseBlob()
+	if store == nil {
+		return "", types.ErrBlobStoreUnavailable
+	}
+	readTxn := store.NewTransaction(false)
 	defer func() { _ = readTxn.Rollback() }()
-	existing, err := d.Blob().Get(readTxn, blobStoreIDKey)
+	existing, err := store.Get(readTxn, blobStoreIDKey)
 	switch {
 	case err == nil && len(existing) > 0:
 		return string(existing), nil
@@ -44,8 +52,8 @@ func (d *Database) blobStoreID() (string, error) {
 		return "", fmt.Errorf("read blob store id: %w", err)
 	}
 	minted := uuid.NewString()
-	writeTxn := d.Blob().NewTransaction(true)
-	if err := d.Blob().Set(writeTxn, blobStoreIDKey, []byte(minted)); err != nil {
+	writeTxn := store.NewTransaction(true)
+	if err := store.Set(writeTxn, blobStoreIDKey, []byte(minted)); err != nil {
 		_ = writeTxn.Rollback()
 		return "", fmt.Errorf("mint blob store id: %w", err)
 	}
@@ -63,7 +71,7 @@ func (d *Database) blobStoreID() (string, error) {
 	// metadata commit that depends on it. Losing this specific key after the
 	// gate has already latched is permanent: the next startup mints a new
 	// id, which can never match the Frozen gate again.
-	if err := d.Blob().Sync(); err != nil {
+	if err := store.Sync(); err != nil {
 		return "", fmt.Errorf("sync blob store id: %w", err)
 	}
 	return minted, nil

--- a/database/blob_store_id_test.go
+++ b/database/blob_store_id_test.go
@@ -177,7 +177,7 @@ func TestBlobStoreIDMismatchIsFatal(t *testing.T) {
 // applies to combined commits.
 func TestBlobStoreIDSyncsAfterMint(t *testing.T) {
 	store := &mockBlobStore{}
-	db := &Database{blob: store}
+	db := &Database{blobRef: newBlobStoreRef(store)}
 
 	id, err := db.blobStoreID()
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestPhase1RejectsBlobStoreIDReadFailure(t *testing.T) {
 	readErr := errors.New("simulated corrupted blob store read")
 	store := &mockBlobStore{getErr: readErr}
 	db := &Database{
-		blob: store,
+		blobRef: newBlobStoreRef(store),
 		config: &Config{
 			StorageMode: "core",
 			Network:     "preprod",
@@ -221,7 +221,7 @@ func TestPhase1RejectsBlobStoreIDReadFailure(t *testing.T) {
 func TestBlobStoreIDSyncFailurePropagates(t *testing.T) {
 	syncErr := errors.New("simulated sync failure")
 	store := &mockBlobStore{syncErr: syncErr}
-	db := &Database{blob: store}
+	db := &Database{blobRef: newBlobStoreRef(store)}
 
 	_, err := db.blobStoreID()
 	require.ErrorIs(t, err, syncErr)

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -397,6 +397,7 @@ func TestResolveUtxoCborUsesTransactionStore(t *testing.T) {
 	copy(txId, []byte("resolve-utxo-pairing-txid"))
 	want := []byte{0x82, 0x03, 0x04}
 	writeTxn := db.BlobTxn(true)
+	t.Cleanup(writeTxn.Release)
 	require.NoError(t, base.SetUtxo(writeTxn.Blob(), txId, 0, want))
 	require.NoError(t, writeTxn.Commit())
 

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
@@ -416,5 +417,75 @@ func TestResolveUtxoCborUsesTransactionStore(t *testing.T) {
 		t,
 		replacement.getUtxo.Load(),
 		"ResolveUtxoCbor ran the transaction's handle through the store installed after it was opened",
+	)
+}
+
+// missingBlockBlobStore is a passthrough whose GetBlock always reports the
+// block absent. Installing one stands in for a replacement that does not
+// contain what the store it replaced did.
+type missingBlockBlobStore struct {
+	blob.BlobStore
+}
+
+func (s *missingBlockBlobStore) GetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	return nil, types.BlockMetadata{}, types.ErrBlobKeyNotFound
+}
+
+// TestBlobIteratorKeepsBatchStoreAcrossReplacement covers the iterator's half
+// of the pairing rule. BlobBlockIterator scans a batch of block keys from one
+// store and then reads each block's CBOR back in a later call, so the scan and
+// the reads have to run against the same store: NextRaw treats a block whose
+// CBOR is missing as skippable and logs a warning, so a replacement between
+// the two would drop blocks from the iteration silently rather than failing.
+func TestBlobIteratorKeepsBatchStoreAcrossReplacement(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	// Fewer than blobIteratorBatchSize blocks, so the whole iteration is
+	// served by one batch and one scan.
+	slots := []uint64{10, 20, 30, 40, 50}
+	for _, slot := range slots {
+		hash := make([]byte, 32)
+		hash[0] = byte(slot)
+		require.NoError(t, db.BlockCreate(models.Block{
+			Slot: slot,
+			Hash: hash,
+			Cbor: []byte{0x82, byte(slot), 0x01},
+			Type: 1,
+		}, nil))
+	}
+
+	iter := db.BlocksFromSlot(0)
+	t.Cleanup(iter.Close)
+
+	// The first call scans the batch, pinning the store it scanned.
+	first, err := iter.NextRaw()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, slots[0], first.Slot)
+
+	db.SetBlobStore(&missingBlockBlobStore{BlobStore: base})
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	var got []uint64
+	for {
+		next, nextErr := iter.NextRaw()
+		require.NoError(t, nextErr)
+		if next == nil {
+			break
+		}
+		got = append(got, next.Slot)
+	}
+	require.Equal(
+		t,
+		slots[1:],
+		got,
+		"blocks scanned before the replacement must still be read from the store they were scanned in",
 	)
 }

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -17,10 +17,12 @@ package database
 import (
 	"bytes"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -190,6 +192,10 @@ func TestSetBlobStoreDrainWaitsForOpenTransaction(t *testing.T) {
 	// A transaction opened after the replacement uses the new store, so it
 	// cannot be what keeps drain waiting.
 	afterTxn := db.BlobTxn(false)
+	// Release is idempotent (Rollback returns early once the transaction is
+	// finished), so registering it here as well as calling it below keeps
+	// the pin from outliving a failure of the require in between.
+	t.Cleanup(afterTxn.Release)
 	require.True(
 		t,
 		afterTxn.BlobStore() == blob.BlobStore(replacement),
@@ -308,4 +314,104 @@ func TestTxnKeepsBlobStoreAcrossReplacement(t *testing.T) {
 	got, err := readTxn.BlobStore().Get(readTxn.Blob(), key)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
+}
+
+// pairingProbeBlobStore is a passthrough that counts the reads which reach it.
+// A read that lands here came from the store installed *now*, so a test that
+// opens a transaction on one store and then installs this one can tell whether
+// an operation ran the transaction's handle through the wrong store.
+type pairingProbeBlobStore struct {
+	blob.BlobStore
+	getTx   atomic.Int64
+	getUtxo atomic.Int64
+}
+
+func (s *pairingProbeBlobStore) GetTx(
+	txn types.Txn,
+	txHash []byte,
+) ([]byte, error) {
+	s.getTx.Add(1)
+	return s.BlobStore.GetTx(txn, txHash)
+}
+
+func (s *pairingProbeBlobStore) GetUtxo(
+	txn types.Txn,
+	txId []byte,
+	outputIdx uint32,
+) ([]byte, error) {
+	s.getUtxo.Add(1)
+	return s.BlobStore.GetUtxo(txn, txId, outputIdx)
+}
+
+// TestResolveTxCborUsesTransactionStore covers the cold path of the CBOR cache
+// against the same pairing rule the rest of the package follows. ResolveTxCbor
+// takes the caller's transaction so uncommitted writes are visible, and that
+// transaction's handle belongs to the store it was opened on. Pinning the
+// installed store instead would send that handle into a store replaced in
+// between, which is what this test forbids.
+func TestResolveTxCborUsesTransactionStore(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	var txHash [32]byte
+	copy(txHash[:], []byte("resolve-tx-pairing-hash"))
+	// Raw CBOR rather than an offset record, so the resolve returns after
+	// the single GetTx this test is measuring.
+	want := []byte{0x82, 0x01, 0x02}
+	writeTxn := db.BlobTxn(true)
+	require.NoError(t, base.SetTx(writeTxn.Blob(), txHash[:], want))
+	require.NoError(t, writeTxn.Commit())
+
+	txn := db.BlobTxn(false)
+	t.Cleanup(txn.Release)
+	require.True(t, txn.BlobStore() == base)
+
+	replacement := &pairingProbeBlobStore{BlobStore: base}
+	db.SetBlobStore(replacement)
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	got, err := db.CborCache().ResolveTxCbor(txn, txHash[:])
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Zero(
+		t,
+		replacement.getTx.Load(),
+		"ResolveTxCbor ran the transaction's handle through the store installed after it was opened",
+	)
+}
+
+// TestResolveUtxoCborUsesTransactionStore is the same contract for the UTxO
+// entry point, which loadCbor reaches with the transaction validation is
+// running under.
+func TestResolveUtxoCborUsesTransactionStore(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	txId := make([]byte, 32)
+	copy(txId, []byte("resolve-utxo-pairing-txid"))
+	want := []byte{0x82, 0x03, 0x04}
+	writeTxn := db.BlobTxn(true)
+	require.NoError(t, base.SetUtxo(writeTxn.Blob(), txId, 0, want))
+	require.NoError(t, writeTxn.Commit())
+
+	txn := db.BlobTxn(false)
+	t.Cleanup(txn.Release)
+	require.True(t, txn.BlobStore() == base)
+
+	replacement := &pairingProbeBlobStore{BlobStore: base}
+	db.SetBlobStore(replacement)
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	got, err := db.CborCache().ResolveUtxoCbor(txId, 0, txn)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Zero(
+		t,
+		replacement.getUtxo.Load(),
+		"ResolveUtxoCbor ran the transaction's handle through the store installed after it was opened",
+	)
 }

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// passthroughBlobStore forwards every call to the store it wraps. Installing
+// one changes the identity of the database's blob store without changing what
+// any operation observes, which is the shape of the real replacement in
+// node.go and node_lifecycle.go: bark.NewBarkBlobStore wraps the store already
+// installed, and the wrapper is then handed to SetBlobStore.
+type passthroughBlobStore struct {
+	blob.BlobStore
+}
+
+// noReceiveWindow is how long the drain tests wait before concluding that a
+// drain that must not have returned has in fact not returned. It only bounds a
+// negative assertion, so it trades test runtime against confidence, not
+// correctness — a drain that is genuinely stuck stays stuck.
+const noReceiveWindow = 100 * time.Millisecond
+
+// drainAsync runs drain on its own goroutine and returns a channel closed when
+// it returns.
+func drainAsync(drain func()) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		drain()
+		close(done)
+	}()
+	return done
+}
+
+// TestSetBlobStoreConcurrentWithReaders is the regression test for the
+// unsynchronized Database.blob field. Readers call the accessor, open
+// transactions (which read the installed store to open the underlying blob
+// transaction), and perform real blob reads while another goroutine replaces
+// the store. Against the unsynchronized field this reports a DATA RACE between
+// SetBlobStore's write and every one of those reads.
+//
+// It also covers the "preserve correct behavior" criterion: every read must
+// still return the value written before the replacement started, because each
+// installed store resolves to the same underlying badger store.
+func TestSetBlobStoreConcurrentWithReaders(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+	// Restore the original store before the test database is torn down, so
+	// cleanup never runs against a wrapper left installed by the writer.
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	key := []byte("blob-store-sync-test-key")
+	want := []byte("blob-store-sync-test-value")
+	writeTxn := db.BlobTxn(true)
+	require.NoError(t, base.Set(writeTxn.Blob(), key, want))
+	require.NoError(t, writeTxn.Commit())
+
+	const iterations = 100
+	const readers = 4
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				// Bare accessor read.
+				if store := db.Blob(); store == nil {
+					t.Error("Blob() returned nil during replacement")
+					return
+				}
+				// Transaction construction reads the installed store to
+				// open the underlying blob transaction, and BlobStore
+				// hands back exactly that store.
+				blobTxn := db.BlobTxn(false)
+				store := blobTxn.BlobStore()
+				if store == nil {
+					t.Error("BlobStore() returned nil during replacement")
+					blobTxn.Release()
+					return
+				}
+				got, getErr := store.Get(blobTxn.Blob(), key)
+				if getErr != nil {
+					t.Errorf("blob get during replacement: %v", getErr)
+					blobTxn.Release()
+					return
+				}
+				if !bytes.Equal(got, want) {
+					t.Errorf(
+						"blob get during replacement: got %q, want %q",
+						got,
+						want,
+					)
+					blobTxn.Release()
+					return
+				}
+				blobTxn.Release()
+				// A combined transaction reads the installed store too.
+				txn := db.Transaction(false)
+				txn.Release()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range iterations {
+			if i%2 == 0 {
+				db.SetBlobStore(&passthroughBlobStore{BlobStore: base})
+			} else {
+				db.SetBlobStore(base)
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
+// TestSetBlobStoreDrainWaitsForOpenTransaction pins down the close policy: the
+// replaced store may be closed once drain returns, and not before. A
+// transaction opened before the replacement is still using the store it opened
+// on, so drain must not return while it is open — and a transaction opened
+// after the replacement runs against the new store and must not hold the old
+// one open.
+func TestSetBlobStoreDrainWaitsForOpenTransaction(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	txn := db.BlobTxn(false)
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			txn.Release()
+		}
+	}
+	t.Cleanup(release)
+
+	replacement := &passthroughBlobStore{BlobStore: base}
+	prev, drain := db.SetBlobStore(replacement)
+	t.Cleanup(func() { db.SetBlobStore(base) })
+	require.NotNil(t, drain)
+	require.True(
+		t,
+		prev == base,
+		"SetBlobStore must return the store it replaced",
+	)
+	require.True(
+		t,
+		db.Blob() == blob.BlobStore(replacement),
+		"the new store must be installed immediately",
+	)
+
+	drained := drainAsync(drain)
+	testutil.RequireNoReceive(
+		t,
+		drained,
+		noReceiveWindow,
+		"drain returned while a transaction on the previous store was open",
+	)
+
+	// A transaction opened after the replacement uses the new store, so it
+	// cannot be what keeps drain waiting.
+	afterTxn := db.BlobTxn(false)
+	require.True(
+		t,
+		afterTxn.BlobStore() == blob.BlobStore(replacement),
+		"a transaction opened after the replacement must use the new store",
+	)
+	afterTxn.Release()
+	testutil.RequireNoReceive(
+		t,
+		drained,
+		noReceiveWindow,
+		"drain returned before the transaction on the previous store ended",
+	)
+
+	release()
+	testutil.RequireReceive(
+		t,
+		drained,
+		5*time.Second,
+		"drain did not return once the previous store had no users left",
+	)
+}
+
+// TestSetBlobStoreDrainWaitsForPinBlob is the same contract for blob work that
+// runs outside a transaction, which is what PinBlob exists for.
+func TestSetBlobStoreDrainWaitsForPinBlob(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	pinned, releasePin := db.PinBlob()
+	require.True(t, pinned == base)
+
+	_, drain := db.SetBlobStore(&passthroughBlobStore{BlobStore: base})
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	drained := drainAsync(drain)
+	testutil.RequireNoReceive(
+		t,
+		drained,
+		noReceiveWindow,
+		"drain returned while a PinBlob pin on the previous store was held",
+	)
+
+	releasePin()
+	testutil.RequireReceive(
+		t,
+		drained,
+		5*time.Second,
+		"drain did not return after the pin was released",
+	)
+}
+
+// TestSetBlobStoreDrainReturnsWhenIdle is the negative case for the two tests
+// above: with nothing pinning the replaced store, drain must not block, so a
+// caller that wants to close the previous store is never made to wait for work
+// that is not there.
+func TestSetBlobStoreDrainReturnsWhenIdle(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	_, drain := db.SetBlobStore(&passthroughBlobStore{BlobStore: base})
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	testutil.RequireReceive(
+		t,
+		drainAsync(drain),
+		5*time.Second,
+		"drain blocked with nothing pinning the previous store",
+	)
+}
+
+// TestTxnKeepsBlobStoreAcrossReplacement covers the pairing half of the
+// ownership rule. A transaction's types.Txn handle belongs to the store it was
+// opened on; re-reading the database's installed store mid-transaction could
+// pair that handle with a different store. BlobStore must keep naming the
+// original, and the transaction must still commit correctly through it.
+func TestTxnKeepsBlobStoreAcrossReplacement(t *testing.T) {
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+
+	txn := db.Transaction(true)
+	defer txn.Release()
+	require.True(t, txn.BlobStore() == base)
+
+	replacement := &passthroughBlobStore{BlobStore: base}
+	_, drain := db.SetBlobStore(replacement)
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	require.True(
+		t,
+		txn.BlobStore() == base,
+		"an open transaction must keep the store it opened on",
+	)
+
+	key := []byte("blob-store-pairing-test-key")
+	want := []byte("blob-store-pairing-test-value")
+	require.NoError(t, txn.BlobStore().Set(txn.Blob(), key, want))
+	require.NoError(t, txn.Commit())
+
+	// Committing is what releases the transaction's pin, so drain must now
+	// complete.
+	testutil.RequireReceive(
+		t,
+		drainAsync(drain),
+		5*time.Second,
+		"drain did not return after the transaction committed",
+	)
+
+	readTxn := db.BlobTxn(false)
+	defer readTxn.Release()
+	got, err := readTxn.BlobStore().Get(readTxn.Blob(), key)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -75,6 +75,7 @@ func TestSetBlobStoreConcurrentWithReaders(t *testing.T) {
 	key := []byte("blob-store-sync-test-key")
 	want := []byte("blob-store-sync-test-value")
 	writeTxn := db.BlobTxn(true)
+	t.Cleanup(writeTxn.Release)
 	require.NoError(t, base.Set(writeTxn.Blob(), key, want))
 	require.NoError(t, writeTxn.Commit())
 
@@ -361,6 +362,7 @@ func TestResolveTxCborUsesTransactionStore(t *testing.T) {
 	// the single GetTx this test is measuring.
 	want := []byte{0x82, 0x01, 0x02}
 	writeTxn := db.BlobTxn(true)
+	t.Cleanup(writeTxn.Release)
 	require.NoError(t, base.SetTx(writeTxn.Blob(), txHash[:], want))
 	require.NoError(t, writeTxn.Commit())
 

--- a/database/block.go
+++ b/database/block.go
@@ -103,7 +103,7 @@ func (d *Database) BlockCreate(block models.Block, txn *Txn) error {
 	if blobTxn == nil {
 		return types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -152,7 +152,7 @@ func (d *Database) SetGenesisCbor(
 	if blobTxn == nil {
 		return types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -192,12 +192,12 @@ func (d *Database) SetGenesisCbor(
 // blob key for the given slot and hash. This is used to validate that
 // existing chain data matches the current genesis configuration.
 func (d *Database) HasGenesisCbor(slot uint64, hash []byte) bool {
-	blob := d.Blob()
+	txn := d.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return false
 	}
-	txn := d.BlobTxn(false)
-	defer txn.Rollback() //nolint:errcheck
 	key := types.BlockBlobKey(slot, hash)
 	_, err := blob.Get(txn.Blob(), key)
 	return err == nil
@@ -208,12 +208,12 @@ func (d *Database) HasGenesisCbor(slot uint64, hash []byte) bool {
 // "no genesis CBOR" (e.g., after Mithril bootstrap) and "genesis CBOR
 // exists but with a different hash" (true network mismatch).
 func (d *Database) HasAnyGenesisCbor(slot uint64) bool {
-	blob := d.Blob()
+	txn := d.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return false
 	}
-	txn := d.BlobTxn(false)
-	defer txn.Rollback() //nolint:errcheck
 	prefix := slices.Concat(
 		[]byte(types.BlockBlobKeyPrefix),
 		types.BlockBlobKeyUint64ToBytes(slot),
@@ -250,7 +250,7 @@ func BlockDeleteTxn(txn *Txn, block models.Block) error {
 	if blobTxn == nil {
 		return types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -281,7 +281,7 @@ func BlockIDByPointLocal(
 	if txn.Blob() == nil {
 		return 0, types.ErrNilTxn
 	}
-	store := db.Blob()
+	store := txn.BlobStore()
 	if store == nil {
 		return 0, types.ErrBlobStoreUnavailable
 	}
@@ -357,7 +357,7 @@ func BlockURL(
 			return types.ErrNilTxn
 		}
 
-		blob := txn.DB().Blob()
+		blob := txn.BlobStore()
 		if blob == nil {
 			return types.ErrBlobStoreUnavailable
 		}
@@ -386,7 +386,7 @@ func blockByKey(txn *Txn, blockKey []byte) (models.Block, error) {
 			"parsing block key: %w", err,
 		)
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
@@ -422,7 +422,7 @@ func BlockByHashTxn(txn *Txn, hash []byte) (models.Block, error) {
 	if blobTxn == nil {
 		return models.Block{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
@@ -474,7 +474,7 @@ func BlockBySlotTxn(txn *Txn, slot uint64) (models.Block, error) {
 	if blobTxn == nil {
 		return models.Block{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
@@ -545,7 +545,7 @@ func (d *Database) blockKeyByIndex(
 	if blobTxn == nil {
 		return nil, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
@@ -616,7 +616,7 @@ func (d *Database) BlockAtOrAfterIndex(
 	if blobTxn == nil {
 		return models.Block{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
@@ -690,7 +690,7 @@ func BlocksRecentTxn(txn *Txn, count int) ([]models.Block, error) {
 	if blobTxn == nil {
 		return ret, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return ret, types.ErrBlobStoreUnavailable
 	}
@@ -756,7 +756,7 @@ func BlockBeforeSlotTxn(txn *Txn, slotNumber uint64) (models.Block, error) {
 	if blobTxn == nil {
 		return models.Block{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return models.Block{}, types.ErrBlobStoreUnavailable
 	}
@@ -827,7 +827,7 @@ func BlocksAfterSlotTxn(txn *Txn, slotNumber uint64) ([]models.Block, error) {
 	if blobTxn == nil {
 		return ret, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return ret, types.ErrBlobStoreUnavailable
 	}
@@ -914,7 +914,7 @@ func (d *Database) CountBlocksAndOldestSlot(
 	if blobTxn == nil {
 		return 0, 0, types.ErrNilTxn
 	}
-	blob := d.Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return 0, 0, types.ErrBlobStoreUnavailable
 	}

--- a/database/block_range.go
+++ b/database/block_range.go
@@ -45,7 +45,7 @@ func ForEachBlockInRange(
 	if blobTxn == nil {
 		return types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -116,8 +116,8 @@ func TestBlockPointByIndexDoesNotReadBlockContent(t *testing.T) {
 	block := testIndexedBlock(42, 7, 0x42)
 	require.NoError(t, db.BlockCreate(block, nil))
 
-	store := &countingBlockReadStore{BlobStore: db.blob}
-	db.blob = store
+	store := &countingBlockReadStore{BlobStore: db.Blob()}
+	db.SetBlobStore(store)
 
 	point, err := db.BlockPointByIndex(block.ID, nil)
 	require.NoError(t, err)
@@ -135,8 +135,8 @@ func TestBlockIDByPointLocalBypassesArchiveFallback(t *testing.T) {
 	block := testIndexedBlock(42, 7, 0x42)
 	require.NoError(t, db.BlockCreate(block, nil))
 
-	store := &localBlockReadStore{BlobStore: db.blob}
-	db.blob = store
+	store := &localBlockReadStore{BlobStore: db.Blob()}
+	db.SetBlobStore(store)
 
 	blockID, err := BlockIDByPointLocal(
 		db,

--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -223,7 +223,8 @@ func (c *TieredCborCache) ResolveUtxoCbor(
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	blob := c.db.Blob()
+	blob, releaseBlob := c.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
@@ -333,7 +334,8 @@ func (c *TieredCborCache) ResolveTxCbor(
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	blob := c.db.Blob()
+	blob, releaseBlob := c.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
@@ -456,7 +458,8 @@ func (c *TieredCborCache) ResolveUtxoCborBatch(
 		return result, types.ErrBlobStoreUnavailable
 	}
 
-	blob := c.db.Blob()
+	blob, releaseBlob := c.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return result, types.ErrBlobStoreUnavailable
 	}
@@ -610,7 +613,8 @@ func (c *TieredCborCache) ResolveTxCborBatch(
 		return result, types.ErrBlobStoreUnavailable
 	}
 
-	blob := c.db.Blob()
+	blob, releaseBlob := c.db.PinBlob()
+	defer releaseBlob()
 	if blob == nil {
 		return result, types.ErrBlobStoreUnavailable
 	}

--- a/database/cbor_cache.go
+++ b/database/cbor_cache.go
@@ -200,12 +200,18 @@ func NewTieredCborCache(config CborCacheConfig, db *Database) *TieredCborCache {
 
 // ResolveUtxoCbor resolves UTxO CBOR data by transaction ID and output index.
 // It checks caches in order: hot UTxO cache, block LRU cache, then blob store.
-// An optional blob transaction can be provided to see uncommitted writes within
-// the same transaction (important for intra-batch UTxO lookups during validation).
+// An optional database transaction can be provided to see uncommitted writes
+// within the same transaction (important for intra-batch UTxO lookups during
+// validation).
+//
+// The parameter is the database transaction rather than its bare blob handle
+// because the cold path has to run against the store that handle belongs to.
+// A bare types.Txn does not say which store that is, so pairing it with the
+// currently installed store would break across a concurrent SetBlobStore.
 func (c *TieredCborCache) ResolveUtxoCbor(
 	txId []byte,
 	outputIdx uint32,
-	blobTxn ...types.Txn,
+	dbTxn ...*Txn,
 ) ([]byte, error) {
 	key := makeUtxoKey(txId, outputIdx)
 
@@ -223,25 +229,28 @@ func (c *TieredCborCache) ResolveUtxoCbor(
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	blob, releaseBlob := c.db.PinBlob()
+	var callerTxn *Txn
+	if len(dbTxn) > 0 {
+		callerTxn = dbTxn[0]
+	}
+
+	// The caller's transaction already chose a store; reuse it rather than
+	// pinning whichever store is installed now. See Database.pinBlobForTxn.
+	blob, releaseBlob := c.db.pinBlobForTxn(callerTxn)
 	defer releaseBlob()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	// Use provided transaction if available, otherwise create a new one
+	// Use the caller's blob handle when it has one -- it belongs to the
+	// store just selected -- otherwise open one on that same store.
 	var txn types.Txn
-	var ownedTxn bool
-	if len(blobTxn) > 0 && blobTxn[0] != nil {
-		txn = blobTxn[0]
-	} else {
+	if callerTxn != nil {
+		txn = callerTxn.Blob()
+	}
+	if txn == nil {
 		txn = blob.NewTransaction(false)
-		ownedTxn = true
-		defer func() {
-			if ownedTxn {
-				txn.Rollback() //nolint:errcheck
-			}
-		}()
+		defer txn.Rollback() //nolint:errcheck
 	}
 
 	utxoData, err := blob.GetUtxo(txn, txId, outputIdx)
@@ -334,7 +343,9 @@ func (c *TieredCborCache) ResolveTxCbor(
 		return nil, types.ErrBlobStoreUnavailable
 	}
 
-	blob, releaseBlob := c.db.PinBlob()
+	// The caller's transaction already chose a store; reuse it rather than
+	// pinning whichever store is installed now. See Database.pinBlobForTxn.
+	blob, releaseBlob := c.db.pinBlobForTxn(txn)
 	defer releaseBlob()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
@@ -342,6 +353,7 @@ func (c *TieredCborCache) ResolveTxCbor(
 
 	// Get TX offset data from blob store. Use the caller's active
 	// blob transaction when provided so uncommitted writes are visible.
+	// It belongs to the store just selected.
 	blobTxn := types.Txn(nil)
 	cacheResolved := true
 	if txn != nil {

--- a/database/commit_timestamp.go
+++ b/database/commit_timestamp.go
@@ -49,8 +49,15 @@ func (b *Database) checkCommitTimestamp() error {
 			metadataErr,
 		)
 	}
-	// Get value from blob
-	blobTimestamp, blobErr := b.Blob().GetCommitTimestamp()
+	// Get value from blob. Pin it: this runs from init, concurrently with
+	// whatever else already holds the database, and the read must not race a
+	// replacement.
+	blobStore, releaseBlob := b.PinBlob()
+	defer releaseBlob()
+	if blobStore == nil {
+		return types.ErrBlobStoreUnavailable
+	}
+	blobTimestamp, blobErr := blobStore.GetCommitTimestamp()
 	if blobErr != nil {
 		return fmt.Errorf(
 			"failed to get blob timestamp from plugin: %w",
@@ -76,9 +83,14 @@ func (b *Database) updateCommitTimestamp(txn *Txn, timestamp int64) error {
 	if err := b.Metadata().SetCommitTimestamp(timestamp, metaTxn); err != nil {
 		return err
 	}
-	// Update blob
+	// Update blob. The timestamp has to land in the store this transaction's
+	// blob handle belongs to, not whichever store is installed now.
 	blobTxn := txn.Blob()
-	if err := b.Blob().SetCommitTimestamp(timestamp, blobTxn); err != nil {
+	blobStore := txn.BlobStore()
+	if blobStore == nil {
+		return types.ErrBlobStoreUnavailable
+	}
+	if err := blobStore.SetCommitTimestamp(timestamp, blobTxn); err != nil {
 		return err
 	}
 	return nil

--- a/database/database.go
+++ b/database/database.go
@@ -83,10 +83,16 @@ func isNilStore(store any) bool {
 
 // Database represents our data storage services
 type Database struct {
-	config          *Config
-	logger          *slog.Logger
-	blob            blob.BlobStore
-	metadata        metadata.MetadataStore
+	config   *Config
+	logger   *slog.Logger
+	metadata metadata.MetadataStore
+	// blobRef is the installed blob store, guarded by blobMu. See
+	// blob_store.go for the ownership, locking, and replacement rules that
+	// apply to both fields; nothing outside that file touches blobRef
+	// directly.
+	blobRef *blobStoreRef
+	blobMu  sync.RWMutex
+
 	cborCache       *TieredCborCache
 	sizeMetricsStop chan struct{}
 	sizeMetricsDone chan struct{}
@@ -112,11 +118,6 @@ type Database struct {
 	// phantom queued writer). Its zero value is directly usable, same as
 	// the sync.RWMutex it replaces, so no constructor change is needed.
 	commitBarrier cancellableBarrier
-}
-
-// Blob returns the underling blob store instance
-func (d *Database) Blob() blob.BlobStore {
-	return d.blob
 }
 
 // PauseCommits blocks until every currently open read-write Txn that
@@ -294,7 +295,7 @@ func New(config *Config, stores Stores) (*Database, error) {
 		return nil, errors.New("metadata store is required")
 	}
 	db := &Database{
-		blob:     stores.Blob,
+		blobRef:  newBlobStoreRef(stores.Blob),
 		metadata: stores.Metadata,
 		logger:   configCopy.Logger,
 		config:   configCopy,
@@ -358,11 +359,23 @@ func New(config *Config, stores Stores) (*Database, error) {
 				case <-db.sizeMetricsStop:
 					return
 				case <-ticker.C:
-					if db.blob != nil {
-						if size, err := db.blob.DiskSize(); err == nil {
+					// Pin rather than reading the field: this loop
+					// outlives any SetBlobStore call (it starts here,
+					// inside New, and node.go/node_lifecycle.go replace
+					// the store afterwards), so it must both read the
+					// reference under the lock and keep the store it
+					// sampled alive for the duration of the DiskSize
+					// call.
+					func() {
+						store, release := db.PinBlob()
+						defer release()
+						if store == nil {
+							return
+						}
+						if size, err := store.DiskSize(); err == nil {
 							blobSizeGauge.Set(float64(size))
 						}
-					}
+					}()
 					if db.metadata != nil {
 						if size, err := db.metadata.DiskSize(); err == nil {
 							metadataSizeGauge.Set(float64(size))
@@ -388,8 +401,4 @@ func (d *Database) StorageMode() string {
 // This can be used for metrics registration or direct cache access.
 func (d *Database) CborCache() *TieredCborCache {
 	return d.cborCache
-}
-
-func (d *Database) SetBlobStore(b blob.BlobStore) {
-	d.blob = b
 }

--- a/database/leios.go
+++ b/database/leios.go
@@ -32,12 +32,12 @@ func (d *Database) SetLeiosEBManifest(
 	hash []byte,
 	manifestRaw []byte,
 ) error {
-	blob := d.Blob()
+	txn := d.BlobTxn(true)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
-	txn := d.BlobTxn(true)
-	defer txn.Rollback() //nolint:errcheck
 	blobTxn := txn.Blob()
 	if blobTxn == nil {
 		return types.ErrNilTxn
@@ -67,12 +67,12 @@ func (d *Database) GetLeiosEBManifest(
 	hash []byte,
 	slot uint64,
 ) (manifestRaw []byte, err error) {
-	blob := d.Blob()
+	txn := d.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
-	txn := d.BlobTxn(false)
-	defer txn.Rollback() //nolint:errcheck
 	blobTxn := txn.Blob()
 	if blobTxn == nil {
 		return nil, types.ErrNilTxn
@@ -118,12 +118,12 @@ func (d *Database) SetLeiosEBTxs(
 	if txsRaw == nil {
 		txsRaw = []cbor.RawMessage{}
 	}
-	blob := d.Blob()
+	txn := d.BlobTxn(true)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
-	txn := d.BlobTxn(true)
-	defer txn.Rollback() //nolint:errcheck
 	blobTxn := txn.Blob()
 	if blobTxn == nil {
 		return types.ErrNilTxn
@@ -156,12 +156,12 @@ func (d *Database) GetLeiosEBTxs(
 	hash []byte,
 	slot uint64,
 ) ([]cbor.RawMessage, error) {
-	blob := d.Blob()
+	txn := d.BlobTxn(false)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
-	txn := d.BlobTxn(false)
-	defer txn.Rollback() //nolint:errcheck
 	blobTxn := txn.Blob()
 	if blobTxn == nil {
 		return nil, types.ErrNilTxn
@@ -219,12 +219,12 @@ func (d *Database) SetLeiosEB(
 	manifestRaw []byte,
 	txsRaw []cbor.RawMessage,
 ) error {
-	blob := d.Blob()
+	txn := d.BlobTxn(true)
+	defer txn.Rollback() //nolint:errcheck
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
-	txn := d.BlobTxn(true)
-	defer txn.Rollback() //nolint:errcheck
 	blobTxn := txn.Blob()
 	if blobTxn == nil {
 		return types.ErrNilTxn

--- a/database/leios_test.go
+++ b/database/leios_test.go
@@ -118,11 +118,11 @@ func TestGetLeiosEBManifestPropagatesRealLegacyReadError(t *testing.T) {
 	slot := uint64(111)
 	readErr := errors.New("legacy read: storage unavailable")
 
-	d.blob = &mockBlobStore{
+	d.SetBlobStore(&mockBlobStore{
 		getErrs: map[string]error{
 			string(types.LegacyLeiosEBManifestKey(hash)): readErr,
 		},
-	}
+	})
 
 	_, err := d.GetLeiosEBManifest(hash, slot)
 	require.ErrorIs(t, err, readErr)
@@ -137,11 +137,11 @@ func TestGetLeiosEBTxsPropagatesRealLegacyReadError(t *testing.T) {
 	slot := uint64(222)
 	readErr := errors.New("legacy read: storage unavailable")
 
-	d.blob = &mockBlobStore{
+	d.SetBlobStore(&mockBlobStore{
 		getErrs: map[string]error{
 			string(types.LegacyLeiosEBManifestKey(hash)): readErr,
 		},
-	}
+	})
 
 	_, err := d.GetLeiosEBTxs(hash, slot)
 	require.ErrorIs(t, err, readErr)

--- a/database/lifecycle/blob_bulk_delete.go
+++ b/database/lifecycle/blob_bulk_delete.go
@@ -111,10 +111,6 @@ func DeleteBlocksAfter(
 	if tipID <= afterID {
 		return 0, nil
 	}
-	blob := db.Blob()
-	if blob == nil {
-		return 0, types.ErrBlobStoreUnavailable
-	}
 	indexPrefix := []byte(types.BlockBlobIndexKeyPrefix)
 	for start := afterID + 1; start <= tipID; {
 		if err := ctx.Err(); err != nil {
@@ -131,6 +127,13 @@ func DeleteBlocksAfter(
 			// discards staged work with no bucket I/O.
 			if irreversible, ok := txn.Blob().(types.IrreversibleTxn); ok {
 				batchIsIrreversible = irreversible.RollbackIsNoop()
+			}
+			// Per batch, from the batch's own transaction: each batch
+			// commits separately, so the store has to be the one that owns
+			// this batch's handles rather than whichever is installed now.
+			blob := txn.BlobStore()
+			if blob == nil {
+				return types.ErrBlobStoreUnavailable
 			}
 			it := blob.NewIterator(
 				txn.Blob(),

--- a/database/lifecycle/snapshot.go
+++ b/database/lifecycle/snapshot.go
@@ -70,7 +70,11 @@ func Snapshot(
 	blobPluginName string,
 	metadataPluginName string,
 ) (m Manifest, err error) {
-	blobBackuper, ok := db.Blob().(blob.Backuper)
+	// Pinned for the whole call: the Backup below runs long, and the store
+	// backing blobBackuper must not be drained and closed while it does.
+	blobStore, releaseBlob := db.PinBlob()
+	defer releaseBlob()
+	blobBackuper, ok := blobStore.(blob.Backuper)
 	if !ok {
 		return Manifest{}, fmt.Errorf(
 			"blob plugin %q does not support snapshotting",

--- a/database/lifecycle/truncate.go
+++ b/database/lifecycle/truncate.go
@@ -75,16 +75,19 @@ func pendingTruncateChecksum(pending PendingTruncate) ([]byte, error) {
 // deleted block object. Recovery must still be able to authenticate that
 // index and retry its idempotent cleanup.
 func latestIndexedBlobBlock(db *database.Database) (models.Block, error) {
-	blob := db.Blob()
-	if blob == nil {
-		return models.Block{}, types.ErrBlobStoreUnavailable
-	}
 	txn := db.BlobTxn(false)
 	var ret models.Block
 	err := txn.Do(func(txn *database.Txn) error {
 		blobTxn := txn.Blob()
 		if blobTxn == nil {
 			return types.ErrNilTxn
+		}
+		// The transaction's own store, which it pins for its lifetime, so
+		// the iterator and the handle it runs on cannot come from two
+		// different installations.
+		blob := txn.BlobStore()
+		if blob == nil {
+			return types.ErrBlobStoreUnavailable
 		}
 		prefix := []byte(types.BlockBlobIndexKeyPrefix)
 		it := blob.NewIterator(blobTxn, types.BlobIteratorOptions{

--- a/database/prune.go
+++ b/database/prune.go
@@ -80,7 +80,11 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 	var materialized int
 	blobTxn := d.BlobTxn(true)
 	if err := blobTxn.Do(func(txn *Txn) error {
-		blockCbor, _, err := d.blob.GetBlock(txn.Blob(), slot, hash)
+		blobStore := txn.BlobStore()
+		if blobStore == nil {
+			return types.ErrBlobStoreUnavailable
+		}
+		blockCbor, _, err := blobStore.GetBlock(txn.Blob(), slot, hash)
 		if err != nil {
 			return fmt.Errorf(
 				"prune block (slot=%d): get block: %w",
@@ -89,13 +93,13 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 			)
 		}
 		for _, ref := range utxoRefs {
-			n, err := d.materializeUtxo(txn.Blob(), slot, hash, blockCbor, ref)
+			n, err := d.materializeUtxo(txn, slot, hash, blockCbor, ref)
 			if err != nil {
 				return err
 			}
 			materialized += n
 		}
-		if err := d.blob.TombstoneBlock(txn.Blob(), slot, hash); err != nil {
+		if err := blobStore.TombstoneBlock(txn.Blob(), slot, hash); err != nil {
 			return fmt.Errorf(
 				"prune block (slot=%d): expire block: %w",
 				slot,
@@ -113,14 +117,24 @@ func (d *Database) PruneBlock(slot uint64, hash []byte) (int, error) {
 // raw CBOR by extracting the bytes from the given block CBOR. Returns 1
 // if the entry was rewritten, 0 if it was already raw, missing, or
 // references a different block.
+//
+// It takes the *Txn rather than a bare types.Txn so the store and the blob
+// transaction handle it writes through come from the same place: reading the
+// database's installed store separately could pair a handle from one store
+// with a call into another after a concurrent SetBlobStore.
 func (d *Database) materializeUtxo(
-	blobTxn types.Txn,
+	txn *Txn,
 	slot uint64,
 	hash []byte,
 	blockCbor []byte,
 	ref models.UtxoId,
 ) (int, error) {
-	utxoData, err := d.blob.GetUtxo(blobTxn, ref.Hash, ref.Idx)
+	blobStore := txn.BlobStore()
+	if blobStore == nil {
+		return 0, types.ErrBlobStoreUnavailable
+	}
+	blobTxn := txn.Blob()
+	utxoData, err := blobStore.GetUtxo(blobTxn, ref.Hash, ref.Idx)
 	if err != nil {
 		// Raced with a consume that already deleted the blob entry. The
 		// metadata row may also be in flight to deleted_slot != 0; either
@@ -179,7 +193,12 @@ func (d *Database) materializeUtxo(
 	}
 	utxoCbor := make([]byte, offset.ByteLength)
 	copy(utxoCbor, blockCbor[offset.ByteOffset:end])
-	if err := d.blob.SetUtxo(blobTxn, ref.Hash, ref.Idx, utxoCbor); err != nil {
+	if err := blobStore.SetUtxo(
+		blobTxn,
+		ref.Hash,
+		ref.Idx,
+		utxoCbor,
+	); err != nil {
 		return 0, fmt.Errorf(
 			"prune block (slot=%d): rewrite utxo %x#%d as raw cbor: %w",
 			slot,

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -200,7 +201,7 @@ func (d *Database) SetTransactionWithOpts(
 		defer txn.Rollback() //nolint:errcheck
 	}
 
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -398,7 +399,7 @@ func (d *Database) SetGapBlockTransaction(
 		defer txn.Rollback() //nolint:errcheck
 	}
 
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -838,7 +839,7 @@ func (d *Database) recoverConsumedUtxo(
 	txn *Txn,
 	enforcePrimaryChain bool,
 ) (*models.Utxo, error) {
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return nil, types.ErrBlobStoreUnavailable
 	}
@@ -1055,7 +1056,7 @@ func (d *Database) SetGenesisTransaction(
 		defer txn.Rollback() //nolint:errcheck
 	}
 
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -1762,16 +1763,22 @@ func (d *Database) DeleteTransactionMetadataLabelsAfterSlot(
 // reason given on deleteUtxoBlobs.
 func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 	const batchSize = 500
-	blob := d.Blob()
-	if blob == nil {
+	// Report an absent blob store up front, so an empty txHashes slice
+	// reports it the same way a populated one does rather than silently
+	// succeeding because the batch loop never ran.
+	if d.Blob() == nil {
 		return types.ErrBlobStoreUnavailable
 	}
 
 	var deleteErrors int
-	deleteBatch := func(blobTxn types.Txn, batch [][]byte) int {
+	deleteBatch := func(
+		store blob.BlobStore,
+		blobTxn types.Txn,
+		batch [][]byte,
+	) int {
 		var batchDeleteErrors int
 		for _, txHash := range batch {
-			if err := blob.DeleteTx(blobTxn, txHash); err != nil {
+			if err := store.DeleteTx(blobTxn, txHash); err != nil {
 				deleteErrors++
 				batchDeleteErrors++
 				d.logger.Warn(
@@ -1784,18 +1791,31 @@ func deleteTxBlobs(d *Database, txHashes [][]byte, txn *Txn) error {
 		return batchDeleteErrors
 	}
 
+	// The store used for each delete comes from whichever transaction owns
+	// the handle that delete runs through, so a concurrent SetBlobStore
+	// cannot leave a handle from one store being deleted through another.
 	if txn != nil && txn.Blob() != nil {
-		deleteBatch(txn.Blob(), txHashes)
+		blob := txn.BlobStore()
+		if blob == nil {
+			return types.ErrBlobStoreUnavailable
+		}
+		deleteBatch(blob, txn.Blob(), txHashes)
 	} else {
 		for start := 0; start < len(txHashes); start += batchSize {
 			end := min(start+batchSize, len(txHashes))
 			batch := txHashes[start:end]
 			batchTxn := NewBlobOnlyTxn(d, true)
+			blob := batchTxn.BlobStore()
+			if blob == nil {
+				batchTxn.Release()
+				return types.ErrBlobStoreUnavailable
+			}
 			batchBlobTxn := batchTxn.Blob()
 			if batchBlobTxn == nil {
+				batchTxn.Release()
 				return types.ErrNilTxn
 			}
-			batchDeleteErrors := deleteBatch(batchBlobTxn, batch)
+			batchDeleteErrors := deleteBatch(blob, batchBlobTxn, batch)
 			if err := batchTxn.Commit(); err != nil {
 				deleteErrors += len(batch) - batchDeleteErrors
 				_ = batchTxn.Rollback()

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -296,7 +296,7 @@ func TestDeleteTxBlobsUsesCallerBlobTxn(t *testing.T) {
 
 	store := &mockBlobStore{}
 	db := &Database{
-		blob: store,
+		blobRef: newBlobStoreRef(store),
 		logger: slog.New(
 			slog.NewJSONHandler(
 				io.Discard,
@@ -322,7 +322,7 @@ func TestDeleteTxBlobsCountsFailedBatchCommit(t *testing.T) {
 	var logs bytes.Buffer
 	store := &mockBlobStore{commitErrs: []error{errors.New("commit failed")}}
 	db := &Database{
-		blob: store,
+		blobRef: newBlobStoreRef(store),
 		logger: slog.New(
 			slog.NewJSONHandler(
 				&logs,
@@ -349,7 +349,7 @@ func TestDeleteUtxoBlobsCountsFailedBatchCommit(t *testing.T) {
 	var logs bytes.Buffer
 	store := &mockBlobStore{commitErrs: []error{errors.New("commit failed")}}
 	db := &Database{
-		blob: store,
+		blobRef: newBlobStoreRef(store),
 		logger: slog.New(
 			slog.NewJSONHandler(
 				&logs,
@@ -401,7 +401,7 @@ func TestTransactionsDeleteRolledbackLogsBlobFailureAndDeletesMetadata(
 		},
 	}
 	db := &Database{
-		blob:     store,
+		blobRef:  newBlobStoreRef(store),
 		metadata: sqliteStore,
 		logger:   logger,
 		config:   &Config{DataDir: dataDir, Logger: logger},
@@ -461,7 +461,7 @@ func TestUtxosDeleteRolledbackLogsBlobFailureAndDeletesMetadata(t *testing.T) {
 		},
 	}
 	db := &Database{
-		blob:     store,
+		blobRef:  newBlobStoreRef(store),
 		metadata: sqliteStore,
 		logger:   logger,
 		config:   &Config{DataDir: dataDir, Logger: logger},

--- a/database/txn.go
+++ b/database/txn.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 )
 
@@ -55,6 +56,15 @@ type Txn struct {
 	db          *Database
 	blobTxn     types.Txn
 	metadataTxn types.Txn
+	// blobStore is the blob store this transaction opened blobTxn on, and
+	// the store every blob operation inside the transaction must use. It
+	// is set once at construction and never cleared, so it stays readable
+	// (and correct) even after the transaction is finished. blobPin is the
+	// pin that keeps that store from being drained out from under the
+	// transaction; it is guarded by lock and cleared by
+	// releaseBlobPinLocked. See blob_store.go.
+	blobStore   blob.BlobStore
+	blobPin     *blobStoreRef
 	lock        sync.Mutex
 	finished    bool
 	committed   bool
@@ -130,12 +140,29 @@ func (t *Txn) releaseCommitBarrierLocked() {
 func (t *Txn) finishLocked() {
 	t.finished = true
 	t.releaseCommitBarrierLocked()
+	t.releaseBlobPinLocked()
+}
+
+// releaseBlobPinLocked drops this transaction's pin on the blob store it
+// opened on, if still held. Like releaseCommitBarrierLocked it clears the
+// field before releasing, so routing it through finishLocked from every
+// terminal path releases exactly once rather than panicking on an unmatched
+// WaitGroup.Done. t.blobStore is deliberately left set: BlobStore must keep
+// answering after the transaction finishes. Callers must hold t.lock.
+func (t *Txn) releaseBlobPinLocked() {
+	if t.blobPin == nil {
+		return
+	}
+	pin := t.blobPin
+	t.blobPin = nil
+	pin.release()
 }
 
 func NewTxn(db *Database, readWrite bool) *Txn {
 	t := &Txn{db: db, readWrite: readWrite}
 	acquireCommitBarrier(t, db.Metadata() != nil)
-	if bs := db.Blob(); bs != nil {
+	pinBlobStoreForTxn(t, db)
+	if bs := t.blobStore; bs != nil {
 		t.blobTxn = bs.NewTransaction(readWrite)
 	}
 	if ms := db.Metadata(); ms != nil {
@@ -170,7 +197,8 @@ func NewTxn(db *Database, readWrite bool) *Txn {
 func NewBlobOnlyTxn(db *Database, readWrite bool) *Txn {
 	t := &Txn{db: db, readWrite: readWrite}
 	acquireCommitBarrier(t, false)
-	if bs := db.Blob(); bs != nil {
+	pinBlobStoreForTxn(t, db)
+	if bs := t.blobStore; bs != nil {
 		t.blobTxn = bs.NewTransaction(readWrite)
 	}
 	return t
@@ -179,6 +207,12 @@ func NewBlobOnlyTxn(db *Database, readWrite bool) *Txn {
 func NewMetadataOnlyTxn(db *Database, readWrite bool) *Txn {
 	t := &Txn{db: db, readWrite: readWrite}
 	acquireCommitBarrier(t, db.Metadata() != nil)
+	// A metadata-only transaction opens no blob transaction, but it still
+	// pins: BlobStore has to answer for it too, because helpers that take a
+	// *Txn (recordBlobOrphansOnCommit and the blob-delete paths it counts
+	// for) are reached with whichever transaction the caller happens to
+	// hold.
+	pinBlobStoreForTxn(t, db)
 	if ms := db.Metadata(); ms != nil {
 		// See NewTxn's matching comment: context.Background() here is the
 		// current propagation boundary, not a metadata-store-internal gap.
@@ -196,8 +230,30 @@ func NewMetadataOnlyTxn(db *Database, readWrite bool) *Txn {
 	return t
 }
 
+// pinBlobStoreForTxn pins db's currently installed blob store for t's
+// lifetime and records which store that was. Every constructor calls it
+// before opening anything, so a transaction's blob work and the store that
+// work runs against are chosen together, once — re-reading Database.Blob
+// later could hand back a different store than the one blobTxn belongs to.
+func pinBlobStoreForTxn(t *Txn, db *Database) {
+	if db == nil {
+		return
+	}
+	t.blobPin = db.pinBlobStore()
+	t.blobStore = t.blobPin.blobStore()
+}
+
 func (t *Txn) DB() *Database {
 	return t.db
+}
+
+// BlobStore returns the blob store this transaction was opened on, which is
+// the store its Blob transaction handle belongs to and the one every blob
+// operation in the transaction must use. It is stable for the transaction's
+// lifetime even if the database's installed store is replaced meanwhile, and
+// it is nil when no blob store was installed at construction.
+func (t *Txn) BlobStore() blob.BlobStore {
+	return t.blobStore
 }
 
 // Metadata returns the underlying metadata transaction handle
@@ -364,6 +420,12 @@ func (t *Txn) Commit() error {
 		// mark the transaction finished here: the recovery rollback still owns
 		// that transition. releaseCommitBarrierLocked is idempotent, so normal
 		// terminal paths may already have released it through finishLocked.
+		// The blob-store pin is deliberately not released here: that recovery
+		// rollback still rolls back blobTxn, which belongs to the pinned
+		// store, so dropping the pin early could let a concurrent
+		// SetBlobStore's drain return -- and its caller close that store --
+		// while the rollback is still running against it. finishLocked
+		// releases it once the rollback concludes.
 		t.releaseCommitBarrierLocked()
 		t.lock.Unlock()
 		if dispatchAfterUnlock {
@@ -419,7 +481,7 @@ func (t *Txn) Commit() error {
 		// commit. Only combined transactions pay the cost -- blob-only bulk
 		// paths sync at their own barriers, and Sync is a store-wide flush, so
 		// the next combined commit also makes those batches durable.
-		if blobStore := t.db.Blob(); blobStore != nil && t.metadataTxn != nil {
+		if blobStore := t.blobStore; blobStore != nil && t.metadataTxn != nil {
 			if syncErr := blobStore.Sync(); syncErr != nil {
 				_ = t.metadataTxn.Rollback()
 				t.finishLocked()

--- a/database/txn_commit_barrier_test.go
+++ b/database/txn_commit_barrier_test.go
@@ -309,7 +309,7 @@ func TestTerminalTxnPathsReleaseCommitBarrierExactlyOnce(t *testing.T) {
 			newDB: func(t *testing.T) *Database {
 				logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 				return &Database{
-					blob:     &mockBlobStore{},
+					blobRef:  newBlobStoreRef(&mockBlobStore{}),
 					metadata: &commitFailingMetadata{err: injected},
 					logger:   logger,
 					config:   &Config{Logger: logger},

--- a/database/txn_sync_test.go
+++ b/database/txn_sync_test.go
@@ -49,7 +49,7 @@ func newSyncBarrierTestDB(
 	require.NoError(t, err)
 	require.NoError(t, sqliteStore.Start(context.Background()))
 	db := &Database{
-		blob:     store,
+		blobRef:  newBlobStoreRef(store),
 		metadata: sqliteStore,
 		logger:   logger,
 		config:   &Config{Logger: logger},

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -138,10 +138,11 @@ func loadCbor(u *models.Utxo, txn *Txn) error {
 	db := txn.DB()
 	// Use tiered cache if available
 	if db.cborCache != nil {
-		// Pass the blob transaction so we can see uncommitted writes
-		// (important for intra-batch UTxO lookups during validation)
-		blobTxn := txn.Blob()
-		cbor, err := db.cborCache.ResolveUtxoCbor(u.TxId, u.OutputIdx, blobTxn)
+		// Pass the transaction so we can see uncommitted writes
+		// (important for intra-batch UTxO lookups during validation).
+		// The transaction, not its bare blob handle: the cold path has to
+		// run against the store that handle was opened on.
+		cbor, err := db.cborCache.ResolveUtxoCbor(u.TxId, u.OutputIdx, txn)
 		if err != nil {
 			if errors.Is(err, types.ErrBlobKeyNotFound) {
 				recoveredCbor, recoverErr := recoverUtxoCbor(

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -66,8 +66,10 @@ var errExactAddressCandidateScanLimit = errors.New(
 // wait for and counts immediately.
 func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 	const batchSize = 500
-	blob := d.Blob()
-	if blob == nil {
+	// Report an absent blob store up front, so an empty utxos slice reports
+	// it the same way a populated one does rather than silently succeeding
+	// because the batch loop never ran.
+	if d.Blob() == nil {
 		return types.ErrBlobStoreUnavailable
 	}
 
@@ -75,6 +77,16 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 	for start := 0; start < len(utxos); start += batchSize {
 		end := min(start+batchSize, len(utxos))
 		batchTxn := NewBlobOnlyTxn(d, true)
+		// Take the store from the batch's own transaction rather than
+		// from the database once up front: each batch commits separately,
+		// so a replacement between batches would otherwise leave later
+		// batches deleting through a store that no longer owns their
+		// transaction handles.
+		blob := batchTxn.BlobStore()
+		if blob == nil {
+			batchTxn.Release()
+			return types.ErrBlobStoreUnavailable
+		}
 		var batchDeleteErrors int
 		for _, utxo := range utxos[start:end] {
 			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
@@ -156,7 +168,7 @@ func loadCbor(u *models.Utxo, txn *Txn) error {
 	}
 
 	// Fallback: direct blob access (for tests without cache)
-	blob := db.Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.ErrBlobStoreUnavailable
 	}
@@ -320,7 +332,7 @@ func fetchTxBlobSlotAndHash(
 	if db == nil || txn == nil {
 		return 0, blockHash, false, nil
 	}
-	blob := db.Blob()
+	blob := txn.BlobStore()
 	blobTxn := txn.Blob()
 	if blob == nil || blobTxn == nil {
 		return 0, blockHash, false, nil
@@ -444,21 +456,25 @@ func repairUtxoBlob(
 	outputIdx uint32,
 	offset *CborOffset,
 ) error {
-	blob := db.Blob()
-	if blob == nil {
-		return nil
-	}
-
 	offsetData := EncodeUtxoOffset(offset)
 
 	// Use the caller's blob txn when it is write-capable
 	if txn != nil && txn.Blob() != nil && txn.IsReadWrite() {
+		blob := txn.BlobStore()
+		if blob == nil {
+			return nil
+		}
 		return blob.SetUtxo(txn.Blob(), txId, outputIdx, offsetData)
 	}
 
 	// Open a dedicated write transaction when the caller txn is
 	// nil or its blob handle is read-only / absent.
 	writeTxn := NewBlobOnlyTxn(db, true)
+	blob := writeTxn.BlobStore()
+	if blob == nil {
+		writeTxn.Release()
+		return nil
+	}
 	if err := blob.SetUtxo(
 		writeTxn.Blob(), txId, outputIdx, offsetData,
 	); err != nil {

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -1393,7 +1393,7 @@ func storeRawBlockUtxoOffsets(
 	if txn == nil || txn.Blob() == nil {
 		return 0, errors.New("blob transaction not available")
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return 0, errors.New("blob store not available")
 	}

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -603,7 +603,9 @@ func (m *DingoStateManager) createUtxo(
 	if err := m.db.CreateUtxo(txn, &utxoModel); err != nil {
 		return fmt.Errorf("create utxo metadata: %w", err)
 	}
-	if blobStore := m.db.Blob(); blobStore != nil {
+	// The transaction's own store, so the handle and the store it is used
+	// with always come from the same installation.
+	if blobStore := txn.BlobStore(); blobStore != nil {
 		if err := blobStore.SetUtxo(
 			txn.Blob(), utxoModel.TxId, utxoModel.OutputIdx,
 			utxo.Output.Cbor(),

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -1715,15 +1715,20 @@ func (ls *LedgerState) durableAppliedFloorAnchorIndex() (uint64, bool, error) {
 func (ls *LedgerState) replayRecoveryBlockFromTxBlob(
 	txHash []byte,
 ) (models.Block, bool, error) {
-	blob := ls.db.Blob()
-	if blob == nil {
-		return models.Block{}, false, nil
-	}
 	txn := ls.db.BlobTxn(false)
-	if txn == nil || txn.Blob() == nil {
+	if txn == nil {
 		return models.Block{}, false, nil
 	}
 	defer txn.Rollback() //nolint:errcheck
+	// The store the transaction was opened on, not whichever is installed
+	// now: the handle below only means anything to that store, and the
+	// transaction's pin is what keeps it alive for this call. Reading
+	// ls.db.Blob() separately could pair a handle from one installation with
+	// a store from another across a concurrent SetBlobStore.
+	blob := txn.BlobStore()
+	if blob == nil || txn.Blob() == nil {
+		return models.Block{}, false, nil
+	}
 
 	txData, err := blob.GetTx(txn.Blob(), txHash)
 	if err != nil {

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1872,7 +1872,12 @@ type orphanedBlock struct {
 // This handles the case where blob committed successfully but metadata failed,
 // leaving orphaned blocks in the blob store.
 func (ls *LedgerState) cleanupOrphanedBlobs(tipSlot uint64) error {
-	blobStore := ls.db.Blob()
+	// Pin rather than reading the installed store: this runs a scan, a
+	// separate write transaction, and a commit against one store, so it has
+	// to keep that store alive for the whole operation rather than sample
+	// whichever is installed at each step.
+	blobStore, releaseBlob := ls.db.PinBlob()
+	defer releaseBlob()
 	if blobStore == nil {
 		return nil // No blob store configured
 	}

--- a/node.go
+++ b/node.go
@@ -734,6 +734,10 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 		if err != nil {
 			return fmt.Errorf("failed to create bark blob store: %w", err)
 		}
+		// The wrapper's upstream is the store it replaces and its Close
+		// forwards there, so the replaced store stays in use: there is
+		// nothing to drain and nothing to close. Both results are
+		// deliberately discarded.
 		n.db.SetBlobStore(barkBlobStore)
 	}
 

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -657,6 +657,10 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to recreate bark blob store: %w", err)
 		}
+		// The wrapper's upstream is the store it replaces and its Close
+		// forwards there, so the replaced store stays in use: there is
+		// nothing to drain and nothing to close. Both results are
+		// deliberately discarded.
 		n.db.SetBlobStore(barkBlobStore)
 	}
 


### PR DESCRIPTION
`Database.blob` was read without synchronization while `SetBlobStore` replaced
the field. The size-metrics goroutine started in `database.New` reads it on a
60s ticker, and `node.go` / `node_lifecycle.go` call `SetBlobStore` after `New`
returns — the lifecycle path while readers are live.

`Database.blob` becomes `blobRef *blobStoreRef` guarded by `blobMu`. Each ref
carries a `WaitGroup` counting operations pinned on it; replacement swaps the
whole ref, so a pin taken before the swap keeps naming the store it was taken
on. `Txn` pins at construction and releases in `finishLocked`.

`SetBlobStore` now returns `(prev, drain func())`: the replaced store is safe to
close once `drain()` returns, and `SetBlobStore` never closes it. Both existing
callers discard the results — bark wraps the previous store and forwards
`Close`, so there is nothing to drain or close there.

Also fixes the pairing hazard wherever a store and a `types.Txn` handle were
chosen separately: `Txn.Commit`'s durability `Sync` used `t.db.Blob()`, so a
replacement mid-commit could sync a different store than the one whose
transaction had just committed. The same shape reached the tiered CBOR cache —
`ResolveUtxoCbor` and `ResolveTxCbor` pinned the installed store and then read
through the caller's transaction handle, which `loadCbor` and
`repairMissingGovernanceProposal` supply. `Database.pinBlobForTxn` now makes
that one decision: the transaction's store when it has a blob handle (its own
pin already keeps that store alive), the installed store otherwise.
`ResolveUtxoCbor`'s optional parameter changes from `...types.Txn` to `...*Txn`
because a bare handle does not name the store it belongs to.
`ledger/replay_recovery.go`, `ledger/state.go` and the conformance state
manager were the remaining members of that class.

`BlobBlockIterator` is the last one, and the worst-behaved: it scanned a batch
of block keys under one pin and read each block's CBOR back under a later one,
so a replacement in between made scanned blocks look absent — and `NextRaw`
skips a missing block with a warning instead of failing, so they left the
iteration silently. The pin now lives with the batch.

## Tests

`TestSetBlobStoreConcurrentWithReaders` reports four distinct data races on the
unfixed code (bare accessor, `NewTxn`, both read/write orderings) and passes
after. The three new-API tests cannot run against unfixed code, so they were
mutation-tested: removing the `Txn` pin fails the drain test; making
`Txn.BlobStore()` re-read `t.db.Blob()` fails the identity test.

`TestResolveTxCborUsesTransactionStore` and
`TestResolveUtxoCborUsesTransactionStore` install a counting passthrough store
after opening the transaction and assert the resolve never reached it. Both
fail against the old store selection ("Should be zero, but was 1") and pass
with it.

`TestBlobIteratorKeepsBatchStoreAcrossReplacement` seeds five blocks, takes one
`NextRaw`, then installs a store whose `GetBlock` always reports the block
absent. Against the old per-call pin it fails with `expected: [20 30 40 50],
actual: nil` — every remaining block silently dropped.

## Validation

`go test -race ./database/...` (23 packages), `./ledger/...`, `./bark/...`,
`./chain/...`, `./mithril/...`, `./internal/node/...`,
`./internal/historyexpiry/...`, `./internal/test/conformance/...`, root;
`golangci-lint run` and `GOOS=windows golangci-lint run` 0 issues;
`make import-boundaries`, `make docs-parity`; conformance 27.9s.

Not run: `make lint` in full (`nilaway`, `modernize`, `golines` absent from
PATH; CI's lint job runs golangci-lint only); `make govulncheck` (network);
DevNet (storage-layer change only, no consensus/protocol code touched);
`make test-live-lifecycle` (needs a live two-node setup).

Resolves #3444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEJSNPB6bA7CVW5EgXxNni

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data race between `SetBlobStore` and database readers: the blob-store field was replaced without synchronization while live operations (the size-metrics ticker, transaction construction, blob reads) were running, and the replaced store had no defined safe point to close.

The installed store is now a mutex-guarded reference whose operations pin the store they work on. `SetBlobStore` returns the replaced store with a `drain()` func and never closes it; `drain()` returns once every pinned operation has finished.

**Behavior changes**
- Transactions pin the store they opened on: `Txn.BlobStore()` returns it, and `Commit`'s durability sync uses it instead of re-reading the current store. Blob work outside a transaction that spans calls should use `PinBlob()`.
- `BlobBlockIterator` now holds one pin per batch, so the store that scans a batch also reads its blocks back; a replacement between the two previously dropped blocks with a warning.
- Blob reads pair a transaction handle with the store it was opened on, never the store installed at call time. `ResolveUtxoCbor`'s optional parameter changes from `...types.Txn` to `...*Txn` because a bare handle doesn't name its store; the same fix lands in the CBOR cache cold path, `ledger`, conformance, lifecycle, and prune code.
- Failure paths in blob deletion and UTxO repair now release the blob-only batch transactions they opened, including the pairing tests' write transactions.
- Race-enabled regression tests cover concurrent replacement, drain semantics, iterator batch pairing, and store pairing.

Resolves #3444

<sup>Written for commit 31aaf54c1d96bbef018c50e0fad3de7dd53a4368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe live replacement of the blob storage backend.
  * Added APIs to access, pin, and replace blob storage, including draining active operations before shutdown.
  * Transactions now remain associated with the blob store they started with.

* **Bug Fixes**
  * Prevented concurrent blob-store replacement from mixing transactions and storage backends.
  * Improved handling when blob storage is unavailable.
  * Ensured long-running operations keep their blob store available throughout execution.

* **Documentation**
  * Documented blob-store replacement, concurrency behavior, ownership, and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
