### PR TITLE
fix(bark): honor block identifiers and batch results in ArchiveService

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6994,6 +6994,20 @@ identity. Only a malformed request (no identifier at all, or a hash that is not
 32 hex-encoded bytes) or a genuine storage failure fails the whole call, the
 former with `InvalidArgument`.
 
+One `not_found` answer is also a node-side signal. When a reference resolved
+through a lookup -- hash alone, slot alone, or height alone -- and the blob
+store then reports the block missing on `GetBlockURL`, the index and the blob
+store disagree, which is a storage inconsistency rather than an absent block.
+The cloud plugins cannot express that difference in the error: `s3` and `gcs`
+return `types.ErrBlobKeyNotFound` both for a block that was never written and
+for a block whose metadata object was lost, so the lookup having already read
+the block is the only evidence available. The client still gets `not_found` --
+there is no URL to hand it, `FetchBlockResponse` has no per-reference error
+field, and failing the call would discard the rest of the batch -- and the
+condition is logged at warn with the block's slot and hash for the operator.
+The hash+slot case resolves without a lookup and so carries no such evidence;
+it is reported as an ordinary `not_found`.
+
 The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
 `GetBlock` and block iterators pass through local values, but resolve
 `types.ErrHistoryExpired` or missing historical block CBOR by calling the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7021,7 +7021,9 @@ The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
 `types.ErrHistoryExpired` or missing historical block CBOR by calling the
 remote Bark archive and downloading the signed URL. A block the archive answers
 under `not_found` surfaces as `types.ErrBlobKeyNotFound`, the same error a
-local blob store reports for a missing block. Bark does not decide which
+local blob store reports for a missing block, but only when the echoed
+reference is the `(slot, hash)` that was requested: a returned block is
+re-verified against the request, so an absence must be too. Bark does not decide which
 local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
 `historyExpiry.enabled` is configured.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1824,8 +1824,11 @@ fallback:
 
 - An archive node uses a signed-URL-capable object-storage blob plugin (`s3` or
   `gcs`) and enables the Bark server with `barkPort`. Bark's archive service
-  maps a requested `(slot, hash)` to the blob store's `GetBlockURL`, returning
-  a signed object URL plus compact block metadata.
+  resolves each requested block reference -- by hash, slot, height, or a
+  consistent combination of them -- to a `(slot, hash)` point, maps that to the
+  blob store's `GetBlockURL`, and returns a signed object URL plus compact
+  block metadata. A reference the node does not hold comes back under
+  `not_found` without discarding the rest of the batch.
 - A node with `historyExpiry.enabled` keeps its local blob plugin and starts
   `internal/historyexpiry.Pruner`. The worker derives its safety window from
   `LedgerState.StabilityWindow()` and scans only blocks older than that window.
@@ -6964,15 +6967,39 @@ services. It exposes archive access over Connect/gRPC and supplies the remote
 archive adapter used by nodes that want historical fallback.
 
 The server side (`bark.Bark`) registers the archive service, health endpoint,
-and gRPC reflection. Archive fetches validate the requested block hash, ask the
-active blob plugin for a signed block URL, and return that URL with block type,
-height, and previous-hash metadata. In practice this makes `s3` and `gcs` the
-archive-node blob backends because they can sign object-storage URLs.
+and gRPC reflection. Archive fetches ask the active blob plugin for a signed
+block URL and return it with block type, height, and previous-hash metadata. In
+practice this makes `s3` and `gcs` the archive-node blob backends because they
+can sign object-storage URLs.
+
+`FetchBlock` resolves each `BlockRef` in the batch by hash and slot together,
+then hash, then slot, then height. Hash and slot together already are the blob
+store's block key, so that case needs no index read and still resolves a block
+written before the hash index existed -- the historical range an archive
+serves. Hash alone is the only identifier unique across forks and resolves
+through the O(1) hash index; slot alone needs a bounded prefix scan; height
+alone is last because block numbers are not indexed at all and resolving one is
+a binary search over the block-ID space (`database.BlockByNumber`). Because the
+point is built from the identifiers the client supplied, hash and slot agree
+with the answer by construction; height is checked against the block metadata
+afterwards.
+
+The batch is answered as a whole. A reference that names no stored block --
+absent, or carrying a height belonging to a different block -- is returned in
+`FetchBlockResponse.not_found` carrying exactly the identifiers the client
+supplied, and every other reference in the batch is still served. Each returned
+`SignedUrl.block` echoes the supplied identifiers verbatim and fills in the
+ones the client omitted, so a hash-only or height-only caller learns the full
+identity. Only a malformed request (no identifier at all, or a hash that is not
+32 hex-encoded bytes) or a genuine storage failure fails the whole call, the
+former with `InvalidArgument`.
 
 The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
 `GetBlock` and block iterators pass through local values, but resolve
 `types.ErrHistoryExpired` or missing historical block CBOR by calling the
-remote Bark archive and downloading the signed URL. Bark does not decide which
+remote Bark archive and downloading the signed URL. A block the archive answers
+under `not_found` surfaces as `types.ErrBlobKeyNotFound`, the same error a
+local blob store reports for a missing block. Bark does not decide which
 local blocks expire; `internal/historyexpiry.Pruner` owns that lifecycle when
 `historyExpiry.enabled` is configured.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6994,19 +6994,17 @@ identity. Only a malformed request (no identifier at all, or a hash that is not
 32 hex-encoded bytes) or a genuine storage failure fails the whole call, the
 former with `InvalidArgument`.
 
-One `not_found` answer is also a node-side signal. When a reference resolved
-through a lookup -- hash alone, slot alone, or height alone -- and the blob
-store then reports the block missing on `GetBlockURL`, the index and the blob
-store disagree, which is a storage inconsistency rather than an absent block.
-The cloud plugins cannot express that difference in the error: `s3` and `gcs`
-return `types.ErrBlobKeyNotFound` both for a block that was never written and
-for a block whose metadata object was lost, so the lookup having already read
-the block is the only evidence available. The client still gets `not_found` --
-there is no URL to hand it, `FetchBlockResponse` has no per-reference error
-field, and failing the call would discard the rest of the batch -- and the
-condition is logged at warn with the block's slot and hash for the operator.
-The hash+slot case resolves without a lookup and so carries no such evidence;
-it is reported as an ordinary `not_found`.
+A resolved-but-unservable block is the exception to batching, and fails the
+whole call. When a reference resolved through a lookup -- hash alone, slot
+alone, or height alone -- and the blob store then reports the block missing on
+`GetBlockURL`, the index and the blob store disagree, which is a storage
+inconsistency rather than an absent block. The cloud plugins cannot express
+that difference in the error: `s3` and `gcs` return `types.ErrBlobKeyNotFound`
+both for a block that was never written and for a block whose metadata object
+was lost, so the lookup having already read the block is the only evidence
+available. The hash+slot case resolves without a lookup and so carries no such
+evidence; it is reported as an ordinary `not_found`, as is a reference that
+misses at resolution.
 
 The client side (`bark.BlobStoreBark`) wraps the configured local blob store.
 `GetBlock` and block iterators pass through local values, but resolve

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6979,10 +6979,20 @@ written before the hash index existed -- the historical range an archive
 serves. Hash alone is the only identifier unique across forks and resolves
 through the O(1) hash index; slot alone needs a bounded prefix scan; height
 alone is last because block numbers are not indexed at all and resolving one is
-a binary search over the block-ID space (`database.BlockByNumber`). Because the
-point is built from the identifiers the client supplied, hash and slot agree
-with the answer by construction; height is checked against the block metadata
-afterwards.
+a binary search over the block-ID space (`database.BlockByNumberBounded`).
+Because the point is built from the identifiers the client supplied, hash and
+slot agree with the answer by construction; height is checked against the block
+metadata afterwards.
+
+That binary search is bounded above by the highest indexed block, and reading
+that bound is a reverse iteration over the block index, which `s3` and `gcs`
+answer by listing every block-index object in the bucket. `ArchiveService` is
+registered without the operator auth interceptor, so `FetchBlock` resolves the
+bound once for the whole batch and only when the batch actually contains a
+height-only reference — resolving it per reference would let one anonymous
+request carrying `DefaultMaxFetchBlockRefs` height-only references cost that
+many full-bucket enumerations. A batch of hash+slot references touches no index
+at all.
 
 The batch is answered as a whole. A reference that names no stored block --
 absent, or carrying a height belonging to a different block -- is returned in

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1549,12 +1549,29 @@ as "not reachable by hash" rather than "not present".
 number is not an indexed blob key — only slot (`bp`), hash (`bh`), and the
 internal sequential ID (`bi`) are — so the lookup binary-searches the ID space
 that block numbers increase with, bounded above by the highest indexed block,
-and probes with `BlockAtOrAfterIndex` so a gap left by a Mithril bootstrap or
-drain import does not end the search early. A number no block carries returns
-`models.ErrBlockNotFound`. It costs O(log n) blob reads where a slot or hash
-lookup costs one, so prefer either of those when the caller has one; bark's
-`ArchiveService.FetchBlock` uses it only for a reference that supplies height
-alone.
+and seeks to the next indexed entry at or after each probe so a gap left by a
+Mithril bootstrap or drain import does not end the search early. A number no
+block carries returns `models.ErrBlockNotFound`. It costs O(log n) blob reads
+where a slot or hash lookup costs one, so prefer either of those when the
+caller has one; bark's `ArchiveService.FetchBlock` uses it only for a reference
+that supplies height alone.
+
+The upper bound is a separate value, `BlockNumberBound`, resolved by
+`ResolveBlockNumberBound` and passed to `BlockByNumberBounded`. Resolving it
+reads the newest `bi` entry through a **reverse** iterator, and the `s3` and
+`gcs` plugins implement a reverse iterator as a full listing of every object
+under the prefix with no early break (`listKeysToFile`) — one resolution
+enumerates every block-index object in the bucket. A caller answering more than
+one block number must therefore resolve the bound once and reuse it;
+`BlockByNumber` resolves its own and is a single-lookup convenience. The zero
+`BlockNumberBound` is unresolved and matches nothing, so a forgotten resolution
+fails closed with `ErrBlockNotFound` rather than searching an empty ID space.
+
+Search probes read the ordered `bi` entry and the block's `_metadata` object,
+never the block CBOR: a probe needs only the block's ID and height to decide
+which way to move, and reading it through the block itself would download a
+whole block object from cloud storage per probe. Only the one matching block is
+read in full.
 
 `lifecycle.ResolveTargetByNumber` keeps its own tip-bounded search rather than
 calling this: a truncate target must not resolve past the persisted tip, while

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1269,7 +1269,7 @@ flowchart LR
 | Logical key | Value | Used by |
 |---|---|---|
 | `bp` + big-endian slot `uint64` + block hash bytes | Raw block CBOR, or expired-history marker `DBT1` | `BlobStore.SetBlock`, `GetBlock`, `TombstoneBlock`, block iterators |
-| `bp..._metadata` | `types.BlockMetadata`: `id`, `type`, `height`, `prev_hash` encoded as CBOR; Badger can use compact `DBM1` binary metadata | `GetBlock` and archive-proxy/history-expiry paths |
+| `bp..._metadata` | `types.BlockMetadata`: `id`, `type`, `height`, `prev_hash` encoded as CBOR; Badger can use compact `DBM1` binary metadata (run mode `serve`/`leios` with storage mode `core`). Which encoding is present depends on the configuration of the node that wrote the block, so decode with `types.UnmarshalBlockMetadata` rather than as CBOR — code outside the plugins reads this key directly. | `GetBlock`, the block-number search, and archive-proxy/history-expiry paths |
 | `bi` + big-endian internal block ID `uint64` | The corresponding `bp...` block key | Block iteration and block-by-index lookup |
 | `bh` + block hash bytes | The corresponding `bp...` block key | Fast block-by-hash lookup |
 | `u` + tx hash bytes + big-endian output index `uint32` | UTxO CBOR or a 52-byte `DOFF` CBOR-offset reference into a block | UTxO resolution and history expiry |
@@ -1571,7 +1571,9 @@ Search probes read the ordered `bi` entry and the block's `_metadata` object,
 never the block CBOR: a probe needs only the block's ID and height to decide
 which way to move, and reading it through the block itself would download a
 whole block object from cloud storage per probe. Only the one matching block is
-read in full.
+read in full. Because that value is read directly rather than through
+`GetBlock`, it is decoded with `types.UnmarshalBlockMetadata`, which accepts
+both the CBOR and the compact `DBM1` encodings.
 
 `lifecycle.ResolveTargetByNumber` keeps its own tip-bounded search rather than
 calling this: a truncate target must not resolve past the persisted tip, while

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1543,6 +1543,23 @@ on a database whose index has not been backfilled. Reserve the by-hash lookup
 for callers that genuinely have only a hash, and treat its `ErrBlockNotFound`
 as "not reachable by hash" rather than "not present".
 
+### Block Number Lookup
+
+`BlockByNumber` resolves a block from its chain block number (height). Block
+number is not an indexed blob key — only slot (`bp`), hash (`bh`), and the
+internal sequential ID (`bi`) are — so the lookup binary-searches the ID space
+that block numbers increase with, bounded above by the highest indexed block,
+and probes with `BlockAtOrAfterIndex` so a gap left by a Mithril bootstrap or
+drain import does not end the search early. A number no block carries returns
+`models.ErrBlockNotFound`. It costs O(log n) blob reads where a slot or hash
+lookup costs one, so prefer either of those when the caller has one; bark's
+`ArchiveService.FetchBlock` uses it only for a reference that supplies height
+alone.
+
+`lifecycle.ResolveTargetByNumber` keeps its own tip-bounded search rather than
+calling this: a truncate target must not resolve past the persisted tip, while
+a read should serve any block the blob store actually holds.
+
 ## SQL Examples Mirroring the Go API
 
 The examples below mirror common `metadata.MetadataStore` methods. Postgres examples use `decode($1, 'hex')`; MySQL equivalents use `UNHEX(?)`, `HEX(col)`, and `` `transaction` `` instead of `"transaction"`.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1571,9 +1571,10 @@ Search probes read the ordered `bi` entry and the block's `_metadata` object,
 never the block CBOR: a probe needs only the block's ID and height to decide
 which way to move, and reading it through the block itself would download a
 whole block object from cloud storage per probe. Only the one matching block is
-read in full. Because that value is read directly rather than through
-`GetBlock`, it is decoded with `types.UnmarshalBlockMetadata`, which accepts
-both the CBOR and the compact `DBM1` encodings.
+read in full. Because the `_metadata` object is read directly rather than
+through `GetBlock`, it is decoded with `types.UnmarshalBlockMetadata`, which
+accepts both the CBOR and the compact `DBM1` encodings. The block CBOR itself
+is unaffected: the matching block is still read through `GetBlock`.
 
 `lifecycle.ResolveTargetByNumber` keeps its own tip-bounded search rather than
 calling this: a truncate target must not resolve past the persisted tip, while

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -196,42 +196,6 @@ func isBlockMissing(err error) bool {
 		errors.Is(err, types.ErrBlobKeyNotFound)
 }
 
