### PR TITLE
fix(ledger): make a recovery rewind reachable and fail closed when it is not

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3835,6 +3835,44 @@ block. It is therefore performed as a sequence of ordinary rollbacks of at most
 block payloads to one security-parameter window. If a later step fails, the
 primary chain remains at the last committed intermediate point; the standard
 startup/live reconciliation paths can synchronize metadata to that valid tip.
+
+Each step's target is read from the chain's live tip (`Chain.PointAtDepth`),
+never from a schedule computed once when the descent began. Nothing serialises
+the descent against chain growth -- it runs under `transactionEventMutex` while
+blockfetch appends under `chainsyncMutex` -- so a fixed schedule goes stale the
+moment one block lands: the next target is then more than `k` below the tip
+`Chain.Rollback` measures fork depth against, and the whole rewind is refused.
+That is issue #3889, where recovery recomputed the same unreachable descent on
+every pipeline restart for hours and never truncated the chain at all. A step
+the chain still refuses is retried a bounded number of times against a freshly
+read tip, and only while `validateAndEmitRollbackUndoEmitted` reports that it
+published nothing -- retrying after a publish would tell a `ledger.tx` consumer
+to undo the same block twice. A descent whose committed steps stop landing
+below the previous one has been outrun by chain growth and gives up rather than
+truncate and re-truncate indefinitely.
+
+`Chain.addRawBlocks` participates in the same window from the other side. It
+releases both chain locks when its transaction closure returns and only then
+does `txn.Do` commit, so its Commit-failure restore runs with the chain open to
+everyone else -- and rolling the primary chain back while blockfetch appends to
+it is exactly what a recovery rewind does. `batchRestoreIsSafeLocked` therefore
+writes the pre-batch snapshot back only while the chain still shows what that
+batch left behind; otherwise a concurrent rollback's result would be overwritten
+with a tip index above the blocks that rollback deleted, leaving the chain
+claiming a tip it does not store.
+
+All five recovery rewinds go through `rewindPrimaryChainForRecovery`, which
+carries the one classification a pipeline restart cannot help with. A rewind
+the chain refuses for exceeding `k`, or a descent that cannot gain on its
+target, leaves recovery with no legal target at all, and restarting only
+re-derives it against a chain that has grown further from the applied tip. The
+tally therefore keys on the applied ledger tip -- the thing that is not moving
+-- rather than on the target, which is recomputed and different on every
+attempt; past `maxRecoveryRewindRejections` refusals at the same applied
+high-water mark the failure is reported as `errHaltLedgerPipeline` with an
+operator hint. Forward progress past that mark clears the tally through
+`resetRecoveryRewindRejections`, alongside the at-tip, replay, and
+Mithril-boundary resets.
 The chain moves before metadata because the retained rollback anchor must remain
 queryable while metadata reconstructs its tip and nonce. If that metadata step
 fails, the primary chain is already at a valid target and the same reconciliation
@@ -3856,9 +3894,11 @@ and rolls both stores back to the last applied ledger tip, then publishes a
 ChainSync obtains a fresh intersection. Other transaction-validation errors
 continue through producer resolution and the unresolved-producer fallback.
 
-The rejection is never terminal. A redelivery of the same failing block at the
-same applied tip is rejected and rewound again but spends no further peer
-rotation, because chain selection has already had its alternate-branch
+The rejection itself is never terminal -- what can become terminal is the
+rewind that carries it out, when the chain refuses that rewind for exceeding
+`k` and the applied tip stops moving (above). A redelivery of the same failing
+block at the same applied tip is rejected and rewound again but spends no
+further peer rotation, because chain selection has already had its alternate-branch
 opportunity for that block and further rotations only close connections. The
 latch that records it keys on the applied tip together with the failing block
 and transaction, so a different rejected block on a newly selected branch gets

