### PR TITLE
fix(chainselection): publish selection events through an ordered lane

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1229,6 +1229,19 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `chainselection.selected_none` | ChainSelector | Best-peer selection transitioned to none (selection stalled) |
 | `chainselection.peer_rollback_handler_panic` | ChainSelector | The PeerRollbackEvent handler panicked; its subscription was torn down |
 | `chainselection.evaluation_panic` | ChainSelector | A background evaluation tick or triggered evaluation panicked; the transition it would have produced was dropped |
+
+Every `chainselection.*` topic above except the two panic topics is published
+through `ChainSelector.publishSelection`, which uses `PublishOrdered` rather
+than `Publish`. The selector's producers are all goroutines that have to keep
+making progress — the EventBus dispatch goroutines for the internal
+`chainselection.peer_activity`, `chainselection.peer_tip_update` and
+`connmanager.conn_closed` subscriptions, plus the selector's own evaluation
+loop — and an inline `Publish` parks its caller on any subscriber that has
+stopped draining. Routing every selector publication through the same per-type
+lanes keeps delivery and per-topic order while confining a blocked subscriber
+to that lane's worker. Publishing one of these topics directly would reintroduce
+the hazard, because a queued chain switch could then be overtaken by one
+published inline.
 | `chainsync.client_added` | ChainsyncState | Client tracking added |
 | `chainsync.client_removed` | ChainsyncState | Client tracking removed |
 | `chainsync.client_synced` | ChainsyncState | Client caught up |
@@ -1299,6 +1312,16 @@ All event types follow the `subsystem.snake_case_name` convention.
   delivery, and reports how many publishers are parked on it — every parked
   publisher observes the same stall, so a per-delivery limit made the log
   volume scale with publisher count rather than with time
+- **Handler-progress watchdog** (`event/handler_progress.go`). The stalled
+  warning above is raised by a publisher that had to wait for capacity, so it
+  cannot fire until the buffer is already full: its time to first signal is a
+  function of buffer size and event rate, not of the fault. One bus-wide
+  goroutine additionally samples every `SubscribeFunc` dispatch goroutine and
+  logs `event subscriber handler not making progress` (with `stuck_for`,
+  `queued`, `buffer`) once per `handlerProgressWarnInterval` (30s) for any
+  handler that has not returned, counting it in
+  `event_subscriber_handler_stalled_total`. `EventBus.StuckHandlerCount()`
+  exposes the same condition programmatically
 - **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
   while holding a lock that a subscriber of that event acquires.** All four can
   wait for capacity, and a subscriber that is merely slow is still allowed the
@@ -1367,7 +1390,9 @@ All event types follow the `subsystem.snake_case_name` convention.
   on the `connmanager.conn_closed` subscription above
 - Prometheus metrics for event delivery tracking and latency, including
   `event_delivery_blocked_total{type,kind}` and
-  `event_async_enqueue_blocked_total{type}` for backpressure
+  `event_async_enqueue_blocked_total{type}` for backpressure, and
+  `event_subscriber_handler_stalled_total{type}` for a handler that has
+  stopped returning
 - `Unsubscribe` only stops *future* deliveries to a `SubscribeFunc`
   subscriber; a handler already dequeued before the call can still be
   executing concurrently after it returns. `UnsubscribeAndWait` additionally

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1274,10 +1274,19 @@ making progress — the EventBus dispatch goroutines for the internal
 `connmanager.conn_closed` subscriptions, plus the selector's own evaluation
 loop — and an inline `Publish` parks its caller on any subscriber that has
 stopped draining. Routing every selector publication through the same per-type
-lanes keeps delivery and per-topic order while confining a blocked subscriber
-to that lane's worker. Publishing one of these six directly would reintroduce
-the hazard, because a queued chain switch could then be overtaken by one
-published inline.
+lanes keeps delivery and per-topic publisher order while confining a blocked
+subscriber to that lane's worker. Publishing one of these six directly would
+reintroduce the hazard, because a queued chain switch could then be overtaken
+by one published inline.
+
+That order is the order publications reach `PublishOrdered`, not the order the
+selector decided the switches in. Every producer decides under `cs.mutex` and
+publishes after releasing it, so two goroutines can decide A then B and enqueue
+B then A, and a subscriber sees B before A. The window is unchanged from the
+inline `Publish` the lanes replaced; closing it would mean publishing under the
+lock, which is what the EventBus rule below forbids. A consumer that must not
+act on a superseded switch has to reconcile against the selector's current best
+peer rather than rely on arrival order.
 
 The other three `chainselection.*` topics are not on ordered lanes and are not
 covered by that guarantee: `chainselection.peer_tip_update` is published inline

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1229,19 +1229,6 @@ All event types follow the `subsystem.snake_case_name` convention.
 | `chainselection.selected_none` | ChainSelector | Best-peer selection transitioned to none (selection stalled) |
 | `chainselection.peer_rollback_handler_panic` | ChainSelector | The PeerRollbackEvent handler panicked; its subscription was torn down |
 | `chainselection.evaluation_panic` | ChainSelector | A background evaluation tick or triggered evaluation panicked; the transition it would have produced was dropped |
-
-Every `chainselection.*` topic above except the two panic topics is published
-through `ChainSelector.publishSelection`, which uses `PublishOrdered` rather
-than `Publish`. The selector's producers are all goroutines that have to keep
-making progress — the EventBus dispatch goroutines for the internal
-`chainselection.peer_activity`, `chainselection.peer_tip_update` and
-`connmanager.conn_closed` subscriptions, plus the selector's own evaluation
-loop — and an inline `Publish` parks its caller on any subscriber that has
-stopped draining. Routing every selector publication through the same per-type
-lanes keeps delivery and per-topic order while confining a blocked subscriber
-to that lane's worker. Publishing one of these topics directly would reintroduce
-the hazard, because a queued chain switch could then be overtaken by one
-published inline.
 | `chainsync.client_added` | ChainsyncState | Client tracking added |
 | `chainsync.client_removed` | ChainsyncState | Client tracking removed |
 | `chainsync.client_synced` | ChainsyncState | Client caught up |
@@ -1276,6 +1263,27 @@ published inline.
 | `peergov.quota_status` | PeerGov | Quota status update |
 | `peergov.bootstrap_exited` | PeerGov | Exited bootstrap mode |
 | `peergov.bootstrap_recovery` | PeerGov | Bootstrap recovery |
+
+The six topics the ChainSelector publishes itself —
+`chainselection.chain_switch`, `selection`, `peer_evicted`,
+`genesis_corroboration_failed`, `genesis_mode_exited` and `selected_none` —
+go through `ChainSelector.publishSelection`, which uses `PublishOrdered` rather
+than `Publish`. The selector's producers are all goroutines that have to keep
+making progress — the EventBus dispatch goroutines for the internal
+`chainselection.peer_activity`, `chainselection.peer_tip_update` and
+`connmanager.conn_closed` subscriptions, plus the selector's own evaluation
+loop — and an inline `Publish` parks its caller on any subscriber that has
+stopped draining. Routing every selector publication through the same per-type
+lanes keeps delivery and per-topic order while confining a blocked subscriber
+to that lane's worker. Publishing one of these six directly would reintroduce
+the hazard, because a queued chain switch could then be overtaken by one
+published inline.
+
+The other three `chainselection.*` topics are not on ordered lanes and are not
+covered by that guarantee: `chainselection.peer_tip_update` is published inline
+by the ouroboros chainsync path and by node wiring, not by the selector, and
+the two panic topics are published inline from the selector's own recovery
+paths, where the point is to report before the goroutine unwinds.
 
 ### EventBus Features
 
@@ -1320,8 +1328,10 @@ published inline.
   logs `event subscriber handler not making progress` (with `stuck_for`,
   `queued`, `buffer`) once per `handlerProgressWarnInterval` (30s) for any
   handler that has not returned, counting it in
-  `event_subscriber_handler_stalled_total`. `EventBus.StuckHandlerCount()`
-  exposes the same condition programmatically
+  `event_subscriber_handler_stalled_total`. Registering a `SubscribeFunc`
+  subscription materializes that counter's zero-valued series, so a healthy
+  bus is distinguishable from a missing subscription.
+  `EventBus.StuckHandlerCount()` exposes the same condition programmatically
 - **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
   while holding a lock that a subscriber of that event acquires.** All four can
   wait for capacity, and a subscriber that is merely slow is still allowed the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1329,9 +1329,10 @@ paths, where the point is to report before the goroutine unwinds.
   `queued`, `buffer`) once per `handlerProgressWarnInterval` (30s) for any
   handler that has not returned, counting it in
   `event_subscriber_handler_stalled_total`. Registering a `SubscribeFunc`
-  subscription materializes that counter's zero-valued series, so a healthy
-  bus is distinguishable from a missing subscription.
-  `EventBus.StuckHandlerCount()` exposes the same condition programmatically
+  subscription materializes that counter's series for its event type at zero,
+  so "nothing has stalled" is distinguishable from "no handler was ever
+  registered for this type". `EventBus.StuckHandlerCount()` exposes the same
+  condition programmatically
 - **Never `Publish`, `PublishAsync`, `PublishOrdered`, or `PublishBlocking`
   while holding a lock that a subscriber of that event acquires.** All four can
   wait for capacity, and a subscriber that is merely slow is still allowed the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1326,10 +1326,12 @@ paths, where the point is to report before the goroutine unwinds.
   function of buffer size and event rate, not of the fault. One bus-wide
   goroutine additionally samples every `SubscribeFunc` dispatch goroutine and
   logs `event subscriber handler not making progress` (with `stuck_for`,
-  `queued`, `buffer`) once per `handlerProgressWarnInterval` (30s) for any
-  handler that has not returned, counting it in
-  `event_subscriber_handler_stalled_total`. Registering a `SubscribeFunc`
-  subscription materializes that counter's series for its event type at zero,
+  `queued`, `buffer`) for any handler that has not returned for
+  `handlerProgressWarnInterval` (30s), counting it in
+  `event_subscriber_handler_stalled_total` and repeating at most once per
+  interval while it stays there. Sampling runs twice per interval, so the
+  first report lands within 45s of the handler ceasing to return. Registering
+  a `SubscribeFunc` subscription materializes that counter's series at zero,
   so "nothing has stalled" is distinguishable from "no handler was ever
   registered for this type". `EventBus.StuckHandlerCount()` exposes the same
   condition programmatically