-// logBlockUnservable records a block the archive resolved out of its own
-// index and then could not sign a URL for.
-//
-// The cloud blob plugins report a lost metadata object with the same
-// types.ErrBlobKeyNotFound they use for an absent block object -- gcs
-// GetBlock and GetBlockURL log the partial write and return that error
-// anyway, and s3 GetBlockURL reads metadata before it ever heads the block
-// object -- so the error alone cannot tell the two apart. What does tell
-// them apart is that a lookup path already read this block: the index says
-// the archive holds it, and the blob store now says it does not.
-//
-// The reference is still answered in not_found. There is no URL to hand the
-// client, FetchBlockResponse has no per-reference error field, and failing
-// the call would discard every other block in the batch -- the exact defect
-// #3442 asked to remove. The operator, who is the only party that can act on
-// it, gets the log line instead.
-func (a *archiveServiceHandler) logBlockUnservable(
-	point common.Point,
-	err error,
-) {
-	if a.bark == nil || a.bark.config.Logger == nil {
-		return
-	}
-	a.bark.config.Logger.Warn(
-		"block resolved from the index but the blob store reports it missing; treating as not_found",
-		"component",
-		"bark",
-		"slot",
-		point.Slot,
-		"hash",
-		hex.EncodeToString(point.Hash),
-		"error",
-		err,
-	)
-}
-
 // FetchBlock resolves each requested block reference to a signed URL. A
 // reference the archive does not hold is reported in
 // FetchBlockResponse.not_found and the rest of the batch is still served;

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -25,9 +25,15 @@ import (
 	archive "github.com/blinklabs-io/bark/proto/v1alpha1/archive"
 	archiveconnect "github.com/blinklabs-io/bark/proto/v1alpha1/archive/archivev1alpha1connect"
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/protocol/common"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// blockHashLength is the byte length of a Cardano block hash, which the
+// hex-encoded BlockRef.hash field has to decode to.
+const blockHashLength = 32
 
 var _ archiveconnect.ArchiveServiceHandler = &archiveServiceHandler{}
 
@@ -35,6 +41,159 @@ type archiveServiceHandler struct {
 	bark *Bark
 }
 
+// blockRefRequest is one validated archive.BlockRef. It keeps which
+// identifiers the client actually supplied, separately from their values,
+// because that is both what has to agree with the stored block and what
+// has to be echoed back in the response.
+type blockRefRequest struct {
+	hashHex   string
+	hash      []byte
+	slot      uint64
+	height    uint64
+	hasHash   bool
+	hasSlot   bool
+	hasHeight bool
+}
+
+// parseBlockRef validates one reference without touching storage. A
+// reference naming no identifier at all, or carrying something that is not
+// a hex-encoded block hash, is not a valid BlockRef under the protocol --
+// it names no block rather than naming a block that happens to be absent
+// -- so it is rejected outright instead of being reported as not_found.
+func parseBlockRef(ref *archive.BlockRef) (blockRefRequest, error) {
+	if ref == nil {
+		return blockRefRequest{}, errors.New("block reference is nil")
+	}
+	if ref.Hash == nil && ref.Slot == nil && ref.Height == nil {
+		return blockRefRequest{}, errors.New(
+			"at least one of hash, slot, or height is required",
+		)
+	}
+	parsed := blockRefRequest{
+		hasHash:   ref.Hash != nil,
+		hasSlot:   ref.Slot != nil,
+		hasHeight: ref.Height != nil,
+		slot:      ref.GetSlot(),
+		height:    ref.GetHeight(),
+	}
+	if parsed.hasHash {
+		hash, err := hex.DecodeString(ref.GetHash())
+		if err != nil {
+			return blockRefRequest{}, fmt.Errorf(
+				"failed decoding hash %q: %w", ref.GetHash(), err,
+			)
+		}
+		if len(hash) != blockHashLength {
+			return blockRefRequest{}, fmt.Errorf(
+				"hash length must be %d bytes, got %d",
+				blockHashLength,
+				len(hash),
+			)
+		}
+		parsed.hashHex = ref.GetHash()
+		parsed.hash = hash
+	}
+	return parsed, nil
+}
+
+// requested rebuilds the reference exactly as the client supplied it, for
+// the not_found list, so the client can match the answer to its question.
+func (r blockRefRequest) requested() *archive.BlockRef {
+	ref := &archive.BlockRef{}
+	if r.hasHash {
+		ref.Hash = new(r.hashHex)
+	}
+	if r.hasSlot {
+		ref.Slot = new(r.slot)
+	}
+	if r.hasHeight {
+		ref.Height = new(r.height)
+	}
+	return ref
+}
+
+// resolved describes a found block. Every identifier the client supplied is
+// preserved verbatim -- a hash sent in upper case comes back in upper case
+// -- and the identifiers it left out are filled in from the stored block,
+// so a hash-only or height-only caller still learns the full identity.
+func (r blockRefRequest) resolved(
+	point common.Point,
+	height uint64,
+) *archive.BlockRef {
+	hashHex := r.hashHex
+	if !r.hasHash {
+		hashHex = hex.EncodeToString(point.Hash)
+	}
+	return &archive.BlockRef{
+		Hash:   new(hashHex),
+		Slot:   new(point.Slot),
+		Height: new(height),
+	}
+}
+
+// resolveBlockPoint maps a validated reference to the (slot, hash) point
+// the blob store keys blocks by.
+//
+// The precedence is hash+slot, then hash, then slot, then height:
+//
+//   - hash and slot together already are the blob store's block key, so
+//     they need no index lookup at all. Going through the hash index
+//     instead would also refuse a block written before that index existed
+//     (#1915), which is exactly the historical range an archive serves.
+//   - a hash alone is the only identifier unique across forks, and it
+//     resolves through an O(1) hash-index read.
+//   - a slot alone needs a bounded prefix scan of that one slot.
+//   - a height alone is last: block numbers are not indexed at all, so
+//     resolving one is a binary search over the block-ID space.
+//
+// Because the point is always built from the identifiers the client
+// supplied, a returned point agrees with them by construction: a hash
+// paired with the wrong slot simply misses the blob key, and a slot-only
+// or hash-only lookup returns the block that carries it. Height is the one
+// identifier that cannot be checked here, since it is not what any of
+// these lookups key on -- FetchBlock validates it against the block
+// metadata instead.
+func resolveBlockPoint(
+	db *database.Database,
+	ref blockRefRequest,
+) (common.Point, error) {
+	switch {
+	case ref.hasHash && ref.hasSlot:
+		return common.NewPoint(ref.slot, ref.hash), nil
+	case ref.hasHash:
+		block, err := database.BlockByHash(db, ref.hash)
+		if err != nil {
+			return common.Point{}, err
+		}
+		return common.NewPoint(block.Slot, block.Hash), nil
+	case ref.hasSlot:
+		block, err := database.BlockBySlot(db, ref.slot)
+		if err != nil {
+			return common.Point{}, err
+		}
+		return common.NewPoint(block.Slot, block.Hash), nil
+	default:
+		block, err := database.BlockByNumber(db, ref.height)
+		if err != nil {
+			return common.Point{}, err
+		}
+		return common.NewPoint(block.Slot, block.Hash), nil
+	}
+}
+
+// isBlockMissing reports whether err means the reference names no stored
+// block, rather than a storage failure. Both spellings occur: the block
+// lookups report a miss as models.ErrBlockNotFound, while the cloud blob
+// plugins report an absent object as types.ErrBlobKeyNotFound.
+func isBlockMissing(err error) bool {
+	return errors.Is(err, models.ErrBlockNotFound) ||
+		errors.Is(err, types.ErrBlobKeyNotFound)
+}
+
+// FetchBlock resolves each requested block reference to a signed URL. A
+// reference the archive does not hold is reported in
+// FetchBlockResponse.not_found and the rest of the batch is still served;
+// only a malformed request or a storage failure fails the whole call.
 func (a *archiveServiceHandler) FetchBlock(
 	ctx context.Context,
 	req *connect.Request[archive.FetchBlockRequest],
@@ -58,32 +217,61 @@ func (a *archiveServiceHandler) FetchBlock(
 		)
 	}
 
+	// Validate the whole batch before acquiring the database, so a
+	// malformed request costs no storage work.
+	refs := make([]blockRefRequest, 0, len(blocks))
+	for i, b := range blocks {
+		ref, err := parseBlockRef(b)
+		if err != nil {
+			return nil, connect.NewError(
+				connect.CodeInvalidArgument,
+				fmt.Errorf("block reference %d: %w", i, err),
+			)
+		}
+		refs = append(refs, ref)
+	}
+
 	db, release, err := a.bark.Acquire()
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
 	defer release()
 
-	for _, b := range blocks {
-		hash, err := hex.DecodeString(b.GetHash())
+	for _, ref := range refs {
+		point, err := resolveBlockPoint(db, ref)
 		if err != nil {
-			return nil,
-				fmt.Errorf("failed decoding hash %q: %w", b.GetHash(), err)
-		}
-		if len(hash) != 32 {
-			return nil,
-				fmt.Errorf("hash length must be 32 bytes, got %d", len(hash))
+			if isBlockMissing(err) {
+				resp.NotFound = append(resp.NotFound, ref.requested())
+				continue
+			}
+			return nil, fmt.Errorf(
+				"failed resolving block reference: %w",
+				err,
+			)
 		}
 
-		point := common.NewPoint(b.GetSlot(), hash)
 		signedURL, metadata, err := database.BlockURL(ctx, db, point)
 		if err != nil {
+			if isBlockMissing(err) {
+				resp.NotFound = append(resp.NotFound, ref.requested())
+				continue
+			}
 			return nil, fmt.Errorf(
 				"failed getting signed url for block [%d, %s]: %w",
 				point.Slot,
-				point.Hash,
+				hex.EncodeToString(point.Hash),
 				err,
 			)
+		}
+
+		// The point already agrees with any hash and slot the client sent
+		// (see resolveBlockPoint), but height is not what any lookup keys
+		// on. A reference whose height belongs to a different block
+		// describes no stored block, so it is reported as not_found rather
+		// than served the block its other identifiers happened to name.
+		if ref.hasHeight && ref.height != metadata.Height {
+			resp.NotFound = append(resp.NotFound, ref.requested())
+			continue
 		}
 
 		blockType := metadata.Type
@@ -92,11 +280,7 @@ func (a *archiveServiceHandler) FetchBlock(
 		}
 
 		resp.Blocks = append(resp.Blocks, &archive.SignedUrl{
-			Block: &archive.BlockRef{
-				Hash:   b.Hash,
-				Slot:   b.Slot,
-				Height: new(metadata.Height),
-			},
+			Block:     ref.resolved(point, metadata.Height),
 			Url:       signedURL.URL.String(),
 			ExpiresAt: timestamppb.New(signedURL.Expires),
 			Meta: &archive.BlockMeta{

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -132,7 +132,11 @@ func (r blockRefRequest) resolved(
 }
 
 // resolveBlockPoint maps a validated reference to the (slot, hash) point
-// the blob store keys blocks by.
+// the blob store keys blocks by, and reports whether resolving it actually
+// read the block out of the store. That second value is what separates "the
+// archive does not hold this block" from "the archive's index holds it but
+// the blob store will not serve it": only a lookup path proves the block was
+// there a moment ago.
 //
 // The precedence is hash+slot, then hash, then slot, then height:
 //
@@ -156,28 +160,30 @@ func (r blockRefRequest) resolved(
 func resolveBlockPoint(
 	db *database.Database,
 	ref blockRefRequest,
-) (common.Point, error) {
+) (common.Point, bool, error) {
 	switch {
 	case ref.hasHash && ref.hasSlot:
-		return common.NewPoint(ref.slot, ref.hash), nil
+		// Taken at face value: nothing was read, so this says nothing
+		// about whether the archive holds the block.
+		return common.NewPoint(ref.slot, ref.hash), false, nil
 	case ref.hasHash:
 		block, err := database.BlockByHash(db, ref.hash)
 		if err != nil {
-			return common.Point{}, err
+			return common.Point{}, false, err
 		}
-		return common.NewPoint(block.Slot, block.Hash), nil
+		return common.NewPoint(block.Slot, block.Hash), true, nil
 	case ref.hasSlot:
 		block, err := database.BlockBySlot(db, ref.slot)
 		if err != nil {
-			return common.Point{}, err
+			return common.Point{}, false, err
 		}
-		return common.NewPoint(block.Slot, block.Hash), nil
+		return common.NewPoint(block.Slot, block.Hash), true, nil
 	default:
 		block, err := database.BlockByNumber(db, ref.height)
 		if err != nil {
-			return common.Point{}, err
+			return common.Point{}, false, err
 		}
-		return common.NewPoint(block.Slot, block.Hash), nil
+		return common.NewPoint(block.Slot, block.Hash), true, nil
 	}
 }
 
@@ -188,6 +194,42 @@ func resolveBlockPoint(
 func isBlockMissing(err error) bool {
 	return errors.Is(err, models.ErrBlockNotFound) ||
 		errors.Is(err, types.ErrBlobKeyNotFound)
+}
+
+// logBlockUnservable records a block the archive resolved out of its own
+// index and then could not sign a URL for.
+//
+// The cloud blob plugins report a lost metadata object with the same
+// types.ErrBlobKeyNotFound they use for an absent block object -- gcs
+// GetBlock and GetBlockURL log the partial write and return that error
+// anyway, and s3 GetBlockURL reads metadata before it ever heads the block
+// object -- so the error alone cannot tell the two apart. What does tell
+// them apart is that a lookup path already read this block: the index says
+// the archive holds it, and the blob store now says it does not.
+//
+// The reference is still answered in not_found. There is no URL to hand the
+// client, FetchBlockResponse has no per-reference error field, and failing
+// the call would discard every other block in the batch -- the exact defect
+// #3442 asked to remove. The operator, who is the only party that can act on
+// it, gets the log line instead.
+func (a *archiveServiceHandler) logBlockUnservable(
+	point common.Point,
+	err error,
+) {
+	if a.bark == nil || a.bark.config.Logger == nil {
+		return
+	}
+	a.bark.config.Logger.Warn(
+		"block resolved from the index but the blob store reports it missing; treating as not_found",
+		"component",
+		"bark",
+		"slot",
+		point.Slot,
+		"hash",
+		hex.EncodeToString(point.Hash),
+		"error",
+		err,
+	)
 }
 
 // FetchBlock resolves each requested block reference to a signed URL. A
@@ -238,7 +280,7 @@ func (a *archiveServiceHandler) FetchBlock(
 	defer release()
 
 	for _, ref := range refs {
-		point, err := resolveBlockPoint(db, ref)
+		point, confirmed, err := resolveBlockPoint(db, ref)
 		if err != nil {
 			if isBlockMissing(err) {
 				resp.NotFound = append(resp.NotFound, ref.requested())
@@ -253,6 +295,9 @@ func (a *archiveServiceHandler) FetchBlock(
 		signedURL, metadata, err := database.BlockURL(ctx, db, point)
 		if err != nil {
 			if isBlockMissing(err) {
+				if confirmed {
+					a.logBlockUnservable(point, err)
+				}
 				resp.NotFound = append(resp.NotFound, ref.requested())
 				continue
 			}

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"connectrpc.com/connect"
 	archive "github.com/blinklabs-io/bark/proto/v1alpha1/archive"
@@ -112,6 +113,14 @@ func (r blockRefRequest) requested() *archive.BlockRef {
 	return ref
 }
 
+// resolvesByHeight reports whether this reference has to be resolved by
+// binary-searching the block-ID space, which is the one resolution path
+// that needs a bound. parseBlockRef guarantees at least one identifier, so
+// a reference carrying neither hash nor slot carries a height.
+func (r blockRefRequest) resolvesByHeight() bool {
+	return !r.hasHash && !r.hasSlot
+}
+
 // resolved describes a found block. Every identifier the client supplied is
 // preserved verbatim -- a hash sent in upper case comes back in upper case
 // -- and the identifiers it left out are filled in from the stored block,
@@ -148,7 +157,8 @@ func (r blockRefRequest) resolved(
 //     resolves through an O(1) hash-index read.
 //   - a slot alone needs a bounded prefix scan of that one slot.
 //   - a height alone is last: block numbers are not indexed at all, so
-//     resolving one is a binary search over the block-ID space.
+//     resolving one is a binary search over the block-ID space, against a
+//     bound the caller resolves once for the whole batch.
 //
 // Because the point is always built from the identifiers the client
 // supplied, a returned point agrees with them by construction: a hash
@@ -160,6 +170,7 @@ func (r blockRefRequest) resolved(
 func resolveBlockPoint(
 	db *database.Database,
 	ref blockRefRequest,
+	bound database.BlockNumberBound,
 ) (common.Point, bool, error) {
 	switch {
 	case ref.hasHash && ref.hasSlot:
@@ -179,7 +190,7 @@ func resolveBlockPoint(
 		}
 		return common.NewPoint(block.Slot, block.Hash), true, nil
 	default:
-		block, err := database.BlockByNumber(db, ref.height)
+		block, err := database.BlockByNumberBounded(db, ref.height, bound)
 		if err != nil {
 			return common.Point{}, false, err
 		}
@@ -243,8 +254,30 @@ func (a *archiveServiceHandler) FetchBlock(
 	}
 	defer release()
 
+	// Height is the one identifier nothing is keyed by, so resolving one is
+	// a binary search bounded above by the highest indexed block. Reading
+	// that bound is a reverse iteration over the block-index prefix, and on
+	// s3 and gcs -- the only backends that sign URLs, so the only ones this
+	// handler is reachable on -- a reverse iterator lists every object under
+	// the prefix with no early break. ArchiveService is unauthenticated, so
+	// resolving the bound per reference let one anonymous request carrying
+	// DefaultMaxFetchBlockRefs height-only references cost that many
+	// full-bucket enumerations. Resolve it once for the batch, and only when
+	// the batch actually contains a reference that needs it: a batch of
+	// hash+slot references still touches no index at all.
+	var bound database.BlockNumberBound
+	if slices.ContainsFunc(refs, blockRefRequest.resolvesByHeight) {
+		bound, err = database.ResolveBlockNumberBound(db)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed resolving highest indexed block: %w",
+				err,
+			)
+		}
+	}
+
 	for _, ref := range refs {
-		point, confirmed, err := resolveBlockPoint(db, ref)
+		point, confirmed, err := resolveBlockPoint(db, ref, bound)
 		if err != nil {
 			if isBlockMissing(err) {
 				resp.NotFound = append(resp.NotFound, ref.requested())

--- a/bark/archive.go
+++ b/bark/archive.go
@@ -296,7 +296,12 @@ func (a *archiveServiceHandler) FetchBlock(
 		if err != nil {
 			if isBlockMissing(err) {
 				if confirmed {
-					a.logBlockUnservable(point, err)
+					return nil, fmt.Errorf(
+						"block %d/%s is indexed but its metadata is unavailable: %w",
+						point.Slot,
+						hex.EncodeToString(point.Hash),
+						err,
+					)
 				}
 				resp.NotFound = append(resp.NotFound, ref.requested())
 				continue

--- a/bark/archive_test.go
+++ b/bark/archive_test.go
@@ -1,0 +1,377 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bark
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	archive "github.com/blinklabs-io/bark/proto/v1alpha1/archive"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/internal/test/dbtest"
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// signedURLBlobProviderName registers the badger blob store behind a
+// deterministic URL signer. Badger itself returns "GetBlockURL not
+// supported", so without this wrapper no in-process test can reach the
+// archive handler's found path at all — only s3 and gcs sign URLs, and
+// both need live cloud credentials.
+const signedURLBlobProviderName = "signedbadger"
+
+// signedURLBlobTestExpiry is the fixed expiry the fake signer stamps on
+// every URL so a test can assert the value the handler propagated.
+var signedURLBlobTestExpiry = time.Date(
+	2030, time.January, 2, 3, 4, 5, 0, time.UTC,
+)
+
+// signedURLBlobStore wraps a local blob store with a signer that mints a
+// deterministic URL for any block the store actually holds, and reports a
+// missing block with the same types.ErrBlobKeyNotFound the cloud plugins
+// use, so the handler's not-found classification is exercised for real.
+type signedURLBlobStore struct {
+	blob.BlobStore
+}
+
+func (s *signedURLBlobStore) GetBlockURL(
+	_ context.Context,
+	txn types.Txn,
+	point ocommon.Point,
+) (types.SignedURL, types.BlockMetadata, error) {
+	_, metadata, err := s.BlobStore.GetBlock(txn, point.Slot, point.Hash)
+	if err != nil {
+		return types.SignedURL{}, types.BlockMetadata{}, err
+	}
+	return types.SignedURL{
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "archive.example.com",
+			Path: fmt.Sprintf(
+				"/%d/%s", point.Slot, hex.EncodeToString(point.Hash),
+			),
+		},
+		Expires: signedURLBlobTestExpiry,
+	}, metadata, nil
+}
+
+type signedURLBlobConfig struct{}
+
+func registerSignedURLBlobProvider(host *hostplugin.Host) error {
+	return hostplugin.Register(
+		host,
+		hostplugin.Descriptor{
+			Capability:  hostplugin.CapabilityStorageBlob,
+			Name:        signedURLBlobProviderName,
+			Description: "Badger with deterministic signed block URLs",
+		},
+		func() signedURLBlobConfig { return signedURLBlobConfig{} },
+		func(
+			_ context.Context,
+			_ signedURLBlobConfig,
+			deps blob.ProviderDependencies,
+		) (*signedURLBlobStore, hostplugin.Instance, error) {
+			store, err := badger.New(
+				badger.WithDataDir(deps.DataDir),
+				badger.WithLogger(deps.Logger),
+				badger.WithDeferOpen(),
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			return &signedURLBlobStore{BlobStore: store},
+				hostplugin.Lifecycle{
+					StartFunc: func(context.Context) error {
+						return store.Start()
+					},
+					StopFunc: store.CloseContext,
+				}, nil
+		},
+	)
+}
+
+// newSigningTestDB builds a test database whose blob store can sign block
+// URLs, which the archive handler needs to produce any SignedUrl at all.
+func newSigningTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := dbtest.NewDatabaseWithOptions(t, dbtest.Options{
+		Config: &database.Config{DataDir: t.TempDir()},
+		Blob: dbtest.StorageProvider{
+			Name:     signedURLBlobProviderName,
+			Register: registerSignedURLBlobProvider,
+		},
+	})
+	require.NoError(t, err)
+	return db
+}
+
+// newArchiveTestHandler builds an archive handler over a signing database
+// seeded with count blocks, and returns both the handler and the blocks.
+func newArchiveTestHandler(
+	t *testing.T,
+	count int,
+) (*archiveServiceHandler, []models.Block) {
+	t.Helper()
+	db := newSigningTestDB(t)
+	blocks := make([]models.Block, 0, count)
+	for i := 1; i <= count; i++ {
+		// #nosec G115 -- fixed small test fixture values.
+		block := testBlock(uint64(i), byte(0x10+i))
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+	}
+	return &archiveServiceHandler{bark: newTestBark(t, db)}, blocks
+}
+
+func fetchBlocks(
+	t *testing.T,
+	handler *archiveServiceHandler,
+	refs ...*archive.BlockRef,
+) *archive.FetchBlockResponse {
+	t.Helper()
+	resp, err := handler.FetchBlock(
+		t.Context(),
+		connect.NewRequest(&archive.FetchBlockRequest{Blocks: refs}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp.Msg
+}
+
+// TestArchiveFetchBlockResolvesSingleReference pins the fully-specified
+// single-reference case: one SignedUrl, no not_found, and the requested
+// identifier fields echoed back verbatim rather than recomputed — the
+// upper-case hash proves the handler returns what was asked for.
+func TestArchiveFetchBlockResolvesSingleReference(t *testing.T) {
+	handler, blocks := newArchiveTestHandler(t, 3)
+	block := blocks[1]
+	requestedHash := strings.ToUpper(hex.EncodeToString(block.Hash))
+
+	msg := fetchBlocks(t, handler, &archive.BlockRef{
+		Hash:   new(requestedHash),
+		Slot:   new(block.Slot),
+		Height: new(block.Number),
+	})
+
+	require.Empty(t, msg.GetNotFound())
+	require.Len(t, msg.GetBlocks(), 1)
+	got := msg.GetBlocks()[0]
+	require.Equal(t, requestedHash, got.GetBlock().GetHash())
+	require.Equal(t, block.Slot, got.GetBlock().GetSlot())
+	require.Equal(t, block.Number, got.GetBlock().GetHeight())
+	require.Equal(
+		t,
+		fmt.Sprintf(
+			"https://archive.example.com/%d/%s",
+			block.Slot,
+			hex.EncodeToString(block.Hash),
+		),
+		got.GetUrl(),
+	)
+	require.True(
+		t,
+		signedURLBlobTestExpiry.Equal(got.GetExpiresAt().AsTime()),
+		"expected expiry %s, got %s",
+		signedURLBlobTestExpiry,
+		got.GetExpiresAt().AsTime(),
+	)
+	require.Equal(
+		t,
+		archive.BlockType_BLOCK_TYPE_BYRON_MAIN,
+		got.GetMeta().GetType(),
+	)
+}
+
+// TestArchiveFetchBlockResolvesIdentifierOnlyReferences covers each
+// identifier the proto allows on its own. The response fills in the
+// identifiers the client did not supply so a hash-only or height-only
+// caller still learns the block's full identity.
+func TestArchiveFetchBlockResolvesIdentifierOnlyReferences(t *testing.T) {
+	handler, blocks := newArchiveTestHandler(t, 3)
+	block := blocks[2]
+	hash := hex.EncodeToString(block.Hash)
+
+	for _, testCase := range []struct {
+		name string
+		ref  *archive.BlockRef
+	}{
+		{name: "hash only", ref: &archive.BlockRef{Hash: new(hash)}},
+		{name: "slot only", ref: &archive.BlockRef{Slot: new(block.Slot)}},
+		{
+			name: "height only",
+			ref:  &archive.BlockRef{Height: new(block.Number)},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			msg := fetchBlocks(t, handler, testCase.ref)
+
+			require.Empty(t, msg.GetNotFound())
+			require.Len(t, msg.GetBlocks(), 1)
+			got := msg.GetBlocks()[0].GetBlock()
+			require.Equal(t, hash, got.GetHash())
+			require.Equal(t, block.Slot, got.GetSlot())
+			require.Equal(t, block.Number, got.GetHeight())
+		})
+	}
+}
+
+// TestArchiveFetchBlockReturnsNotFoundWithoutDiscardingBatch proves a
+// missing reference no longer aborts the whole request: the blocks that do
+// exist still come back, and each missing reference is echoed under
+// not_found carrying only the fields the client supplied.
+func TestArchiveFetchBlockReturnsNotFoundWithoutDiscardingBatch(
+	t *testing.T,
+) {
+	handler, blocks := newArchiveTestHandler(t, 3)
+	firstHash := hex.EncodeToString(blocks[0].Hash)
+	lastHash := hex.EncodeToString(blocks[2].Hash)
+	missingHash := strings.Repeat("ab", 32)
+	missingHeight := uint64(9999)
+
+	msg := fetchBlocks(
+		t,
+		handler,
+		&archive.BlockRef{Hash: new(firstHash), Slot: new(blocks[0].Slot)},
+		&archive.BlockRef{Hash: new(missingHash)},
+		&archive.BlockRef{Hash: new(lastHash), Slot: new(blocks[2].Slot)},
+		&archive.BlockRef{Height: new(missingHeight)},
+	)
+
+	require.Len(t, msg.GetBlocks(), 2)
+	require.Equal(t, firstHash, msg.GetBlocks()[0].GetBlock().GetHash())
+	require.Equal(t, lastHash, msg.GetBlocks()[1].GetBlock().GetHash())
+
+	require.Len(t, msg.GetNotFound(), 2)
+	require.Equal(t, missingHash, msg.GetNotFound()[0].GetHash())
+	require.Nil(t, msg.GetNotFound()[0].Slot)
+	require.Nil(t, msg.GetNotFound()[0].Height)
+	require.Equal(t, missingHeight, msg.GetNotFound()[1].GetHeight())
+	require.Nil(t, msg.GetNotFound()[1].Hash)
+}
+
+// TestArchiveFetchBlockTreatsInconsistentReferenceAsNotFound covers a
+// well-formed reference whose identifiers name different blocks. No stored
+// block satisfies all of them, so it is reported as not_found — a fork or
+// a stale client index, not a malformed request — and the rest of the
+// batch is unaffected.
+func TestArchiveFetchBlockTreatsInconsistentReferenceAsNotFound(
+	t *testing.T,
+) {
+	handler, blocks := newArchiveTestHandler(t, 3)
+	first, second := blocks[0], blocks[1]
+	firstHash := hex.EncodeToString(first.Hash)
+	secondHash := hex.EncodeToString(second.Hash)
+
+	for _, testCase := range []struct {
+		name string
+		ref  *archive.BlockRef
+	}{
+		{
+			name: "hash and slot disagree",
+			ref: &archive.BlockRef{
+				Hash: new(firstHash),
+				Slot: new(second.Slot),
+			},
+		},
+		{
+			name: "hash and height disagree",
+			ref: &archive.BlockRef{
+				Hash:   new(firstHash),
+				Height: new(second.Number),
+			},
+		},
+		{
+			name: "slot and height disagree",
+			ref: &archive.BlockRef{
+				Slot:   new(first.Slot),
+				Height: new(second.Number),
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			msg := fetchBlocks(
+				t,
+				handler,
+				testCase.ref,
+				&archive.BlockRef{
+					Hash: new(secondHash),
+					Slot: new(second.Slot),
+				},
+			)
+
+			require.Len(t, msg.GetNotFound(), 1)
+			require.Len(t, msg.GetBlocks(), 1)
+			require.Equal(
+				t, secondHash, msg.GetBlocks()[0].GetBlock().GetHash(),
+			)
+		})
+	}
+}
+
+// TestArchiveFetchBlockRejectsMalformedReference separates a malformed
+// reference from a missing one. A reference carrying no identifier, or a
+// hash that is not a 32-byte hex string, is not a valid BlockRef at all,
+// so the whole request fails with InvalidArgument instead of quietly
+// landing in not_found.
+func TestArchiveFetchBlockRejectsMalformedReference(t *testing.T) {
+	handler, blocks := newArchiveTestHandler(t, 1)
+	validHash := hex.EncodeToString(blocks[0].Hash)
+
+	for _, testCase := range []struct {
+		name string
+		ref  *archive.BlockRef
+	}{
+		{name: "no identifier", ref: &archive.BlockRef{}},
+		{
+			name: "hash not hex",
+			ref:  &archive.BlockRef{Hash: new(strings.Repeat("zz", 32))},
+		},
+		{
+			name: "hash too short",
+			ref:  &archive.BlockRef{Hash: new(strings.Repeat("ab", 16))},
+		},
+		{name: "empty hash", ref: &archive.BlockRef{Hash: new("")}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := handler.FetchBlock(
+				t.Context(),
+				connect.NewRequest(&archive.FetchBlockRequest{
+					Blocks: []*archive.BlockRef{
+						{
+							Hash: new(validHash),
+							Slot: new(blocks[0].Slot),
+						},
+						testCase.ref,
+					},
+				}),
+			)
+			require.Error(t, err)
+			require.Equal(
+				t, connect.CodeInvalidArgument, connect.CodeOf(err),
+			)
+		})
+	}
+}

--- a/bark/archive_test.go
+++ b/bark/archive_test.go
@@ -15,7 +15,6 @@
 package bark
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -327,13 +326,15 @@ func TestArchiveFetchBlockReturnsNotFoundWithoutDiscardingBatch(
 
 // TestArchiveFetchBlockRejectsMissingMetadata covers an indexed block whose
 // URL metadata is unavailable. The index lookup already proved the block
-// exists, so this is a storage error rather than a missing block.
+// exists, so this is a storage error rather than a missing block, and it
+// fails the call.
+//
+// The other two cases pin the boundary of that rule. A hash+slot reference
+// resolves without reading anything, so a miss there is an ordinary absent
+// block as far as the handler can tell; and a hash naming no stored block
+// misses at resolution, before the blob store is asked for a URL at all.
+// Neither is evidence of an inconsistency, so neither may fail the call.
 func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
-	var logs bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(
-		&logs,
-		&slog.HandlerOptions{Level: slog.LevelDebug},
-	))
 	// testBlock is deterministic, so the second seeded block's hash is
 	// known before the store that has to refuse to sign it is built.
 	lostHash := hex.EncodeToString(testBlock(2, 0x12).Hash)
@@ -341,7 +342,7 @@ func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
 		t,
 		3,
 		map[string]struct{}{lostHash: {}},
-		logger,
+		nil,
 	)
 	lost, served := blocks[1], blocks[0]
 	require.Equal(t, lostHash, hex.EncodeToString(lost.Hash))
@@ -356,26 +357,18 @@ func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrBlobKeyNotFound)
 
-	// hash+slot resolves with no lookup, so a miss there is an ordinary
-	// absent block as far as the handler can tell, and must not be logged
-	// as an inconsistency.
-	logs.Reset()
 	msg := fetchBlocks(t, handler, &archive.BlockRef{
 		Hash: new(lostHash),
 		Slot: new(lost.Slot),
 	})
 	require.Len(t, msg.GetNotFound(), 1)
 	require.Empty(t, msg.GetBlocks())
-	require.Empty(t, logs.String())
 
-	// A hash that names no stored block fails at resolution, before the
-	// blob store is asked for anything.
-	logs.Reset()
 	msg = fetchBlocks(t, handler, &archive.BlockRef{
 		Hash: new(strings.Repeat("ab", 32)),
 	})
 	require.Len(t, msg.GetNotFound(), 1)
-	require.Empty(t, logs.String())
+	require.Empty(t, msg.GetBlocks())
 }
 
 // TestArchiveFetchBlockTreatsInconsistentReferenceAsNotFound covers a

--- a/bark/archive_test.go
+++ b/bark/archive_test.go
@@ -15,9 +15,11 @@
 package bark
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"testing"
@@ -55,6 +57,15 @@ var signedURLBlobTestExpiry = time.Date(
 // use, so the handler's not-found classification is exercised for real.
 type signedURLBlobStore struct {
 	blob.BlobStore
+	// unsignable holds hex block hashes whose metadata object is treated
+	// as lost: GetBlockURL reports types.ErrBlobKeyNotFound while the block
+	// itself stays readable through GetBlock. That is the partial-write
+	// shape both cloud plugins collapse into the same error they use for a
+	// block that was never written (gcs GetBlockURL logs the difference and
+	// returns ErrBlobKeyNotFound regardless; s3 GetBlockURL reads metadata
+	// before it heads the block object at all), so it cannot be produced by
+	// deleting anything -- it has to be injected here.
+	unsignable map[string]struct{}
 }
 
 func (s *signedURLBlobStore) GetBlockURL(
@@ -62,6 +73,14 @@ func (s *signedURLBlobStore) GetBlockURL(
 	txn types.Txn,
 	point ocommon.Point,
 ) (types.SignedURL, types.BlockMetadata, error) {
+	if _, ok := s.unsignable[hex.EncodeToString(point.Hash)]; ok {
+		return types.SignedURL{}, types.BlockMetadata{}, fmt.Errorf(
+			"metadata object for block [%d, %s] is missing: %w",
+			point.Slot,
+			hex.EncodeToString(point.Hash),
+			types.ErrBlobKeyNotFound,
+		)
+	}
 	_, metadata, err := s.BlobStore.GetBlock(txn, point.Slot, point.Hash)
 	if err != nil {
 		return types.SignedURL{}, types.BlockMetadata{}, err
@@ -80,7 +99,14 @@ func (s *signedURLBlobStore) GetBlockURL(
 
 type signedURLBlobConfig struct{}
 
-func registerSignedURLBlobProvider(host *hostplugin.Host) error {
+// registerSignedURLBlobProvider registers the store, treating the given hex
+// block hashes as unsignable. dbtest builds a fresh plugin.Host per
+// database, so each test gets its own registration and the shared provider
+// name does not collide.
+func registerSignedURLBlobProvider(
+	host *hostplugin.Host,
+	unsignable map[string]struct{},
+) error {
 	return hostplugin.Register(
 		host,
 		hostplugin.Descriptor{
@@ -102,7 +128,11 @@ func registerSignedURLBlobProvider(host *hostplugin.Host) error {
 			if err != nil {
 				return nil, nil, err
 			}
-			return &signedURLBlobStore{BlobStore: store},
+			signing := &signedURLBlobStore{
+				BlobStore:  store,
+				unsignable: unsignable,
+			}
+			return signing,
 				hostplugin.Lifecycle{
 					StartFunc: func(context.Context) error {
 						return store.Start()
@@ -115,13 +145,20 @@ func registerSignedURLBlobProvider(host *hostplugin.Host) error {
 
 // newSigningTestDB builds a test database whose blob store can sign block
 // URLs, which the archive handler needs to produce any SignedUrl at all.
-func newSigningTestDB(t *testing.T) *database.Database {
+// Hashes in unsignable are the exception: the store holds those blocks but
+// refuses to sign them, so GetBlockURL reports them missing.
+func newSigningTestDB(
+	t *testing.T,
+	unsignable map[string]struct{},
+) *database.Database {
 	t.Helper()
 	db, err := dbtest.NewDatabaseWithOptions(t, dbtest.Options{
 		Config: &database.Config{DataDir: t.TempDir()},
 		Blob: dbtest.StorageProvider{
-			Name:     signedURLBlobProviderName,
-			Register: registerSignedURLBlobProvider,
+			Name: signedURLBlobProviderName,
+			Register: func(host *hostplugin.Host) error {
+				return registerSignedURLBlobProvider(host, unsignable)
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -135,7 +172,21 @@ func newArchiveTestHandler(
 	count int,
 ) (*archiveServiceHandler, []models.Block) {
 	t.Helper()
-	db := newSigningTestDB(t)
+	return newArchiveTestHandlerWithLogger(t, count, nil, nil)
+}
+
+// newArchiveTestHandlerWithLogger builds an archive handler over a signing
+// database seeded with count blocks, refusing to sign the hex block hashes
+// in unsignable and logging through logger. A nil logger leaves NewBark's
+// discard logger in place.
+func newArchiveTestHandlerWithLogger(
+	t *testing.T,
+	count int,
+	unsignable map[string]struct{},
+	logger *slog.Logger,
+) (*archiveServiceHandler, []models.Block) {
+	t.Helper()
+	db := newSigningTestDB(t, unsignable)
 	blocks := make([]models.Block, 0, count)
 	for i := 1; i <= count; i++ {
 		// #nosec G115 -- fixed small test fixture values.
@@ -143,7 +194,9 @@ func newArchiveTestHandler(
 		require.NoError(t, db.BlockCreate(block, nil))
 		blocks = append(blocks, block)
 	}
-	return &archiveServiceHandler{bark: newTestBark(t, db)}, blocks
+	b, err := NewBark(BarkConfig{DB: db, Port: 1, Logger: logger})
+	require.NoError(t, err)
+	return &archiveServiceHandler{bark: b}, blocks
 }
 
 func fetchBlocks(
@@ -270,6 +323,79 @@ func TestArchiveFetchBlockReturnsNotFoundWithoutDiscardingBatch(
 	require.Nil(t, msg.GetNotFound()[0].Height)
 	require.Equal(t, missingHeight, msg.GetNotFound()[1].GetHeight())
 	require.Nil(t, msg.GetNotFound()[1].Hash)
+}
+
+// TestArchiveFetchBlockLogsUnservableResolvedBlock covers the one shape a
+// not_found answer can hide: the block is in the archive's index, and the
+// blob store still reports it missing when asked for a URL. Both cloud
+// plugins return types.ErrBlobKeyNotFound for a lost metadata object and
+// for a block that was never written, so the error cannot distinguish them
+// — a lookup having already read the block is what does.
+//
+// The client answer stays not_found, since there is no URL to give it and
+// failing the call would discard the rest of the batch. The operator gets a
+// log line naming the block. The hash+slot and unknown-hash cases below pin
+// the other half of that contract: neither resolves through a lookup, so
+// neither is evidence of anything and neither may log.
+func TestArchiveFetchBlockLogsUnservableResolvedBlock(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+	// testBlock is deterministic, so the second seeded block's hash is
+	// known before the store that has to refuse to sign it is built.
+	lostHash := hex.EncodeToString(testBlock(2, 0x12).Hash)
+	handler, blocks := newArchiveTestHandlerWithLogger(
+		t,
+		3,
+		map[string]struct{}{lostHash: {}},
+		logger,
+	)
+	lost, served := blocks[1], blocks[0]
+	require.Equal(t, lostHash, hex.EncodeToString(lost.Hash))
+	servedHash := hex.EncodeToString(served.Hash)
+
+	msg := fetchBlocks(
+		t,
+		handler,
+		&archive.BlockRef{Hash: new(lostHash)},
+		&archive.BlockRef{
+			Hash: new(servedHash),
+			Slot: new(served.Slot),
+		},
+	)
+
+	require.Len(t, msg.GetBlocks(), 1, "rest of the batch is still served")
+	require.Equal(t, servedHash, msg.GetBlocks()[0].GetBlock().GetHash())
+	require.Len(t, msg.GetNotFound(), 1)
+	require.Equal(t, lostHash, msg.GetNotFound()[0].GetHash())
+
+	logged := logs.String()
+	require.Contains(t, logged, "blob store reports it missing")
+	require.Contains(t, logged, lostHash)
+	require.Contains(t, logged, fmt.Sprintf("slot=%d", lost.Slot))
+
+	// hash+slot resolves with no lookup, so a miss there is an ordinary
+	// absent block as far as the handler can tell, and must not be logged
+	// as an inconsistency.
+	logs.Reset()
+	msg = fetchBlocks(t, handler, &archive.BlockRef{
+		Hash: new(lostHash),
+		Slot: new(lost.Slot),
+	})
+	require.Len(t, msg.GetNotFound(), 1)
+	require.Empty(t, msg.GetBlocks())
+	require.Empty(t, logs.String())
+
+	// A hash that names no stored block fails at resolution, before the
+	// blob store is asked for anything.
+	logs.Reset()
+	msg = fetchBlocks(t, handler, &archive.BlockRef{
+		Hash: new(strings.Repeat("ab", 32)),
+	})
+	require.Len(t, msg.GetNotFound(), 1)
+	require.Empty(t, logs.String())
 }
 
 // TestArchiveFetchBlockTreatsInconsistentReferenceAsNotFound covers a

--- a/bark/archive_test.go
+++ b/bark/archive_test.go
@@ -15,12 +15,13 @@
 package bark
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,6 +66,73 @@ type signedURLBlobStore struct {
 	// before it heads the block object at all), so it cannot be produced by
 	// deleting anything -- it has to be injected here.
 	unsignable map[string]struct{}
+	// counts, when non-nil, records the blob operations a request causes.
+	counts *blobOpCounts
+}
+
+// blobOpCounts records the blob operations that matter to the cost of a
+// FetchBlock batch. Badger answers all of them locally and cheaply, so a
+// regression in how many of them a request makes is invisible in wall
+// clock here and only shows up as load on s3 or gcs -- counting them is
+// the only way an in-process test can see it.
+type blobOpCounts struct {
+	// reverseIndexScans counts reverse iterations over the block-index
+	// prefix. Each one is a full listing of every block-index object in
+	// the bucket on s3 and gcs (listKeysToFile, no early break).
+	reverseIndexScans atomic.Int64
+	// forwardIndexScans counts forward iterations over the block-index
+	// prefix. These are prefix-bounded range LISTs.
+	forwardIndexScans atomic.Int64
+	// blockReads counts whole-block reads: a block object downloaded in
+	// full from the store.
+	blockReads atomic.Int64
+	// metadataReads counts reads of the small per-block metadata object,
+	// which carries the block ID and height without the block CBOR.
+	metadataReads atomic.Int64
+}
+
+func (c *blobOpCounts) reset() {
+	c.reverseIndexScans.Store(0)
+	c.forwardIndexScans.Store(0)
+	c.blockReads.Store(0)
+	c.metadataReads.Store(0)
+}
+
+func (s *signedURLBlobStore) NewIterator(
+	txn types.Txn,
+	opts types.BlobIteratorOptions,
+) types.BlobIterator {
+	if s.counts != nil &&
+		bytes.HasPrefix(opts.Prefix, []byte(types.BlockBlobIndexKeyPrefix)) {
+		if opts.Reverse {
+			s.counts.reverseIndexScans.Add(1)
+		} else {
+			s.counts.forwardIndexScans.Add(1)
+		}
+	}
+	return s.BlobStore.NewIterator(txn, opts)
+}
+
+func (s *signedURLBlobStore) GetBlock(
+	txn types.Txn,
+	slot uint64,
+	hash []byte,
+) ([]byte, types.BlockMetadata, error) {
+	if s.counts != nil {
+		s.counts.blockReads.Add(1)
+	}
+	return s.BlobStore.GetBlock(txn, slot, hash)
+}
+
+func (s *signedURLBlobStore) Get(
+	txn types.Txn,
+	key []byte,
+) ([]byte, error) {
+	if s.counts != nil &&
+		bytes.HasSuffix(key, []byte(types.BlockBlobMetadataKeySuffix)) {
+		s.counts.metadataReads.Add(1)
+	}
+	return s.BlobStore.Get(txn, key)
 }
 
 func (s *signedURLBlobStore) GetBlockURL(
@@ -80,6 +148,9 @@ func (s *signedURLBlobStore) GetBlockURL(
 			types.ErrBlobKeyNotFound,
 		)
 	}
+	// s.BlobStore, not s: the real cloud GetBlockURL reads the metadata
+	// object and heads the block object, so this stand-in must not be
+	// counted as a whole-block read.
 	_, metadata, err := s.BlobStore.GetBlock(txn, point.Slot, point.Hash)
 	if err != nil {
 		return types.SignedURL{}, types.BlockMetadata{}, err
@@ -98,13 +169,21 @@ func (s *signedURLBlobStore) GetBlockURL(
 
 type signedURLBlobConfig struct{}
 
+// archiveTestOptions tunes the database an archive test handler runs on.
+type archiveTestOptions struct {
+	// unsignable holds hex block hashes GetBlockURL must refuse to sign.
+	unsignable map[string]struct{}
+	// counts, when non-nil, records the blob operations requests cause.
+	counts *blobOpCounts
+}
+
 // registerSignedURLBlobProvider registers the store, treating the given hex
 // block hashes as unsignable. dbtest builds a fresh plugin.Host per
 // database, so each test gets its own registration and the shared provider
 // name does not collide.
 func registerSignedURLBlobProvider(
 	host *hostplugin.Host,
-	unsignable map[string]struct{},
+	opts archiveTestOptions,
 ) error {
 	return hostplugin.Register(
 		host,
@@ -129,7 +208,8 @@ func registerSignedURLBlobProvider(
 			}
 			signing := &signedURLBlobStore{
 				BlobStore:  store,
-				unsignable: unsignable,
+				unsignable: opts.unsignable,
+				counts:     opts.counts,
 			}
 			return signing,
 				hostplugin.Lifecycle{
@@ -148,7 +228,7 @@ func registerSignedURLBlobProvider(
 // refuses to sign them, so GetBlockURL reports them missing.
 func newSigningTestDB(
 	t *testing.T,
-	unsignable map[string]struct{},
+	opts archiveTestOptions,
 ) *database.Database {
 	t.Helper()
 	db, err := dbtest.NewDatabaseWithOptions(t, dbtest.Options{
@@ -156,7 +236,7 @@ func newSigningTestDB(
 		Blob: dbtest.StorageProvider{
 			Name: signedURLBlobProviderName,
 			Register: func(host *hostplugin.Host) error {
-				return registerSignedURLBlobProvider(host, unsignable)
+				return registerSignedURLBlobProvider(host, opts)
 			},
 		},
 	})
@@ -171,21 +251,18 @@ func newArchiveTestHandler(
 	count int,
 ) (*archiveServiceHandler, []models.Block) {
 	t.Helper()
-	return newArchiveTestHandlerWithLogger(t, count, nil, nil)
+	return newArchiveTestHandlerWithOptions(t, count, archiveTestOptions{})
 }
 
-// newArchiveTestHandlerWithLogger builds an archive handler over a signing
-// database seeded with count blocks, refusing to sign the hex block hashes
-// in unsignable and logging through logger. A nil logger leaves NewBark's
-// discard logger in place.
-func newArchiveTestHandlerWithLogger(
+// newArchiveTestHandlerWithOptions builds an archive handler over a signing
+// database seeded with count blocks, configured by opts.
+func newArchiveTestHandlerWithOptions(
 	t *testing.T,
 	count int,
-	unsignable map[string]struct{},
-	logger *slog.Logger,
+	opts archiveTestOptions,
 ) (*archiveServiceHandler, []models.Block) {
 	t.Helper()
-	db := newSigningTestDB(t, unsignable)
+	db := newSigningTestDB(t, opts)
 	blocks := make([]models.Block, 0, count)
 	for i := 1; i <= count; i++ {
 		// #nosec G115 -- fixed small test fixture values.
@@ -193,7 +270,7 @@ func newArchiveTestHandlerWithLogger(
 		require.NoError(t, db.BlockCreate(block, nil))
 		blocks = append(blocks, block)
 	}
-	b, err := NewBark(BarkConfig{DB: db, Port: 1, Logger: logger})
+	b, err := NewBark(BarkConfig{DB: db, Port: 1})
 	require.NoError(t, err)
 	return &archiveServiceHandler{bark: b}, blocks
 }
@@ -338,11 +415,10 @@ func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
 	// testBlock is deterministic, so the second seeded block's hash is
 	// known before the store that has to refuse to sign it is built.
 	lostHash := hex.EncodeToString(testBlock(2, 0x12).Hash)
-	handler, blocks := newArchiveTestHandlerWithLogger(
-		t,
-		3,
-		map[string]struct{}{lostHash: {}},
-		nil,
+	handler, blocks := newArchiveTestHandlerWithOptions(t, 3,
+		archiveTestOptions{
+			unsignable: map[string]struct{}{lostHash: {}},
+		},
 	)
 	lost, served := blocks[1], blocks[0]
 	require.Equal(t, lostHash, hex.EncodeToString(lost.Hash))
@@ -369,6 +445,75 @@ func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
 	})
 	require.Len(t, msg.GetNotFound(), 1)
 	require.Empty(t, msg.GetBlocks())
+}
+
+// TestArchiveFetchBlockResolvesHeightBoundOncePerBatch pins the blob cost
+// of a height-only batch.
+//
+// Height is the one identifier nothing is keyed by, so resolving one is a
+// binary search bounded above by the highest indexed block. Reading that
+// bound is a reverse iteration over the block-index prefix, and on s3 and
+// gcs -- the only backends that sign URLs, so the only ones this handler
+// runs on -- a reverse iterator lists every block-index object in the
+// bucket with no early break. ArchiveService takes no operator
+// credentials, so resolving the bound once per reference let a single
+// anonymous request carrying DefaultMaxFetchBlockRefs height-only
+// references cost that many full-bucket enumerations.
+//
+// The counts are asserted exactly rather than as an upper bound. Badger
+// answers every one of these cheaply and locally, so a regression costs no
+// measurable time here and would surface only as cloud-storage load.
+func TestArchiveFetchBlockResolvesHeightBoundOncePerBatch(t *testing.T) {
+	const blockCount = 16
+	counts := &blobOpCounts{}
+	handler, blocks := newArchiveTestHandlerWithOptions(t, blockCount,
+		archiveTestOptions{counts: counts},
+	)
+
+	heightRefs := make([]*archive.BlockRef, 0, len(blocks))
+	pointRefs := make([]*archive.BlockRef, 0, len(blocks))
+	for _, block := range blocks {
+		heightRefs = append(heightRefs, &archive.BlockRef{
+			Height: new(block.Number),
+		})
+		hash := hex.EncodeToString(block.Hash)
+		pointRefs = append(pointRefs, &archive.BlockRef{
+			Hash: new(hash),
+			Slot: new(block.Slot),
+		})
+	}
+
+	counts.reset()
+	msg := fetchBlocks(t, handler, heightRefs...)
+	require.Len(t, msg.GetBlocks(), blockCount)
+	require.Empty(t, msg.GetNotFound())
+
+	require.Equal(
+		t,
+		int64(1),
+		counts.reverseIndexScans.Load(),
+		"the highest indexed block must be resolved once for the batch, not once per reference",
+	)
+	require.Equal(
+		t,
+		int64(blockCount),
+		counts.blockReads.Load(),
+		"only the matched block is read in full; search probes read the metadata object instead of the block CBOR",
+	)
+	require.Positive(
+		t,
+		counts.metadataReads.Load(),
+		"the search must be reading metadata objects",
+	)
+
+	// A batch that needs no height search must resolve no bound at all, so
+	// hash+slot references stay free of index work entirely.
+	counts.reset()
+	msg = fetchBlocks(t, handler, pointRefs...)
+	require.Len(t, msg.GetBlocks(), blockCount)
+	require.Empty(t, msg.GetNotFound())
+	require.Zero(t, counts.reverseIndexScans.Load())
+	require.Zero(t, counts.forwardIndexScans.Load())
 }
 
 // TestArchiveFetchBlockTreatsInconsistentReferenceAsNotFound covers a

--- a/bark/archive_test.go
+++ b/bark/archive_test.go
@@ -325,19 +325,10 @@ func TestArchiveFetchBlockReturnsNotFoundWithoutDiscardingBatch(
 	require.Nil(t, msg.GetNotFound()[1].Hash)
 }
 
-// TestArchiveFetchBlockLogsUnservableResolvedBlock covers the one shape a
-// not_found answer can hide: the block is in the archive's index, and the
-// blob store still reports it missing when asked for a URL. Both cloud
-// plugins return types.ErrBlobKeyNotFound for a lost metadata object and
-// for a block that was never written, so the error cannot distinguish them
-// — a lookup having already read the block is what does.
-//
-// The client answer stays not_found, since there is no URL to give it and
-// failing the call would discard the rest of the batch. The operator gets a
-// log line naming the block. The hash+slot and unknown-hash cases below pin
-// the other half of that contract: neither resolves through a lookup, so
-// neither is evidence of anything and neither may log.
-func TestArchiveFetchBlockLogsUnservableResolvedBlock(t *testing.T) {
+// TestArchiveFetchBlockRejectsMissingMetadata covers an indexed block whose
+// URL metadata is unavailable. The index lookup already proved the block
+// exists, so this is a storage error rather than a missing block.
+func TestArchiveFetchBlockRejectsMissingMetadata(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(
 		&logs,
@@ -356,31 +347,20 @@ func TestArchiveFetchBlockLogsUnservableResolvedBlock(t *testing.T) {
 	require.Equal(t, lostHash, hex.EncodeToString(lost.Hash))
 	servedHash := hex.EncodeToString(served.Hash)
 
-	msg := fetchBlocks(
-		t,
-		handler,
-		&archive.BlockRef{Hash: new(lostHash)},
-		&archive.BlockRef{
-			Hash: new(servedHash),
-			Slot: new(served.Slot),
-		},
-	)
-
-	require.Len(t, msg.GetBlocks(), 1, "rest of the batch is still served")
-	require.Equal(t, servedHash, msg.GetBlocks()[0].GetBlock().GetHash())
-	require.Len(t, msg.GetNotFound(), 1)
-	require.Equal(t, lostHash, msg.GetNotFound()[0].GetHash())
-
-	logged := logs.String()
-	require.Contains(t, logged, "blob store reports it missing")
-	require.Contains(t, logged, lostHash)
-	require.Contains(t, logged, fmt.Sprintf("slot=%d", lost.Slot))
+	_, err := handler.FetchBlock(t.Context(), connect.NewRequest(
+		&archive.FetchBlockRequest{Blocks: []*archive.BlockRef{
+			{Hash: new(lostHash)},
+			{Hash: new(servedHash), Slot: new(served.Slot)},
+		}},
+	))
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrBlobKeyNotFound)
 
 	// hash+slot resolves with no lookup, so a miss there is an ordinary
 	// absent block as far as the handler can tell, and must not be logged
 	// as an inconsistency.
 	logs.Reset()
-	msg = fetchBlocks(t, handler, &archive.BlockRef{
+	msg := fetchBlocks(t, handler, &archive.BlockRef{
 		Hash: new(lostHash),
 		Slot: new(lost.Slot),
 	})

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -387,6 +387,18 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 
 	blocks := resp.Msg.GetBlocks()
 	if len(blocks) != 1 {
+		// The archive reports a block it does not hold under not_found and
+		// still answers the rest of the batch, so an empty blocks list with
+		// a not_found entry is a missing block rather than a broken
+		// archive. Report it the way a local blob store reports one.
+		if len(blocks) == 0 && len(resp.Msg.GetNotFound()) > 0 {
+			return nil, types.BlockMetadata{},
+				fmt.Errorf(
+					"bark: archive has no block at slot %d: %w",
+					slot,
+					types.ErrBlobKeyNotFound,
+				)
+		}
 		return nil, types.BlockMetadata{},
 			fmt.Errorf("expected 1 block, got %d", len(blocks))
 	}

--- a/bark/blob.go
+++ b/bark/blob.go
@@ -356,6 +356,33 @@ func (b *BlobStoreBark) GetBlockLocal(
 	return b.upstream.GetBlock(txn, slot, hash)
 }
 
+// archiveReportedMissing reports whether notFound answers the reference
+// this node actually asked for. FetchBlock echoes an unresolved reference
+// back carrying the identifiers the caller supplied, and this client always
+// supplies both slot and hash, so the answer for this request carries both
+// too. Anything else describes a different block and is not evidence that
+// this one is absent. The hash is compared case-insensitively because the
+// field is hex text echoed verbatim.
+func archiveReportedMissing(
+	notFound []*archivev1alpha1.BlockRef,
+	slot uint64,
+	hash []byte,
+) bool {
+	wantHash := hex.EncodeToString(hash)
+	for _, ref := range notFound {
+		if ref == nil || ref.Slot == nil || ref.Hash == nil {
+			continue
+		}
+		if ref.GetSlot() != slot {
+			continue
+		}
+		if strings.EqualFold(ref.GetHash(), wantHash) {
+			return true
+		}
+	}
+	return false
+}
+
 // fetchBlockFromArchive resolves a (slot, hash) block via the bark archive
 // service: requests a signed URL, downloads the CBOR, and returns it along
 // with the metadata carried in the archive response.
@@ -388,10 +415,19 @@ func (b *BlobStoreBark) fetchBlockFromArchive(
 	blocks := resp.Msg.GetBlocks()
 	if len(blocks) != 1 {
 		// The archive reports a block it does not hold under not_found and
-		// still answers the rest of the batch, so an empty blocks list with
-		// a not_found entry is a missing block rather than a broken
-		// archive. Report it the way a local blob store reports one.
-		if len(blocks) == 0 && len(resp.Msg.GetNotFound()) > 0 {
+		// still answers the rest of the batch, so an empty blocks list
+		// carrying the not_found entry for this reference is a missing
+		// block rather than a broken archive. Report it the way a local
+		// blob store reports one.
+		//
+		// The entry has to be the one that was asked for. A returned block
+		// is re-verified against (slot, hash) by verifyArchiveBlock, but
+		// nothing re-verifies an absence, so an archive echoing some other
+		// reference would otherwise have this node record the requested
+		// block as missing on the strength of an answer about a different
+		// block.
+		if len(blocks) == 0 &&
+			archiveReportedMissing(resp.Msg.GetNotFound(), slot, hash) {
 			return nil, types.BlockMetadata{},
 				fmt.Errorf(
 					"bark: archive has no block at slot %d: %w",

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -54,6 +54,11 @@ type fakeArchive struct {
 	oversize       bool
 	substituteBody []byte
 
+	// serveNotFound models the archive answering a well-formed request for
+	// a block it does not hold: an empty blocks list with the reference
+	// echoed under not_found, rather than a transport error.
+	serveNotFound bool
+
 	fetchCalls int
 }
 
@@ -65,6 +70,13 @@ func (a *fakeArchive) FetchBlock(
 	resp := &archive.FetchBlockResponse{}
 	for _, b := range req.Msg.GetBlocks() {
 		hashHex := b.GetHash()
+		if a.serveNotFound {
+			resp.NotFound = append(resp.NotFound, &archive.BlockRef{
+				Hash: b.Hash,
+				Slot: b.Slot,
+			})
+			continue
+		}
 		if _, ok := a.blocks[hashHex]; !ok {
 			a.t.Fatalf("fakeArchive: unexpected block requested: %s", hashHex)
 		}
@@ -1032,4 +1044,28 @@ func TestBarkIterator_PassesThroughLiveValues(t *testing.T) {
 
 	assert.Zero(t, archiveSrv.fetchCalls,
 		"no archive call must occur when no tombstones are present")
+}
+
+// TestGetBlock_ReportsArchiveNotFoundAsMissingKey pins the client half of
+// the batched archive contract: a block the archive does not hold now comes
+// back as an ordinary response carrying a not_found reference, not as a
+// transport error, and the wrapper has to translate that into the same
+// types.ErrBlobKeyNotFound a local blob store reports so callers can tell a
+// missing block from a broken archive.
+func TestGetBlock_ReportsArchiveNotFoundAsMissingKey(t *testing.T) {
+	db := newTestDB(t)
+	block := archiveBlockFixtures(t, 1)[0]
+
+	blocks, configure := serveArchiveBlock(t, block)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+	fakeArch.serveNotFound = true
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	hash := block.Hash()
+	_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
+	require.ErrorIs(t, err, types.ErrBlobKeyNotFound)
 }

--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -59,6 +60,11 @@ type fakeArchive struct {
 	// echoed under not_found, rather than a transport error.
 	serveNotFound bool
 
+	// notFoundRef, when set alongside serveNotFound, is echoed under
+	// not_found in place of the reference that was asked about. It models
+	// a confused or hostile archive answering about a different block.
+	notFoundRef *archive.BlockRef
+
 	fetchCalls int
 }
 
@@ -71,10 +77,11 @@ func (a *fakeArchive) FetchBlock(
 	for _, b := range req.Msg.GetBlocks() {
 		hashHex := b.GetHash()
 		if a.serveNotFound {
-			resp.NotFound = append(resp.NotFound, &archive.BlockRef{
-				Hash: b.Hash,
-				Slot: b.Slot,
-			})
+			missing := a.notFoundRef
+			if missing == nil {
+				missing = &archive.BlockRef{Hash: b.Hash, Slot: b.Slot}
+			}
+			resp.NotFound = append(resp.NotFound, missing)
 			continue
 		}
 		if _, ok := a.blocks[hashHex]; !ok {
@@ -1067,5 +1074,91 @@ func TestGetBlock_ReportsArchiveNotFoundAsMissingKey(t *testing.T) {
 
 	hash := block.Hash()
 	_, _, err := store.GetBlock(rTxn, block.SlotNumber(), hash[:])
+	require.ErrorIs(t, err, types.ErrBlobKeyNotFound)
+}
+
+// TestGetBlock_RejectsArchiveNotFoundForDifferentBlock pins the other half
+// of that translation. A block the archive returns is re-verified against
+// the requested slot and hash by verifyArchiveBlock, but nothing
+// re-verifies an absence, so an archive echoing a reference that was never
+// asked about must not be able to make this node record the requested
+// block as missing. Each case below answers about some other block, and
+// none of them may map to types.ErrBlobKeyNotFound.
+func TestGetBlock_RejectsArchiveNotFoundForDifferentBlock(t *testing.T) {
+	block := archiveBlockFixtures(t, 1)[0]
+	hash := block.Hash()
+	hashHex := hex.EncodeToString(hash[:])
+	slot := block.SlotNumber()
+
+	for _, testCase := range []struct {
+		name string
+		ref  *archive.BlockRef
+	}{
+		{
+			name: "different hash",
+			ref: &archive.BlockRef{
+				Hash: new(strings.Repeat("ab", 32)),
+				Slot: new(slot),
+			},
+		},
+		{
+			name: "different slot",
+			ref: &archive.BlockRef{
+				Hash: new(hashHex),
+				Slot: new(slot + 1),
+			},
+		},
+		{
+			name: "hash omitted",
+			ref:  &archive.BlockRef{Slot: new(slot)},
+		},
+		{
+			name: "slot omitted",
+			ref:  &archive.BlockRef{Hash: new(hashHex)},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := newTestDB(t)
+			blocks, configure := serveArchiveBlock(t, block)
+			baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+			configure(fakeArch)
+			fakeArch.serveNotFound = true
+			fakeArch.notFoundRef = testCase.ref
+
+			store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+			rTxn := store.NewTransaction(false)
+			t.Cleanup(func() { _ = rTxn.Rollback() })
+
+			_, _, err := store.GetBlock(rTxn, slot, hash[:])
+			require.Error(t, err)
+			require.NotErrorIs(t, err, types.ErrBlobKeyNotFound)
+		})
+	}
+}
+
+// TestGetBlock_AcceptsArchiveNotFoundWithDifferentHashCase pins that the
+// echoed hash is compared as hex text rather than as bytes of a string:
+// the field is case-insensitive hex, and an archive that upper-cases it is
+// still answering about the block that was requested.
+func TestGetBlock_AcceptsArchiveNotFoundWithDifferentHashCase(t *testing.T) {
+	db := newTestDB(t)
+	block := archiveBlockFixtures(t, 1)[0]
+	hash := block.Hash()
+	slot := block.SlotNumber()
+
+	blocks, configure := serveArchiveBlock(t, block)
+	baseURL, fakeArch, httpClient := startFakeArchive(t, blocks)
+	configure(fakeArch)
+	fakeArch.serveNotFound = true
+	fakeArch.notFoundRef = &archive.BlockRef{
+		Hash: new(strings.ToUpper(hex.EncodeToString(hash[:]))),
+		Slot: new(slot),
+	}
+
+	store := newBarkBlobStoreForTest(t, db, baseURL, httpClient)
+	rTxn := store.NewTransaction(false)
+	t.Cleanup(func() { _ = rTxn.Rollback() })
+
+	_, _, err := store.GetBlock(rTxn, slot, hash[:])
 	require.ErrorIs(t, err, types.ErrBlobKeyNotFound)
 }

--- a/database/block.go
+++ b/database/block.go
@@ -651,6 +651,11 @@ func blockIndexEntryAtOrAfterTxn(
 // or previous hash can read a few dozen bytes instead of a whole block
 // object. A tombstoned block still has its metadata, so this also answers
 // for history that has expired locally.
+//
+// The value is decoded with types.UnmarshalBlockMetadata rather than as
+// CBOR: badger writes a compact binary encoding instead when compact block
+// metadata is enabled, so which encoding is at the key depends on how the
+// node that wrote the block was configured.
 func blockMetadataByKey(
 	txn *Txn,
 	blockKey []byte,
@@ -673,8 +678,8 @@ func blockMetadataByKey(
 		}
 		return types.BlockMetadata{}, err
 	}
-	var metadata types.BlockMetadata
-	if _, err := cbor.Decode(raw, &metadata); err != nil {
+	metadata, err := types.UnmarshalBlockMetadata(raw)
+	if err != nil {
 		return types.BlockMetadata{}, fmt.Errorf(
 			"decoding metadata for block key %x: %w",
 			blockKey,

--- a/database/block.go
+++ b/database/block.go
@@ -336,6 +336,117 @@ func BlockBySlot(db *Database, slot uint64) (models.Block, error) {
 	return ret, err
 }
 
+// BlockNumberBound is the upper bound a block-number search runs against:
+// the highest block currently indexed.
+//
+// It is a value a caller resolves and carries, rather than something each
+// lookup rediscovers, because resolving it is the expensive half. Reading
+// the highest indexed block means a reverse iteration over the block-index
+// ("bi") prefix, and the s3 and gcs blob plugins implement a reverse
+// iterator by listing every object under the prefix into a temporary file
+// with no early break (listKeysToFile). One resolution is therefore a full
+// enumeration of every block-index object in the bucket. A caller resolving
+// more than one block number -- the bark archive service answers up to
+// DefaultMaxFetchBlockRefs of them per unauthenticated request -- must
+// resolve the bound once and reuse it for the whole batch.
+type BlockNumberBound struct {
+	// HighestID is the internal sequential ID of the highest indexed
+	// block, and the top of the ID space a search walks.
+	HighestID uint64
+	// HighestNumber is the chain block number that block carries. No
+	// larger number can resolve.
+	HighestNumber uint64
+	// Resolved reports that a highest indexed block was found. The zero
+	// value is deliberately unresolved rather than "bound of zero": an
+	// unresolved bound matches no block number at all, so a caller that
+	// forgets to resolve one gets ErrBlockNotFound instead of a search
+	// over an empty ID space that quietly reports the same thing for a
+	// different reason. An empty chain resolves to the same zero value.
+	Resolved bool
+}
+
+// ResolveBlockNumberBound reads the highest indexed block to bound a
+// block-number search. See BlockNumberBound for why the result is worth
+// carrying across lookups.
+func ResolveBlockNumberBound(db *Database) (BlockNumberBound, error) {
+	var ret BlockNumberBound
+	txn := db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		var err error
+		ret, err = ResolveBlockNumberBoundTxn(txn)
+		return err
+	})
+	return ret, err
+}
+
+// ResolveBlockNumberBoundTxn resolves the bound within an existing
+// transaction. It reads only the ordered block-index entries and the small
+// per-block metadata object of the newest one, never block CBOR.
+func ResolveBlockNumberBoundTxn(txn *Txn) (BlockNumberBound, error) {
+	if txn == nil {
+		return BlockNumberBound{}, types.ErrNilTxn
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return BlockNumberBound{}, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return BlockNumberBound{}, types.ErrBlobStoreUnavailable
+	}
+	prefix := []byte(types.BlockBlobIndexKeyPrefix)
+	it := blob.NewIterator(blobTxn, types.BlobIteratorOptions{
+		Reverse: true,
+		Prefix:  prefix,
+	})
+	if it == nil {
+		return BlockNumberBound{}, errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	// 0xff sorts after any index key, so reverse iteration from it starts
+	// at the newest block. Same seek BlocksRecentTxn uses.
+	seek := append(slices.Clone(prefix), 0xff)
+	for it.Seek(seek); it.ValidForPrefix(prefix); it.Next() {
+		item := it.Item()
+		if item == nil {
+			continue
+		}
+		indexKey := item.Key()
+		if indexKey == nil {
+			continue
+		}
+		blockKey, err := item.ValueCopy(nil)
+		if err != nil {
+			return BlockNumberBound{}, err
+		}
+		metadata, err := blockMetadataByKey(txn, blockKey)
+		if err != nil {
+			// A stale index entry pointing at a block that is gone is
+			// skipped rather than fatal, so the bound and the forward
+			// search that uses it agree about which entries count.
+			if errors.Is(err, models.ErrBlockNotFound) {
+				continue
+			}
+			return BlockNumberBound{}, err
+		}
+		// The index value is an indirection to the block blob, so a stale
+		// mapping can resolve to a block filed under a different ID. Only
+		// trust an entry whose block agrees with the index key.
+		if !bytes.Equal(indexKey, types.BlockBlobIndexKey(metadata.ID)) {
+			continue
+		}
+		return BlockNumberBound{
+			HighestID:     metadata.ID,
+			HighestNumber: metadata.Height,
+			Resolved:      true,
+		}, nil
+	}
+	if err := it.Err(); err != nil {
+		return BlockNumberBound{}, err
+	}
+	return BlockNumberBound{}, nil
+}
+
 // BlockByNumber resolves the block carrying the given chain block number
 // (height). Block numbers are not indexed in the blob store -- only slot,
 // hash, and the internal sequential ID are -- so this binary-searches the
@@ -343,6 +454,10 @@ func BlockBySlot(db *Database, slot uint64) (models.Block, error) {
 // highest indexed block. A number no block carries returns
 // models.ErrBlockNotFound, so a caller can tell a genuine miss from a
 // storage failure.
+//
+// This resolves the bound itself and is therefore a single-lookup call.
+// Resolve a BlockNumberBound once and use BlockByNumberBounded when
+// answering more than one number.
 //
 // database/lifecycle.ResolveTargetByNumber keeps its own tip-bounded
 // search rather than calling this: a truncate target must not resolve past
@@ -363,47 +478,210 @@ func BlockByNumberTxn(txn *Txn, number uint64) (models.Block, error) {
 	if txn == nil {
 		return models.Block{}, types.ErrNilTxn
 	}
-	highest, err := BlocksRecentTxn(txn, 1)
+	bound, err := ResolveBlockNumberBoundTxn(txn)
 	if err != nil {
 		return models.Block{}, err
 	}
-	// An empty chain, or a number past the highest one stored, cannot
-	// match: block numbers increase with the internal ID the search walks.
-	if len(highest) == 0 || number > highest[0].Number {
-		return models.Block{}, models.ErrBlockNotFound
+	return BlockByNumberBoundedTxn(txn, number, bound)
+}
+
+// BlockByNumberBounded resolves a block number against an already-resolved
+// bound, so a batch of numbers costs one ResolveBlockNumberBound rather
+// than one per number.
+func BlockByNumberBounded(
+	db *Database,
+	number uint64,
+	bound BlockNumberBound,
+) (models.Block, error) {
+	var ret models.Block
+	txn := db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		var err error
+		ret, err = BlockByNumberBoundedTxn(txn, number, bound)
+		return err
+	})
+	return ret, err
+}
+
+func BlockByNumberBoundedTxn(
+	txn *Txn,
+	number uint64,
+	bound BlockNumberBound,
+) (models.Block, error) {
+	blockKey, err := blockKeyByNumberBoundedTxn(txn, number, bound)
+	if err != nil {
+		return models.Block{}, err
 	}
-	lo, hi := BlockInitialIndex, highest[0].ID
+	return blockByKey(txn, blockKey)
+}
+
+// blockKeyByNumberBoundedTxn binary-searches the block-index space for the
+// block carrying number and returns its blob key.
+//
+// Probes read the ordered index entries and the small per-block metadata
+// object, never the block CBOR: a probe only needs the block's ID and
+// height to decide which way to move, and blockByKey would download the
+// whole block object from cloud storage to answer that. Only the one
+// matching block is read in full, by the caller.
+func blockKeyByNumberBoundedTxn(
+	txn *Txn,
+	number uint64,
+	bound BlockNumberBound,
+) ([]byte, error) {
+	if txn == nil {
+		return nil, types.ErrNilTxn
+	}
+	// An unresolved bound, an empty chain, or a number past the highest one
+	// stored cannot match: block numbers increase with the internal ID the
+	// search walks.
+	if !bound.Resolved || number > bound.HighestNumber {
+		return nil, models.ErrBlockNotFound
+	}
+	lo, hi := BlockInitialIndex, bound.HighestID
 	for lo <= hi {
 		mid := lo + (hi-lo)/2
-		// BlockAtOrAfterIndex, not BlockByIndex: a probe landing in a gap
-		// of a sparse (Mithril bootstrap/drain-imported) ID space must
-		// seek forward to the next indexed block rather than fail, and a
+		// At or after mid, not exactly mid: a probe landing in a gap of a
+		// sparse (Mithril bootstrap/drain-imported) ID space must seek
+		// forward to the next indexed block rather than fail, and a
 		// fallback that merely lowered hi would never find a target above
 		// the gap.
-		block, err := txn.DB().BlockAtOrAfterIndex(mid, txn)
+		entry, err := blockIndexEntryAtOrAfterTxn(txn, mid)
 		if err != nil {
 			if errors.Is(err, models.ErrBlockNotFound) {
 				hi = mid - 1
 				continue
 			}
-			return models.Block{}, err
+			return nil, err
 		}
-		if block.ID > hi {
+		if entry.id > hi {
 			hi = mid - 1
 			continue
 		}
 		switch {
-		case block.Number == number:
-			return block, nil
-		case block.Number < number:
-			// block.ID, not mid+1: the seek forward may have landed above
-			// mid, and re-probing (mid, block.ID) only finds it again.
-			lo = block.ID + 1
+		case entry.number == number:
+			return entry.blockKey, nil
+		case entry.number < number:
+			// entry.id, not mid+1: the seek forward may have landed above
+			// mid, and re-probing (mid, entry.id) only finds it again.
+			lo = entry.id + 1
 		default:
 			hi = mid - 1
 		}
 	}
-	return models.Block{}, models.ErrBlockNotFound
+	return nil, models.ErrBlockNotFound
+}
+
+// blockIndexEntry is one ordered block-index entry, resolved far enough to
+// navigate by without reading the block itself.
+type blockIndexEntry struct {
+	id       uint64
+	number   uint64
+	blockKey []byte
+}
+
+// blockIndexEntryAtOrAfterTxn returns the first block-index entry whose
+// chain index is greater than or equal to blockIndex. It is the
+// CBOR-free counterpart of Database.BlockAtOrAfterIndex and applies the
+// same staleness rules: an entry whose block is gone, or whose block is
+// filed under a different ID than the entry, is skipped.
+func blockIndexEntryAtOrAfterTxn(
+	txn *Txn,
+	blockIndex uint64,
+) (blockIndexEntry, error) {
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return blockIndexEntry{}, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return blockIndexEntry{}, types.ErrBlobStoreUnavailable
+	}
+	prefix := []byte(types.BlockBlobIndexKeyPrefix)
+	it := blob.NewIterator(
+		blobTxn,
+		types.BlobIteratorOptions{Prefix: prefix},
+	)
+	if it == nil {
+		return blockIndexEntry{}, errors.New("blob iterator is nil")
+	}
+	defer it.Close()
+	it.Seek(types.BlockBlobIndexKey(blockIndex))
+	for it.ValidForPrefix(prefix) {
+		item := it.Item()
+		if item == nil {
+			it.Next()
+			continue
+		}
+		indexKey := item.Key()
+		if indexKey == nil {
+			it.Next()
+			continue
+		}
+		blockKey, err := item.ValueCopy(nil)
+		if err != nil {
+			return blockIndexEntry{}, err
+		}
+		metadata, err := blockMetadataByKey(txn, blockKey)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				it.Next()
+				continue
+			}
+			return blockIndexEntry{}, err
+		}
+		if !bytes.Equal(indexKey, types.BlockBlobIndexKey(metadata.ID)) {
+			it.Next()
+			continue
+		}
+		return blockIndexEntry{
+			id:       metadata.ID,
+			number:   metadata.Height,
+			blockKey: blockKey,
+		}, nil
+	}
+	if err := it.Err(); err != nil {
+		return blockIndexEntry{}, err
+	}
+	return blockIndexEntry{}, models.ErrBlockNotFound
+}
+
+// blockMetadataByKey reads the metadata object stored alongside a block
+// without downloading the block CBOR. The two live at separate blob keys
+// in every plugin, so a caller that needs only a block's ID, height, type,
+// or previous hash can read a few dozen bytes instead of a whole block
+// object. A tombstoned block still has its metadata, so this also answers
+// for history that has expired locally.
+func blockMetadataByKey(
+	txn *Txn,
+	blockKey []byte,
+) (types.BlockMetadata, error) {
+	if txn == nil {
+		return types.BlockMetadata{}, types.ErrNilTxn
+	}
+	blobTxn := txn.Blob()
+	if blobTxn == nil {
+		return types.BlockMetadata{}, types.ErrNilTxn
+	}
+	blob := txn.DB().Blob()
+	if blob == nil {
+		return types.BlockMetadata{}, types.ErrBlobStoreUnavailable
+	}
+	raw, err := blob.Get(blobTxn, types.BlockBlobMetadataKey(blockKey))
+	if err != nil {
+		if errors.Is(err, types.ErrBlobKeyNotFound) {
+			return types.BlockMetadata{}, models.ErrBlockNotFound
+		}
+		return types.BlockMetadata{}, err
+	}
+	var metadata types.BlockMetadata
+	if _, err := cbor.Decode(raw, &metadata); err != nil {
+		return types.BlockMetadata{}, fmt.Errorf(
+			"decoding metadata for block key %x: %w",
+			blockKey,
+			err,
+		)
+	}
+	return metadata, nil
 }
 
 func BlockURL(

--- a/database/block.go
+++ b/database/block.go
@@ -336,6 +336,76 @@ func BlockBySlot(db *Database, slot uint64) (models.Block, error) {
 	return ret, err
 }
 
+// BlockByNumber resolves the block carrying the given chain block number
+// (height). Block numbers are not indexed in the blob store -- only slot,
+// hash, and the internal sequential ID are -- so this binary-searches the
+// internal-ID space that block numbers increase with, bounded above by the
+// highest indexed block. A number no block carries returns
+// models.ErrBlockNotFound, so a caller can tell a genuine miss from a
+// storage failure.
+//
+// database/lifecycle.ResolveTargetByNumber keeps its own tip-bounded
+// search rather than calling this: a truncate target must not resolve past
+// the persisted tip, while a read should serve any block the blob store
+// actually holds.
+func BlockByNumber(db *Database, number uint64) (models.Block, error) {
+	var ret models.Block
+	txn := db.Transaction(false)
+	err := txn.Do(func(txn *Txn) error {
+		var err error
+		ret, err = BlockByNumberTxn(txn, number)
+		return err
+	})
+	return ret, err
+}
+
+func BlockByNumberTxn(txn *Txn, number uint64) (models.Block, error) {
+	if txn == nil {
+		return models.Block{}, types.ErrNilTxn
+	}
+	highest, err := BlocksRecentTxn(txn, 1)
+	if err != nil {
+		return models.Block{}, err
+	}
+	// An empty chain, or a number past the highest one stored, cannot
+	// match: block numbers increase with the internal ID the search walks.
+	if len(highest) == 0 || number > highest[0].Number {
+		return models.Block{}, models.ErrBlockNotFound
+	}
+	lo, hi := BlockInitialIndex, highest[0].ID
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		// BlockAtOrAfterIndex, not BlockByIndex: a probe landing in a gap
+		// of a sparse (Mithril bootstrap/drain-imported) ID space must
+		// seek forward to the next indexed block rather than fail, and a
+		// fallback that merely lowered hi would never find a target above
+		// the gap.
+		block, err := txn.DB().BlockAtOrAfterIndex(mid, txn)
+		if err != nil {
+			if errors.Is(err, models.ErrBlockNotFound) {
+				hi = mid - 1
+				continue
+			}
+			return models.Block{}, err
+		}
+		if block.ID > hi {
+			hi = mid - 1
+			continue
+		}
+		switch {
+		case block.Number == number:
+			return block, nil
+		case block.Number < number:
+			// block.ID, not mid+1: the seek forward may have landed above
+			// mid, and re-probing (mid, block.ID) only finds it again.
+			lo = block.ID + 1
+		default:
+			hi = mid - 1
+		}
+	}
+	return models.Block{}, models.ErrBlockNotFound
+}
+
 func BlockURL(
 	ctx context.Context,
 	db *Database,

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -342,6 +342,60 @@ func TestBlockByNumberSkipsSparseIndexGap(t *testing.T) {
 	require.Equal(t, blocks[4].ID, above.ID)
 }
 
+// TestResolveBlockNumberBoundIsSeparableFromTheSearch pins the split that
+// keeps a batch of block-number lookups from re-reading the chain tip once
+// per number. Resolving the bound is a reverse iteration over the block
+// index, which the s3 and gcs plugins answer by listing every block-index
+// object in the bucket, so the bound is resolved by the caller and carried
+// into each search.
+func TestResolveBlockNumberBoundIsSeparableFromTheSearch(t *testing.T) {
+	db := newTestDB(t)
+
+	empty, err := ResolveBlockNumberBound(db)
+	require.NoError(t, err)
+	require.False(t, empty.Resolved, "an empty chain bounds nothing")
+
+	blocks := make([]models.Block, 0, 5)
+	for i := uint64(1); i <= 5; i++ {
+		block := testIndexedBlock(i*10, i, byte(i))
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+	}
+
+	bound, err := ResolveBlockNumberBound(db)
+	require.NoError(t, err)
+	require.True(t, bound.Resolved)
+	require.Equal(t, blocks[4].ID, bound.HighestID)
+	require.Equal(t, blocks[4].Number, bound.HighestNumber)
+
+	// One bound answers every number in the chain.
+	for _, want := range blocks {
+		got, err := BlockByNumberBounded(db, want.Number, bound)
+		require.NoError(t, err)
+		require.Equal(t, want.ID, got.ID)
+		require.Equal(t, want.Slot, got.Slot)
+		require.True(t, bytes.Equal(want.Hash, got.Hash))
+	}
+
+	_, err = BlockByNumberBounded(db, blocks[4].Number+1, bound)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
+// TestBlockByNumberBoundedRejectsUnresolvedBound pins the fail-closed zero
+// value: a caller that never resolved a bound must get ErrBlockNotFound
+// rather than a search over an ID space the bound says is empty, which
+// would report the same thing for the wrong reason.
+func TestBlockByNumberBoundedRejectsUnresolvedBound(t *testing.T) {
+	db := newTestDB(t)
+	for i := uint64(1); i <= 3; i++ {
+		block := testIndexedBlock(i*10, i, byte(i))
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	_, err := BlockByNumberBounded(db, 1, BlockNumberBound{})
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}
+
 // TestBlockByNumberReportsMissingNumbersAsNotFound proves an absent height
 // is reported as models.ErrBlockNotFound rather than a generic error, which
 // is what lets the bark archive service classify it as a not_found

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -293,3 +293,70 @@ func TestBlockBeforeSlotSyntheticOnlyNotFound(t *testing.T) {
 	_, err := BlockBeforeSlot(db, 120)
 	require.ErrorIs(t, err, models.ErrBlockNotFound)
 }
+
+// TestBlockByNumberResolvesEveryIndexedBlock pins the height-identifier
+// lookup the bark archive service needs: block numbers are not indexed in
+// the blob store, so the resolution is a binary search over the block-ID
+// space and every number in the chain must come back as its own block.
+func TestBlockByNumberResolvesEveryIndexedBlock(t *testing.T) {
+	db := newTestDB(t)
+	blocks := make([]models.Block, 0, 5)
+	for i := uint64(1); i <= 5; i++ {
+		block := testIndexedBlock(i*10, i, byte(i))
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+	}
+
+	for _, want := range blocks {
+		got, err := BlockByNumber(db, want.Number)
+		require.NoError(t, err)
+		require.Equal(t, want.ID, got.ID)
+		require.Equal(t, want.Slot, got.Slot)
+		require.True(t, bytes.Equal(want.Hash, got.Hash))
+	}
+}
+
+// TestBlockByNumberSkipsSparseIndexGap proves the search tolerates gaps in
+// the block-ID space, which a Mithril bootstrap or drain import leaves
+// behind, rather than treating a missing probe as the end of the range. A
+// target above the gap is the discriminating case: a fallback that merely
+// shrinks the upper bound on a missing probe converges into the low range
+// and never finds it.
+func TestBlockByNumberSkipsSparseIndexGap(t *testing.T) {
+	db := newTestDB(t)
+	ids := []uint64{1, 2, 3, 1000, 1001, 1002}
+	blocks := make([]models.Block, 0, len(ids))
+	for i, id := range ids {
+		// #nosec G115 -- fixed small test fixture values.
+		block := testIndexedBlock(id*10, id, byte(i+1))
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+	}
+
+	below, err := BlockByNumber(db, blocks[1].Number)
+	require.NoError(t, err)
+	require.Equal(t, blocks[1].ID, below.ID)
+
+	above, err := BlockByNumber(db, blocks[4].Number)
+	require.NoError(t, err)
+	require.Equal(t, blocks[4].ID, above.ID)
+}
+
+// TestBlockByNumberReportsMissingNumbersAsNotFound proves an absent height
+// is reported as models.ErrBlockNotFound rather than a generic error, which
+// is what lets the bark archive service classify it as a not_found
+// reference instead of failing the whole batch.
+func TestBlockByNumberReportsMissingNumbersAsNotFound(t *testing.T) {
+	db := newTestDB(t)
+
+	_, err := BlockByNumber(db, 1)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	for i := uint64(1); i <= 3; i++ {
+		block := testIndexedBlock(i*10, i, byte(i))
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	_, err = BlockByNumber(db, 99)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+}

--- a/database/block_test.go
+++ b/database/block_test.go
@@ -381,6 +381,60 @@ func TestResolveBlockNumberBoundIsSeparableFromTheSearch(t *testing.T) {
 	require.ErrorIs(t, err, models.ErrBlockNotFound)
 }
 
+// TestBlockByNumberResolvesCompactBlockMetadata pins the height lookup
+// against the other block-metadata encoding. The badger plugin writes a
+// compact binary value instead of CBOR for run mode "serve" or "leios"
+// with storage mode "core", and the search reads that value directly
+// rather than through GetBlock, so decoding it as CBOR would fail every
+// height lookup and every bound resolution on exactly the configurations
+// a production node runs.
+func TestBlockByNumberResolvesCompactBlockMetadata(t *testing.T) {
+	db, err := newTestDatabaseWithRunMode(
+		t,
+		&Config{DataDir: "", StorageMode: types.StorageModeCore},
+		"serve",
+	)
+	require.NoError(t, err)
+
+	blocks := make([]models.Block, 0, 5)
+	for i := uint64(1); i <= 5; i++ {
+		block := testIndexedBlock(i*10, i, byte(i))
+		require.NoError(t, db.BlockCreate(block, nil))
+		blocks = append(blocks, block)
+	}
+
+	// The stored value really is the compact encoding, not CBOR -- without
+	// this the test would still pass if the plugin silently fell back.
+	txn := db.BlobTxn(false)
+	t.Cleanup(func() { _ = txn.Rollback() })
+	raw, err := db.Blob().Get(
+		txn.Blob(),
+		types.BlockBlobMetadataKey(
+			types.BlockBlobKey(blocks[0].Slot, blocks[0].Hash),
+		),
+	)
+	require.NoError(t, err)
+	require.True(
+		t,
+		bytes.HasPrefix(raw, types.BlockMetadataBinaryMagic[:]),
+		"expected compact block metadata for run mode serve and storage mode core",
+	)
+
+	bound, err := ResolveBlockNumberBound(db)
+	require.NoError(t, err)
+	require.True(t, bound.Resolved)
+	require.Equal(t, blocks[4].ID, bound.HighestID)
+	require.Equal(t, blocks[4].Number, bound.HighestNumber)
+
+	for _, want := range blocks {
+		got, err := BlockByNumber(db, want.Number)
+		require.NoError(t, err)
+		require.Equal(t, want.ID, got.ID)
+		require.Equal(t, want.Slot, got.Slot)
+		require.True(t, bytes.Equal(want.Hash, got.Hash))
+	}
+}
+
 // TestBlockByNumberBoundedRejectsUnresolvedBound pins the fail-closed zero
 // value: a caller that never resolved a bound must get ErrBlockNotFound
 // rather than a search over an ID space the bound says is empty, which

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -416,6 +416,23 @@ func (it *s3StreamIterator) reset(seek []byte) {
 	} else if it.store.prefix != "" {
 		input.Prefix = aws.String(it.store.prefix)
 	}
+	// Bound the listing server-side at the seek key. Without this, Seek lists
+	// the whole prefix and discards keys below the seek in advance() -- and
+	// bark's unauthenticated ArchiveService drives a seek into the full "bi"
+	// prefix on every probe of its height binary search, so one anonymous
+	// request costs order N keys per probe. gcs bounds the same listing with
+	// query.StartOffset.
+	//
+	// StartAfter is exclusive, so it cannot be the seek key itself. A strict
+	// prefix of the seek key is strictly less than the seek key and than every
+	// key after it, so it is a safe lower bound; it can admit a handful of keys
+	// sharing that prefix but sorting below the seek, which advance() drops.
+	if len(seek) > 0 {
+		full := it.store.fullKey(string(seek))
+		if bound := full[:len(full)-1]; bound > aws.ToString(input.Prefix) {
+			input.StartAfter = aws.String(bound)
+		}
+	}
 	it.paginator = s3.NewListObjectsV2Paginator(it.store.client, input)
 	it.page = nil
 	it.pageIdx = 0

--- a/database/plugin/blob/aws/seek_bound_test.go
+++ b/database/plugin/blob/aws/seek_bound_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+//go:build dingo_extra_plugins
+
+package aws
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// fakeS3List serves just enough ListObjectsV2 to drive s3StreamIterator, and
+// records the start-after parameter of every request it answers.
+type fakeS3List struct {
+	mu         sync.Mutex
+	keys       []string // full object keys, sorted
+	startAfter []string // one entry per ListObjectsV2 request
+	returned   int      // total keys returned across all requests
+}
+
+func (f *fakeS3List) handler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	prefix := q.Get("prefix")
+	after := q.Get("start-after")
+	if tok := q.Get("continuation-token"); tok != "" {
+		after = tok
+	}
+	f.mu.Lock()
+	f.startAfter = append(f.startAfter, q.Get("start-after"))
+	f.mu.Unlock()
+
+	var out []string
+	for _, k := range f.keys {
+		if prefix != "" && !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		if after != "" && k <= after {
+			continue
+		}
+		out = append(out, k)
+	}
+	const page = 1000
+	truncated := false
+	if len(out) > page {
+		out = out[:page]
+		truncated = true
+	}
+	f.mu.Lock()
+	f.returned += len(out)
+	f.mu.Unlock()
+
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
+	fmt.Fprintf(&b, "<IsTruncated>%t</IsTruncated>", truncated)
+	for _, k := range out {
+		fmt.Fprintf(&b, "<Contents><Key>%s</Key><Size>1</Size></Contents>", k)
+	}
+	if truncated && len(out) > 0 {
+		fmt.Fprintf(
+			&b,
+			"<NextContinuationToken>%s</NextContinuationToken>",
+			out[len(out)-1],
+		)
+	}
+	b.WriteString(`</ListBucketResult>`)
+	w.Header().Set("Content-Type", "application/xml")
+	_, _ = w.Write([]byte(b.String()))
+}
+
+// TestS3SeekBoundsListServerSide pins that seeking a forward iterator asks the
+// server to start near the seek key instead of listing the whole prefix and
+// discarding keys client-side.
+//
+// bark's ArchiveService is unauthenticated, and height-only block references
+// drive a binary search whose every probe seeks into the full "bi" prefix. With
+// no server-side bound each probe lists the prefix from the start, so one
+// anonymous request costs order N keys per probe.
+func TestS3SeekBoundsListServerSide(t *testing.T) {
+	const total = 20000
+	fake := &fakeS3List{}
+	for i := range total {
+		key := fmt.Sprintf("bi%06d", i)
+		fake.keys = append(fake.keys, hex.EncodeToString([]byte(key)))
+	}
+	sort.Strings(fake.keys)
+
+	srv := httptest.NewServer(http.HandlerFunc(fake.handler))
+	defer srv.Close()
+
+	store, err := NewWithOptions(
+		WithBucket("test-bucket"),
+		WithEndpoint(srv.URL),
+		WithRegion("us-east-1"),
+	)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	// Start() would need a real bucket; the iterator only needs the client.
+	store.client = s3.New(s3.Options{
+		BaseEndpoint: aws.String(srv.URL),
+		Region:       "us-east-1",
+		UsePathStyle: true,
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		),
+	})
+
+	seek := []byte(fmt.Sprintf("bi%06d", total/2))
+	it := &s3StreamIterator{store: store, prefix: []byte("bi")}
+	it.reset(seek)
+	if it.err != nil {
+		t.Fatalf("seek: %v", it.err)
+	}
+	if !it.valid {
+		t.Fatal("seek landed on no key")
+	}
+	if got := it.key; got != string(seek) {
+		t.Fatalf("seek key = %q, want %q", got, string(seek))
+	}
+
+	fake.mu.Lock()
+	reqs := append([]string(nil), fake.startAfter...)
+	returned := fake.returned
+	fake.mu.Unlock()
+
+	t.Logf(
+		"seek to mid-point of %d keys: %d ListObjectsV2 request(s), "+
+			"%d key(s) returned",
+		total,
+		len(reqs),
+		returned,
+	)
+
+	bounded := 0
+	for _, s := range reqs {
+		if s != "" {
+			bounded++
+		}
+	}
+	if bounded == 0 {
+		t.Fatalf(
+			"seek to the mid-point issued %d ListObjectsV2 request(s) and "+
+				"returned %d key(s), none carrying start-after: the whole "+
+				"prefix is listed and discarded client-side",
+			len(reqs),
+			returned,
+		)
+	}
+	// The bound is a strict prefix of the seek key, so a handful of keys just
+	// below it can still come back -- but not half the bucket.
+	if returned > total/10 {
+		t.Fatalf(
+			"seek returned %d of %d keys; the server-side bound is not "+
+				"restricting the listing",
+			returned,
+			total,
+		)
+	}
+}

--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -15,7 +15,6 @@
 package badger
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -154,10 +153,6 @@ type badgerItem struct {
 	item *badger.Item
 }
 
-var blockMetadataBinaryMagic = [4]byte{'D', 'B', 'M', '1'}
-
-const blockMetadataPrevHashMaxLen = 32
-
 func buildBlockBlobKey(dst []byte, slot uint64, hash []byte) {
 	copy(dst, types.BlockBlobKeyPrefix)
 	binary.BigEndian.PutUint64(
@@ -180,54 +175,21 @@ func buildBlockBlobMetadataKey(dst []byte, baseKey []byte) {
 	copy(dst[len(baseKey):], types.BlockBlobMetadataKeySuffix)
 }
 
+// marshalBlockMetadataInto and unmarshalBlockMetadata delegate to
+// database/types. The encoding is not private to this plugin: the value
+// sits at a shared BlockBlobMetadataKey that generic database code reads
+// directly, and which of the two encodings is there depends on the
+// writing node's configuration, so the codec has to be shared with every
+// reader.
 func marshalBlockMetadataInto(
 	dst []byte,
 	metadata types.BlockMetadata,
 ) error {
-	prevHashLen := len(metadata.PrevHash)
-	if prevHashLen > blockMetadataPrevHashMaxLen {
-		return fmt.Errorf(
-			"invalid block metadata prev hash length: %d",
-			prevHashLen,
-		)
-	}
-	copy(dst[:4], blockMetadataBinaryMagic[:])
-	binary.BigEndian.PutUint64(dst[4:12], metadata.ID)
-	binary.BigEndian.PutUint64(dst[12:20], uint64(metadata.Type))
-	binary.BigEndian.PutUint64(dst[20:28], metadata.Height)
-	binary.BigEndian.PutUint32(
-		dst[28:32],
-		uint32(prevHashLen),
-	)
-	copy(dst[32:], metadata.PrevHash)
-	return nil
+	return types.MarshalBlockMetadataInto(dst, metadata)
 }
 
 func unmarshalBlockMetadata(data []byte) (types.BlockMetadata, error) {
-	if len(data) >= 32 && bytes.Equal(data[:4], blockMetadataBinaryMagic[:]) {
-		prevHashLen := binary.BigEndian.Uint32(data[28:32])
-		expectedLen := 32 + int(prevHashLen)
-		if len(data) != expectedLen {
-			return types.BlockMetadata{}, fmt.Errorf(
-				"invalid block metadata length: got %d, want %d",
-				len(data),
-				expectedLen,
-			)
-		}
-		prevHash := make([]byte, prevHashLen)
-		copy(prevHash, data[32:])
-		return types.BlockMetadata{
-			ID:       binary.BigEndian.Uint64(data[4:12]),
-			Type:     uint(binary.BigEndian.Uint64(data[12:20])),
-			Height:   binary.BigEndian.Uint64(data[20:28]),
-			PrevHash: prevHash,
-		}, nil
-	}
-	var metadata types.BlockMetadata
-	if _, err := cbor.Decode(data, &metadata); err != nil {
-		return types.BlockMetadata{}, err
-	}
-	return metadata, nil
+	return types.UnmarshalBlockMetadata(data)
 }
 
 func (i *badgerItem) Key() []byte {
@@ -678,7 +640,7 @@ func (d *BlobStoreBadger) SetBlock(
 	hashIndexKeyLen := len(types.BlockHashIndexKeyPrefix) + len(hash)
 	packedLen := keyLen + indexKeyLen + metadataKeyLen + hashIndexKeyLen
 	if d.compactBlockMetadata {
-		packedLen += 32 + len(prevHash)
+		packedLen += types.BlockMetadataBinarySize(prevHash)
 	}
 	packed := make([]byte, packedLen)
 	key := packed[:keyLen]

--- a/database/plugin/blob/badger/metadata_fuzz_test.go
+++ b/database/plugin/blob/badger/metadata_fuzz_test.go
@@ -28,7 +28,7 @@ func FuzzCompactBlockMetadataRoundTrip(f *testing.F) {
 
 	f.Fuzz(
 		func(t *testing.T, id uint64, typeValue uint64, height uint64, prevHash []byte) {
-			if len(prevHash) > blockMetadataPrevHashMaxLen {
+			if len(prevHash) > types.BlockMetadataPrevHashMaxLen {
 				return
 			}
 
@@ -76,10 +76,10 @@ func FuzzUnmarshalBlockMetadata(f *testing.F) {
 		if err != nil {
 			return
 		}
-		if len(metadata.PrevHash) > blockMetadataPrevHashMaxLen {
+		if len(metadata.PrevHash) > types.BlockMetadataPrevHashMaxLen {
 			t.Fatalf("metadata prev hash length = %d, want <= %d",
 				len(metadata.PrevHash),
-				blockMetadataPrevHashMaxLen,
+				types.BlockMetadataPrevHashMaxLen,
 			)
 		}
 	})

--- a/database/test_database_test.go
+++ b/database/test_database_test.go
@@ -37,6 +37,20 @@ func newTestDatabase(
 	return newTestDatabaseWithHost(tb, config, false)
 }
 
+// newTestDatabaseWithRunMode builds a test database whose blob store is
+// resolved with the given run mode. It exists because the badger plugin
+// switches block metadata to a compact binary encoding for run mode
+// "serve" or "leios" with storage mode "core", and nothing else in these
+// tests reaches that encoding.
+func newTestDatabaseWithRunMode(
+	tb testing.TB,
+	config *Config,
+	runMode string,
+) (*Database, error) {
+	tb.Helper()
+	return newTestDatabaseWithHostRunMode(tb, config, false, runMode)
+}
+
 // newTestDatabaseWithHost is the shared body behind newTestDatabase and
 // openForRecoveryTest (database/node_settings_gates_test.go): register the
 // badger and sqlite providers, resolve the blob and metadata stores from
@@ -54,6 +68,16 @@ func newTestDatabaseWithHost(
 	keepOnError bool,
 ) (*Database, error) {
 	tb.Helper()
+	return newTestDatabaseWithHostRunMode(tb, config, keepOnError, "")
+}
+
+func newTestDatabaseWithHostRunMode(
+	tb testing.TB,
+	config *Config,
+	keepOnError bool,
+	runMode string,
+) (*Database, error) {
+	tb.Helper()
 	if config == nil {
 		config = DefaultConfig
 	}
@@ -69,7 +93,8 @@ func newTestDatabaseWithHost(
 		plugin.CapabilityStorageBlob, "badger", nil,
 		blob.ProviderDependencies{
 			DataDir: config.DataDir, StorageMode: config.StorageMode,
-			Logger: config.Logger, PromRegistry: config.PromRegistry,
+			RunMode: runMode,
+			Logger:  config.Logger, PromRegistry: config.PromRegistry,
 		},
 	)
 	if err != nil {

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -17,6 +17,7 @@ package types
 import (
 	"bytes"
 	"database/sql/driver"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -346,6 +347,94 @@ type BlockMetadata struct {
 	Type     uint
 	Height   uint64
 	PrevHash []byte
+}
+
+// BlockMetadataBinaryMagic is the four-byte prefix identifying the compact
+// binary encoding of BlockMetadata. The badger plugin writes that encoding
+// instead of CBOR when compact block metadata is enabled (run mode "serve"
+// or "leios" with storage mode "core"), so the value stored at a block's
+// BlockBlobMetadataKey is one of two encodings depending on how the node
+// was configured when the block was written. Anything reading that key
+// directly has to accept both: use UnmarshalBlockMetadata rather than
+// decoding it as CBOR. The bytes "DBM1" cannot begin a CBOR-encoded
+// BlockMetadata, which starts with an array header byte, so the two are
+// unambiguous.
+var BlockMetadataBinaryMagic = [4]byte{'D', 'B', 'M', '1'}
+
+// BlockMetadataBinaryHeaderLen is the fixed part of the compact encoding:
+// the magic, then ID, type, and height as big-endian uint64s, then the
+// previous-hash length as a big-endian uint32.
+const BlockMetadataBinaryHeaderLen = 32
+
+// BlockMetadataPrevHashMaxLen bounds the previous-hash field of the
+// compact encoding, whose length prefix must stay within a block hash.
+const BlockMetadataPrevHashMaxLen = 32
+
+// BlockMetadataBinarySize returns the length MarshalBlockMetadataInto
+// needs for metadata carrying the given previous hash.
+func BlockMetadataBinarySize(prevHash []byte) int {
+	return BlockMetadataBinaryHeaderLen + len(prevHash)
+}
+
+// MarshalBlockMetadataInto writes the compact binary encoding of metadata
+// into dst, which must be exactly BlockMetadataBinarySize long. Writing
+// into a caller-supplied buffer lets the blob plugin pack the metadata
+// value into the same allocation as the keys it writes alongside it.
+func MarshalBlockMetadataInto(dst []byte, metadata BlockMetadata) error {
+	prevHashLen := len(metadata.PrevHash)
+	if prevHashLen > BlockMetadataPrevHashMaxLen {
+		return fmt.Errorf(
+			"invalid block metadata prev hash length: %d",
+			prevHashLen,
+		)
+	}
+	if len(dst) != BlockMetadataBinarySize(metadata.PrevHash) {
+		return fmt.Errorf(
+			"invalid block metadata buffer length: got %d, want %d",
+			len(dst),
+			BlockMetadataBinarySize(metadata.PrevHash),
+		)
+	}
+	copy(dst[:4], BlockMetadataBinaryMagic[:])
+	binary.BigEndian.PutUint64(dst[4:12], metadata.ID)
+	binary.BigEndian.PutUint64(dst[12:20], uint64(metadata.Type))
+	binary.BigEndian.PutUint64(dst[20:28], metadata.Height)
+	binary.BigEndian.PutUint32(dst[28:32], uint32(prevHashLen))
+	copy(dst[32:], metadata.PrevHash)
+	return nil
+}
+
+// UnmarshalBlockMetadata decodes a block metadata value in either
+// encoding, dispatching on BlockMetadataBinaryMagic and falling back to
+// CBOR. This is the only supported way to read the value at a
+// BlockBlobMetadataKey, since which encoding is there depends on the
+// writing node's configuration rather than on the plugin being read.
+func UnmarshalBlockMetadata(data []byte) (BlockMetadata, error) {
+	if len(data) >= BlockMetadataBinaryHeaderLen &&
+		bytes.Equal(data[:4], BlockMetadataBinaryMagic[:]) {
+		prevHashLen := binary.BigEndian.Uint32(data[28:32])
+		expectedLen := BlockMetadataBinaryHeaderLen + int(prevHashLen)
+		if len(data) != expectedLen {
+			return BlockMetadata{}, fmt.Errorf(
+				"invalid block metadata length: got %d, want %d",
+				len(data),
+				expectedLen,
+			)
+		}
+		prevHash := make([]byte, prevHashLen)
+		copy(prevHash, data[BlockMetadataBinaryHeaderLen:])
+		return BlockMetadata{
+			ID:       binary.BigEndian.Uint64(data[4:12]),
+			Type:     uint(binary.BigEndian.Uint64(data[12:20])),
+			Height:   binary.BigEndian.Uint64(data[20:28]),
+			PrevHash: prevHash,
+		}, nil
+	}
+	var metadata BlockMetadata
+	if _, err := cbor.Decode(data, &metadata); err != nil {
+		return BlockMetadata{}, err
+	}
+	return metadata, nil
 }
 
 // SignedURL is a url that has been pre-signed and has an expiration time

--- a/database/types/types.go
+++ b/database/types/types.go
@@ -413,6 +413,18 @@ func UnmarshalBlockMetadata(data []byte) (BlockMetadata, error) {
 	if len(data) >= BlockMetadataBinaryHeaderLen &&
 		bytes.Equal(data[:4], BlockMetadataBinaryMagic[:]) {
 		prevHashLen := binary.BigEndian.Uint32(data[28:32])
+		// The same bound the encoder enforces. A value carrying a longer
+		// previous hash is one MarshalBlockMetadataInto could not have
+		// written, so it is corrupt rather than merely unexpected, and
+		// decoding it would propagate an impossible block record instead
+		// of reporting the damage.
+		if prevHashLen > BlockMetadataPrevHashMaxLen {
+			return BlockMetadata{}, fmt.Errorf(
+				"invalid block metadata prev hash length: got %d, max %d",
+				prevHashLen,
+				BlockMetadataPrevHashMaxLen,
+			)
+		}
 		expectedLen := BlockMetadataBinaryHeaderLen + int(prevHashLen)
 		if len(data) != expectedLen {
 			return BlockMetadata{}, fmt.Errorf(

--- a/database/types/types_test.go
+++ b/database/types/types_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/binary"
 	"errors"
 	"math/big"
 	"reflect"
@@ -248,6 +249,51 @@ func TestNullableHashScan(t *testing.T) {
 
 	if err := h.Scan(123); err == nil {
 		t.Fatal("Scan(int) should error")
+	}
+}
+
+// TestUnmarshalBlockMetadataRejectsOversizedPrevHash pins the decoder half
+// of the previous-hash bound. MarshalBlockMetadataInto refuses to write one
+// longer than a block hash, but a stored value can also be corrupt, and a
+// decoder that trusted the length prefix would hand its caller a
+// BlockMetadata the encoder could never have produced -- which then
+// propagates into a block record as if it were real.
+func TestUnmarshalBlockMetadataRejectsOversizedPrevHash(t *testing.T) {
+	const oversized = types.BlockMetadataPrevHashMaxLen + 1
+	data := make([]byte, types.BlockMetadataBinaryHeaderLen+oversized)
+	copy(data[:4], types.BlockMetadataBinaryMagic[:])
+	binary.BigEndian.PutUint64(data[4:12], 7)
+	binary.BigEndian.PutUint64(data[12:20], 1)
+	binary.BigEndian.PutUint64(data[20:28], 42)
+	binary.BigEndian.PutUint32(data[28:32], oversized)
+
+	// The value is self-consistent -- its declared length matches its
+	// actual length -- so only the bound rejects it.
+	if _, err := types.UnmarshalBlockMetadata(data); err == nil {
+		t.Fatal("UnmarshalBlockMetadata accepted an oversized prev hash")
+	}
+}
+
+// TestBlockMetadataCompactRoundTrip pins the encoding both the badger
+// plugin and the block-number search depend on, at the shared boundary
+// they now share it across.
+func TestBlockMetadataCompactRoundTrip(t *testing.T) {
+	want := types.BlockMetadata{
+		ID:       9,
+		Type:     4,
+		Height:   1234,
+		PrevHash: bytes.Repeat([]byte{0xab}, 32),
+	}
+	buf := make([]byte, types.BlockMetadataBinarySize(want.PrevHash))
+	if err := types.MarshalBlockMetadataInto(buf, want); err != nil {
+		t.Fatalf("MarshalBlockMetadataInto: %v", err)
+	}
+	got, err := types.UnmarshalBlockMetadata(buf)
+	if err != nil {
+		t.Fatalf("UnmarshalBlockMetadata: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
`ArchiveService.FetchBlock` used only `BlockRef.hash` and required a 32-byte hex
string, while the protocol permits a reference identified by hash, slot, height,
or a consistent combination. It also returned an error on the first missing
block instead of returning the rest of the batch with the missing reference in
`FetchBlockResponse.not_found`.

Resolution precedence is `hash+slot` -> `hash` -> `slot` -> `height`.
`hash+slot` resolves with no index lookup because `(slot, hash)` is the blob
store's key; this is load-bearing, since `BlockByHash` is a hard miss for blocks
written before the `bh` index (#1915), and routing hash+slot through that index
would stop an archive node serving exactly the pre-index range it exists to
serve. Height is last: block number is not an indexed blob key, so it needs a
binary search over the block-ID space (new `database.BlockByNumber`).

Hash and slot agree by construction, since the point is built from the supplied
identifiers; height is compared against `metadata.Height` after `BlockURL`
returns. A well-formed reference whose identifiers name different blocks
describes no stored block and yields `not_found`. A reference with no identifier
or a non-hex hash is not a valid `BlockRef` and fails `InvalidArgument`
(previously `CodeUnknown`); parsing runs for the whole batch before `Acquire()`.

No generated protobuf changed — `bark@v0.1.0`'s `archive.proto` already declares
all three identifiers optional and `not_found`.

The in-repo consumer `bark/blob.go` now maps an archive `not_found` answer to
`types.ErrBlobKeyNotFound`, so a missing block reports identically whether it
came from local storage or the archive.

Batching a missing block into `not_found` would otherwise hide a storage
inconsistency, since `s3` and `gcs` return `types.ErrBlobKeyNotFound` both for
a block that was never written and for a block whose metadata object was lost.
`resolveBlockPoint` therefore reports whether resolving the reference actually
read the block; a hash-only, slot-only, or height-only reference that then
fails `GetBlockURL` as missing means the index and the blob store disagree, and
26beae50 fails the whole call for it. `hash+slot` resolves with no lookup, so
it carries no such evidence and stays an ordinary `not_found`, as does a
reference that misses at resolution.

`bark/blob.go` maps a `not_found` answer to `types.ErrBlobKeyNotFound` only
when the echoed reference is the `(slot, hash)` that was requested.
`verifyArchiveBlock` re-verifies a returned block against the request, so an
absence has to be re-verified too; otherwise an archive answering about a
different block could have this node record the requested one as missing.

## Tests

Identifier-only, mixed found/missing batch, inconsistent-reference, and
malformed-reference cases all fail on the unfixed handler and pass after. The
single-reference (hash+slot) case passed before the change and is kept as a
regression guard, not as new evidence.
`TestArchiveFetchBlockRejectsMissingMetadata` covers the index/blob-store
disagreement and both non-evidence cases.

`TestArchiveFetchBlockResolvesHeightBoundOncePerBatch` counts blob operations
through a wrapper around the test store, because the cost this PR originally
got wrong is invisible in wall clock on badger. It fails two ways without the
fix: 16 reverse index enumerations instead of 1 when the bound is resolved per
reference, and 70 whole-block reads instead of 16 when search probes go through
`blockByKey`. `TestGetBlock_RejectsArchiveNotFoundForDifferentBlock` fails on
all four of its cases without the `not_found` identity check.
`TestBlockByNumberResolvesCompactBlockMetadata` runs the search against
badger's compact `DBM1` metadata encoding and fails with a decode error without
the shared codec; it asserts the stored value really carries the magic, so it
cannot pass on a silent fallback to CBOR.

## Validation

`go test -race ./bark/...` and `./database/`; `golangci-lint` 0 issues on
`./bark/...` and `./database/...` (also `GOOS=windows`); `make
import-boundaries`, `make docs-parity`; conformance 23.6s.
`TestAddrClearsAfterStopTimesOut` in `bark` is a machine-timing flake unrelated
to this diff: it needs `Shutdown` to miss a 20ms deadline, and on an idle
machine it fails the same way on `main` (3 of 6 runs at 429dbdbb, 3 of 6 at
26beae50, 4 of 6 at this branch). It passes in CI and under `-race`.

Not run: `make lint` in full (`nilaway`, `modernize`, `golines` absent from
PATH); `make govulncheck` (network); DevNet (archive RPC handler and one blob
read helper, outside its documented scope); `make sql-check` (no SQL change).

## Cost of a height-only batch

An earlier revision of this description claimed a worst-case all-height batch
cost "roughly 2,400 index seeks". That was wrong, as
https://github.com/blinklabs-io/dingo/pull/3937#discussion_r3939173342 measured:
it counted only the binary search and not the tip lookup each reference
performed before it. `BlockByNumber` resolved the highest indexed block itself,
and on `s3` and `gcs` a reverse iterator over the `bi` prefix is
`listKeysToFile`, a full listing of every block-index object in the bucket with
no early break. `ArchiveService` carries no operator auth interceptor, so 100
height-only refs in one anonymous request meant 100 full-bucket enumerations
(~1.2e7 objects each at mainnet size), plus ~2,400 whole-block object GETs,
since probes resolved through `blockByKey`.

Fixed in a3727370. The bound is now `database.BlockNumberBound`, resolved once
per batch by `ResolveBlockNumberBound` and passed to `BlockByNumberBounded`,
and only when the batch contains a height-only reference at all. Search probes
read the ordered index entry and the block's small `_metadata` object instead
of the block CBOR; only the matched block is read in full.

Measured with a counting blob wrapper, 16 height-only refs against a 16-block
chain:

| | before | after |
|---|---|---|
| reverse `bi` enumerations | 16 | 1 |
| forward `bi` seeks | 54 | 54 |
| whole-block reads | 70 | 16 |
| metadata reads | 0 | 55 |

The same refs sent as `hash+slot` do no index work either way. Extrapolated to
the reviewed shape, 100 height-only refs at mainnet size go from 100 full-bucket
enumerations and ~2,400 whole-block GETs to 1 enumeration, ~2,400 small metadata
GETs, and 100 whole-block GETs.

Class audit of the other resolution paths: `hash+slot` reads nothing; `hash`
alone is one `bh` index GET plus one block read; `slot` alone is a forward
iterator over the `bp<slot>` prefix, and both cloud plugins pass that prefix
into the LIST request (`aws/database.go:414`, `gcs/database.go:507`), so it is a
bounded range LIST rather than a full listing.

A prefix on the LIST is not on its own enough for a *seeking* forward iterator,
which is what the height binary search drives. `s3StreamIterator.reset` set only
`Prefix` and never `StartAfter`, so each `Seek` listed the whole `bi` prefix and
discarded keys below the seek client-side; gcs was already bounded server-side
with `query.StartOffset`. That moved the unauthenticated enumeration from the
reverse tip lookup into the seek rather than removing it. `reset` now sets
`StartAfter` to a strict prefix of the seek key — exclusive, so it cannot be the
seek key itself, and the client-side filter still drops the handful it admits.
Seeking the mid-point of 20,000 `bi` objects goes from 11 `ListObjectsV2`
requests returning 11,000 keys to 1 request returning 1,000
(`TestS3SeekBoundsListServerSide`).

The remaining per-reference cost is one whole-block GET for the block that is
served, which the `hash` and `slot` paths already paid before this PR.
`resolveBlockPoint` only needs the `(slot, hash)` point, so that read could be
avoided for all three paths by resolving to a point rather than a block; that is
a wider change to `BlockByHash`/`BlockBySlot`'s shape and is not attempted here.

Reading the `_metadata` object directly also meant the block-metadata codec had
to be shared. Badger writes a compact `DBM1` binary encoding instead of CBOR for
run mode `serve`/`leios` with storage mode `core`, so decoding that value as
CBOR would have failed every height lookup on those configurations (found by
cubic). The codec moved to `database/types` next to `BlockMetadata`, since which
encoding is at the key depends on the writing node's configuration rather than
on the plugin reading it.

Resolves #3442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEJSNPB6bA7CVW5EgXxNni

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ArchiveService.FetchBlock` previously required a 32-byte hex hash and failed the whole batch at the first missing block. It now resolves each reference by hash, slot, height, or any consistent combination and reports missing ones under `not_found` while serving the rest. Resolves #3442.

**Block reference resolution**
- Precedence is hash+slot, then hash, then slot, then height; hash+slot needs no index read and still serves blocks written before the `bh` index (#1915).
- Height-only resolution binary-searches the block-ID space (`database.BlockByNumber`), with the upper bound resolved once per batch — resolving it per reference costs a full bucket enumeration on s3/gcs.
- A reference that names no stored block, or whose identifiers disagree, yields `not_found`; malformed references (no identifier, non-32-byte hash) fail the whole call with `InvalidArgument`.
- A lookup-resolved block the blob store then reports missing is a storage inconsistency and fails the call; hash+slot carries no such evidence and stays an ordinary miss.
- Answered refs echo supplied identifiers verbatim and fill in omitted ones.

**Cost, client, and codec**
- The s3 blob iterator now bounds a seeking forward listing server-side via `StartAfter` (gcs already did with `StartOffset`), so each height-search probe no longer lists the whole `bi` prefix.
- Probes read the ordered index entry and the small `_metadata` object instead of the block CBOR; a batch of hash+slot references still touches no index.
- `bark/blob.go` maps an archive `not_found` answer to `types.ErrBlobKeyNotFound` only when the echoed reference matches the requested slot and hash.
- Block metadata is decoded through a shared `types.UnmarshalBlockMetadata` that accepts both the CBOR and compact `DBM1` encodings and rejects oversized prev-hash lengths.

<sup>Written for commit 69cd505adeafb26313aaac22408622aad9ed710d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archive block retrieval now supports references by hash, slot, height, or hash-and-slot.
  - Block lookups by block height are now supported, including efficient handling of sparse archives.
  - Missing blocks are reported individually without discarding successful results from the same request.
  - Archive responses provide missing identifiers when a lookup succeeds.

- **Performance**
  - Archive and object-storage lookups use more efficient bounded searches, reducing unnecessary data scans.

- **Documentation**
  - Updated architecture and database documentation to describe block reference resolution and height-based lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