--- a/chain/batch_restore_internal_test.go
+++ b/chain/batch_restore_internal_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain
+
+import (
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// TestBatchRestoreIsSafeLocked pins which chain states a failed add batch may
+// write its pre-batch snapshot back over.
+//
+// addRawBlocks releases both chain locks when its transaction closure returns
+// and only then does txn.Do commit, so the Commit-failure restore runs with
+// the chain open to everyone else. Rolling the primary chain back while
+// blockfetch appends to it is not a corner case -- it is what a ledger
+// recovery rewind does on every deterministic rejection -- and the restore
+// used to write its snapshot back unconditionally. That raised tipBlockIndex
+// to a value above the blocks the concurrent rollback had already deleted, so
+// the chain claimed a tip it did not store: the ledger's windowed rewind then
+// asked for the point a security parameter behind that tip and was told the
+// block did not exist (issue #3889).
+func TestBatchRestoreIsSafeLocked(t *testing.T) {
+	applied := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("applied")},
+		BlockNumber: 10,
+	}
+	const appliedIndex = uint64(10)
+
+	for _, tc := range []struct {
+		name  string
+		chain *Chain
+		want  bool
+	}{
+		{
+			name: "unchanged since the batch",
+			chain: &Chain{
+				tipBlockIndex: appliedIndex,
+				currentTip:    applied,
+			},
+			want: true,
+		},
+		{
+			name: "concurrent rollback lowered the tip",
+			chain: &Chain{
+				tipBlockIndex: appliedIndex - 4,
+				currentTip: ochainsync.Tip{
+					Point: ocommon.Point{
+						Slot: 60,
+						Hash: []byte("rolled-back"),
+					},
+					BlockNumber: 6,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "concurrent append raised the tip",
+			chain: &Chain{
+				tipBlockIndex: appliedIndex + 1,
+				currentTip: ochainsync.Tip{
+					Point: ocommon.Point{
+						Slot: 110,
+						Hash: []byte("appended"),
+					},
+					BlockNumber: 11,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "same index, different block",
+			chain: &Chain{
+				tipBlockIndex: appliedIndex,
+				currentTip: ochainsync.Tip{
+					Point: ocommon.Point{
+						Slot: 100,
+						Hash: []byte("other-fork"),
+					},
+					BlockNumber: 10,
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.chain.batchRestoreIsSafeLocked(applied, appliedIndex)
+			if got != tc.want {
+				t.Fatalf(
+					"batchRestoreIsSafeLocked() = %v, want %v",
+					got,
+					tc.want,
+				)
+			}
+		})
+	}
+}

--- a/chain/batch_restore_internal_test.go
+++ b/chain/batch_restore_internal_test.go
@@ -40,6 +40,7 @@ func TestBatchRestoreIsSafeLocked(t *testing.T) {
 		BlockNumber: 10,
 	}
 	const appliedIndex = uint64(10)
+	const appliedGeneration = uint64(1)
 
 	for _, tc := range []struct {
 		name  string
@@ -49,8 +50,9 @@ func TestBatchRestoreIsSafeLocked(t *testing.T) {
 		{
 			name: "unchanged since the batch",
 			chain: &Chain{
-				tipBlockIndex: appliedIndex,
-				currentTip:    applied,
+				tipBlockIndex:      appliedIndex,
+				mutationGeneration: appliedGeneration,
+				currentTip:         applied,
 			},
 			want: true,
 		},
@@ -98,7 +100,9 @@ func TestBatchRestoreIsSafeLocked(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.chain.batchRestoreIsSafeLocked(applied, appliedIndex)
+			got := tc.chain.batchRestoreIsSafeLocked(
+				applied, appliedIndex, appliedGeneration,
+			)
 			if got != tc.want {
 				t.Fatalf(
 					"batchRestoreIsSafeLocked() = %v, want %v",

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -686,6 +686,29 @@ func (c *Chain) AddRawBlocksWithCallback(
 	return c.addRawBlocks(blocks, callback)
 }
 
+// batchRestoreIsSafeLocked reports whether a failed add batch may write its
+// pre-batch snapshot back over the current chain state.
+//
+// It may only do so while the chain still shows exactly what that batch left
+// behind. addRawBlocks releases c.mutex and c.manager.mutex when its
+// transaction closure returns, before txn.Do commits, so any other goroutine
+// can move the chain before the Commit-failure path runs -- and rolling the
+// primary chain back while blockfetch appends to it is what every ledger
+// recovery rewind does. Writing the snapshot over a rollback's result raises
+// tipBlockIndex back above blocks that rollback deleted, leaving the chain
+// claiming a tip it does not store: the next rollback measures an inflated
+// fork depth against it, and any lookup in the resurrected span reports the
+// block as missing.
+//
+// Callers must hold c.mutex and c.manager.mutex.
+func (c *Chain) batchRestoreIsSafeLocked(
+	appliedTip ochainsync.Tip,
+	appliedTipBlockIndex uint64,
+) bool {
+	return c.tipBlockIndex == appliedTipBlockIndex &&
+		bytes.Equal(c.currentTip.Point.Hash, appliedTip.Point.Hash)
+}
+
 func (c *Chain) addRawBlocks(
 	blocks []RawBlock,
 	callback func(RawBlock, *database.Txn) error,
@@ -713,11 +736,13 @@ func (c *Chain) addRawBlocks(
 		// leaving the in-memory chain advanced. Capture the
 		// snapshot here so we can also restore on Commit failure.
 		var (
-			snapshotTaken      bool
-			savedTip           ochainsync.Tip
-			savedTipBlockIndex uint64
-			savedHeaders       []queuedHeader
-			savedBlocks        []ocommon.Point
+			savedTip             ochainsync.Tip
+			savedTipBlockIndex   uint64
+			savedHeaders         []queuedHeader
+			savedBlocks          []ocommon.Point
+			batchApplied         bool
+			appliedTip           ochainsync.Tip
+			appliedTipBlockIndex uint64
 		)
 		err := txn.Do(func(txn *database.Txn) error {
 			batch := blocks[batchOffset : batchOffset+batchSize]
@@ -734,7 +759,6 @@ func (c *Chain) addRawBlocks(
 			if !c.persistent {
 				savedBlocks = slices.Clone(c.blocks)
 			}
-			snapshotTaken = true
 			for _, rb := range batch {
 				evt, err := c.addRawBlockLocked(
 					rb,
@@ -756,23 +780,47 @@ func (c *Chain) addRawBlocks(
 					)
 				}
 			}
+			// Record what this batch leaves behind so the Commit-failure
+			// path below can tell its own state from someone else's.
+			batchApplied = true
+			appliedTip = c.currentTip
+			appliedTipBlockIndex = c.tipBlockIndex
 			return nil
 		})
 		if err != nil {
 			// Cover the Commit-failure path: closure returned nil
 			// but txn.Do's later Commit failed, so memory still
 			// reflects the post-batch tip while the DB rolled
-			// back. Re-acquire the locks and restore. Restoring
-			// after a closure-internal error path is a safe no-op
-			// because the closure already wrote the same values.
-			if snapshotTaken {
+			// back. Re-acquire the locks and restore -- but only
+			// while the chain still shows exactly what this batch
+			// left behind.
+			//
+			// The locks are released when the closure returns, so
+			// another goroutine can move the chain before this runs,
+			// and rolling the primary chain back while blockfetch
+			// appends to it is a normal pairing rather than a corner
+			// case: it is what every ledger recovery rewind does.
+			// Writing the pre-batch snapshot over a rollback's result
+			// raises tipBlockIndex back above blocks that rollback
+			// deleted, leaving the chain claiming a tip it does not
+			// store -- an inflated fork depth on the next rollback and
+			// a not-found lookup for any index in the resurrected
+			// span. A closure-internal error already restored under
+			// the lock, so there is nothing left to do for it here
+			// either.
+			if batchApplied {
 				c.mutex.Lock()
 				c.manager.mutex.Lock()
-				c.currentTip = savedTip
-				c.tipBlockIndex = savedTipBlockIndex
-				c.headers = savedHeaders
-				if !c.persistent {
-					c.blocks = savedBlocks
+				if c.batchRestoreIsSafeLocked(
+					appliedTip,
+					appliedTipBlockIndex,
+				) {
+					c.currentTip = savedTip
+					c.tipBlockIndex = savedTipBlockIndex
+					c.headers = savedHeaders
+					if !c.persistent {
+						c.blocks = savedBlocks
+					}
 				}
 				c.manager.mutex.Unlock()
 				c.mutex.Unlock()

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -54,6 +54,7 @@ type Chain struct {
 	iterators            []*ChainIterator
 	currentTip           ochainsync.Tip
 	tipBlockIndex        uint64
+	mutationGeneration   uint64
 	lastCommonBlockIndex uint64
 	id                   ChainId
 	mutex                sync.RWMutex
@@ -481,6 +482,7 @@ func (c *Chain) addBlockLocked(
 		BlockNumber: blockNumber,
 	}
 	c.tipBlockIndex = newBlockIndex
+	c.mutationGeneration++
 	if notifyWaiters {
 		c.notifyWaitingIterators()
 	}
@@ -641,6 +643,7 @@ func (c *Chain) addRawBlockLocked(
 		BlockNumber: rb.BlockNumber,
 	}
 	c.tipBlockIndex = newBlockIndex
+	c.mutationGeneration++
 	// Build event for deferred publication (same pattern as
 	// addBlockLocked — publish after the transaction commits).
 	if c.eventBus != nil {
@@ -704,8 +707,10 @@ func (c *Chain) AddRawBlocksWithCallback(
 func (c *Chain) batchRestoreIsSafeLocked(
 	appliedTip ochainsync.Tip,
 	appliedTipBlockIndex uint64,
+	appliedGeneration uint64,
 ) bool {
 	return c.tipBlockIndex == appliedTipBlockIndex &&
+		c.mutationGeneration == appliedGeneration &&
 		bytes.Equal(c.currentTip.Point.Hash, appliedTip.Point.Hash)
 }
 
@@ -738,11 +743,13 @@ func (c *Chain) addRawBlocks(
 		var (
 			savedTip             ochainsync.Tip
 			savedTipBlockIndex   uint64
+			savedGeneration      uint64
 			savedHeaders         []queuedHeader
 			savedBlocks          []ocommon.Point
 			batchApplied         bool
 			appliedTip           ochainsync.Tip
 			appliedTipBlockIndex uint64
+			appliedGeneration    uint64
 		)
 		err := txn.Do(func(txn *database.Txn) error {
 			batch := blocks[batchOffset : batchOffset+batchSize]
@@ -755,6 +762,7 @@ func (c *Chain) addRawBlocks(
 			}
 			savedTip = c.currentTip
 			savedTipBlockIndex = c.tipBlockIndex
+			savedGeneration = c.mutationGeneration
 			savedHeaders = slices.Clone(c.headers)
 			if !c.persistent {
 				savedBlocks = slices.Clone(c.blocks)
@@ -768,6 +776,7 @@ func (c *Chain) addRawBlocks(
 				if err != nil {
 					c.currentTip = savedTip
 					c.tipBlockIndex = savedTipBlockIndex
+					c.mutationGeneration = savedGeneration
 					c.headers = savedHeaders
 					if !c.persistent {
 						c.blocks = savedBlocks
@@ -785,6 +794,7 @@ func (c *Chain) addRawBlocks(
 			batchApplied = true
 			appliedTip = c.currentTip
 			appliedTipBlockIndex = c.tipBlockIndex
+			appliedGeneration = c.mutationGeneration
 			return nil
 		})
 		if err != nil {
@@ -814,9 +824,11 @@ func (c *Chain) addRawBlocks(
 				if c.batchRestoreIsSafeLocked(
 					appliedTip,
 					appliedTipBlockIndex,
+					appliedGeneration,
 				) {
 					c.currentTip = savedTip
 					c.tipBlockIndex = savedTipBlockIndex
+					c.mutationGeneration = savedGeneration
 					c.headers = savedHeaders
 					if !c.persistent {
 						c.blocks = savedBlocks
@@ -1246,6 +1258,7 @@ func (c *Chain) rollbackLocked(
 		BlockNumber: tmpBlock.Number,
 	}
 	c.tipBlockIndex = rollbackBlockIndex
+	c.mutationGeneration++
 	// Update iterators for rollback
 	for _, iter := range c.iterators {
 		// Reverse iterators never deliver rollback markers, but if a

--- a/ledger/block_event.go
+++ b/ledger/block_event.go
@@ -222,15 +222,35 @@ func (ls *LedgerState) publishBlockEvent(
 // It does not close the window completely: the chain can still grow between
 // this validation and the rollback and push the rollback past the security
 // parameter, and an I/O failure mid-truncation is not predictable at all.
-// Both leave the chain needing recovery regardless.
+// Both leave the chain needing recovery regardless -- see
+// validateAndEmitRollbackUndoEmitted for the one caller that can retry the
+// first of those instead.
 func (ls *LedgerState) validateAndEmitRollbackUndo(
 	point ocommon.Point,
 ) error {
+	_, err := ls.validateAndEmitRollbackUndoEmitted(point)
+	return err
+}
+
+// validateAndEmitRollbackUndoEmitted is validateAndEmitRollbackUndo, also
+// reporting whether it read any block to undo.
+//
+// A caller that retries the same rollback after the chain rejects it needs
+// that answer. Retrying is only sound while nothing was published: a second
+// pass emits undo events for blocks the first pass already covered, so a
+// ledger.tx consumer would be told to undo them twice. Reporting the read
+// rather than the publish is deliberately conservative -- a block that decodes
+// to no transactions publishes nothing, and a caller that treats it as emitted
+// merely declines a retry it could have taken.
+func (ls *LedgerState) validateAndEmitRollbackUndoEmitted(
+	point ocommon.Point,
+) (bool, error) {
 	if err := ls.chain.ValidateRollback(point); err != nil {
-		return err
+		return false, err
 	}
-	ls.emitRollbackTransactionEvents(ls.blocksAboveSlot(point.Slot))
-	return nil
+	blocks := ls.blocksAboveSlot(point.Slot)
+	ls.emitRollbackTransactionEvents(blocks)
+	return len(blocks) > 0, nil
 }
 
 // blocksAboveSlot returns the blocks a rollback to slot would discard,

--- a/ledger/header_validation_recovery.go
+++ b/ledger/header_validation_recovery.go
@@ -174,7 +174,7 @@ func (ls *LedgerState) tryRecoverFromHeaderValidationError(
 		)
 	}
 
-	if err := ls.rollbackPrimaryChainInSecurityParamWindows(
+	if err := ls.rewindPrimaryChainForRecovery(
 		rewindPoint,
 	); err != nil {
 		if ls.yieldedToChainSelection(

--- a/ledger/recovery_rewind_window_test.go
+++ b/ledger/recovery_rewind_window_test.go
@@ -1,0 +1,456 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestShelleyGenesisCfgWithK is newTestShelleyGenesisCfg with a caller
+// chosen security parameter, so a windowed rewind can be exercised with a
+// window small enough to need several steps over a short test chain.
+func newTestShelleyGenesisCfgWithK(
+	t testing.TB,
+	k int,
+) *cardano.CardanoNodeConfig {
+	t.Helper()
+	shelleyGenesisJSON := fmt.Sprintf(`{
+		"activeSlotsCoeff": 0.05,
+		"securityParam": %d,
+		"slotsPerKESPeriod": 129600,
+		"systemStart": "2022-10-25T00:00:00Z"
+	}`, k)
+	cfg := &cardano.CardanoNodeConfig{}
+	require.NoError(
+		t,
+		cfg.LoadShelleyGenesisFromReader(strings.NewReader(shelleyGenesisJSON)),
+	)
+	return cfg
+}
+
+// seedTestChain appends count linked blocks to the primary chain, spaced ten
+// slots apart so an appended block can always claim tip.Slot+1 without
+// colliding with a block that is already stored.
+func seedTestChain(
+	t testing.TB,
+	pc *chain.Chain,
+	prefix string,
+	count int,
+) []chain.RawBlock {
+	t.Helper()
+	raw := make([]chain.RawBlock, 0, count)
+	var prev []byte
+	for i := 1; i <= count; i++ {
+		h := testHashBytes(fmt.Sprintf("%s-%d", prefix, i))
+		raw = append(raw, chain.RawBlock{
+			Slot:        uint64(i * 10), //nolint:gosec
+			Hash:        h,
+			BlockNumber: uint64(i), //nolint:gosec
+			Type:        1,
+			PrevHash:    prev,
+			Cbor:        []byte{0x80},
+		})
+		prev = h
+	}
+	require.NoError(t, pc.AddRawBlocks(raw))
+	return raw
+}
+
+// TestWindowedRewindConvergesWhilePrimaryChainExtends pins the descent
+// schedule in rollbackPrimaryChainInSecurityParamWindows against a primary
+// chain that keeps growing underneath it, which is what a recovery rewind
+// races with on a syncing node: blockfetch appends to the chain under
+// chainsyncMutex while the ledger pipeline runs recovery under
+// transactionEventMutex, so nothing serialises the two.
+//
+// The function used to read the chain tip once and then derive every
+// intermediate target as snapshot-n*window. One block appended after that
+// snapshot makes the next target window+1 below the chain's live tip, and
+// Chain.Rollback refuses it as exceeding K. The whole rewind then fails, the
+// pipeline restarts, and recovery recomputes the same doomed schedule against
+// a tip that has grown further -- issue #3889, where that loop ran for nine
+// hours and 1150 restarts without the chain ever being truncated.
+//
+// Each step must therefore be derived from the chain's live tip, so it is a
+// legal K-bounded rollback by construction no matter how far the chain has
+// advanced since the rewind began.
+func TestWindowedRewindConvergesWhilePrimaryChainExtends(t *testing.T) {
+	const (
+		securityParam = 8
+		blockCount    = 240
+	)
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: securityParam}),
+	)
+	pc := cm.PrimaryChain()
+	raw := seedTestChain(t, pc, "windowed-race", blockCount)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfgWithK(t, securityParam),
+		EventBus:          bus,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	// SecurityParam() is era-derived; without this the Byron fallback window
+	// dwarfs the chain and no intermediate step is ever taken.
+	ls.currentEra = eras.ShelleyEraDesc
+	require.Equal(
+		t,
+		securityParam,
+		ls.SecurityParam(),
+		"rewind window must match the chain manager's k",
+	)
+
+	// Extend the primary chain by one block every time the rewind moves the
+	// tip, mimicking blockfetch appending while recovery descends. One block
+	// per step is slower than the window each step covers, so a rewind that
+	// re-reads the live tip still converges.
+	stop := make(chan struct{})
+	var appender sync.WaitGroup
+	appender.Add(1)
+	go func() {
+		defer appender.Done()
+		lastPoint := pc.Tip().Point
+		for seq := 0; ; seq++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			tip := pc.Tip()
+			if tip.Point.Slot == lastPoint.Slot &&
+				bytes.Equal(tip.Point.Hash, lastPoint.Hash) {
+				continue
+			}
+			next := chain.RawBlock{
+				Slot: tip.Point.Slot + 1,
+				Hash: testHashBytes(
+					fmt.Sprintf("windowed-race-append-%d", seq),
+				),
+				BlockNumber: tip.BlockNumber + 1,
+				Type:        1,
+				PrevHash:    tip.Point.Hash,
+				Cbor:        []byte{0x80},
+			}
+			if err := pc.AddRawBlocks([]chain.RawBlock{next}); err != nil {
+				// The tip moved again between the read and the add;
+				// re-read and try the next one.
+				continue
+			}
+			lastPoint = ocommon.NewPoint(next.Slot, next.Hash)
+		}
+	}()
+
+	target := ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
+	rewindErr := ls.rollbackPrimaryChainInSecurityParamWindows(target)
+	close(stop)
+	appender.Wait()
+
+	require.NotErrorIs(
+		t,
+		rewindErr,
+		chain.ErrRollbackExceedsSecurityParam,
+		"a windowed step must stay within K of the chain's live tip",
+	)
+	require.NoError(t, rewindErr)
+}
+
+// TestDeterministicTxRecoveryHaltsOnUnreachableRewind pins the second half of
+// issue #3889: a recovery rewind the chain refuses as exceeding K is not a
+// transient failure, so repeating it at an applied tip that never advances
+// must become terminal instead of restarting the pipeline forever.
+//
+// recoverFromDeterministicTxValidationError used to return the refusal as a
+// plain error. ledgerProcessBlocks treats anything that is not
+// errHaltLedgerPipeline as retryable, so the node logged "block processing
+// failed, restarting pipeline", waited out the backoff, and recomputed the
+// same impossible rewind -- 1150 times over nine hours in the report, with the
+// stuck-pipeline watchdog correctly announcing that the failure was
+// deterministic while the node kept retrying anyway.
+func TestDeterministicTxRecoveryHaltsOnUnreachableRewind(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	// A chain k of 2 against the ledger's much larger window means the
+	// single rewind step is refused on fork depth, which is the refusal the
+	// recovery path has to classify.
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 2}))
+	raw := seedTestChain(t, cm.PrimaryChain(), "halt-on-unreachable", 5)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		EventBus:          bus,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	require.Greater(t, ls.SecurityParam(), 2, "ledger window must exceed k")
+
+	// The applied tip sits at the first block and the rejected block is the
+	// chain tip, so the rewind target is four blocks below a chain whose k
+	// is 2 and every rewind to it is refused.
+	ls.currentTip.Point = ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
+	validationErr := &txValidationError{
+		BlockPoint: ocommon.NewPoint(raw[4].Slot, raw[4].Hash),
+		TxHash:     testHashBytes("halt-on-unreachable-tx"),
+		Cause: conway.PlutusScriptFailedError{
+			Err: errors.New("error explicitly called"),
+		},
+	}
+	require.True(t, isDeterministicTxValidationError(validationErr.Cause))
+
+	var lastErr error
+	halted := false
+	// Well past any bounded retry budget: an unreachable rewind still being
+	// retried after this many attempts is the nine-hour loop.
+	for range 32 {
+		_, lastErr = ls.recoverFromDeterministicTxValidationError(
+			validationErr,
+		)
+		require.Error(t, lastErr)
+		require.ErrorIs(t, lastErr, chain.ErrRollbackExceedsSecurityParam)
+		if errors.Is(lastErr, errHaltLedgerPipeline) {
+			halted = true
+			break
+		}
+	}
+	require.True(
+		t,
+		halted,
+		"a recovery rewind refused as exceeding K must stop the pipeline "+
+			"rather than be retried forever: %v",
+		lastErr,
+	)
+}
+
+// TestRecoveryRewindHaltBudgetResetsOnTipProgress pins the other side of that
+// budget. The halt is for a rewind that stays unreachable at an applied tip
+// that never moves; once the ledger advances past that tip the situation is a
+// different one and must start with a fresh budget rather than inherit a tally
+// that has nothing to do with it.
+func TestRecoveryRewindHaltBudgetResetsOnTipProgress(t *testing.T) {
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 2}))
+	raw := seedTestChain(t, cm.PrimaryChain(), "halt-budget-reset", 5)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		EventBus:          bus,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	target := ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
+	for range maxRecoveryRewindRejections {
+		rewindErr := ls.rewindPrimaryChainForRecovery(target)
+		require.ErrorIs(
+			t,
+			rewindErr,
+			chain.ErrRollbackExceedsSecurityParam,
+		)
+		require.NotErrorIs(t, rewindErr, errHaltLedgerPipeline)
+	}
+	// Forward progress past the tip the refusals could not cross clears the
+	// tally, so the budget starts over instead of halting on the next one.
+	ls.resetRecoveryRewindRejections(raw[3].Slot)
+	rewindErr := ls.rewindPrimaryChainForRecovery(target)
+	require.ErrorIs(t, rewindErr, chain.ErrRollbackExceedsSecurityParam)
+	require.NotErrorIs(t, rewindErr, errHaltLedgerPipeline)
+}
+
+// TestRecoveryRewindHaltsThoughTargetMovesAndDepthGrows pins the shape the
+// live reproduction on Preview showed (issue #3889: a replay wedged at slot
+// 41098815 for over twenty minutes across 97 rejection attempts on one
+// transaction).
+//
+// Two properties of that run decide whether a fix works:
+//
+//   - The rewind target is recomputed on every attempt and differs every time
+//     -- intermediate points 1768501, 1774034, 1773427, 1779454, 1782037,
+//     1769017 -- all beyond K. So the terminal condition cannot key on one
+//     target that keeps failing; there is no such target. It keys on the
+//     applied ledger tip, which is the thing that is not moving.
+//   - The depth that must be rolled back grows monotonically, because the peer
+//     keeps extending the fork while the local tip is pinned
+//     (fork_path_headers 2462, 5031, 7615; fork_depth 5010 then 6020). A
+//     rewind already beyond K never comes back into range on its own, which is
+//     what makes the loop unrecoverable rather than merely slow.
+//
+// The chain is therefore extended between attempts, so every attempt computes
+// a different step target against a larger gap, and the halt must still
+// arrive.
+func TestRecoveryRewindHaltsThoughTargetMovesAndDepthGrows(t *testing.T) {
+	const (
+		chainK        = 4
+		ledgerWindow  = 8
+		startingChain = 40
+		growthPerTry  = 5
+		maxAttempts   = 16
+	)
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	// The chain enforces a smaller k than the ledger's rewind window, so every
+	// step the descent computes is refused wherever the tip has moved to.
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: chainK}),
+	)
+	pc := cm.PrimaryChain()
+	raw := seedTestChain(t, pc, "moving-target", startingChain)
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Stop)
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfgWithK(t, ledgerWindow),
+		EventBus:          bus,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.currentEra = eras.ShelleyEraDesc
+	require.Equal(t, ledgerWindow, ls.SecurityParam())
+
+	// The applied ledger tip stays at the first block for the whole test:
+	// that is the "tip pinned at slot 41098815" half of the report.
+	appliedTip := ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
+	ls.currentTip.Point = appliedTip
+	validationErr := &txValidationError{
+		BlockPoint: ocommon.NewPoint(
+			raw[startingChain-1].Slot,
+			raw[startingChain-1].Hash,
+		),
+		TxHash: testHashBytes("moving-target-tx"),
+		Cause: conway.PlutusScriptFailedError{
+			Err: errors.New("error explicitly called"),
+		},
+	}
+	require.True(t, isDeterministicTxValidationError(validationErr.Cause))
+
+	seenTargets := map[string]struct{}{}
+	var (
+		chainTips []uint64
+		halted    bool
+		attempts  int
+		lastErr   error
+	)
+	for range maxAttempts {
+		attempts++
+		chainTips = append(chainTips, pc.Tip().Point.Slot)
+		_, lastErr = ls.recoverFromDeterministicTxValidationError(
+			validationErr,
+		)
+		require.ErrorIs(t, lastErr, chain.ErrRollbackExceedsSecurityParam)
+		seenTargets[lastErr.Error()] = struct{}{}
+		if errors.Is(lastErr, errHaltLedgerPipeline) {
+			halted = true
+			break
+		}
+		// The peer keeps serving the fork while the ledger tip is stuck, so
+		// the next attempt faces a deeper rollback than this one did.
+		grow := make([]chain.RawBlock, 0, growthPerTry)
+		prev := pc.Tip()
+		for i := range growthPerTry {
+			h := testHashBytes(
+				fmt.Sprintf("moving-target-grow-%d-%d", attempts, i),
+			)
+			grow = append(grow, chain.RawBlock{
+				Slot:        prev.Point.Slot + 10,
+				Hash:        h,
+				BlockNumber: prev.BlockNumber + 1,
+				Type:        1,
+				PrevHash:    prev.Point.Hash,
+				Cbor:        []byte{0x80},
+			})
+			prev = ochainsync.Tip{
+				Point:       ocommon.NewPoint(prev.Point.Slot+10, h),
+				BlockNumber: prev.BlockNumber + 1,
+			}
+		}
+		require.NoError(t, pc.AddRawBlocks(grow))
+	}
+
+	require.True(
+		t,
+		halted,
+		"a rewind that stays beyond K must stop the pipeline even though "+
+			"every attempt computes a different target: %v",
+		lastErr,
+	)
+	require.Greater(
+		t,
+		len(seenTargets),
+		1,
+		"the test must exercise a target that moves between attempts",
+	)
+	require.Greater(
+		t,
+		chainTips[len(chainTips)-1],
+		chainTips[0],
+		"the fork must extend while the applied ledger tip stays pinned",
+	)
+	require.True(
+		t,
+		slices.IsSorted(chainTips),
+		"required rollback depth must only grow across attempts: %v",
+		chainTips,
+	)
+}

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -809,9 +809,10 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 
 	window := uint64(securityParam) //nolint:gosec // positive, checked above
 	var (
-		haveLastStep bool
-		lastStepSlot uint64
-		stalls       int
+		haveLastStep       bool
+		lastStepSlot       uint64
+		overKRetries       int
+		nonConvergingSteps int
 	)
 	for {
 		tip := ls.chain.Tip()
@@ -869,8 +870,8 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 		emitted, err := ls.validateAndEmitRollbackUndoEmitted(next)
 		if err != nil {
 			if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) &&
-				stalls < maxWindowedRewindStalls {
-				stalls++
+				overKRetries < maxWindowedRewindRetries {
+				overKRetries++
 				continue
 			}
 			return stepErr(err)
@@ -878,8 +879,8 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 		if err := ls.chain.Rollback(next); err != nil {
 			if !emitted &&
 				errors.Is(err, chain.ErrRollbackExceedsSecurityParam) &&
-				stalls < maxWindowedRewindStalls {
-				stalls++
+				overKRetries < maxWindowedRewindRetries {
+				overKRetries++
 				continue
 			}
 			return stepErr(err)
@@ -887,14 +888,15 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 		if final {
 			return nil
 		}
+		overKRetries = 0
 		// Each committed step must land below the previous one. It will not
 		// when the chain grew by at least the window the step just covered,
 		// and a descent that never gains on its target would otherwise
 		// truncate and re-truncate the chain for as long as peers keep
 		// serving blocks.
 		if haveLastStep && next.Slot >= lastStepSlot {
-			stalls++
-			if stalls > maxWindowedRewindStalls {
+			nonConvergingSteps++
+			if nonConvergingSteps > maxWindowedRewindNonConvergingSteps {
 				return fmt.Errorf(
 					"%w: target slot %d, step slot %d, chain tip slot %d",
 					errRecoveryRewindNotConverging,
@@ -904,7 +906,7 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 				)
 			}
 		} else {
-			stalls = 0
+			nonConvergingSteps = 0
 		}
 		haveLastStep = true
 		lastStepSlot = next.Slot
@@ -920,13 +922,14 @@ var errRecoveryRewindNotConverging = errors.New(
 	"recovery rewind is not gaining on its target",
 )
 
-// maxWindowedRewindStalls bounds consecutive windowed steps the chain refuses
-// for exceeding K. Each step is derived from the chain's live tip, so a
-// refusal means blocks landed between that read and the truncation; re-reading
-// the tip is what clears it, and a couple of retries covers any realistic
-// interleaving. Past that the chain is being extended at least as fast as the
-// descent moves and the rewind is not going to complete.
-const maxWindowedRewindStalls = 3
+// maxWindowedRewindRetries bounds consecutive retries after a rollback is
+// refused for exceeding K. A successful step resets this budget.
+const maxWindowedRewindRetries = 3
+
+// maxWindowedRewindNonConvergingSteps bounds consecutive committed steps that
+// fail to move the rewind target closer. It is independent of the retry
+// budget, so transient over-K refusals cannot consume this convergence budget.
+const maxWindowedRewindNonConvergingSteps = 3
 
 // maxRecoveryRewindRejections bounds how many consecutive recovery rewinds may
 // be refused for exceeding the security parameter at an applied ledger tip

--- a/ledger/replay_recovery.go
+++ b/ledger/replay_recovery.go
@@ -336,7 +336,7 @@ func (ls *LedgerState) tryRecoverFromTxValidationError(
 	}
 	primaryChainRewound := false
 	if rewindPrimaryChain && !primaryChainAlreadyHeld {
-		if err := ls.rollbackPrimaryChainInSecurityParamWindows(
+		if err := ls.rewindPrimaryChainForRecovery(
 			rewindPoint,
 		); err != nil {
 			return false, fmt.Errorf(
@@ -642,7 +642,7 @@ func (ls *LedgerState) recoverFromDeterministicTxValidationError(
 			validationErr.Cause,
 		)
 	}
-	if err := ls.rollbackPrimaryChainInSecurityParamWindows(rewindPoint); err != nil {
+	if err := ls.rewindPrimaryChainForRecovery(rewindPoint); err != nil {
 		if errors.Is(err, chain.ErrRollbackPointNotOnChain) {
 			return true, nil
 		}
@@ -775,6 +775,17 @@ func (ls *LedgerState) publishReplayRecoveryNonConvergingResync(
 // bounds the blocks retained for event delivery. A failure leaves the chain at
 // the last committed intermediate point; startup/live reconciliation can then
 // replay or finish rolling metadata back to that valid primary-chain tip.
+//
+// Every step's target is read from the chain's live tip (Chain.PointAtDepth),
+// not from a schedule computed once at entry. Nothing serialises this descent
+// against chain growth -- it holds transactionEventMutex while blockfetch
+// appends under chainsyncMutex -- so a schedule fixed up front goes stale as
+// soon as one block lands: the next target is then window+n below the tip
+// Chain.Rollback measures fork depth against, and the whole rewind is refused
+// for exceeding K. That is issue #3889, where recovery recomputed the same
+// doomed descent on every pipeline restart for nine hours and never truncated
+// the chain at all. Reading the tip per step makes each rollback K-bounded by
+// construction however far the chain has moved.
 func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 	point ocommon.Point,
 ) error {
@@ -787,73 +798,263 @@ func (ls *LedgerState) rollbackPrimaryChainInSecurityParamWindows(
 	ls.transactionEventMutex.Lock()
 	defer ls.transactionEventMutex.Unlock()
 
-	targetIndex := uint64(0)
+	// Refuse to truncate anything toward a target the store does not hold:
+	// the descent commits each step as it goes, so discovering the target is
+	// unreachable part-way leaves the chain shortened for nothing.
 	if point.Slot > 0 || len(point.Hash) > 0 {
-		targetBlock, err := database.BlockByPoint(ls.db, point)
-		if err != nil {
-			return fmt.Errorf("lookup replay recovery target: %w", err)
+		if _, err := database.BlockByPoint(ls.db, point); err != nil {
+			return fmt.Errorf("lookup recovery target: %w", err)
 		}
-		targetIndex = targetBlock.ID
 	}
 
-	tip := ls.chain.Tip()
-	if tip.Point.Slot == point.Slot &&
-		bytes.Equal(tip.Point.Hash, point.Hash) {
-		return nil
-	}
-	tipBlock, err := database.BlockByPoint(ls.db, tip.Point)
-	if err != nil {
-		return fmt.Errorf("lookup primary chain tip: %w", err)
-	}
-	tipIndex := tipBlock.ID
-	if tipIndex < targetIndex {
-		return fmt.Errorf(
-			"primary chain tip index %d is behind replay recovery target %d",
-			tipIndex,
-			targetIndex,
-		)
-	}
-	window := uint64(securityParam)
-	for tipIndex-targetIndex > window {
-		nextIndex := tipIndex - window
-		nextBlock, err := ls.db.BlockByIndex(nextIndex, nil)
+	window := uint64(securityParam) //nolint:gosec // positive, checked above
+	var (
+		haveLastStep bool
+		lastStepSlot uint64
+		stalls       int
+	)
+	for {
+		tip := ls.chain.Tip()
+		if tip.Point.Slot == point.Slot &&
+			bytes.Equal(tip.Point.Hash, point.Hash) {
+			return nil
+		}
+		if tip.Point.Slot < point.Slot {
+			return fmt.Errorf(
+				"primary chain tip slot %d is behind recovery target slot %d",
+				tip.Point.Slot,
+				point.Slot,
+			)
+		}
+		// The step target is the deepest legal one: exactly a security
+		// parameter behind the current tip, or the recovery point itself once
+		// that is the nearer of the two. A chain shorter than the window holds
+		// no such point and may be replaced whole.
+		next := point
+		windowPoint, found, err := ls.chain.PointAtDepth(window)
 		if err != nil {
 			return fmt.Errorf(
-				"lookup intermediate replay recovery block %d: %w",
-				nextIndex,
+				"lookup intermediate recovery point at depth %d: %w",
+				window,
 				err,
 			)
 		}
-		nextPoint := ocommon.NewPoint(nextBlock.Slot, nextBlock.Hash)
-		// Validate, then emit undo events, before each window's
-		// truncation. This function's own doc comment notes the chain can
-		// move between reading the tip and rewinding to it, so the
-		// rejection here is reachable, not theoretical: emitting without
-		// it would tell subscribers to undo blocks the failed rewind
+		if found && windowPoint.Slot > point.Slot {
+			next = windowPoint
+		}
+		final := next.Slot == point.Slot &&
+			bytes.Equal(next.Hash, point.Hash)
+		stepErr := func(err error) error {
+			if final {
+				return fmt.Errorf(
+					"rollback primary chain to recovery point: %w",
+					err,
+				)
+			}
+			return fmt.Errorf(
+				"rollback primary chain to intermediate point at slot %d: %w",
+				next.Slot,
+				err,
+			)
+		}
+		// Validate, then emit undo events, before each truncation: emitting
+		// without it would tell subscribers to undo blocks a failed rewind
 		// leaves applied. See validateAndEmitRollbackUndo.
-		if err := ls.validateAndEmitRollbackUndo(nextPoint); err != nil {
-			return fmt.Errorf(
-				"rollback primary chain to intermediate point %d: %w",
-				nextIndex,
+		//
+		// Blocks landing between the tip read and either of the two calls
+		// below puts this step over K by however many arrived, and
+		// re-reading the tip is what clears it. The retry is only taken
+		// while nothing has been emitted, so a ledger.tx consumer is never
+		// told to undo the same block twice.
+		emitted, err := ls.validateAndEmitRollbackUndoEmitted(next)
+		if err != nil {
+			if errors.Is(err, chain.ErrRollbackExceedsSecurityParam) &&
+				stalls < maxWindowedRewindStalls {
+				stalls++
+				continue
+			}
+			return stepErr(err)
+		}
+		if err := ls.chain.Rollback(next); err != nil {
+			if !emitted &&
+				errors.Is(err, chain.ErrRollbackExceedsSecurityParam) &&
+				stalls < maxWindowedRewindStalls {
+				stalls++
+				continue
+			}
+			return stepErr(err)
+		}
+		if final {
+			return nil
+		}
+		// Each committed step must land below the previous one. It will not
+		// when the chain grew by at least the window the step just covered,
+		// and a descent that never gains on its target would otherwise
+		// truncate and re-truncate the chain for as long as peers keep
+		// serving blocks.
+		if haveLastStep && next.Slot >= lastStepSlot {
+			stalls++
+			if stalls > maxWindowedRewindStalls {
+				return fmt.Errorf(
+					"%w: target slot %d, step slot %d, chain tip slot %d",
+					errRecoveryRewindNotConverging,
+					point.Slot,
+					next.Slot,
+					tip.Point.Slot,
+				)
+			}
+		} else {
+			stalls = 0
+		}
+		haveLastStep = true
+		lastStepSlot = next.Slot
+	}
+}
+
+// errRecoveryRewindNotConverging reports a windowed rewind whose committed
+// steps stopped gaining on their target because the primary chain was being
+// extended at least as fast as the descent moved. Like an over-K refusal it
+// leaves recovery with no reachable rewind, so rewindPrimaryChainForRecovery
+// counts it against the same terminal budget.
+var errRecoveryRewindNotConverging = errors.New(
+	"recovery rewind is not gaining on its target",
+)
+
+// maxWindowedRewindStalls bounds consecutive windowed steps the chain refuses
+// for exceeding K. Each step is derived from the chain's live tip, so a
+// refusal means blocks landed between that read and the truncation; re-reading
+// the tip is what clears it, and a couple of retries covers any realistic
+// interleaving. Past that the chain is being extended at least as fast as the
+// descent moves and the rewind is not going to complete.
+const maxWindowedRewindStalls = 3
+
+// maxRecoveryRewindRejections bounds how many consecutive recovery rewinds may
+// be refused for exceeding the security parameter at an applied ledger tip
+// that never advances, before the failure is declared unrepairable (issue
+// #3889).
+//
+// A refusal here is not a verdict about a block, it is the recovery itself
+// being impossible: the rewind that would reject the branch cannot be
+// performed. Restarting the pipeline re-derives it against a chain the peer has
+// only extended further from the pinned applied tip, so the depth that must be
+// rolled back grows monotonically and a rewind already beyond K never comes
+// back into range on its own. That is what makes the loop unrecoverable rather
+// than merely slow: 1150 restarts across nine hours as first reported, and 97
+// attempts over twenty minutes in the live Preview reproduction, with the
+// stuck-pipeline watchdog correctly announcing the failure as deterministic
+// throughout.
+//
+// The applied tip is the convergence signal, as it is for the Mithril boundary
+// sibling. The rewind target itself is recomputed every attempt and differs
+// every time (intermediate points 1768501, 1774034, 1773427, 1779454, 1782037,
+// 1769017 in that run), so there is no failing target to key on and no failure
+// identity that could be allowed to rearm the budget.
+const maxRecoveryRewindRejections = 3
+
+type recoveryRewindProgress struct {
+	highWaterTipSlot uint64
+	rejections       int
+	halted           bool
+}
+
+// observeRecoveryRewindRejection tallies one recovery rewind refused for
+// exceeding K and reports whether the budget is spent. Runs on the ledger
+// pipeline goroutine, like its at-tip, replay, and Mithril siblings, so the
+// tally needs no lock of its own.
+func (ls *LedgerState) observeRecoveryRewindRejection(
+	tipSlot uint64,
+) (int, bool) {
+	if ls.recoveryRewind == nil ||
+		tipSlot > ls.recoveryRewind.highWaterTipSlot {
+		ls.recoveryRewind = &recoveryRewindProgress{
+			highWaterTipSlot: tipSlot,
+			rejections:       1,
+		}
+	} else {
+		ls.recoveryRewind.rejections++
+	}
+	rejections := ls.recoveryRewind.rejections
+	if rejections > maxRecoveryRewindRejections {
+		ls.recoveryRewind.halted = true
+	}
+	return rejections, ls.recoveryRewind.halted
+}
+
+// resetRecoveryRewindRejections clears the tally once the applied ledger tip
+// advances past the high-water mark the refusals could not cross. The node is
+// following the chain again, so a later refusal is a different situation and
+// starts with a fresh budget.
+func (ls *LedgerState) resetRecoveryRewindRejections(newTipSlot uint64) {
+	if ls.recoveryRewind == nil ||
+		newTipSlot <= ls.recoveryRewind.highWaterTipSlot {
+		return
+	}
+	ls.recoveryRewind = nil
+}
+
+// rewindPrimaryChainForRecovery is the windowed rewind every recovery path
+// takes, plus the one classification a pipeline restart cannot help with.
+//
+// A rewind the chain refuses for exceeding K leaves recovery with no legal
+// target at all, so the caller's error would otherwise return to
+// ledgerProcessBlocks as an ordinary retryable failure and be recomputed on
+// the next restart, forever. Once the refusal has repeated at an applied tip
+// that never moved, it is reported as errHaltLedgerPipeline: the node stops,
+// says so once at ERROR with the terminal gauge set, and leaves the decision
+// to an operator instead of spinning at the backoff interval.
+func (ls *LedgerState) rewindPrimaryChainForRecovery(
+	point ocommon.Point,
+) error {
+	err := ls.rollbackPrimaryChainInSecurityParamWindows(point)
+	if err == nil ||
+		(!errors.Is(err, chain.ErrRollbackExceedsSecurityParam) &&
+			!errors.Is(err, errRecoveryRewindNotConverging)) {
+		return err
+	}
+	ls.RLock()
+	tipSlot := ls.currentTip.Point.Slot
+	ls.RUnlock()
+	rejections, exhausted := ls.observeRecoveryRewindRejection(tipSlot)
+	if !exhausted {
+		if ls.config.Logger != nil {
+			ls.config.Logger.Warn(
+				"recovery rewind refused for exceeding the security parameter; the primary chain has outrun the applied ledger tip",
+				"component",
+				"ledger",
+				"rewind_target_slot",
+				point.Slot,
+				"ledger_tip_slot",
+				tipSlot,
+				"primary_chain_tip_slot",
+				ls.chain.Tip().Point.Slot,
+				"rejections",
+				rejections,
+				"error",
 				err,
 			)
 		}
-		if err := ls.chain.Rollback(nextPoint); err != nil {
-			return fmt.Errorf(
-				"rollback primary chain to intermediate point %d: %w",
-				nextIndex,
-				err,
-			)
-		}
-		tipIndex = nextIndex
+		return err
 	}
-	if err := ls.validateAndEmitRollbackUndo(point); err != nil {
-		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
+	if ls.config.Logger != nil {
+		ls.config.Logger.Error(
+			"recovery rewind cannot be performed and repeating it is not advancing the ledger tip, halting ledger pipeline",
+			"component",
+			"ledger",
+			"rewind_target_slot",
+			point.Slot,
+			"ledger_tip_slot",
+			tipSlot,
+			"primary_chain_tip_slot",
+			ls.chain.Tip().Point.Slot,
+			"rejections",
+			rejections,
+			"error",
+			err,
+			"hint",
+			"the node has stopped following the chain; the rewind recovery needs is deeper than the security parameter allows, so restarting the pipeline reproduces it -- investigate the rejected block or resync the node",
+		)
 	}
-	if err := ls.chain.Rollback(point); err != nil {
-		return fmt.Errorf("rollback primary chain to recovery point: %w", err)
-	}
-	return nil
+	return fmt.Errorf("%w (%w)", errHaltLedgerPipeline, err)
 }
 
 func (ls *LedgerState) recoveryRollbackExceedsMithrilBoundary(
@@ -1067,7 +1268,7 @@ func (ls *LedgerState) recoverAtTipFromTxValidationError(
 		"attempt", attempts,
 		"holding", ls.atTipRecoveryHolding,
 	)
-	if err := ls.rollbackPrimaryChainInSecurityParamWindows(
+	if err := ls.rewindPrimaryChainForRecovery(
 		rewindPoint,
 	); err != nil {
 		return false, fmt.Errorf(
@@ -1239,7 +1440,7 @@ func (ls *LedgerState) rejectRecoveryAtMithrilBoundary(
 		return fmt.Errorf("%s: %w", errContext, errHaltLedgerPipeline)
 	}
 	logRejection(mithrilLedgerSlot, rewindPoint)
-	if err := ls.rollbackPrimaryChainInSecurityParamWindows(rewindPoint); err != nil {
+	if err := ls.rewindPrimaryChainForRecovery(rewindPoint); err != nil {
 		return fmt.Errorf(
 			"rewind primary chain to Mithril trust boundary: %w",
 			err,

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1005,6 +1005,12 @@ type LedgerState struct {
 	// reject-and-retry loop into a terminal condition even when replay reports
 	// changing failing block or transaction identities.
 	mithrilBoundaryRecovery *mithrilBoundaryRecoveryProgress
+	// Consecutive recovery rewinds the chain refused for exceeding the
+	// security parameter without the applied tip advancing (issue #3889).
+	// The refusal means recovery has no legal rewind target at all, so a
+	// pipeline restart re-derives the same impossible rewind; the tally is
+	// what turns that loop into a terminal condition.
+	recoveryRewind *recoveryRewindProgress
 	// Cross-fork continuation audit (issue #3005). Armed by a local
 	// rollback and consumed by the blockfetch handler; see
 	// ledger/continuation_audit.go for the cost and soundness argument.
@@ -6089,6 +6095,7 @@ func (ls *LedgerState) ledgerProcessBlocksFromSource(
 				ls.resetReplayRecoveryNonProgress(pendingTip.Point.Slot)
 				ls.resetDeterministicTxRecovery(pendingTip.Point.Slot)
 				ls.resetMithrilBoundaryRejections(pendingTip.Point.Slot)
+				ls.resetRecoveryRewindRejections(pendingTip.Point.Slot)
 				ls.checkpointWrittenForEpoch = localCheckpointWritten
 				if wantEnableValidation {
 					ls.validationEnabled = true


### PR DESCRIPTION
Fixes #3889

## Why

A recovery rewind read the primary chain tip once, then derived every
intermediate target as `snapshot - n*k`. Nothing serialises that descent
against chain growth — it runs under `transactionEventMutex` while blockfetch
appends under `chainsyncMutex` — so one block landing after the snapshot put
the next target more than `k` below the tip `Chain.Rollback` measures fork
depth against, and the rewind was refused. That error reached
`ledgerProcessBlocks` as an ordinary retryable failure, the pipeline restarted,
and recovery recomputed the same unreachable descent against a chain that had
grown further from the pinned applied tip.

The live Preview reproduction in the issue shows both halves:

```
WARN  rejecting rollback that exceeds security parameter K
      fork_depth=5010 security_param=432 rollback_slot=41098815
WARN  block processing failed, restarting pipeline
      error="... rollback primary chain to intermediate point 1774034:
             rollback depth exceeds security parameter K"
```

97 attempts on one transaction, tip pinned at slot 41098815 for over twenty
minutes, the intermediate point different every attempt (1768501, 1774034,
1773427, 1779454, 1782037, 1769017) and the fork depth growing monotonically
because the peer keeps extending while the local tip is stuck. The watchdog
announced the failure as deterministic and the node kept retrying anyway.

## What changed

**`ledger/replay_recovery.go` — each step comes from the live tip.**
`rollbackPrimaryChainInSecurityParamWindows` now asks the chain for the point a
security parameter behind its *current* tip (`Chain.PointAtDepth`) on every
iteration, so each rollback is k-bounded by construction however far the chain
has moved. A step the chain still refuses is retried a bounded number of times
against a freshly read tip, and only while nothing was published — retrying
after a publish would tell a `ledger.tx` consumer to undo the same block twice.
A descent whose committed steps stop landing below the previous one has been
outrun by chain growth and gives up instead of truncating and re-truncating for
as long as peers serve blocks.

**`ledger/replay_recovery.go` — an unreachable rewind fails closed.** All five
recovery rewind call sites now go through `rewindPrimaryChainForRecovery`. An
over-K refusal (or a non-converging descent) means recovery has no legal target
at all, and a restart only re-derives it against a larger gap, so the refusals
are tallied against the applied ledger tip. Past
`maxRecoveryRewindRejections` at the same applied high-water mark the failure is
reported as `errHaltLedgerPipeline`: the pipeline stops, logs once at ERROR with
an operator hint, and sets `dingo_ledger_pipeline_halted`. Forward progress past
that mark clears the tally through `resetRecoveryRewindRejections`, alongside
the existing at-tip, replay, and Mithril-boundary resets.

The tally keys on the applied tip rather than on the target because the target
is recomputed and different on every attempt — memoising "this target failed"
would never fire. It is the same convergence signal
`observeMithrilBoundaryRejection` already uses, for the same reason.

**`ledger/block_event.go` — `validateAndEmitRollbackUndoEmitted`.** The
reject-then-emit guard is unchanged and still inseparable; it now also reports
whether it read any block to undo, which is what makes the retry above sound.
Reporting the read rather than the publish is deliberately conservative.

**`chain/chain.go` — a failed add batch must not resurrect a lowered tip.**
`addRawBlocks` releases both chain locks when its transaction closure returns
and only then does `txn.Do` commit, so the Commit-failure restore ran with the
chain open to everyone else. Rolling the primary chain back while blockfetch
appends to it is exactly what a recovery rewind does, and the unconditional
restore wrote a pre-batch snapshot over the rollback's result, raising
`tipBlockIndex` above blocks the rollback had deleted — the chain then claimed a
tip it did not store, and the windowed rewind's next `PointAtDepth` reported the
block missing. `batchRestoreIsSafeLocked` restores only while the chain still
shows what that batch left behind. Found by the regression test below, with the
stomp confirmed directly by instrumenting the restore path (`have=68 saved=76`,
`have=83 saved=91`).

## Why halt rather than clamp

A rollback deeper than `k` is outside what the protocol permits, so silently
clamping the target would move the chain somewhere recovery did not ask for.
The change makes the *legal* rewind reachable — each step is exactly `k` from
the live tip, which is what the windowed helper always intended — and when even
that is refused it reports the condition rather than inventing a target. The
deterministic rejection itself stays non-terminal, unchanged: what becomes
terminal is only the rewind that carries it out being impossible.

## Tests and why they discriminate

All three ledger tests compile against `main` and fail there:

- `TestWindowedRewindConvergesWhilePrimaryChainExtends` — a goroutine extends
  the primary chain each time the descent moves the tip. On `main`: 25/25 runs
  fail with `rollback primary chain to intermediate point 208: rollback depth
  exceeds security parameter K`. With the fix: 360/360 runs pass under `-race`
  at `GOMAXPROCS` 2, 8, and default.
- `TestDeterministicTxRecoveryHaltsOnUnreachableRewind` — repeats
  `recoverFromDeterministicTxValidationError` against a rewind the chain always
  refuses. On `main` it never halts after 32 attempts; the failure message is
  the reported one.
- `TestRecoveryRewindHaltsThoughTargetMovesAndDepthGrows` — pins the live run's
  two properties: the chain is extended between attempts so every attempt
  computes a *different* step target against a *larger* gap, the applied ledger
  tip stays pinned, and the halt must still arrive. It asserts the targets
  actually differed and the depth actually grew, so it fails both for a fix that
  memoises a failing target and for one that lets a growing depth rearm the
  budget. On `main`: `rollback primary chain to intermediate point 107: rollback
  depth exceeds security parameter K`, never terminal.
- `TestRecoveryRewindHaltBudgetResetsOnTipProgress` — the other side of the
  budget: a tip advance past the stalled high-water mark starts a fresh one.
- `chain/batch_restore_internal_test.go` — unit-pins which chain states the
  failed-batch restore may write over (unchanged, concurrent rollback,
  concurrent append, same index different block).

## Validation

- `go test ./ledger/... ./chain/... ./database/... -count=1` — pass.
- `go test ./internal/test/conformance/ -count=1` — pass.
- `go build ./...`, `go vet` — clean.
- `make lint` — golangci-lint 0 issues on all four passes (repo, antithesis,
  examples, `GOOS=windows`).
- `make docs-parity` and `go test ./internal/architecture` — pass.
- Full `go test -race -timeout 30m ./...` — the only failures are
  `TestEntrypointForwardsSignalsDuringMithrilBootstrap` and
  `TestEntrypointSignalHandlingSurvivesBootstrapToServeHandoff` in
  `./bin`, which fail identically on unmodified `origin/main` under the same
  full-suite load and pass in isolation on both. Pre-existing, unrelated.

## Checks not run

- **DevNet (`internal/test/devnet/run-tests.sh`)** — not run: Docker is not
  available in this environment (`docker info` fails).
- **`nilaway`** — not run: not installed here, and it is not pinned or in CI.
  golangci-lint, which is, reports 0 issues.
- **Antithesis** — not run: requires infrastructure not available here.

## Docs

`ARCHITECTURE.md` updated: the windowed-rewind paragraph now states that step
targets come from the live tip and why, the bounded retry and its
no-publish precondition, the descent's give-up condition, the
`addRawBlocks` restore rule, and the new terminal bound with its applied-tip
convergence signal. The "the rejection is never terminal" sentence is corrected
to distinguish the verdict from the rewind. `DATABASE.md` needs no change: no
schema, key, or storage-format change.

## Scope

The underlying Plutus rejection that triggered the live run is #3935 and is not
touched here. This is the amplifier only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes recovery rewinds derive each step target from the chain's live tip instead of a snapshot taken when the descent began, so chain growth between steps can no longer push a rollback past the security parameter and get it refused forever. When a rewind stays unreachable at a pinned applied tip, the pipeline now halts with an operator hint instead of restarting and recomputing the same impossible rewind, fixing #3889.

**Bug Fixes**
- Each rewind step reads the point `k` behind the live tip via `Chain.PointAtDepth`; a step the chain still refuses is retried a bounded number of times against a fresh tip, and only when it published no undo events so `ledger.tx` consumers are never told to undo the same block twice.
- A descent whose committed steps stop landing below the previous one gives up as non-converging rather than re-truncating indefinitely; the retry and non-convergence budgets are separate so transient over-`k` refusals can't consume the convergence budget.
- All five recovery rewinds route through `rewindPrimaryChainForRecovery`, which tallies over-`k` refusals at an applied tip that never advances and reports `errHaltLedgerPipeline` past `maxRecoveryRewindRejections`; advancing past that tip clears the tally.
- `addRawBlocks` now restores its pre-batch snapshot on commit failure only while the chain still shows exactly what that batch left behind—same tip index, tip hash, and mutation generation—so a concurrent recovery rollback result is never overwritten with a tip the chain no longer stores.

<sup>Written for commit c72fcfb5cbb6bb1ecba37b8d844868c44d0b3a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery rewinds by recalculating targets from the current chain tip.
  - Recovery now retries transient rewind failures while preventing endless retries when progress cannot be made.
  - The ledger pipeline halts after repeated unrecoverable rewind rejections.
  - Improved protection against inconsistent chain state during concurrent rollback and block restoration.

- **Documentation**
  - Updated architecture documentation to clarify recovery rewind behavior and failure handling.

- **Tests**
  - Added coverage for recovery convergence, halt conditions, progress resets, and concurrent chain updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->