--- a/chainselection/peer_activity_stall_test.go
+++ b/chainselection/peer_activity_stall_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+)
+
+// peerActivityStallBuffer stands in for the production
+// event.DefaultSubscriberBuffer (1024) used by the node's
+// chainselection.peer_activity subscription. The mechanism under test is
+// buffer-size independent: a handler that stops returning stops draining, and
+// the buffer only decides how long that takes to become visible. In the
+// blinklabs-io/dingo#3550 Preview run the 1024-slot buffer took 12h31m of
+// keepalive traffic to fill, which is exactly why the buffer is shrunk here
+// rather than the events slowed down.
+const peerActivityStallBuffer = 4
+
+// blockedConsumer is a downstream EventBus consumer that parks inside its
+// handler until the test releases it, modelling the ledger's
+// chainselection.chain_switch subscriber blocked on ls.chainsyncMutex while
+// the chainsync pipeline is not making progress.
+type blockedConsumer struct {
+	release   chan struct{}
+	closeOnce sync.Once
+	delivered atomic.Int64
+	entered   atomic.Int64
+}
+
+func newBlockedConsumer(t *testing.T) *blockedConsumer {
+	t.Helper()
+	return &blockedConsumer{release: make(chan struct{})}
+}
+
+func (b *blockedConsumer) handle(event.Event) {
+	b.entered.Add(1)
+	<-b.release
+	b.delivered.Add(1)
+}
+
+func (b *blockedConsumer) unblock() {
+	b.closeOnce.Do(func() { close(b.release) })
+}
+
+// newStalledSelectionFixture builds a ChainSelector with one tracked best peer
+// and a downstream chainselection.chain_selection consumer that never returns.
+// chain_selection is published by publishSelectionEvents on every accepted
+// TouchPeerActivity that has a best peer, so it is the deterministic member of
+// the same synchronous fan-out that also carries chain_switch.
+func newStalledSelectionFixture(
+	t *testing.T,
+) (*event.EventBus, *ChainSelector, *blockedConsumer, ouroboros.ConnectionId) {
+	t.Helper()
+
+	bus := event.NewEventBus(nil, nil)
+	consumer := newBlockedConsumer(t)
+	// LIFO cleanup: the consumer is released before the bus is stopped, or
+	// EventBus.shutdown would wait forever on the parked dispatch goroutine.
+	t.Cleanup(bus.Stop)
+	t.Cleanup(consumer.unblock)
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:          bus,
+		StaleTipThreshold: time.Hour,
+	})
+
+	connId := newTestConnectionId(1)
+	cs.UpdatePeerTip(connId, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("best")},
+		BlockNumber: 50,
+	}, nil)
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer(), "fixture needs a selected best peer")
+
+	// Subscribed only after the setup publishes above have drained, so the
+	// fixture itself cannot park on its own blocked consumer.
+	//
+	// SubscriberBackpressureBlock models a downstream that stays blocked:
+	// under the default Detach the wait ends at event.channelDeliveryTimeout
+	// and the subscriber is dropped, which is what the 92b2e3e6 build in the
+	// issue did not do at all and is a different failure (permanent silent
+	// loss) rather than the stall under test here.
+	bus.SubscribeFuncWithBufferPolicy(
+		ChainSelectionEventType,
+		1,
+		event.SubscriberBackpressureBlock,
+		consumer.handle,
+	)
+	return bus, cs, consumer, connId
+}
+
+// A blocked downstream consumer must not stop the internal
+// chainselection.peer_activity subscriber from draining. The Preview run in
+// blinklabs-io/dingo#3550 shows the opposite: the handler stopped returning,
+// its 1024-slot buffer filled over the next 12h31m, and from then on every
+// keepalive response parked a protocol goroutine inside EventBus.Publish
+// (ouroboros/keepalive.go) with 299 of them blocked by the end of the log.
+func TestPeerActivityHandlerKeepsDrainingWhileDownstreamConsumerBlocks(
+	t *testing.T,
+) {
+	bus, cs, consumer, connId := newStalledSelectionFixture(t)
+
+	var handled atomic.Int64
+	// Mirrors the node's subscribeChainSelectorEvents wiring for
+	// chainselection.peer_activity, with the blocking policy so a stalled
+	// handler is measured rather than the detach timer.
+	bus.SubscribeFuncWithBufferPolicy(
+		PeerActivityEventType,
+		peerActivityStallBuffer,
+		event.SubscriberBackpressureBlock,
+		func(evt event.Event) {
+			cs.HandlePeerActivityEvent(evt)
+			handled.Add(1)
+		},
+	)
+
+	// Enough touches to overrun the subscriber buffer several times over.
+	const touches = peerActivityStallBuffer * 4
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		for range touches {
+			bus.Publish(
+				PeerActivityEventType,
+				event.NewEvent(
+					PeerActivityEventType,
+					PeerActivityEvent{ConnectionId: connId},
+				),
+			)
+		}
+	}()
+
+	// The negative case: a blocked downstream must not park the keepalive-side
+	// publishers. Every publish has to return.
+	testutil.RequireReceive(t, published, 10*time.Second,
+		"keepalive publishers parked on the peer_activity subscriber: a "+
+			"blocked downstream consumer must not park protocol goroutines",
+	)
+	testutil.WaitForCondition(t, func() bool {
+		return handled.Load() == touches
+	}, 10*time.Second,
+		"the internal peer_activity subscriber stopped draining while a "+
+			"downstream consumer was blocked",
+	)
+	require.Zero(t, consumer.delivered.Load(),
+		"fixture invariant: the downstream consumer is still blocked",
+	)
+
+	// Releasing the downstream consumer must still deliver the selection
+	// events the activity path produced: they are deferred, not discarded.
+	consumer.unblock()
+	testutil.WaitForCondition(t, func() bool {
+		return consumer.delivered.Load() > 0
+	}, 10*time.Second,
+		"selection events produced by the activity path were never delivered",
+	)
+}
+
+// Deferring publication must not reorder chain switches: a subscriber that
+// acts on chainselection.chain_switch (the ledger repoints its chainsync
+// cursor at NewConnectionId) ends up on the wrong peer if an older switch is
+// delivered after a newer one.
+func TestChainSwitchEventsPreserveSelectionOrder(t *testing.T) {
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	_, evtCh := bus.SubscribeWithBuffer(ChainSwitchEventType, 64)
+
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:          bus,
+		StaleTipThreshold: time.Hour,
+	})
+
+	connA := newTestConnectionId(1)
+	connB := newTestConnectionId(2)
+
+	const switches = 8
+	want := make([]ouroboros.ConnectionId, 0, switches)
+	blockNumber := uint64(50)
+	for i := range switches {
+		conn := connA
+		if i%2 == 1 {
+			conn = connB
+		}
+		blockNumber++
+		cs.UpdatePeerTip(conn, ochainsync.Tip{
+			Point: ocommon.Point{
+				Slot: 100 + blockNumber,
+				Hash: []byte(conn.String()),
+			},
+			BlockNumber: blockNumber,
+		}, nil)
+		cs.EvaluateAndSwitch()
+		want = append(want, conn)
+	}
+
+	got := make([]ouroboros.ConnectionId, 0, switches)
+	for range switches {
+		evt := testutil.RequireReceive(t, evtCh, 10*time.Second,
+			"chain switch event was never delivered",
+		)
+		data, ok := evt.Data.(ChainSwitchEvent)
+		require.True(t, ok, "expected ChainSwitchEvent, got %T", evt.Data)
+		got = append(got, data.NewConnectionId)
+	}
+	require.Equal(t, want, got,
+		"chain switch events must be delivered in selection order",
+	)
+}

--- a/chainselection/peer_activity_stall_test.go
+++ b/chainselection/peer_activity_stall_test.go
@@ -183,7 +183,14 @@ func TestPeerActivityHandlerKeepsDrainingWhileDownstreamConsumerBlocks(
 // acts on chainselection.chain_switch (the ledger repoints its chainsync
 // cursor at NewConnectionId) ends up on the wrong peer if an older switch is
 // delivered after a newer one.
-func TestChainSwitchEventsPreserveSelectionOrder(t *testing.T) {
+//
+// What this pins is publisher order, which is the whole of what the lane
+// promises. All eight switches are decided and published from this goroutine,
+// so decision order and publish order coincide here. They do not in general:
+// every producer decides under cs.mutex and publishes after releasing it, so
+// two goroutines can decide in one order and enqueue in the other, and no lane
+// prevents that (wolf31o2 review). See publishSelection.
+func TestChainSwitchEventsPreservePublishOrder(t *testing.T) {
 	bus := event.NewEventBus(nil, nil)
 	t.Cleanup(bus.Stop)
 
@@ -227,6 +234,6 @@ func TestChainSwitchEventsPreserveSelectionOrder(t *testing.T) {
 		got = append(got, data.NewConnectionId)
 	}
 	require.Equal(t, want, got,
-		"chain switch events must be delivered in selection order",
+		"chain switch events must be delivered in publish order",
 	)
 }

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1338,12 +1338,21 @@ func (cs *ChainSelector) triggerEvaluation() {
 // once its 1024-slot buffer filled every keepalive response parked a
 // gouroboros protocol goroutine in ouroboros.keepaliveClientResponse.
 //
-// PublishOrdered keeps both delivery and order: each event type has its own
-// FIFO lane drained by exactly one worker, so events of a type reach
-// subscribers in the order they were published here, and a subscriber that
-// blocks parks only that lane's worker. Every chainselection publication goes
-// through this helper precisely so a queued chain switch can never be
-// overtaken by one published directly.
+// PublishOrdered keeps both delivery and publisher order: each event type has
+// its own FIFO lane drained by exactly one worker, so events of a type reach
+// subscribers in the order they were handed to PublishOrdered, and a
+// subscriber that blocks parks only that lane's worker. Every chainselection
+// publication goes through this helper precisely so a queued chain switch can
+// never be overtaken by one published directly.
+//
+// The order preserved is the order publications arrive here, not the order the
+// switches were decided in. Every producer decides under cs.mutex and
+// publishes after releasing it -- EvaluateAndSwitch and TouchPeerActivity both
+// do -- so two goroutines can decide A then B and still enqueue B then A, and
+// a subscriber sees B before A. That window is unchanged from the inline
+// Publish this replaced, and closing it would mean publishing while holding
+// cs.mutex, which is the deadlock shape #3550 is about avoiding (wolf31o2
+// review).
 func (cs *ChainSelector) publishSelection(
 	eventType event.EventType,
 	evt event.Event,

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -618,7 +618,7 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 			PeerEvictedEventType,
 			PeerEvictedEvent{ConnectionId: *evictedConn},
 		)
-		cs.config.EventBus.Publish(PeerEvictedEventType, evt)
+		cs.publishSelection(PeerEvictedEventType, evt)
 	}
 
 	if !accepted {
@@ -798,7 +798,7 @@ func (cs *ChainSelector) RemovePeer(connId ouroboros.ConnectionId) {
 	// Publish event outside the lock to prevent deadlock if subscribers
 	// call back into ChainSelector
 	if switchEvent != nil {
-		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+		cs.publishSelection(ChainSwitchEventType, *switchEvent)
 	}
 	cs.publishPendingGenesisExitEvent()
 	cs.publishPendingSelectedNoneEvent()
@@ -1321,6 +1321,39 @@ func (cs *ChainSelector) triggerEvaluation() {
 	}
 }
 
+// publishSelection hands a chain-selection event to the EventBus without
+// parking the calling goroutine on a subscriber that has stopped draining.
+//
+// Every chainselection event is produced on a goroutine that has to keep
+// making progress: the EventBus dispatch goroutines for the internal
+// peer_activity, peer_tip_update and conn_closed subscriptions, and the
+// selector's own evaluation loop. EventBus.Publish hands the event to each
+// subscriber channel inline and waits for buffer capacity, so a subscriber
+// that stops draining stops its producer too.
+//
+// blinklabs-io/dingo#3550 is that chain end to end: a
+// chainselection.chain_switch consumer stopped draining, TouchPeerActivity
+// parked inside publishSelectionEvents -> EventBus.Publish, the internal
+// chainselection.peer_activity subscriber therefore stopped draining, and
+// once its 1024-slot buffer filled every keepalive response parked a
+// gouroboros protocol goroutine in ouroboros.keepaliveClientResponse.
+//
+// PublishOrdered keeps both delivery and order: each event type has its own
+// FIFO lane drained by exactly one worker, so events of a type reach
+// subscribers in the order they were published here, and a subscriber that
+// blocks parks only that lane's worker. Every chainselection publication goes
+// through this helper precisely so a queued chain switch can never be
+// overtaken by one published directly.
+func (cs *ChainSelector) publishSelection(
+	eventType event.EventType,
+	evt event.Event,
+) {
+	if cs.config.EventBus == nil {
+		return
+	}
+	cs.config.EventBus.PublishOrdered(eventType, evt)
+}
+
 func (cs *ChainSelector) publishSelectionEvents(
 	switchEvent *event.Event,
 	selectionEvent *event.Event,
@@ -1330,13 +1363,13 @@ func (cs *ChainSelector) publishSelectionEvents(
 		return
 	}
 	if switchEvent != nil {
-		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+		cs.publishSelection(ChainSwitchEventType, *switchEvent)
 	}
 	if selectionEvent != nil {
-		cs.config.EventBus.Publish(ChainSelectionEventType, *selectionEvent)
+		cs.publishSelection(ChainSelectionEventType, *selectionEvent)
 	}
 	if corroborationEvent != nil {
-		cs.config.EventBus.Publish(
+		cs.publishSelection(
 			GenesisCorroborationFailedEventType,
 			*corroborationEvent,
 		)
@@ -1356,7 +1389,7 @@ func (cs *ChainSelector) publishPendingGenesisExitEvent() {
 	cs.pendingGenesisExit = nil
 	cs.mutex.Unlock()
 	if pending != nil {
-		cs.config.EventBus.Publish(
+		cs.publishSelection(
 			GenesisModeExitedEventType,
 			event.NewEvent(GenesisModeExitedEventType, *pending),
 		)
@@ -1390,7 +1423,7 @@ func (cs *ChainSelector) publishPendingSelectedNoneEvent() {
 	cs.pendingSelectedNone = nil
 	cs.mutex.Unlock()
 	if pending != nil {
-		cs.config.EventBus.Publish(
+		cs.publishSelection(
 			ChainSelectedNoneEventType,
 			event.NewEvent(ChainSelectedNoneEventType, *pending),
 		)
@@ -1959,7 +1992,7 @@ func (cs *ChainSelector) cleanupStalePeers() {
 	// Publish event outside the lock to prevent deadlock if subscribers
 	// call back into ChainSelector
 	if switchEvent != nil {
-		cs.config.EventBus.Publish(ChainSwitchEventType, *switchEvent)
+		cs.publishSelection(ChainSwitchEventType, *switchEvent)
 	}
 	cs.publishPendingGenesisExitEvent()
 	cs.publishPendingSelectedNoneEvent()

--- a/chainselection/selector_test.go
+++ b/chainselection/selector_test.go
@@ -292,6 +292,34 @@ func TestChainSelectorRemoveBestPeer(t *testing.T) {
 	assert.Nil(t, cs.GetBestPeer())
 }
 
+// drainChainSwitchesUntilBest consumes chain switch events up to and including
+// the one that selects wantConn.
+//
+// ChainSelector.publishSelection hands events to an EventBus ordered lane
+// instead of delivering them inline, so "whatever is queued at this instant"
+// is not a barrier: a drain written as len(ch) can run ahead of the setup
+// switches and then read one of them as the event under test. The switch to
+// the peer the test has just asserted is best is a real barrier.
+func drainChainSwitchesUntilBest(
+	t *testing.T,
+	evtCh <-chan event.Event,
+	wantConn ouroboros.ConnectionId,
+) {
+	t.Helper()
+	for {
+		evt := testutil.RequireReceive(
+			t,
+			evtCh,
+			5*time.Second,
+			"chain switch event selecting the expected best peer",
+		)
+		data, ok := evt.Data.(ChainSwitchEvent)
+		if ok && data.NewConnectionId.String() == wantConn.String() {
+			return
+		}
+	}
+}
+
 func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	eventBus := event.NewEventBus(nil, nil)
 	cs := NewChainSelector(ChainSelectorConfig{
@@ -320,10 +348,8 @@ func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, connId1, *cs.GetBestPeer())
 
-	// Drain any events from the initial selection
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
+	// Drain the events from the initial selection
+	drainChainSwitchesUntilBest(t, evtCh, connId1)
 
 	// Remove the best peer - this should emit ChainSwitchEvent
 	cs.RemovePeer(connId1)
@@ -333,16 +359,17 @@ func TestChainSelectorRemoveBestPeerEmitsChainSwitchEvent(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 
 	// Verify ChainSwitchEvent was emitted
-	select {
-	case evt := <-evtCh:
-		switchEvt, ok := evt.Data.(ChainSwitchEvent)
-		require.True(t, ok, "expected ChainSwitchEvent")
-		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
-		assert.Equal(t, connId2, switchEvt.NewConnectionId)
-		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected ChainSwitchEvent was not emitted")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		evtCh,
+		5*time.Second,
+		"expected ChainSwitchEvent was not emitted",
+	)
+	switchEvt, ok := evt.Data.(ChainSwitchEvent)
+	require.True(t, ok, "expected ChainSwitchEvent")
+	assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
+	assert.Equal(t, connId2, switchEvt.NewConnectionId)
+	assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
 }
 
 func TestChainSelectorSelectBestChain(t *testing.T) {
@@ -903,10 +930,8 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, connId1, *cs.GetBestPeer())
 
-	// Drain any events from the initial selection
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
+	// Drain the events from the initial selection
+	drainChainSwitchesUntilBest(t, evtCh, connId1)
 
 	// Wait for peer1 to become "very stale" (2x threshold = 100ms)
 	// cleanupStalePeers uses 2x StaleTipThreshold for removal
@@ -917,11 +942,6 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 
 	// Keep peer2 fresh
 	cs.UpdatePeerTip(connId2, tip2, nil)
-
-	// Drain any events from tip update
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
 
 	// Trigger cleanup - this should emit ChainSwitchEvent when best peer is
 	// removed
@@ -934,16 +954,17 @@ func TestChainSelectorStalePeerCleanupEmitsChainSwitchEvent(t *testing.T) {
 	assert.Equal(t, connId2, *cs.GetBestPeer())
 
 	// Verify ChainSwitchEvent was emitted
-	select {
-	case evt := <-evtCh:
-		switchEvt, ok := evt.Data.(ChainSwitchEvent)
-		require.True(t, ok, "expected ChainSwitchEvent")
-		assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
-		assert.Equal(t, connId2, switchEvt.NewConnectionId)
-		assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected ChainSwitchEvent was not emitted")
-	}
+	evt := testutil.RequireReceive(
+		t,
+		evtCh,
+		5*time.Second,
+		"expected ChainSwitchEvent was not emitted",
+	)
+	switchEvt, ok := evt.Data.(ChainSwitchEvent)
+	require.True(t, ok, "expected ChainSwitchEvent")
+	assert.Equal(t, connId1, switchEvt.PreviousConnectionId)
+	assert.Equal(t, connId2, switchEvt.NewConnectionId)
+	assert.Equal(t, tip2.BlockNumber, switchEvt.NewTip.BlockNumber)
 	cs.mutex.RLock()
 	defer cs.mutex.RUnlock()
 	_, eligibleFound := cs.eligible[connId1]
@@ -1168,9 +1189,7 @@ func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, revivedConn, *cs.GetBestPeer())
 
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
+	drainChainSwitchesUntilBest(t, evtCh, revivedConn)
 
 	require.Eventually(t, func() bool {
 		peerTip := cs.GetPeerTip(revivedConn)
@@ -1182,29 +1201,21 @@ func TestChainSelectorTouchPeerActivityEmitsChainSwitchEvent(t *testing.T) {
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, incumbentConn, *cs.GetBestPeer())
 
-	for len(evtCh) > 0 {
-		<-evtCh
-	}
+	drainChainSwitchesUntilBest(t, evtCh, incumbentConn)
 
 	cs.TouchPeerActivity(revivedConn)
 
 	require.NotNil(t, cs.GetBestPeer())
 	assert.Equal(t, revivedConn, *cs.GetBestPeer())
 
-	var switchEvt ChainSwitchEvent
-	require.Eventually(t, func() bool {
-		select {
-		case evt := <-evtCh:
-			data, ok := evt.Data.(ChainSwitchEvent)
-			if !ok {
-				return false
-			}
-			switchEvt = data
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 5*time.Millisecond, "activity-driven switch should emit event")
+	activityEvt := testutil.RequireReceive(
+		t,
+		evtCh,
+		5*time.Second,
+		"activity-driven switch should emit event",
+	)
+	switchEvt, ok := activityEvt.Data.(ChainSwitchEvent)
+	require.True(t, ok, "expected ChainSwitchEvent")
 
 	assert.Equal(t, incumbentConn, switchEvt.PreviousConnectionId)
 	assert.Equal(t, revivedConn, switchEvt.NewConnectionId)

--- a/event/doc.go
+++ b/event/doc.go
@@ -103,6 +103,14 @@
 // reported by the event_delivery_blocked_total metric and an "event
 // delivery stalled" warning.
 //
+// That warning comes from a parked publisher, so it cannot fire before
+// the subscriber's buffer is full: how soon it appears depends on the
+// buffer size and event rate rather than on the fault. A SubscribeFunc
+// handler that has stopped returning is reported directly, by a
+// bus-wide watchdog, as an "event subscriber handler not making
+// progress" warning and the event_subscriber_handler_stalled_total
+// metric. See handler_progress.go.
+//
 // # Subscribing
 //
 //	eventBus.SubscribeFunc(chain.ChainForkEventType, func(evt event.Event) {

--- a/event/doc.go
+++ b/event/doc.go
@@ -109,9 +109,11 @@
 // handler that has stopped returning is reported directly, by a
 // bus-wide watchdog, as an "event subscriber handler not making
 // progress" warning and the event_subscriber_handler_stalled_total
-// metric. That counter carries a zero-valued series for every
-// SubscribeFunc subscription, so a bus with no stall is
-// distinguishable from one where the subscription is missing. See
+// metric. Registering the first SubscribeFunc subscription for an
+// event type materializes that counter's series for the type at zero,
+// so "nothing has stalled" is distinguishable from "no handler was
+// ever registered for this type". The granularity is the event type,
+// not the subscription, and the series outlives an unsubscribe. See
 // handler_progress.go.
 //
 // # Subscribing

--- a/event/doc.go
+++ b/event/doc.go
@@ -109,7 +109,10 @@
 // handler that has stopped returning is reported directly, by a
 // bus-wide watchdog, as an "event subscriber handler not making
 // progress" warning and the event_subscriber_handler_stalled_total
-// metric. See handler_progress.go.
+// metric. That counter carries a zero-valued series for every
+// SubscribeFunc subscription, so a bus with no stall is
+// distinguishable from one where the subscription is missing. See
+// handler_progress.go.
 //
 // # Subscribing
 //

--- a/event/doc.go
+++ b/event/doc.go
@@ -109,10 +109,15 @@
 // handler that has stopped returning is reported directly, by a
 // bus-wide watchdog, as an "event subscriber handler not making
 // progress" warning and the event_subscriber_handler_stalled_total
-// metric. Registering the first SubscribeFunc subscription for an
-// event type materializes that counter's series for the type at zero,
-// so "nothing has stalled" is distinguishable from "no handler was
-// ever registered for this type". The granularity is the event type,
+// metric. The watchdog samples twice per
+// handlerProgressWarnInterval, so the first report lands within one
+// and a half of those (45s at the 30s default) of the handler ceasing
+// to return, and repeats at most once per interval after that.
+//
+// Registering the first SubscribeFunc subscription for an event type
+// materializes that counter's series for the type at zero, so
+// "nothing has stalled" is distinguishable from "no handler was ever
+// registered for this type". The granularity is the event type,
 // not the subscription, and the series outlives an unsubscribe. See
 // handler_progress.go.
 //

--- a/event/event.go
+++ b/event/event.go
@@ -177,6 +177,11 @@ type EventBus struct {
 	stopSeq         uint64
 	stopMu          sync.RWMutex
 	stopOpMu        sync.Mutex // Serializes Stop() calls to prevent duplicate worker pools
+
+	// handlerProgressInterval is this bus's snapshot of
+	// handlerProgressWarnInterval, taken once at construction. See
+	// handler_progress.go.
+	handlerProgressInterval time.Duration
 }
 
 // NewEventBus creates a new EventBus with async worker pool
@@ -193,6 +198,8 @@ func NewEventBus(
 		Logger:              logger,
 		asyncQueue:          make(chan asyncEvent, AsyncQueueSize),
 		stopCh:              make(chan struct{}),
+
+		handlerProgressInterval: handlerProgressWarnInterval,
 	}
 	if promRegistry != nil {
 		e.initMetrics(promRegistry)
@@ -202,6 +209,8 @@ func NewEventBus(
 		e.asyncWg.Add(1)
 		go e.asyncWorker()
 	}
+	e.asyncWg.Add(1)
+	go e.handlerProgressWatchdog(e.stopCh)
 	return e
 }
 
@@ -315,6 +324,16 @@ type channelSubscriber struct {
 	// of with time. See TestDeliverStallWarningIsRateLimitedPerSubscriber.
 	stallNextWarn   time.Time
 	stallSuppressed int
+
+	// handlerStartedAt is the unix-nano time the dispatch goroutine entered
+	// its handler, or 0 when no handler is running. handlerWarnedAt is the
+	// last time handlerProgressWatchdog reported this subscription, and is
+	// cleared with handlerStartedAt so a recovered handler is not left
+	// suppressed. Both stay zero for subscribers with no dispatch goroutine
+	// (Subscribe/SubscribeWithBuffer), whose read loop the bus does not own
+	// and therefore cannot observe. See handler_progress.go.
+	handlerStartedAt atomic.Int64
+	handlerWarnedAt  atomic.Int64
 }
 
 // warnStalled reports a subscriber that is not draining, at most once per
@@ -770,7 +789,9 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 			if e.terminalClosing.Load() {
 				return
 			}
+			chSub.beginHandler(time.Now())
 			e.safeHandlerCall(handlerFunc, evt, nil)
+			chSub.endHandler()
 		}
 	}(
 		chSub.ch,
@@ -853,7 +874,10 @@ func (e *EventBus) SubscribeFuncStrict(
 			if e.terminalClosing.Load() {
 				return
 			}
-			if e.safeHandlerCall(handlerFunc, evt, onPanic) {
+			chSub.beginHandler(time.Now())
+			panicked := e.safeHandlerCall(handlerFunc, evt, onPanic)
+			chSub.endHandler()
+			if panicked {
 				// The handler panicked: stop delivering events to it rather
 				// than looping back for the next one as if nothing failed.
 				e.Unsubscribe(eventType, subId)
@@ -1491,6 +1515,7 @@ func (e *EventBus) shutdown(restart bool) {
 	}
 	e.asyncQueue = make(chan asyncEvent, AsyncQueueSize)
 	e.stopCh = make(chan struct{})
+	restartStopCh := e.stopCh
 	e.stopped = false
 	e.stopMu.Unlock()
 
@@ -1499,6 +1524,8 @@ func (e *EventBus) shutdown(restart bool) {
 		e.asyncWg.Add(1)
 		go e.asyncWorker()
 	}
+	e.asyncWg.Add(1)
+	go e.handlerProgressWatchdog(restartStopCh)
 }
 
 func (e *EventBus) refreshSubscriberSnapshotLocked(eventType EventType) {

--- a/event/event.go
+++ b/event/event.go
@@ -326,14 +326,23 @@ type channelSubscriber struct {
 	stallSuppressed int
 
 	// handlerStartedAt is the unix-nano time the dispatch goroutine entered
-	// its handler, or 0 when no handler is running. handlerWarnedAt is the
-	// last time handlerProgressWatchdog reported this subscription, and is
-	// cleared with handlerStartedAt so a recovered handler is not left
-	// suppressed. Both stay zero for subscribers with no dispatch goroutine
+	// its handler, or 0 when no handler is running. It is written only by
+	// that dispatch goroutine.
+	//
+	// handlerWarnedAt and handlerWarnedFor are handlerProgressWatchdog's
+	// rate limiter: when it last reported this subscription, and the
+	// handlerStartedAt value that report was about. They are written only by
+	// the watchdog, of which a bus runs exactly one at a time. Keying the
+	// stamp to the invocation, rather than clearing it on each new one, is
+	// what stops a report that raced the handler's return from landing on
+	// the next invocation and suppressing its own first report.
+	//
+	// All three stay zero for subscribers with no dispatch goroutine
 	// (Subscribe/SubscribeWithBuffer), whose read loop the bus does not own
 	// and therefore cannot observe. See handler_progress.go.
 	handlerStartedAt atomic.Int64
 	handlerWarnedAt  atomic.Int64
+	handlerWarnedFor atomic.Int64
 }
 
 // warnStalled reports a subscriber that is not draining, at most once per
@@ -766,6 +775,7 @@ func (e *EventBus) SubscribeFuncWithBufferPolicy(
 	)
 	e.subscriberWg.Add(1)
 	e.stopMu.RUnlock()
+	e.observeHandlerProgress(eventType)
 
 	go func(evtCh <-chan Event, handlerFunc EventHandlerFunc, done chan struct{}) {
 		defer close(done)
@@ -851,6 +861,7 @@ func (e *EventBus) SubscribeFuncStrict(
 	)
 	e.subscriberWg.Add(1)
 	e.stopMu.RUnlock()
+	e.observeHandlerProgress(eventType)
 
 	go func(evtCh <-chan Event, handlerFunc EventHandlerFunc, done chan struct{}) {
 		defer close(done)

--- a/event/handler_progress.go
+++ b/event/handler_progress.go
@@ -126,13 +126,17 @@ func (e *EventBus) StuckHandlerCount() int {
 }
 
 // observeHandlerProgress materializes the zero-valued handler-stall series for
-// a subscription the watchdog can observe. The counter is only ever
-// incremented by a stall, so without this a healthy bus exports no series at
-// all for the event type and a Prometheus query cannot tell "no handler here
-// has ever stalled" from "this subscription was never registered" -- the two
-// answers an operator most needs to distinguish. Called for the SubscribeFunc
-// paths only: a Subscribe channel's read loop is not owned by the bus, so the
-// watchdog never reports it and a series for it would always read zero.
+// an event type the watchdog can observe. The counter is only ever incremented
+// by a stall, so without this a healthy bus exports no series at all for the
+// type and a Prometheus query cannot tell "no handler for this type has ever
+// stalled" from "no handler for this type was ever registered" -- the two
+// answers an operator most needs to distinguish.
+//
+// The series is per event type, so subscriptions to one type share it, and it
+// outlives their unsubscribe like any other counter. Called for the
+// SubscribeFunc paths only: a Subscribe channel's read loop is not owned by
+// the bus, so the watchdog never reports it and a series for it would always
+// read zero.
 func (e *EventBus) observeHandlerProgress(eventType EventType) {
 	if e.metrics == nil {
 		return

--- a/event/handler_progress.go
+++ b/event/handler_progress.go
@@ -31,12 +31,12 @@ var handlerProgressWarnInterval = 30 * time.Second
 // its handler. Called immediately before the handler runs, and paired with
 // endHandler.
 //
-// The rate limiter is cleared here as well as in endHandler: each invocation
-// gets its own grace period, and clearing on both edges means a watchdog tick
-// that races endHandler cannot leave a stale timestamp behind that suppresses
-// the report for the next event.
+// It deliberately does not touch the watchdog's rate-limit stamp. Clearing it
+// here would race the watchdog: a tick that read the previous invocation's
+// start time can write its stamp after this store, and the cleared field would
+// then be re-set for an invocation that has just begun. The stamp instead
+// carries the start time it belongs to, so a stale one cannot match.
 func (c *channelSubscriber) beginHandler(now time.Time) {
-	c.handlerWarnedAt.Store(0)
 	c.handlerStartedAt.Store(now.UnixNano())
 }
 
@@ -45,45 +45,51 @@ func (c *channelSubscriber) beginHandler(now time.Time) {
 // one: only a handler that has not returned is reported.
 func (c *channelSubscriber) endHandler() {
 	c.handlerStartedAt.Store(0)
-	c.handlerWarnedAt.Store(0)
 }
 
 // handlerStuckFor reports how long the current handler invocation has been
-// running, and whether one is running at all.
+// running, which invocation that is (its unix-nano start time, 0 when none),
+// and whether one is running at all.
 func (c *channelSubscriber) handlerStuckFor(
 	now time.Time,
-) (time.Duration, bool) {
+) (time.Duration, int64, bool) {
 	started := c.handlerStartedAt.Load()
 	if started == 0 {
-		return 0, false
+		return 0, 0, false
 	}
 	elapsed := now.Sub(time.Unix(0, started))
 	if elapsed < 0 {
-		return 0, true
+		return 0, started, true
 	}
-	return elapsed, true
+	return elapsed, started, true
 }
 
 // warnStuckHandler reports a subscription whose handler has not returned, at
 // most once per interval per subscription. Returns true when the subscription
 // is currently stuck, whether or not this call logged.
+//
+// Called only from handlerProgressWatchdog, which is what makes the unlocked
+// read-then-write of the two stamp fields safe: a bus runs one watchdog at a
+// time, and nothing else writes them.
 func (c *channelSubscriber) warnStuckHandler(
 	now time.Time,
 	interval time.Duration,
 ) bool {
-	elapsed, running := c.handlerStuckFor(now)
+	elapsed, started, running := c.handlerStuckFor(now)
 	if !running || elapsed < interval {
 		return false
 	}
-	// Rate-limit per subscription. endHandler resets this, so a handler that
-	// recovers starts from a clean slate rather than staying suppressed.
-	lastWarn := c.handlerWarnedAt.Load()
-	if lastWarn != 0 && now.Sub(time.Unix(0, lastWarn)) < interval {
-		return true
+	// Rate-limit per invocation, not per subscription: a stamp left behind
+	// for an invocation that has since returned names a different start
+	// time, so it cannot suppress the first report for the current one.
+	if c.handlerWarnedFor.Load() == started {
+		lastWarn := c.handlerWarnedAt.Load()
+		if lastWarn != 0 && now.Sub(time.Unix(0, lastWarn)) < interval {
+			return true
+		}
 	}
-	if !c.handlerWarnedAt.CompareAndSwap(lastWarn, now.UnixNano()) {
-		return true
-	}
+	c.handlerWarnedAt.Store(now.UnixNano())
+	c.handlerWarnedFor.Store(started)
 	if c.logger != nil {
 		c.logger.Warn(
 			"event subscriber handler not making progress",
@@ -111,12 +117,27 @@ func (e *EventBus) StuckHandlerCount() int {
 	now := time.Now()
 	count := 0
 	for _, sub := range e.channelSubscriberSnapshot() {
-		if elapsed, running := sub.handlerStuckFor(now); running &&
+		if elapsed, _, running := sub.handlerStuckFor(now); running &&
 			elapsed >= e.handlerProgressInterval {
 			count++
 		}
 	}
 	return count
+}
+
+// observeHandlerProgress materializes the zero-valued handler-stall series for
+// a subscription the watchdog can observe. The counter is only ever
+// incremented by a stall, so without this a healthy bus exports no series at
+// all for the event type and a Prometheus query cannot tell "no handler here
+// has ever stalled" from "this subscription was never registered" -- the two
+// answers an operator most needs to distinguish. Called for the SubscribeFunc
+// paths only: a Subscribe channel's read loop is not owned by the bus, so the
+// watchdog never reports it and a series for it would always read zero.
+func (e *EventBus) observeHandlerProgress(eventType EventType) {
+	if e.metrics == nil {
+		return
+	}
+	e.metrics.handlerStalls.WithLabelValues(string(eventType)).Add(0)
 }
 
 // channelSubscriberSnapshot copies the live channel subscribers out from under

--- a/event/handler_progress.go
+++ b/event/handler_progress.go
@@ -96,13 +96,18 @@ func (c *channelSubscriber) handlerStuckFor(
 // Called only from handlerProgressWatchdog, which is what makes the unlocked
 // read-then-write of the two stamp fields safe: a bus runs one watchdog at a
 // time, and nothing else writes them.
+// It returns whether the handler is stalled, and separately whether this call
+// actually emitted a report. They differ on the rate-limited path: the handler
+// is still stalled, but the report is suppressed. The counter tracks reports,
+// not samples -- handlerProgressTick samples twice per interval, so counting
+// samples would move it at twice the documented once-per-interval rate.
 func (c *channelSubscriber) warnStuckHandler(
 	now time.Time,
 	interval time.Duration,
-) bool {
+) (stalled bool, reported bool) {
 	elapsed, started, running := c.handlerStuckFor(now)
 	if !running || elapsed < interval {
-		return false
+		return false, false
 	}
 	// Rate-limit per invocation, not per subscription: a stamp left behind
 	// for an invocation that has since returned names a different start
@@ -110,7 +115,7 @@ func (c *channelSubscriber) warnStuckHandler(
 	if c.handlerWarnedFor.Load() == started {
 		lastWarn := c.handlerWarnedAt.Load()
 		if lastWarn != 0 && now.Sub(time.Unix(0, lastWarn)) < interval {
-			return true
+			return true, false
 		}
 	}
 	c.handlerWarnedAt.Store(now.UnixNano())
@@ -125,7 +130,7 @@ func (c *channelSubscriber) warnStuckHandler(
 			"blocked_publishers", c.stallWaiters.Load(),
 		)
 	}
-	return true
+	return true, true
 }
 
 // StuckHandlerCount reports how many SubscribeFunc subscriptions currently
@@ -210,7 +215,8 @@ func (e *EventBus) handlerProgressWatchdog(stopCh chan struct{}) {
 			return
 		case now := <-ticker.C:
 			for _, sub := range e.channelSubscriberSnapshot() {
-				if sub.warnStuckHandler(now, interval) && e.metrics != nil {
+				_, reported := sub.warnStuckHandler(now, interval)
+				if reported && e.metrics != nil {
 					e.metrics.handlerStalls.WithLabelValues(
 						string(sub.eventType),
 					).Inc()

--- a/event/handler_progress.go
+++ b/event/handler_progress.go
@@ -16,9 +16,11 @@ package event
 
 import "time"
 
-// handlerProgressWarnInterval is how long a SubscribeFunc handler may stay
-// inside a single event before the subscription is reported as not making
-// progress, and how often that report repeats while it stays there.
+// handlerProgressWarnInterval is the stall threshold: how long a SubscribeFunc
+// handler may stay inside a single event before the subscription becomes
+// eligible to be reported as not making progress, and how often that report
+// repeats while it stays there. Reporting is driven by a sampler, so the first
+// report lands within one and a half of these -- see handlerProgressTick.
 // Overridden in tests.
 //
 // Each EventBus snapshots it once, in NewEventBus, into
@@ -26,6 +28,29 @@ import "time"
 // so re-reading a package variable on every tick would race any test that
 // overrides it against every bus an earlier test left running.
 var handlerProgressWarnInterval = 30 * time.Second
+
+// handlerProgressTick is how often handlerProgressWatchdog samples handlers,
+// given the interval a handler may be stuck for before it is reported.
+//
+// It is deliberately shorter than that interval. warnStuckHandler needs a full
+// interval to have elapsed, so sampling once per interval puts the first
+// report anywhere in (interval, 2*interval]: a handler that stops returning
+// just after a sample has been stuck for a hair under one interval at the next
+// one, is skipped, and waits a whole further period. Sampling twice per
+// interval bounds the first report at 1.5 intervals, which is what event/doc.go
+// and ARCHITECTURE.md state (wolf31o2 review).
+//
+// The repeat rate is unaffected: warnStuckHandler still suppresses a report
+// within one interval of the last one for the same invocation.
+func handlerProgressTick(interval time.Duration) time.Duration {
+	tick := interval / 2
+	if tick <= 0 {
+		// Only reachable for a sub-2ns interval, which no caller sets.
+		// time.NewTicker panics on a non-positive period.
+		return interval
+	}
+	return tick
+}
 
 // beginHandler records that this subscription's dispatch goroutine has entered
 // its handler. Called immediately before the handler runs, and paired with
@@ -167,16 +192,17 @@ func (e *EventBus) channelSubscriberSnapshot() []*channelSubscriber {
 // makes the time to first signal a function of the buffer size and the event
 // rate rather than of the fault: the chainselection.peer_activity handler in
 // blinklabs-io/dingo#3550 stopped returning 12h31m before its 1024-slot buffer
-// filled and said so. This watchdog observes the handler itself, so the report
-// arrives one interval after the handler stops making progress no matter how
-// much headroom the buffer has.
+// filled and said so. This watchdog observes the handler itself, so the first
+// report arrives within one and a half intervals of the handler ceasing to
+// make progress -- see handlerProgressTick -- no matter how much headroom the
+// buffer has.
 //
 // stopCh is passed in rather than read from e: a Stop/restart cycle swaps
 // e.stopCh, and this worker must watch the generation it was started under.
 func (e *EventBus) handlerProgressWatchdog(stopCh chan struct{}) {
 	defer e.asyncWg.Done()
 	interval := e.handlerProgressInterval
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(handlerProgressTick(interval))
 	defer ticker.Stop()
 	for {
 		select {

--- a/event/handler_progress.go
+++ b/event/handler_progress.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import "time"
+
+// handlerProgressWarnInterval is how long a SubscribeFunc handler may stay
+// inside a single event before the subscription is reported as not making
+// progress, and how often that report repeats while it stays there.
+// Overridden in tests.
+//
+// Each EventBus snapshots it once, in NewEventBus, into
+// handlerProgressInterval. The watchdog is a long-lived background goroutine,
+// so re-reading a package variable on every tick would race any test that
+// overrides it against every bus an earlier test left running.
+var handlerProgressWarnInterval = 30 * time.Second
+
+// beginHandler records that this subscription's dispatch goroutine has entered
+// its handler. Called immediately before the handler runs, and paired with
+// endHandler.
+//
+// The rate limiter is cleared here as well as in endHandler: each invocation
+// gets its own grace period, and clearing on both edges means a watchdog tick
+// that races endHandler cannot leave a stale timestamp behind that suppresses
+// the report for the next event.
+func (c *channelSubscriber) beginHandler(now time.Time) {
+	c.handlerWarnedAt.Store(0)
+	c.handlerStartedAt.Store(now.UnixNano())
+}
+
+// endHandler records that the handler returned. Clearing the start time is
+// what makes a subscription that is merely busy indistinguishable from an idle
+// one: only a handler that has not returned is reported.
+func (c *channelSubscriber) endHandler() {
+	c.handlerStartedAt.Store(0)
+	c.handlerWarnedAt.Store(0)
+}
+
+// handlerStuckFor reports how long the current handler invocation has been
+// running, and whether one is running at all.
+func (c *channelSubscriber) handlerStuckFor(
+	now time.Time,
+) (time.Duration, bool) {
+	started := c.handlerStartedAt.Load()
+	if started == 0 {
+		return 0, false
+	}
+	elapsed := now.Sub(time.Unix(0, started))
+	if elapsed < 0 {
+		return 0, true
+	}
+	return elapsed, true
+}
+
+// warnStuckHandler reports a subscription whose handler has not returned, at
+// most once per interval per subscription. Returns true when the subscription
+// is currently stuck, whether or not this call logged.
+func (c *channelSubscriber) warnStuckHandler(
+	now time.Time,
+	interval time.Duration,
+) bool {
+	elapsed, running := c.handlerStuckFor(now)
+	if !running || elapsed < interval {
+		return false
+	}
+	// Rate-limit per subscription. endHandler resets this, so a handler that
+	// recovers starts from a clean slate rather than staying suppressed.
+	lastWarn := c.handlerWarnedAt.Load()
+	if lastWarn != 0 && now.Sub(time.Unix(0, lastWarn)) < interval {
+		return true
+	}
+	if !c.handlerWarnedAt.CompareAndSwap(lastWarn, now.UnixNano()) {
+		return true
+	}
+	if c.logger != nil {
+		c.logger.Warn(
+			"event subscriber handler not making progress",
+			"type", c.eventType,
+			"stuck_for", elapsed.Truncate(time.Millisecond),
+			"queued", len(c.ch),
+			"buffer", cap(c.ch),
+			"blocked_publishers", c.stallWaiters.Load(),
+		)
+	}
+	return true
+}
+
+// StuckHandlerCount reports how many SubscribeFunc subscriptions currently
+// have a handler that has been running longer than handlerProgressWarnInterval.
+//
+// Exported so the node can surface the condition alongside its other health
+// signals: a required internal consumer that has stopped returning is a node
+// fault, and waiting for its buffer to fill turns a 30-second symptom into a
+// half-day one (blinklabs-io/dingo#3550).
+func (e *EventBus) StuckHandlerCount() int {
+	if e == nil {
+		return 0
+	}
+	now := time.Now()
+	count := 0
+	for _, sub := range e.channelSubscriberSnapshot() {
+		if elapsed, running := sub.handlerStuckFor(now); running &&
+			elapsed >= e.handlerProgressInterval {
+			count++
+		}
+	}
+	return count
+}
+
+// channelSubscriberSnapshot copies the live channel subscribers out from under
+// e.mu so the watchdog never holds the bus lock while logging.
+func (e *EventBus) channelSubscriberSnapshot() []*channelSubscriber {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if len(e.channelSubsById) == 0 {
+		return nil
+	}
+	subs := make([]*channelSubscriber, 0, len(e.channelSubsById))
+	for _, sub := range e.channelSubsById {
+		subs = append(subs, sub)
+	}
+	return subs
+}
+
+// handlerProgressWatchdog reports subscriptions whose handler has stopped
+// returning.
+//
+// The existing stall report is raised by a publisher that had to wait for
+// buffer capacity, so it can only fire once the buffer is already full. That
+// makes the time to first signal a function of the buffer size and the event
+// rate rather than of the fault: the chainselection.peer_activity handler in
+// blinklabs-io/dingo#3550 stopped returning 12h31m before its 1024-slot buffer
+// filled and said so. This watchdog observes the handler itself, so the report
+// arrives one interval after the handler stops making progress no matter how
+// much headroom the buffer has.
+//
+// stopCh is passed in rather than read from e: a Stop/restart cycle swaps
+// e.stopCh, and this worker must watch the generation it was started under.
+func (e *EventBus) handlerProgressWatchdog(stopCh chan struct{}) {
+	defer e.asyncWg.Done()
+	interval := e.handlerProgressInterval
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case now := <-ticker.C:
+			for _, sub := range e.channelSubscriberSnapshot() {
+				if sub.warnStuckHandler(now, interval) && e.metrics != nil {
+					e.metrics.handlerStalls.WithLabelValues(
+						string(sub.eventType),
+					).Inc()
+				}
+			}
+		}
+	}
+}

--- a/event/handler_progress_test.go
+++ b/event/handler_progress_test.go
@@ -223,7 +223,9 @@ func TestStuckHandlerRateLimitIsPerInvocation(t *testing.T) {
 	first := time.Now()
 	c.beginHandler(first)
 	firstWarn := first.Add(interval)
-	require.True(t, c.warnStuckHandler(firstWarn, interval))
+	stalled, reported := c.warnStuckHandler(firstWarn, interval)
+	require.True(t, stalled)
+	require.True(t, reported)
 	require.Equal(t, 1, stuckHandlerWarnings(&buf))
 
 	// Replay the losing interleaving. The tick above sampled `first`; the
@@ -239,16 +241,26 @@ func TestStuckHandlerRateLimitIsPerInvocation(t *testing.T) {
 	// The second invocation has now been stuck for a full interval of its
 	// own and must be reported, even though the stale stamp is younger than
 	// one interval.
-	require.True(t, c.warnStuckHandler(second.Add(interval), interval))
+	stalled, reported = c.warnStuckHandler(second.Add(interval), interval)
+	require.True(t, stalled)
+	require.True(t, reported)
 	require.Equal(t, 2, stuckHandlerWarnings(&buf),
 		"a report stamped for an invocation that already returned must not "+
 			"suppress the first report for the one running now",
 	)
 
 	// The rate limit still holds within one invocation.
-	require.True(
+	stalled, reported = c.warnStuckHandler(
+		second.Add(interval+interval/2),
+		interval,
+	)
+	require.True(t, stalled, "the handler is still stuck")
+	require.False(
 		t,
-		c.warnStuckHandler(second.Add(interval+interval/2), interval),
+		reported,
+		"a suppressed sample must not count as a report; the counter is "+
+			"driven off this and handlerProgressTick samples twice per "+
+			"interval",
 	)
 	require.Equal(t, 2, stuckHandlerWarnings(&buf),
 		"repeat reports for the same invocation stay rate-limited",
@@ -331,4 +343,41 @@ func TestHandlerProgressSamplesTwicePerInterval(t *testing.T) {
 				"bound to hold (interval=%s)", interval,
 		)
 	}
+}
+
+// TestHandlerStallCounterMatchesWarnRate pins the counter to the report rate
+// rather than the sample rate. handlerProgressTick samples twice per interval,
+// so counting every stalled sample moved
+// event_subscriber_handler_stalled_total at twice the rate ARCHITECTURE.md and
+// event/doc.go document for it, and twice the rate of the warning it is meant
+// to accompany.
+func TestHandlerStallCounterMatchesWarnRate(t *testing.T) {
+	const interval = time.Second
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	c := newChannelSubscriber(handlerProgressTestType, 1, logger)
+
+	start := time.Now()
+	c.beginHandler(start)
+
+	reports := 0
+	// Ten intervals sampled at the real tick rate (interval/2).
+	for i := 1; i <= 20; i++ {
+		now := start.Add(time.Duration(i) * interval / 2)
+		if _, reported := c.warnStuckHandler(now, interval); reported {
+			reports++
+		}
+	}
+
+	warnings := stuckHandlerWarnings(&buf)
+	require.Equal(t, warnings, reports,
+		"every report must correspond to exactly one warning",
+	)
+	require.LessOrEqual(t, reports, 11,
+		"a handler wedged for ten intervals must not report more than "+
+			"once per interval, however often it is sampled",
+	)
 }

--- a/event/handler_progress_test.go
+++ b/event/handler_progress_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+)
+
+const handlerProgressTestType EventType = "test.handler_progress"
+
+// A subscriber whose handler has stopped returning is invisible until its
+// buffer fills, because the only stall report the bus has is raised by a
+// publisher that had to wait for capacity. In blinklabs-io/dingo#3550 the
+// chainselection.peer_activity handler stopped returning at 18:02 and the
+// first "event delivery stalled" line appeared 12h31m later, once 1024
+// keepalive events had piled up behind it. The handler being stuck is the
+// fact worth reporting, and it is knowable immediately.
+func TestSubscriberHandlerStuckIsReportedBeforeBufferFills(t *testing.T) {
+	origInterval := handlerProgressWarnInterval
+	handlerProgressWarnInterval = 20 * time.Millisecond
+	t.Cleanup(func() { handlerProgressWarnInterval = origInterval })
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	bus := NewEventBus(nil, logger)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	// Close, not Stop: Stop restarts the worker pool, and the restarted
+	// watchdog would read handlerProgressWarnInterval concurrently with this
+	// test's cleanup restoring it.
+	t.Cleanup(bus.Close)
+	t.Cleanup(unblock)
+
+	// A buffer far larger than the number of events published: nothing here
+	// ever waits for capacity, so the existing full-buffer stall warning
+	// cannot fire.
+	bus.SubscribeFuncWithBuffer(
+		handlerProgressTestType,
+		1024,
+		func(Event) { <-release },
+	)
+
+	bus.Publish(
+		handlerProgressTestType,
+		NewEvent(handlerProgressTestType, "stuck"),
+	)
+
+	testutil.WaitForConditionWithInterval(t, func() bool {
+		return strings.Contains(
+			buf.String(),
+			"event subscriber handler not making progress",
+		)
+	}, 5*time.Second, time.Millisecond,
+		"a handler that stopped returning must be reported without waiting "+
+			"for its buffer to fill",
+	)
+	require.NotContains(t, buf.String(), "event delivery stalled",
+		"the buffer never filled, so this must be the handler report",
+	)
+	require.Contains(t, buf.String(),
+		"type="+string(handlerProgressTestType),
+		"the report must name the subscriber's event type",
+	)
+
+	unblock()
+
+	// A handler that returns must clear the condition rather than keep
+	// reporting for the life of the subscription.
+	warnings := strings.Count(
+		buf.String(),
+		"event subscriber handler not making progress",
+	)
+	testutil.WaitForCondition(t, func() bool {
+		return bus.StuckHandlerCount() == 0
+	}, 5*time.Second, "the handler returned, so nothing should still be stuck")
+	settled := strings.Count(
+		buf.String(),
+		"event subscriber handler not making progress",
+	)
+	require.GreaterOrEqual(t, settled, warnings)
+
+	before := strings.Count(
+		buf.String(),
+		"event subscriber handler not making progress",
+	)
+	testutil.RequireNoReceive(
+		t,
+		handlerProgressWarningsAfter(t, &buf, before),
+		200*time.Millisecond,
+		"the report must stop once the handler is making progress again",
+	)
+}
+
+// handlerProgressWarningsAfter reports on its channel as soon as the warning
+// count rises above want, so the caller can assert that it does not.
+func handlerProgressWarningsAfter(
+	t *testing.T,
+	buf *lockedBuffer,
+	want int,
+) <-chan int {
+	t.Helper()
+	ch := make(chan int, 1)
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	go func() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				got := strings.Count(
+					buf.String(),
+					"event subscriber handler not making progress",
+				)
+				if got > want {
+					select {
+					case ch <- got:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+// The report has to say which subscriber is stuck and for how long, or an
+// operator cannot tell a wedged internal consumer from ordinary slow work.
+func TestStuckHandlerReportIdentifiesSubscriber(t *testing.T) {
+	origInterval := handlerProgressWarnInterval
+	handlerProgressWarnInterval = 20 * time.Millisecond
+	t.Cleanup(func() { handlerProgressWarnInterval = origInterval })
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	bus := NewEventBus(nil, logger)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	// Close, not Stop: Stop restarts the worker pool, and the restarted
+	// watchdog would read handlerProgressWarnInterval concurrently with this
+	// test's cleanup restoring it.
+	t.Cleanup(bus.Close)
+	t.Cleanup(unblock)
+
+	bus.SubscribeFuncWithBufferPolicy(
+		handlerProgressTestType,
+		8,
+		SubscriberBackpressureBlock,
+		func(Event) { <-release },
+	)
+	bus.Publish(
+		handlerProgressTestType,
+		NewEvent(handlerProgressTestType, "stuck"),
+	)
+
+	testutil.WaitForConditionWithInterval(t, func() bool {
+		return bus.StuckHandlerCount() == 1 &&
+			strings.Contains(
+				buf.String(),
+				"event subscriber handler not making progress",
+			)
+	}, 5*time.Second, time.Millisecond,
+		"the bus should report exactly one stuck handler",
+	)
+	logs := buf.String()
+	require.Contains(t, logs, "stuck_for=")
+	require.Contains(t, logs, "queued=")
+	require.Contains(t, logs, "buffer=8")
+}

--- a/event/handler_progress_test.go
+++ b/event/handler_progress_test.go
@@ -309,3 +309,26 @@ func TestHandlerStallSeriesExistsBeforeAnyStall(t *testing.T) {
 		),
 	)
 }
+
+// The watchdog samples on a ticker, and warnStuckHandler needs a full interval
+// to have elapsed, so the first report lands on the first sample at least one
+// interval after the handler stopped returning. Sampling once per interval
+// therefore puts it anywhere in (interval, 2*interval] -- 30s to 60s at the
+// production value, against the "within one and a half intervals" the
+// watchdog, event/doc.go and ARCHITECTURE.md state. Sampling at most twice per
+// interval is what makes that bound hold.
+func TestHandlerProgressSamplesTwicePerInterval(t *testing.T) {
+	for _, interval := range []time.Duration{
+		time.Millisecond,
+		20 * time.Millisecond,
+		handlerProgressWarnInterval,
+	} {
+		tick := handlerProgressTick(interval)
+		require.Positive(t, tick, "time.NewTicker panics on a non-positive period")
+		require.LessOrEqual(t, tick, interval/2,
+			"first report is bounded by interval+tick, so tick must not "+
+				"exceed half the interval for the documented 1.5*interval "+
+				"bound to hold (interval=%s)", interval,
+		)
+	}
+}

--- a/event/handler_progress_test.go
+++ b/event/handler_progress_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
@@ -197,4 +199,113 @@ func TestStuckHandlerReportIdentifiesSubscriber(t *testing.T) {
 	require.Contains(t, logs, "stuck_for=")
 	require.Contains(t, logs, "queued=")
 	require.Contains(t, logs, "buffer=8")
+}
+
+// A watchdog tick that races the handler's return must not silence the report
+// for the invocation that follows it.
+//
+// handlerStuckFor can load the running invocation's start time and then, before
+// the tick writes its rate-limit stamp, have that handler return and the
+// dispatch loop begin the next event. The stamp then lands while a different
+// invocation is running. Keying it to the invocation it actually described is
+// what keeps it from suppressing that invocation's own first report — a stamp
+// cleared on each begin cannot, because the racing write happens after the
+// clear.
+func TestStuckHandlerRateLimitIsPerInvocation(t *testing.T) {
+	const interval = time.Second
+
+	var buf lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	c := newChannelSubscriber(handlerProgressTestType, 1, logger)
+
+	first := time.Now()
+	c.beginHandler(first)
+	firstWarn := first.Add(interval)
+	require.True(t, c.warnStuckHandler(firstWarn, interval))
+	require.Equal(t, 1, stuckHandlerWarnings(&buf))
+
+	// Replay the losing interleaving. The tick above sampled `first`; the
+	// handler returned and the dispatch loop began the next event before the
+	// tick's stamp was written, so the stamp is applied here, after
+	// beginHandler.
+	second := first.Add(interval / 2)
+	c.endHandler()
+	c.beginHandler(second)
+	c.handlerWarnedAt.Store(firstWarn.UnixNano())
+	c.handlerWarnedFor.Store(first.UnixNano())
+
+	// The second invocation has now been stuck for a full interval of its
+	// own and must be reported, even though the stale stamp is younger than
+	// one interval.
+	require.True(t, c.warnStuckHandler(second.Add(interval), interval))
+	require.Equal(t, 2, stuckHandlerWarnings(&buf),
+		"a report stamped for an invocation that already returned must not "+
+			"suppress the first report for the one running now",
+	)
+
+	// The rate limit still holds within one invocation.
+	require.True(
+		t,
+		c.warnStuckHandler(second.Add(interval+interval/2), interval),
+	)
+	require.Equal(t, 2, stuckHandlerWarnings(&buf),
+		"repeat reports for the same invocation stay rate-limited",
+	)
+}
+
+func stuckHandlerWarnings(buf *lockedBuffer) int {
+	return strings.Count(
+		buf.String(),
+		"event subscriber handler not making progress",
+	)
+}
+
+// event_subscriber_handler_stalled_total only ever moves on a stall, so a
+// healthy bus would export no series for it at all and a query could not tell
+// "nothing here has stalled" from "this subscription does not exist" — which
+// is the distinction an operator watching for a wedged internal consumer
+// needs. Registering a SubscribeFunc subscription materializes its zero.
+func TestHandlerStallSeriesExistsBeforeAnyStall(t *testing.T) {
+	const funcType EventType = "test.handler_stall.func"
+	const chanType EventType = "test.handler_stall.chan"
+
+	registry := prometheus.NewRegistry()
+	eb := NewEventBus(registry, nil)
+	t.Cleanup(eb.Close)
+
+	require.Equal(
+		t,
+		0,
+		promtestutil.CollectAndCount(eb.metrics.handlerStalls),
+		"nothing is subscribed yet",
+	)
+
+	eb.SubscribeFunc(funcType, func(Event) {})
+	require.Equal(
+		t,
+		1,
+		promtestutil.CollectAndCount(eb.metrics.handlerStalls),
+		"a SubscribeFunc subscription must publish its zero",
+	)
+
+	// A Subscribe channel's read loop is not owned by the bus, so the
+	// watchdog never reports it. A series for it would be permanently zero
+	// and would misrepresent the subscription as observed.
+	_, _ = eb.Subscribe(chanType)
+	require.Equal(
+		t,
+		1,
+		promtestutil.CollectAndCount(eb.metrics.handlerStalls),
+		"a channel subscription is not observable and gets no series",
+	)
+
+	require.Equal(
+		t,
+		float64(0),
+		promtestutil.ToFloat64(
+			eb.metrics.handlerStalls.WithLabelValues(string(funcType)),
+		),
+	)
 }

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -26,6 +26,7 @@ type eventMetrics struct {
 	deliveryTimeouts    *prometheus.CounterVec
 	deliveryBlocked     *prometheus.CounterVec
 	asyncEnqueueBlocked *prometheus.CounterVec
+	handlerStalls       *prometheus.CounterVec
 }
 
 func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
@@ -72,6 +73,14 @@ func (e *EventBus) initMetrics(promRegistry prometheus.Registerer) {
 			Name: "event_async_enqueue_blocked_total",
 			Help: "total async publishes that waited for queue capacity, " +
 				"by event type",
+		},
+		[]string{"type"},
+	)
+	e.metrics.handlerStalls = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "event_subscriber_handler_stalled_total",
+			Help: "observations of a subscriber handler that had not " +
+				"returned within the progress interval, by event type",
 		},
 		[]string{"type"},
 	)

--- a/ouroboros/consensus_conformance_test.go
+++ b/ouroboros/consensus_conformance_test.go
@@ -17,9 +17,11 @@ package ouroboros
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -132,13 +134,33 @@ func TestConsensusConformanceKGuardIsLive(t *testing.T) {
 const (
 	tipEventBuffer    = 4096
 	switchEventBuffer = 1024
+	// switchBarrierTimeout bounds the wait for the barrier below. It is a
+	// deadlock bound, not a settling delay: the barrier is already queued
+	// behind the switches when the wait starts, so the normal cost is one
+	// lane hand-off.
+	switchBarrierTimeout = 30 * time.Second
 )
+
+// switchBarrier is a sentinel published through the chain-switch ordered lane
+// so Stabilize can tell "no switch was decided" from "the switch has not been
+// delivered yet".
+//
+// ChainSelector.publishSelection routes chain switches through
+// EventBus.PublishOrdered (blinklabs-io/dingo#3550), so EvaluateAndSwitch
+// returns before the lane worker has handed them to subscribers. A lane is a
+// FIFO drained by exactly one worker, so a sentinel enqueued after those
+// switches is delivered after them: receiving it back is proof that every
+// switch published earlier on this goroutine has already reached the
+// subscription. Its Data type is not ChainSwitchEvent, so it is skipped rather
+// than recorded as a decision.
+type switchBarrier struct{}
 
 // replayAdapter implements consensus.Replayer by driving dingo's real
 // chainsync handlers and chain selector. The harness identifies peers by
 // the vector's peer_id; the adapter synthesizes a stable ConnectionId per
 // peer_id.
 type replayAdapter struct {
+	t        *testing.T
 	o        *Ouroboros
 	cs       *chainselection.ChainSelector
 	bus      *event.EventBus
@@ -195,6 +217,7 @@ func newReplayAdapter(
 	})
 	o.eventBus = bus
 	return &replayAdapter{
+		t:        t,
 		o:        o,
 		cs:       cs,
 		bus:      bus,
@@ -249,24 +272,52 @@ func (a *replayAdapter) RollBackward(
 }
 
 func (a *replayAdapter) Stabilize() {
+	a.t.Helper()
 	// Drain queued peer-tip updates into the selector, force a synchronous
-	// evaluation, then collect any switch decisions it emitted. All
-	// synchronous: no sleeps, no races.
+	// evaluation, then collect any switch decisions it emitted. No sleeps
+	// and no polling.
+	//
+	// chainselection.peer_tip_update is still published inline, on this
+	// goroutine, by chainsyncClientRollForward, so every tip update is
+	// already queued by the time Stabilize runs and a non-blocking drain
+	// sees all of them. Chain switches are not: they go through an ordered
+	// lane, so they need the barrier below.
 	drainEvents(a.tipCh, func(evt event.Event) {
 		a.tipEventsSeen++
 		a.cs.HandlePeerTipUpdateEvent(evt)
 	})
 	a.cs.EvaluateAndSwitch()
-	drainEvents(a.switchCh, func(evt event.Event) {
-		e, ok := evt.Data.(chainselection.ChainSwitchEvent)
-		if !ok {
+	a.collectSwitchesThroughBarrier()
+}
+
+// collectSwitchesThroughBarrier records every chain switch the selector has
+// published so far, using a sentinel enqueued behind them as the drain barrier.
+// See switchBarrier for why a non-blocking drain is not one.
+func (a *replayAdapter) collectSwitchesThroughBarrier() {
+	a.t.Helper()
+	if !a.bus.PublishOrdered(
+		chainselection.ChainSwitchEventType,
+		event.NewEvent(chainselection.ChainSwitchEventType, switchBarrier{}),
+	) {
+		a.t.Fatal("event bus refused the chain-switch barrier")
+	}
+	for {
+		evt := testutil.RequireReceive(
+			a.t,
+			a.switchCh,
+			switchBarrierTimeout,
+			"chain-switch barrier",
+		)
+		switch e := evt.Data.(type) {
+		case switchBarrier:
 			return
+		case chainselection.ChainSwitchEvent:
+			a.switches = append(a.switches, format.SwitchEvent{
+				PreviousTip: fromGouroborosTip(e.PreviousTip),
+				NewTip:      fromGouroborosTip(e.NewTip),
+			})
 		}
-		a.switches = append(a.switches, format.SwitchEvent{
-			PreviousTip: fromGouroborosTip(e.PreviousTip),
-			NewTip:      fromGouroborosTip(e.NewTip),
-		})
-	})
+	}
 }
 
 func (a *replayAdapter) BestTip() (format.Tip, bool) {

--- a/ouroboros/consensus_conformance_test.go
+++ b/ouroboros/consensus_conformance_test.go
@@ -316,6 +316,16 @@ func (a *replayAdapter) collectSwitchesThroughBarrier() {
 				PreviousTip: fromGouroborosTip(e.PreviousTip),
 				NewTip:      fromGouroborosTip(e.NewTip),
 			})
+		default:
+			// Only the selector and the barrier above publish on this
+			// lane, so anything else is a bug in one of them. Skipping it
+			// would still terminate -- the barrier is behind it in the
+			// same FIFO -- but it would drop a switch decision the
+			// harness then reports as "never switched", which is a much
+			// worse diagnosis than naming the payload.
+			a.t.Fatalf(
+				"unexpected %T on the chain_switch lane", evt.Data,
+			)
 		}
 	}
 }


### PR DESCRIPTION
The blocking path is a synchronous fan-out dependency chain, not a lock cycle.

`Ouroboros.keepaliveClientResponse` publishes `chainselection.peer_activity`
synchronously on the keepalive protocol goroutine. The single subscriber is a
plain `SubscribeFunc` whose dispatch goroutine runs the handler inline, so
nothing drains its 1024-slot buffer while the handler runs. The handler reaches
`TouchPeerActivity` -> `publishSelectionEvents` -> `EventBus.Publish`, which
parks when a downstream subscriber's buffer is full. That downstream consumer is
`LedgerState.handleChainSwitchEvent`, which holds `ls.chainsyncMutex` and reaches
back into `cs.mutex`.

So: the chain_switch consumer stops, its buffer fills, the peer_activity handler
parks in `Publish`, peer_activity stops draining, its buffer fills, and every
keepalive response parks a protocol goroutine. The reported run shows the last
chain extension 12h31m before the first stall warning — the time for 1024
keepalive events to fill the buffer.

The peer-governance and chain-selection legs were checked and are bounded
(`peergov.p.mu`, `chainsync.clientConnIdMutex`, `connmanager.connectionsMutex`
hold no publish, DNS, dial or sleep). No ABBA cycle exists.

All seven selector publish sites now use `EventBus.PublishOrdered`. Per-type
FIFO lanes preserve delivery and per-topic publisher order while confining a
blocked subscriber to that lane's worker, so no selector caller parks. Routing
every selector topic through the same helper keeps a queued chain switch from
being overtaken by one published inline.

The order preserved is the order publications reach `PublishOrdered`, not the
order the switches were decided in: every producer decides under `cs.mutex` and
publishes after releasing it, so two goroutines can decide A then B and enqueue
B then A. That window is unchanged from the inline `Publish`, and closing it
would mean publishing under the lock.

A bus-wide handler-progress watchdog reports a `SubscribeFunc` handler that has
stopped returning, counted in `event_subscriber_handler_stalled_total`. It
samples twice per `handlerProgressWarnInterval`, so the first report lands
within 1.5 intervals — 45s at the 30s default — and repeats at most once per
interval. The counter tracks reports rather than samples, so it moves at that
same once-per-interval rate.

The existing stalled warning is raised by a parked publisher, so it cannot fire
until the buffer is already full — 45s versus 12h31m.

## Tests

`TestPeerActivityHandlerKeepsDrainingWhileDownstreamConsumerBlocks` times out on
unfixed code with keepalive publishers parked, with a captured goroutine stack
showing the stalled handler and a parked keepalive-side publisher; it passes
after. `TestChainSwitchEventsPreservePublishOrder` passes before and after as an
ordering guard; it drives every switch from the test goroutine, so it pins
publish order only. The watchdog tests were proven failing-first by removing
only the `beginHandler`/`endHandler` instrumentation.

`ouroboros/consensus_conformance_test.go` needed a real drain barrier:
`EvaluateAndSwitch` returns before the lane worker has delivered, so the
replay adapter's non-blocking drain raced it and recorded no switch decision
(`TestConsensusConformanceVectors` failed on macOS and Windows CI). It now
enqueues a sentinel behind the switches and drains up to it.

Review follow-ups, each proven failing-first by neutering only the fix:
`TestStuckHandlerRateLimitIsPerInvocation` (watchdog rate limit keyed to the
invocation rather than cleared on each begin),
`TestHandlerStallSeriesExistsBeforeAnyStall` (zero-valued
`event_subscriber_handler_stalled_total` series registered at subscribe time),
and `TestHandlerProgressSamplesTwicePerInterval` (sampling twice per interval,
so the first report is bounded at 1.5 intervals rather than 2).

## Validation

`go test -race` on `./chainselection/`, `./event/...`, `./ouroboros/...`,
`./ledger/...`, `./chainsync/...`, `./peergov/...`, `./connmanager/...`,
`./internal/...`, root; `-count=3` on the two changed packages;
`golangci-lint run ./...` and `GOOS=windows golangci-lint run ./...` 0 issues;
`make import-boundaries`, `make docs-parity`; conformance 370.3s. The
conformance replay was also run `-count=30` plain and `-count=10` under `-race`
after the barrier change, to confirm the previous failure was not merely made
less likely. `./event/` was also run `-count=5` under `-race`, and
`./chainselection/` and `./ouroboros/` `-count=5`, since a concurrency change
attracts flakes; none appeared.

Not run: the 24-hour Preview run that produced the evidence; `make lint` in
full (`nilaway`, `modernize` and `golines` are absent from PATH, so only the
`golangci-lint` and `import-boundaries` parts of that target ran locally --
CI's lint job is the first place the full gate runs); DevNet (needs a live
multi-node network); `make sql-check` (no SQL change). `make govulncheck` was
not run locally; CI's govulncheck job covers it.

## Notes for review

Scope: the `chainselection/` half is this issue. The `event/` watchdog is
bus-wide and would also surface the `ledger.blockfetch` case tracked in #3529,
though it changes no delivery, detach or blocking behavior — it only observes.
It splits cleanly along file boundaries if a reviewer wants it moved.

`PublishOrdered` allocates a 10000-entry lane per event type on first use
(~560KB each): ~1.1MB in Praos steady state, ~3.4MB worst case. That cuts
slightly against #2106's shrinking of `DefaultSubscriberBuffer`. A per-lane size
parameter was not added, since it changes shared EventBus API for a
chainselection-local concern.

Left open deliberately: `peer_activity` uses the default
`SubscriberBackpressureDetach`, so on current main a full buffer permanently
unsubscribes this required internal consumer after `channelDeliveryTimeout` and
nothing re-subscribes. Static finding, not executed here; `event/event.go`
already documents this hazard for the analogous `PeerRollbackEvent`
subscription, which uses `SubscriberBackpressureBlock`.

Resolves #3550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEJSNPB6bA7CVW5EgXxNni

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a chain-selection stall that could park every keepalive protocol goroutine by routing the selector's `chainselection` publications through per-type ordered lanes, and adds a handler-progress watchdog to report stuck handlers before buffers fill.

- `PublishOrdered` keeps per-topic delivery order while confining a blocked subscriber to that lane's worker.
- The watchdog logs `event subscriber handler not making progress` after 30s, keyed per handler invocation; `event_subscriber_handler_stalled_total` counts only actual reports (once per interval), not samples, and carries a zero-valued series per event type once a `SubscribeFunc` subscription registers.
- `StuckHandlerCount()` exposes the condition programmatically.
- The conformance replay drains the chain-switch lane through a sentinel barrier and fails on unexpected payloads, fixing a CI race on macOS and Windows.
- Resolves #3550.

<sup>Written for commit 5a86d149c93fe723a72c6e3dd443254133302624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Chain-selection events are now delivered in publish order.
  - A slow event consumer no longer blocks unrelated chain-selection activity.

- **Monitoring**
  - Added detection and reporting for subscriber handlers that remain unresponsive.
  - Added metrics to track stalled event handlers by event type.

- **Documentation**
  - Updated architecture and event-system documentation to describe event ordering and handler-stall monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
