### PR TITLE
test(conformance): exercise Dingo era validation entry points

### DIFF
--- a/internal/test/conformance/README.md
+++ b/internal/test/conformance/README.md
@@ -227,6 +227,45 @@ Cross-repo change cascades that must re-run this suite:
    bookkeeping) so each vector starts from a genuinely empty database --
    see each backend's own "Reset semantics" above for how.
 
+## Dingo validation entry point coverage
+
+A green corpus run is **not** evidence that Dingo's own transaction validation
+ran. The shared harness validates each vector with
+`common.VerifyTransaction` over `conformance.ConformanceValidationRules`, a
+list of upstream `gouroboros` rule functions. Nothing in that path reaches
+`ledger/eras`' `EraDesc.ValidateTxFunc` -- `ValidateTxByron` through
+`ValidateTxDijkstra` -- which is what the node runs against live transactions
+and which differs from the upstream list (Conway and Dijkstra substitute Dingo
+implementations for the committee-certificate, unknown-voter, Plutus, fee and
+PlutusV1/V2 feature rules; the pre-Alonzo eras replace the upstream fee and
+max-size rules outright).
+
+Stubbing `ValidateTxConway` to `return nil` leaves
+`TestRulesConformanceVectors` reporting 315/315, 100%.
+
+`entry_points_test.go` and `entry_points_replay_test.go` close that gap:
+
+- `TestConformanceVectorsExerciseDingoEraEntryPoints` replays the corpus a
+  second time, routing every vector transaction through the production entry
+  point for the era its protocol parameters select, and asserts **per vector**
+  that the entry point resolved the inputs that transaction declares through
+  live ledger state. The assertion is independent of the verdict, so it is not
+  satisfied by a validator that returns the vector fixture's own result.
+  Dingo's rule set is a superset of the corpus rule set (it keeps the fee and
+  max-size rules the corpus excludes because the vectors carry
+  Haskell-computed values), so agreement on verdicts is not asserted here.
+- `TestDingoEraRegistryExposesValidationEntryPoints` fails on a `nil`
+  `ValidateTxFunc` or a protocol-major-version gap between adjacent eras.
+- `TestDingoEraEntryPointsRejectInputlessTransaction` covers **every** era in
+  the registry, not just Conway. The corpus is Conway-only and validation
+  rules are duplicated per era, so Conway coverage says nothing about
+  `ValidateTxShelley` or `ValidateTxDijkstra`.
+- `TestEntryPointExecutionFaultDetectsBypassedValidator` and
+  `TestDingoEraEntryPointsReportsMissingValidator` prove the detectors detect,
+  by substituting a no-op validator, a fixture-only verdict, a
+  reject-without-reading validator, and a nil registry entry, and requiring
+  each to be reported.
+
 ## Corpus replay budget
 
 One full replay of the vector corpus is the single most expensive thing in this
@@ -239,6 +278,16 @@ Each backend replays the corpus **exactly once per `go test` process**, and
 every consumer reads that one memoized result set: the pass/fail gate, the
 progress statistics, and the cross-backend comparison. The vector extraction is
 shared the same way, once rather than once per replay. See `corpus_test.go`.
+
+The one deliberate exception is the SQLite-only entry-point replay described in
+[Dingo validation entry point coverage](#dingo-validation-entry-point-coverage).
+The shared harness offers no hook for a caller-supplied validator, so that
+coverage is not obtainable from the harness pass at any replay count. It is
+also memoized once per process, and it runs against SQLite only because entry
+points do not vary by storage backend. Its cost is the state replay rather than
+the validation: with the entry-point call removed the pass takes the same wall
+clock. Measured on one machine, it took the package from 23.8s to 46.1s
+uninstrumented, and from 585s to 891s under `-race`.
 
 Before this, a Linux CI run with both DSNs configured replayed the corpus eight
 times:
@@ -292,6 +341,8 @@ access patterns. That needs **one** pass per dialect, not several.
 | `state_manager_postgres.go` | `NewDingoPostgresStateManager` — same `DingoStateManager`, real Postgres connection with schema isolation (`dingo_extra_plugins` build tag) |
 | `state_manager_mysql.go` | `NewDingoMysqlStateManager` — same `DingoStateManager`, real MySQL connection with database isolation (`dingo_extra_plugins` build tag) |
 | `state_manager_backend_test.go` | Real-backend acceptance tests against the default SQLite manager: restart survival, transaction rollback, and an epoch-transition/stake-snapshot test driving `ledger/governance.ProcessEpoch` and `ledger/snapshot.Manager` end to end |
+| `entry_points_test.go` | Assertions that Dingo's production era validation entry points actually execute for the corpus, plus the per-era and detector-proving regression tests |
+| `entry_points_replay_test.go` | Entry-point replay machinery: era-registry read, observing ledger state, per-vector routing evidence, and the bypass detector predicate |
 | `state_provider.go`   | State-query adapters used by the harness -- every read queries the real backend live (see its type doc comment for the one narrow, documented exception) |
 | `docker-compose.yml`  | Local PostgreSQL and MySQL for the SQL-backed tests |
 

--- a/internal/test/conformance/entry_points_replay_test.go
+++ b/internal/test/conformance/entry_points_replay_test.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sort"
 
@@ -357,7 +358,13 @@ func collectEntryPointVectors(testdataRoot string) ([]string, error) {
 		root := filepath.Join(testdataRoot, sub)
 		paths, err := conformance.CollectVectorFiles(root)
 		if err != nil {
-			if sub == "synthetic" {
+			// A corpus that ships no synthetic/ directory is legitimate, so
+			// that one case is skipped. Every other failure is reported: an
+			// unreadable vector or an IO error would otherwise shrink the
+			// vector set silently, and a partial corpus that still routes
+			// some transactions reports as full entry-point coverage --
+			// the exact failure mode these tests exist to catch.
+			if sub == "synthetic" && errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 			return nil, fmt.Errorf("collect %s vectors: %w", sub, err)

--- a/internal/test/conformance/entry_points_replay_test.go
+++ b/internal/test/conformance/entry_points_replay_test.go
@@ -380,7 +380,10 @@ func collectEntryPointVectors(testdataRoot string) ([]string, error) {
 // points. State advancement mirrors the harness: successful transactions are
 // applied, epoch events cross the boundary, and a rollback event restores the
 // initial state and re-applies the journaled transactions at or below the
-// target slot.
+// target slot. The one modelled difference is that only transactions are
+// journaled, not epoch events, so a rollback that follows an epoch boundary
+// is reported as an error rather than replayed -- no corpus vector does that
+// today.
 func replayEntryPoints(
 	sm *DingoStateManager,
 	testdataRoot string,
@@ -452,6 +455,7 @@ func replayVectorEntryPoints(
 
 	epoch := initialState.CurrentEpoch
 	var applied []appliedTx
+	var epochCrossed bool
 
 	for idx, event := range vector.Events {
 		switch event.Type {
@@ -495,7 +499,23 @@ func replayVectorEntryPoints(
 				return ev
 			}
 			pp = sm.GetProtocolParameters()
+			epochCrossed = true
 		case conformance.EventTypeRollback:
+			if epochCrossed {
+				// The harness restores initialProtocolParams and replays its
+				// journaled epoch events on rollback. This pass journals only
+				// transactions, so it can neither undo an enacted parameter
+				// change nor re-cross a boundary. No vector in the corpus
+				// rolls back after an epoch event, so rather than model a
+				// path nothing exercises -- and silently route later
+				// transactions through an era selected from stale parameters
+				// -- fail loudly if one ever appears.
+				ev.Err = fmt.Errorf(
+					"event %d: rollback after an epoch boundary is not modelled by this replay; journal epoch events and restore the vector's initial protocol parameters before relying on it",
+					idx,
+				)
+				return ev
+			}
 			retained, err := rollbackEntryPointReplay(
 				sm, initialState, pp, applied, event.RollbackSlot,
 			)
@@ -567,6 +587,11 @@ func routeVectorTransaction(
 // reload the vector's initial state, and re-apply the journaled transactions
 // at or below the target slot. Re-applied transactions are not routed again;
 // they already produced their evidence on first execution.
+//
+// pp is the vector's initial protocol parameters. replayVectorEntryPoints
+// refuses a rollback that follows an epoch boundary, so the parameters still
+// active here are the ones LoadForVector produced, which is what the harness
+// restores explicitly from its own initialProtocolParams.
 func rollbackEntryPointReplay(
 	sm *DingoStateManager,
 	initialState *conformance.ParsedInitialState,

--- a/internal/test/conformance/entry_points_replay_test.go
+++ b/internal/test/conformance/entry_points_replay_test.go
@@ -1,0 +1,610 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+)
+
+// This file is the entry-point replay machinery; entry_points_test.go holds
+// the assertions. It is a _test.go file because every identifier in it is
+// test-only and unexported, and .golangci.yml sets run.tests: false, so the
+// same code in a plain .go file is reported as unused by the linter while
+// still being exercised by the package's tests.
+//
+// The shared ouroboros-mock harness validates each vector transaction with
+// common.VerifyTransaction over conformance.ConformanceValidationRules -- a
+// list of upstream gouroboros rule functions. Nothing in that path reaches
+// Dingo's own era validation entry points (eras.EraDesc.ValidateTxFunc, i.e.
+// ValidateTxByron .. ValidateTxDijkstra), which are what the node actually
+// runs against live transactions and which differ from the upstream list:
+// Conway and Dijkstra substitute Dingo implementations for the committee
+// certificate, unknown voter, Plutus, fee and PlutusV1/V2 feature rules, and
+// the pre-Alonzo eras replace the upstream fee and max-size rules outright.
+//
+// The consequence is that the corpus pass rate is independent of those entry
+// points: with ValidateTxConway stubbed to `return nil`, all 315 vectors still
+// report as passing. This file routes every corpus vector transaction through
+// the production entry point for its era as well, and records evidence that
+// the entry point actually consulted ledger state derived from the
+// transaction, so a bypassed or fixture-only validator cannot read as a pass.
+
+// validateTxFunc is eras.EraDesc.ValidateTxFunc's signature.
+type validateTxFunc = func(
+	common.Transaction,
+	uint64,
+	common.LedgerState,
+	common.ProtocolParameters,
+) error
+
+// eraEntryPoint is one era's production transaction-validation entry point,
+// read from Dingo's era registry rather than restated here. Restating the
+// list would defeat the purpose: an era whose ValidateTxFunc is dropped from
+// the registry has to show up as a missing entry point, not as a local copy
+// that keeps working.
+type eraEntryPoint struct {
+	Validate        validateTxFunc
+	Name            string
+	Id              uint
+	MinMajorVersion uint
+	MaxMajorVersion uint
+}
+
+// dingoEraEntryPoints reads the production validation entry point out of each
+// era descriptor. An era with no ValidateTxFunc is reported rather than
+// skipped: a nil entry point is exactly the "validation path bypassed" state
+// these tests exist to catch.
+func dingoEraEntryPoints(eraList []eras.EraDesc) ([]eraEntryPoint, error) {
+	if len(eraList) == 0 {
+		return nil, errors.New("era registry is empty")
+	}
+	entries := make([]eraEntryPoint, 0, len(eraList))
+	var missing []string
+	for _, era := range eraList {
+		if era.ValidateTxFunc == nil {
+			missing = append(missing, era.Name)
+			continue
+		}
+		entries = append(entries, eraEntryPoint{
+			Validate:        era.ValidateTxFunc,
+			Name:            era.Name,
+			Id:              era.Id,
+			MinMajorVersion: era.MinMajorVersion,
+			MaxMajorVersion: era.MaxMajorVersion,
+		})
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf(
+			"eras with no production validation entry point: %v",
+			missing,
+		)
+	}
+	return entries, nil
+}
+
+// entryPointForProtocolVersion resolves the era entry point covering a
+// protocol major version, mirroring eras.EraForVersionIn.
+func entryPointForProtocolVersion(
+	entries []eraEntryPoint,
+	majorVersion uint,
+) (eraEntryPoint, bool) {
+	for _, entry := range entries {
+		if majorVersion >= entry.MinMajorVersion &&
+			majorVersion <= entry.MaxMajorVersion {
+			return entry, true
+		}
+	}
+	return eraEntryPoint{}, false
+}
+
+// protocolMajorVersion reports the protocol major version carried by pp. It
+// is what selects the era, and therefore which production entry point a
+// vector's transactions belong to.
+//
+// Every parameter type from Shelley onward implements
+// common.PoolRuleProtocolParameters; the Utxorpc projection is the fallback
+// for anything that does not.
+func protocolMajorVersion(pp common.ProtocolParameters) (uint, error) {
+	if pp == nil {
+		return 0, errors.New("nil protocol parameters")
+	}
+	if versioned, ok := pp.(common.PoolRuleProtocolParameters); ok {
+		return versioned.ProtocolMajorVersion(), nil
+	}
+	upp, err := pp.Utxorpc()
+	if err != nil {
+		return 0, fmt.Errorf("project protocol parameters: %w", err)
+	}
+	version := upp.GetProtocolVersion()
+	if version == nil {
+		return 0, errors.New("protocol parameters carry no protocol version")
+	}
+	return uint(version.GetMajor()), nil
+}
+
+// observedLedgerState wraps the real DingoStateProvider and records the reads
+// a validation entry point performs through it.
+//
+// It embeds the concrete provider rather than the common.LedgerState
+// interface so that the optional capabilities Dingo's era validation asserts
+// for -- eras.CommitteeCredentialState among them -- keep resolving. Wrapping
+// the interface would silently strip them and change what the entry point
+// validates.
+type observedLedgerState struct {
+	*DingoStateProvider
+	utxoLookups map[string]struct{}
+	reads       int
+}
+
+// The wrapper must keep satisfying everything the real provider satisfies,
+// including the optional capability Dingo's Conway and Dijkstra validation
+// type-asserts for. Losing it here would change what the entry point
+// validates while still reporting as "routed".
+var (
+	_ common.LedgerState            = (*observedLedgerState)(nil)
+	_ eras.CommitteeCredentialState = (*observedLedgerState)(nil)
+)
+
+func newObservedLedgerState(
+	provider *DingoStateProvider,
+) *observedLedgerState {
+	return &observedLedgerState{
+		DingoStateProvider: provider,
+		utxoLookups:        make(map[string]struct{}),
+	}
+}
+
+// reset clears the recorded reads so one observer can serve consecutive
+// routings without attributing an earlier transaction's lookups to a later
+// one.
+func (o *observedLedgerState) reset() {
+	clear(o.utxoLookups)
+	o.reads = 0
+}
+
+// UtxoById records the input reference before delegating. The lookup is
+// recorded even when it fails: an entry point that asked for an input it
+// could not resolve still executed, which is what is being observed.
+func (o *observedLedgerState) UtxoById(
+	id common.TransactionInput,
+) (common.Utxo, error) {
+	o.reads++
+	if id != nil {
+		o.utxoLookups[utxoLookupKey(id)] = struct{}{}
+	}
+	return o.DingoStateProvider.UtxoById(id)
+}
+
+// NetworkId records the read performed by the network-id rules.
+func (o *observedLedgerState) NetworkId() uint {
+	o.reads++
+	return o.DingoStateProvider.NetworkId()
+}
+
+// CostModels records the read performed by the script rules.
+func (o *observedLedgerState) CostModels() map[common.PlutusLanguage]common.CostModel {
+	o.reads++
+	return o.DingoStateProvider.CostModels()
+}
+
+// utxoLookupKey is the canonical identity of a transaction input, used to
+// match what an entry point looked up against what the transaction declared.
+// It deliberately does not use TransactionInput.String(), whose format is not
+// part of any contract.
+func utxoLookupKey(id common.TransactionInput) string {
+	txId := id.Id()
+	return fmt.Sprintf("%x#%d", txId[:], id.Index())
+}
+
+// entryPointRouting is the evidence produced by routing one vector
+// transaction through a production era validation entry point.
+type entryPointRouting struct {
+	// Err is what the entry point returned. A non-nil Err is not a test
+	// failure: Dingo's rule set is a strict superset of the corpus rule set
+	// (it keeps the fee and max-size rules the corpus excludes because the
+	// vectors carry Haskell-computed values), so a vector the corpus accepts
+	// may still be rejected here. What is asserted is that the entry point
+	// ran and read transaction-derived state, not what it decided.
+	Err error
+
+	// EraName is the era whose entry point was used.
+	EraName string
+
+	// EntryPoint identifies the production function that ran.
+	EntryPoint string
+
+	// EventIndex is the transaction event's index within the vector.
+	EventIndex int
+
+	// DeclaredInputs is the number of inputs the transaction declares.
+	DeclaredInputs int
+
+	// LookedUpInputs is how many of those declared inputs the entry point
+	// resolved through the ledger state. This is the transaction-derived
+	// signal: a no-op, bypassed, or fixture-only validator resolves none.
+	LookedUpInputs int
+
+	// StateReads is the total number of observed ledger-state reads.
+	StateReads int
+}
+
+// vectorEntryPointEvidence records one vector's trip through the production
+// entry points, preserving per-vector identity so an aggregate cannot hide a
+// vector whose validation path never ran.
+type vectorEntryPointEvidence struct {
+	// Err is a replay failure (decode, initial state, epoch boundary). It is
+	// a test failure: it means the vector produced no entry-point evidence.
+	Err error
+
+	Path     string
+	Title    string
+	TxEvents int
+	Routings []entryPointRouting
+}
+
+// routeTransaction runs one transaction through a production era validation
+// entry point against the observed ledger state and returns the evidence.
+func routeTransaction(
+	entry eraEntryPoint,
+	entryPointName string,
+	tx common.Transaction,
+	slot uint64,
+	ls *observedLedgerState,
+	pp common.ProtocolParameters,
+	eventIndex int,
+) entryPointRouting {
+	inputs := tx.Inputs()
+	declared := make(map[string]struct{}, len(inputs))
+	for _, input := range inputs {
+		if input == nil {
+			continue
+		}
+		declared[utxoLookupKey(input)] = struct{}{}
+	}
+
+	ls.reset()
+	err := entry.Validate(tx, slot, ls, pp)
+
+	lookedUp := 0
+	for key := range declared {
+		if _, ok := ls.utxoLookups[key]; ok {
+			lookedUp++
+		}
+	}
+
+	return entryPointRouting{
+		Err:            err,
+		EraName:        entry.Name,
+		EntryPoint:     entryPointName,
+		EventIndex:     eventIndex,
+		DeclaredInputs: len(declared),
+		LookedUpInputs: lookedUp,
+		StateReads:     ls.reads,
+	}
+}
+
+// entryPointExecutionFault reports why a routing fails to prove that the
+// production validation path executed, or nil when it does prove it.
+//
+// The predicate is deliberately independent of the validation verdict. It is
+// satisfied only by evidence the entry point could not have produced without
+// looking at this transaction: the ledger-state lookups of the inputs the
+// transaction itself declares. A validator that returns a canned verdict --
+// nil, an error, or a value copied from the vector fixture -- performs none
+// of those lookups and is reported here.
+func entryPointExecutionFault(routing entryPointRouting) error {
+	if routing.EraName == "" || routing.EntryPoint == "" {
+		return errors.New(
+			"no production era validation entry point was resolved for this transaction",
+		)
+	}
+	if routing.DeclaredInputs == 0 {
+		// A transaction with no inputs is invalid in every era (Byron's
+		// InputSetEmpty rule and the UtxoValidateInputSetEmptyUtxo rule from
+		// Shelley onward), so there is nothing to look up and acceptance is
+		// itself proof the path did not run.
+		if routing.Err == nil {
+			return fmt.Errorf(
+				"%s accepted a transaction with no inputs; a validating entry point must reject one",
+				routing.EntryPoint,
+			)
+		}
+		return nil
+	}
+	if routing.LookedUpInputs == 0 {
+		return fmt.Errorf(
+			"%s resolved none of the transaction's %d declared inputs through the ledger state (%d total state reads); the production validation path did not run",
+			routing.EntryPoint,
+			routing.DeclaredInputs,
+			routing.StateReads,
+		)
+	}
+	return nil
+}
+
+// entryPointFuncName is the reporting name of an era's production entry
+// point, e.g. "eras.ValidateTxConway".
+func entryPointFuncName(entry eraEntryPoint) string {
+	return "eras.ValidateTx" + entry.Name
+}
+
+// collectEntryPointVectors walks the same corpus roots the shared harness
+// walks, so this pass and the harness pass see the same vector set.
+func collectEntryPointVectors(testdataRoot string) ([]string, error) {
+	var all []string
+	for _, sub := range []string{"eras", "synthetic"} {
+		root := filepath.Join(testdataRoot, sub)
+		paths, err := conformance.CollectVectorFiles(root)
+		if err != nil {
+			if sub == "synthetic" {
+				continue
+			}
+			return nil, fmt.Errorf("collect %s vectors: %w", sub, err)
+		}
+		all = append(all, paths...)
+	}
+	if len(all) == 0 {
+		return nil, fmt.Errorf("no vectors found under %s", testdataRoot)
+	}
+	sort.Strings(all)
+	return all, nil
+}
+
+// replayEntryPoints replays the corpus against sm, routing every transaction
+// event through the production era entry point resolved from the vector's own
+// protocol parameters.
+//
+// It is a separate replay from the shared harness's, because the harness has
+// no hook for a caller-supplied validator and never reaches Dingo's entry
+// points. State advancement mirrors the harness: successful transactions are
+// applied, epoch events cross the boundary, and a rollback event restores the
+// initial state and re-applies the journaled transactions at or below the
+// target slot.
+func replayEntryPoints(
+	sm *DingoStateManager,
+	testdataRoot string,
+	entries []eraEntryPoint,
+) ([]vectorEntryPointEvidence, error) {
+	paths, err := collectEntryPointVectors(testdataRoot)
+	if err != nil {
+		return nil, err
+	}
+	loader := conformance.NewPParamsLoaderFromTestdata(testdataRoot)
+	provider := NewDingoStateProvider(sm)
+	observer := newObservedLedgerState(provider)
+
+	evidence := make([]vectorEntryPointEvidence, 0, len(paths))
+	for _, path := range paths {
+		ev := replayVectorEntryPoints(sm, loader, observer, entries, path)
+		// The corpus is extracted to a fresh temp directory per process, so
+		// the absolute path is not a stable subtest name. Report the path
+		// relative to the corpus root instead.
+		if rel, err := filepath.Rel(testdataRoot, path); err == nil {
+			ev.Path = rel
+		}
+		evidence = append(evidence, ev)
+	}
+	return evidence, nil
+}
+
+// appliedTx is a journaled transaction, retained so a rollback event can
+// re-apply the transactions at or below its target slot.
+type appliedTx struct {
+	tx   common.Transaction
+	slot uint64
+}
+
+func replayVectorEntryPoints(
+	sm *DingoStateManager,
+	loader *conformance.PParamsLoader,
+	observer *observedLedgerState,
+	entries []eraEntryPoint,
+	path string,
+) vectorEntryPointEvidence {
+	ev := vectorEntryPointEvidence{Path: path}
+
+	vector, err := conformance.DecodeTestVector(path)
+	if err != nil {
+		ev.Err = fmt.Errorf("decode vector: %w", err)
+		return ev
+	}
+	ev.Title = vector.Title
+
+	initialState, err := conformance.ParseInitialState(vector.InitialState)
+	if err != nil {
+		ev.Err = fmt.Errorf("parse initial state: %w", err)
+		return ev
+	}
+	pp, err := loader.LoadForVector(vector, initialState)
+	if err != nil {
+		ev.Err = fmt.Errorf("load protocol parameters: %w", err)
+		return ev
+	}
+	if err := sm.Reset(); err != nil {
+		ev.Err = fmt.Errorf("reset state: %w", err)
+		return ev
+	}
+	if err := sm.LoadInitialState(initialState, pp); err != nil {
+		ev.Err = fmt.Errorf("load initial state: %w", err)
+		return ev
+	}
+
+	epoch := initialState.CurrentEpoch
+	var applied []appliedTx
+
+	for idx, event := range vector.Events {
+		switch event.Type {
+		case conformance.EventTypeTransaction:
+			ev.TxEvents++
+			tx, err := decodeVectorTransaction(event.TxBytes)
+			if err != nil {
+				// The harness tolerates a decode failure on an
+				// expected-failure event; so does this pass, but the event is
+				// not counted as one that reached an entry point.
+				if event.Success {
+					ev.Err = fmt.Errorf(
+						"event %d: decode transaction: %w",
+						idx,
+						err,
+					)
+					return ev
+				}
+				ev.TxEvents--
+				continue
+			}
+			routing, err := routeVectorTransaction(
+				entries, observer, tx, event.Slot, pp, idx,
+			)
+			if err != nil {
+				ev.Err = err
+				return ev
+			}
+			ev.Routings = append(ev.Routings, routing)
+			if event.Success {
+				if err := sm.ApplyTransaction(tx, event.Slot); err != nil {
+					ev.Err = fmt.Errorf("event %d: apply: %w", idx, err)
+					return ev
+				}
+				applied = append(applied, appliedTx{tx: tx, slot: event.Slot})
+			}
+		case conformance.EventTypePassEpoch:
+			epoch += event.EpochDelta
+			if err := sm.ProcessEpochBoundary(epoch); err != nil {
+				ev.Err = fmt.Errorf("event %d: epoch boundary: %w", idx, err)
+				return ev
+			}
+			pp = sm.GetProtocolParameters()
+		case conformance.EventTypeRollback:
+			retained, err := rollbackEntryPointReplay(
+				sm, initialState, pp, applied, event.RollbackSlot,
+			)
+			if err != nil {
+				ev.Err = fmt.Errorf("event %d: rollback: %w", idx, err)
+				return ev
+			}
+			applied = retained
+			epoch = initialState.CurrentEpoch
+		case conformance.EventTypePassTick:
+			// No state effect; the harness only advances its slot cursor.
+		}
+	}
+	return ev
+}
+
+// routeVectorTransaction resolves the era entry point from the active
+// protocol parameters and routes tx through it.
+func routeVectorTransaction(
+	entries []eraEntryPoint,
+	observer *observedLedgerState,
+	tx common.Transaction,
+	slot uint64,
+	pp common.ProtocolParameters,
+	eventIndex int,
+) (entryPointRouting, error) {
+	major, err := protocolMajorVersion(pp)
+	if err != nil {
+		return entryPointRouting{}, fmt.Errorf(
+			"event %d: resolve protocol major version: %w",
+			eventIndex,
+			err,
+		)
+	}
+	entry, ok := entryPointForProtocolVersion(entries, major)
+	if !ok {
+		return entryPointRouting{}, fmt.Errorf(
+			"event %d: no era covers protocol major version %d",
+			eventIndex,
+			major,
+		)
+	}
+	if entry.Name != entryPointCorpusDecodeEra {
+		// decodeVectorTransaction decodes the corpus as Conway. A vector whose
+		// parameters place it in another era would be handed to that era's
+		// entry point as a Conway transaction, so fail loudly instead of
+		// reporting coverage the run does not have.
+		return entryPointRouting{}, fmt.Errorf(
+			"event %d: protocol major version %d selects era %s but the corpus is decoded as %s; add a decoder for %s before claiming its entry point is covered",
+			eventIndex,
+			major,
+			entry.Name,
+			entryPointCorpusDecodeEra,
+			entry.Name,
+		)
+	}
+	return routeTransaction(
+		entry,
+		entryPointFuncName(entry),
+		tx,
+		slot,
+		observer,
+		pp,
+		eventIndex,
+	), nil
+}
+
+// rollbackEntryPointReplay mirrors the shared harness's rollback: reset,
+// reload the vector's initial state, and re-apply the journaled transactions
+// at or below the target slot. Re-applied transactions are not routed again;
+// they already produced their evidence on first execution.
+func rollbackEntryPointReplay(
+	sm *DingoStateManager,
+	initialState *conformance.ParsedInitialState,
+	pp common.ProtocolParameters,
+	applied []appliedTx,
+	targetSlot uint64,
+) ([]appliedTx, error) {
+	retained := make([]appliedTx, 0, len(applied))
+	for _, entry := range applied {
+		if entry.slot <= targetSlot {
+			retained = append(retained, entry)
+		}
+	}
+	if err := sm.Reset(); err != nil {
+		return nil, fmt.Errorf("reset: %w", err)
+	}
+	if err := sm.LoadInitialState(initialState, pp); err != nil {
+		return nil, fmt.Errorf("reload initial state: %w", err)
+	}
+	for _, entry := range retained {
+		if err := sm.ApplyTransaction(entry.tx, entry.slot); err != nil {
+			return nil, fmt.Errorf("replay slot %d: %w", entry.slot, err)
+		}
+	}
+	return retained, nil
+}
+
+// entryPointCorpusDecodeEra is the era decodeVectorTransaction decodes as.
+const entryPointCorpusDecodeEra = conway.EraNameConway
+
+// decodeVectorTransaction decodes a vector transaction. The corpus is Conway,
+// and the shared harness decodes it the same way; routeVectorTransaction
+// cross-checks the decoded era against the era the vector's protocol
+// parameters select, so a future corpus in another era cannot pass unnoticed.
+func decodeVectorTransaction(txBytes []byte) (common.Transaction, error) {
+	tx := &conway.ConwayTransaction{}
+	if _, err := cbor.Decode(txBytes, tx); err != nil {
+		return nil, err
+	}
+	return tx, nil
+}

--- a/internal/test/conformance/entry_points_test.go
+++ b/internal/test/conformance/entry_points_test.go
@@ -1,0 +1,549 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	"github.com/stretchr/testify/require"
+)
+
+// entryPointEraList is the era table these tests cover. Dijkstra is included
+// deliberately: it is off by default at runtime but its ValidateTxFunc is a
+// production entry point, and per-era rule duplication means an entry point
+// that is only covered for Conway proves nothing about the others.
+func entryPointEraList() []eras.EraDesc {
+	return eras.ActiveEras(true)
+}
+
+// entryPointCorpusRun is the memoized entry-point replay. It is a second
+// replay of the corpus, separate from sqliteCorpusResults: the shared
+// ouroboros-mock harness validates with its own upstream rule list and offers
+// no hook for a caller-supplied validator, so there is no way to observe
+// Dingo's entry points from inside the harness pass. corpus_test.go's
+// "replay once per backend" reasoning still holds for storage-dialect
+// coverage; what this pass buys is different, and is not obtainable from the
+// harness replay at any count.
+//
+// The cost is the state replay, not the validation. Running this pass with
+// the entry-point call removed takes the same wall clock as running it with
+// the call in place, so eras.ValidateTx* is free at this corpus size; what
+// the pass pays for is a second Reset/LoadInitialState/ApplyTransaction pass
+// over the corpus, which is roughly what the harness replay itself costs.
+// Measured on one machine, the package went from 585s to 891s under -race.
+// It runs against SQLite only -- the Postgres and MySQL replays exist for
+// storage-dialect coverage, and the entry points do not vary by backend.
+//
+// It replays once per process, like sqliteCorpusResults, so a build that adds
+// more consumers of this evidence does not add more replays.
+type entryPointCorpusRun struct {
+	err      error
+	entries  []eraEntryPoint
+	evidence []vectorEntryPointEvidence
+}
+
+var (
+	entryPointCorpusOnce sync.Once
+	entryPointCorpusData entryPointCorpusRun
+)
+
+func entryPointCorpusEvidence(t *testing.T) entryPointCorpusRun {
+	t.Helper()
+	entryPointCorpusOnce.Do(func() {
+		entries, err := dingoEraEntryPoints(entryPointEraList())
+		if err != nil {
+			entryPointCorpusData = entryPointCorpusRun{err: err}
+			return
+		}
+		root, err := corpusTestdataRoot()
+		if err != nil {
+			entryPointCorpusData = entryPointCorpusRun{err: err}
+			return
+		}
+		sm, err := NewDingoStateManager()
+		if err != nil {
+			entryPointCorpusData = entryPointCorpusRun{
+				err: fmt.Errorf("new sqlite state manager: %w", err),
+			}
+			return
+		}
+		defer sm.Close()
+		evidence, err := replayEntryPoints(sm, root, entries)
+		entryPointCorpusData = entryPointCorpusRun{
+			err:      err,
+			entries:  entries,
+			evidence: evidence,
+		}
+	})
+	require.NoError(t, entryPointCorpusData.err, "entry point corpus replay")
+	return entryPointCorpusData
+}
+
+// TestDingoEraRegistryExposesValidationEntryPoints fails when any era's
+// production transaction-validation entry point is missing from the registry.
+//
+// A nil ValidateTxFunc is the cheapest way to bypass validation for an era,
+// and nothing else in the conformance package notices: the shared harness
+// never reads the registry.
+func TestDingoEraRegistryExposesValidationEntryPoints(t *testing.T) {
+	entries, err := dingoEraEntryPoints(entryPointEraList())
+	require.NoError(t, err)
+	require.Len(t, entries, len(entryPointEraList()))
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	t.Logf("era validation entry points: %v", names)
+
+	// The registry must cover every protocol major version the corpus can
+	// select, without a gap between adjacent eras.
+	for i := 1; i < len(entries); i++ {
+		require.Equal(
+			t,
+			entries[i-1].MaxMajorVersion+1,
+			entries[i].MinMajorVersion,
+			"protocol major version gap between %s and %s leaves versions with no validation entry point",
+			entries[i-1].Name,
+			entries[i].Name,
+		)
+	}
+}
+
+// TestDingoEraEntryPointsReportsMissingValidator proves the registry check
+// above detects the state it exists to catch. Without it,
+// TestDingoEraRegistryExposesValidationEntryPoints would assert something
+// that is true of any table, including one whose entry points were removed.
+func TestDingoEraEntryPointsReportsMissingValidator(t *testing.T) {
+	eraList := entryPointEraList()
+	require.NotEmpty(t, eraList)
+
+	bypassed := make([]eras.EraDesc, len(eraList))
+	copy(bypassed, eraList)
+	bypassed[len(bypassed)-1].ValidateTxFunc = nil
+
+	_, err := dingoEraEntryPoints(bypassed)
+	require.ErrorContains(
+		t,
+		err,
+		"no production validation entry point",
+		"an era with no validation entry point must be reported",
+	)
+	require.ErrorContains(t, err, eraList[len(eraList)-1].Name)
+
+	_, err = dingoEraEntryPoints(nil)
+	require.Error(t, err, "an empty era registry must be reported")
+}
+
+// TestConformanceVectorsExerciseDingoEraEntryPoints routes every corpus
+// vector through Dingo's production validation entry point for its era and
+// asserts, per vector, that the entry point actually executed against ledger
+// state derived from that vector's transactions.
+//
+// TestRulesConformanceVectors cannot make this assertion: it reports the
+// shared harness's verdict, which is produced by upstream gouroboros rules
+// and stays green with ValidateTxConway stubbed out entirely.
+func TestConformanceVectorsExerciseDingoEraEntryPoints(t *testing.T) {
+	run := entryPointCorpusEvidence(t)
+	require.NotEmpty(
+		t,
+		run.evidence,
+		"corpus replay produced no vectors; an empty corpus would otherwise "+
+			"report as full entry-point coverage",
+	)
+
+	reportEntryPointCoverage(t, run)
+
+	var routedVectors int
+	for _, ev := range run.evidence {
+		t.Run(ev.Path, func(t *testing.T) {
+			require.NoError(t, ev.Err, "vector %s: %s", ev.Path, ev.Title)
+			require.Len(
+				t,
+				ev.Routings,
+				ev.TxEvents,
+				"vector %s routed %d of %d transaction events through a "+
+					"production entry point",
+				ev.Path,
+				len(ev.Routings),
+				ev.TxEvents,
+			)
+			for _, routing := range ev.Routings {
+				require.NoErrorf(
+					t,
+					entryPointExecutionFault(routing),
+					"vector %s (%s) event %d",
+					ev.Path,
+					ev.Title,
+					routing.EventIndex,
+				)
+			}
+		})
+		if len(ev.Routings) > 0 {
+			routedVectors++
+		}
+	}
+
+	require.Positive(
+		t,
+		routedVectors,
+		"no vector routed a transaction through a production validation "+
+			"entry point",
+	)
+}
+
+// reportEntryPointCoverage logs which eras the corpus actually reached, so an
+// aggregate pass cannot be read as covering eras the corpus never touches.
+func reportEntryPointCoverage(t *testing.T, run entryPointCorpusRun) {
+	t.Helper()
+	perEra := make(map[string]int)
+	var routings int
+	for _, ev := range run.evidence {
+		for _, routing := range ev.Routings {
+			perEra[routing.EntryPoint]++
+			routings++
+		}
+	}
+	eraNames := make([]string, 0, len(perEra))
+	for name := range perEra {
+		eraNames = append(eraNames, name)
+	}
+	sort.Strings(eraNames)
+
+	t.Logf("Dingo validation entry point coverage (sqlite):")
+	t.Logf("  Vectors replayed: %d", len(run.evidence))
+	t.Logf("  Transactions routed: %d", routings)
+	for _, name := range eraNames {
+		t.Logf("  %s: %d transactions", name, perEra[name])
+	}
+	for _, entry := range run.entries {
+		if perEra[entryPointFuncName(entry)] == 0 {
+			t.Logf(
+				"  %s: 0 transactions (no %s vectors in this corpus; covered "+
+					"by TestDingoEraEntryPointsRejectInputlessTransaction only)",
+				entryPointFuncName(entry),
+				entry.Name,
+			)
+		}
+	}
+}
+
+// TestEntryPointExecutionFaultDetectsBypassedValidator proves the detector
+// used by TestConformanceVectorsExerciseDingoEraEntryPoints actually
+// discriminates: it accepts the production entry point and rejects both a
+// no-op validator and one that returns the vector fixture's own verdict
+// without consulting ledger state.
+//
+// Without this, the coverage assertion above would be unfalsifiable, which is
+// the same failure mode as the aggregate pass rate it exists to backstop.
+func TestEntryPointExecutionFaultDetectsBypassedValidator(t *testing.T) {
+	root, err := corpusTestdataRoot()
+	require.NoError(t, err)
+	entries, err := dingoEraEntryPoints(entryPointEraList())
+	require.NoError(t, err)
+
+	sm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	probe := loadEntryPointProbeTransaction(t, root, sm)
+	observer := newObservedLedgerState(NewDingoStateProvider(sm))
+	major, err := protocolMajorVersion(probe.pp)
+	require.NoError(t, err)
+	production, ok := entryPointForProtocolVersion(entries, major)
+	require.True(t, ok, "no era covers protocol major version %d", major)
+
+	route := func(validate validateTxFunc) entryPointRouting {
+		entry := production
+		entry.Validate = validate
+		return routeTransaction(
+			entry,
+			entryPointFuncName(production),
+			probe.tx,
+			probe.slot,
+			observer,
+			probe.pp,
+			0,
+		)
+	}
+
+	t.Run("production entry point is accepted", func(t *testing.T) {
+		routing := route(production.Validate)
+		require.NoError(t, entryPointExecutionFault(routing))
+		require.Positive(
+			t,
+			routing.LookedUpInputs,
+			"%s must resolve the transaction's declared inputs",
+			entryPointFuncName(production),
+		)
+	})
+
+	t.Run("no-op validator is detected", func(t *testing.T) {
+		routing := route(func(
+			common.Transaction,
+			uint64,
+			common.LedgerState,
+			common.ProtocolParameters,
+		) error {
+			return nil
+		})
+		require.Error(
+			t,
+			entryPointExecutionFault(routing),
+			"a validator that accepts everything without reading state must "+
+				"be reported as a bypassed validation path",
+		)
+	})
+
+	t.Run("fixture-only verdict is detected", func(t *testing.T) {
+		// The worst case for an outcome-based check: a validator that returns
+		// exactly the verdict the vector fixture declares. Every accept/reject
+		// comparison against the corpus would agree with it.
+		routing := route(func(
+			common.Transaction,
+			uint64,
+			common.LedgerState,
+			common.ProtocolParameters,
+		) error {
+			if probe.expectSuccess {
+				return nil
+			}
+			return errors.New("vector fixture says this transaction fails")
+		})
+		require.Error(
+			t,
+			entryPointExecutionFault(routing),
+			"a verdict copied from the vector fixture must be reported as a "+
+				"bypassed validation path",
+		)
+	})
+
+	t.Run("rejecting validator that reads no state is detected", func(t *testing.T) {
+		routing := route(func(
+			common.Transaction,
+			uint64,
+			common.LedgerState,
+			common.ProtocolParameters,
+		) error {
+			return errors.New("rejected without looking")
+		})
+		require.Error(
+			t,
+			entryPointExecutionFault(routing),
+			"returning an error is not evidence the validation path ran",
+		)
+	})
+}
+
+// entryPointProbe is a single real corpus transaction plus the state it was
+// loaded against, used to exercise the detector.
+type entryPointProbe struct {
+	tx            common.Transaction
+	pp            common.ProtocolParameters
+	path          string
+	slot          uint64
+	expectSuccess bool
+}
+
+// loadEntryPointProbeTransaction loads the first corpus vector carrying a
+// transaction with at least one declared input, and leaves sm holding that
+// vector's initial state. Using real vector data rather than a constructed
+// transaction is deliberate: the detector must be shown to work on the same
+// input the coverage assertion runs on.
+func loadEntryPointProbeTransaction(
+	t *testing.T,
+	root string,
+	sm *DingoStateManager,
+) entryPointProbe {
+	t.Helper()
+	paths, err := collectEntryPointVectors(root)
+	require.NoError(t, err)
+	loader := conformance.NewPParamsLoaderFromTestdata(root)
+
+	for _, path := range paths {
+		vector, err := conformance.DecodeTestVector(path)
+		if err != nil {
+			continue
+		}
+		initialState, err := conformance.ParseInitialState(vector.InitialState)
+		if err != nil {
+			continue
+		}
+		pp, err := loader.LoadForVector(vector, initialState)
+		if err != nil {
+			continue
+		}
+		for _, event := range vector.Events {
+			if event.Type != conformance.EventTypeTransaction {
+				continue
+			}
+			tx, err := decodeVectorTransaction(event.TxBytes)
+			if err != nil || len(tx.Inputs()) == 0 {
+				continue
+			}
+			require.NoError(t, sm.Reset())
+			require.NoError(t, sm.LoadInitialState(initialState, pp))
+			return entryPointProbe{
+				tx:            tx,
+				pp:            pp,
+				path:          filepath.Base(path),
+				slot:          event.Slot,
+				expectSuccess: event.Success,
+			}
+		}
+	}
+	t.Fatal("no corpus vector carries a transaction with declared inputs")
+	return entryPointProbe{}
+}
+
+// TestDingoEraEntryPointsRejectInputlessTransaction covers every era in the
+// registry, not just the era the corpus happens to contain.
+//
+// The corpus is Conway-only, and validation rules are duplicated per era, so
+// Conway coverage says nothing about ValidateTxShelley or ValidateTxDijkstra.
+// A transaction with no inputs is invalid in every era (Byron's own
+// InputSetEmpty rule, and UtxoValidateInputSetEmptyUtxo from Shelley onward),
+// which makes it a rule the whole table can be held to. The paired no-op
+// assertion is what makes this a detector rather than a restatement: the same
+// input is accepted by a validator that does nothing.
+func TestDingoEraEntryPointsRejectInputlessTransaction(t *testing.T) {
+	entries, err := dingoEraEntryPoints(entryPointEraList())
+	require.NoError(t, err)
+
+	sm, err := NewDingoStateManager()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+	observer := newObservedLedgerState(NewDingoStateProvider(sm))
+
+	probes := inputlessEraProbes()
+	for _, entry := range entries {
+		t.Run(entry.Name, func(t *testing.T) {
+			probe, ok := probes[entry.Name]
+			require.Truef(
+				t,
+				ok,
+				"era %s has no input-less transaction probe; add one so its "+
+					"production entry point is covered",
+				entry.Name,
+			)
+			require.Empty(t, probe.tx.Inputs())
+
+			routing := routeTransaction(
+				entry,
+				entryPointFuncName(entry),
+				probe.tx,
+				0,
+				observer,
+				probe.pp,
+				0,
+			)
+			require.NoErrorf(
+				t,
+				entryPointExecutionFault(routing),
+				"%s accepted a transaction with no inputs",
+				entryPointFuncName(entry),
+			)
+
+			bypassed := entry
+			bypassed.Validate = func(
+				common.Transaction,
+				uint64,
+				common.LedgerState,
+				common.ProtocolParameters,
+			) error {
+				return nil
+			}
+			bypassedRouting := routeTransaction(
+				bypassed,
+				entryPointFuncName(entry),
+				probe.tx,
+				0,
+				observer,
+				probe.pp,
+				0,
+			)
+			require.Errorf(
+				t,
+				entryPointExecutionFault(bypassedRouting),
+				"a no-op replacement for %s must be detected",
+				entryPointFuncName(entry),
+			)
+		})
+	}
+}
+
+// eraProbe is an era-appropriate transaction and the protocol parameters its
+// entry point requires.
+type eraProbe struct {
+	tx common.Transaction
+	pp common.ProtocolParameters
+}
+
+// inputlessEraProbes returns one input-less transaction per era, keyed by era
+// name. Each era's entry point type-asserts its own parameter type, so the
+// parameters have to match or the entry point returns
+// eras.ErrIncompatibleProtocolParams before reaching any rule.
+func inputlessEraProbes() map[string]eraProbe {
+	return map[string]eraProbe{
+		byron.EraNameByron: {
+			tx: &byron.ByronTransaction{},
+			pp: nil,
+		},
+		shelley.EraNameShelley: {
+			tx: &shelley.ShelleyTransaction{},
+			pp: &shelley.ShelleyProtocolParameters{},
+		},
+		allegra.EraNameAllegra: {
+			tx: &allegra.AllegraTransaction{},
+			pp: &allegra.AllegraProtocolParameters{},
+		},
+		mary.EraNameMary: {
+			tx: &mary.MaryTransaction{},
+			pp: &mary.MaryProtocolParameters{},
+		},
+		alonzo.EraNameAlonzo: {
+			tx: &alonzo.AlonzoTransaction{},
+			pp: &alonzo.AlonzoProtocolParameters{},
+		},
+		babbage.EraNameBabbage: {
+			tx: &babbage.BabbageTransaction{},
+			pp: &babbage.BabbageProtocolParameters{},
+		},
+		conway.EraNameConway: {
+			tx: &conway.ConwayTransaction{},
+			pp: &conway.ConwayProtocolParameters{},
+		},
+		dijkstra.EraNameDijkstra: {
+			tx: &dijkstra.DijkstraTransaction{},
+			pp: &dijkstra.DijkstraProtocolParameters{},
+		},
+	}
+}

--- a/internal/test/conformance/entry_points_test.go
+++ b/internal/test/conformance/entry_points_test.go
@@ -508,9 +508,18 @@ type eraProbe struct {
 }
 
 // inputlessEraProbes returns one input-less transaction per era, keyed by era
-// name. Each era's entry point type-asserts its own parameter type, so the
-// parameters have to match or the entry point returns
-// eras.ErrIncompatibleProtocolParams before reaching any rule.
+// name.
+//
+// From Shelley onward each entry point type-asserts its own parameter type,
+// so the parameters have to match or the entry point returns
+// eras.ErrIncompatibleProtocolParams before reaching any rule -- which would
+// satisfy the input-less assertion for the wrong reason.
+//
+// Byron is the exception and carries nil: ValidateTxByron never asserts on
+// pp, and gouroboros has no Byron protocol-parameters type to supply. It runs
+// its structural rules unconditionally (byronValidateInputsNotEmpty is what
+// rejects the probe) and its UTxO-aware rules whenever a ledger state is
+// given, passing pp through to rules that ignore it.
 func inputlessEraProbes() map[string]eraProbe {
 	return map[string]eraProbe{
 		byron.EraNameByron: {


### PR DESCRIPTION
The shared harness validates each vector with `common.VerifyTransaction` against
upstream gouroboros rule funcs. Nothing in that path reaches `ledger/eras`'
`EraDesc.ValidateTxFunc`, and `HarnessConfig` has no validator hook, so a green
aggregate did not prove Dingo's own era entry points ran.

Demonstrated before the change by patching `ValidateTxConway` to
`return nil` unconditionally: 315/315 vectors passed, 100% pass rate. A
completely bypassed Dingo validator read as a full pass.

Each vector is now routed through the production entry point for its era, and
routing is judged on transaction-derived evidence rather than on the verdict:
the entry point must resolve, through the live `DingoStateProvider`, the input
references the transaction itself declares. Verdicts are deliberately not
compared, because Dingo's Conway rule set is a superset of the corpus set (it
keeps fee and max-size rules the corpus excludes for Haskell-precomputed
values), and because a fixture-only validator agrees with the corpus by
construction.

With the same bypass applied after this change, the aggregate stays green and
the new test fails all 315 subtests with
`eras.ValidateTxConway resolved none of the transaction's 1 declared inputs
through the ledger state (0 total state reads); the production validation path
did not run`.

## Era coverage

The corpus is Conway-only and the harness hard-decodes `ConwayTransaction`, so
corpus-driven input-resolution detection covers Conway: 315 vectors, 2433
transactions. Routing cross-checks the era selected from each vector's protocol
major version against the decode era and fails loudly if a future corpus adds
another era.

All 8 eras (Byron through Dijkstra) are covered separately by a registry-driven
detector that requires each era's entry point to reject an input-less
transaction and requires a no-op substitute for that era to be reported.
Zero-transaction eras are logged explicitly so an aggregate pass cannot be
misread as full-era corpus coverage.

Detector-proving cases: no-op validator, fixture-only verdict, reject-without-
reading validator, and a nil `ValidateTxFunc` in the registry — each must be
reported.

Both files are `_test.go` deliberately: `.golangci.yml` sets `run.tests: false`,
so the same test-only code in a plain `.go` file produced 20 `unused` findings.

## Cost

The entry-point pass is a second corpus state replay; the harness exposes no
validator hook, so it is not obtainable from the harness pass at any replay
count. Measured apples-to-apples, non-race, same machine: 23.8s -> 46.1s.
Removing the `entry.Validate` call leaves wall clock unchanged, so
`eras.ValidateTx*` is free — the cost is `Reset`/`LoadInitialState`/
`ApplyTransaction`. Nothing pathological was added.

This fits the configured budgets (`make test` and both CI test jobs use
`-timeout 30m`; the race job is SQLite-only with `timeout-minutes: 90`). It does
not fit go's 10m default.

An alternative that would recover the cost is routing inside
`DingoStateManager.ApplyTransaction` during the harness's own replay. Not taken:
it touches `state_manager.go` (conflict surface with #3901), covers only applied
transactions so expected-failure vectors would never reach an entry point, and
needs tx-hash attribution since neither `Reset` nor `LoadInitialState` delimits
a vector.

## Validation

`go test -race -count=1 -timeout 1800s ./internal/test/conformance/...` PASS
891s; non-race PASS 46.1s; `golangci-lint` 0 issues (isolated cache);
`make import-boundaries`, `make docs-parity`.

Not run: `make lint` in full (`nilaway`, `modernize`, `golines` absent from
PATH); `GOOS=windows` lint; `make sql-check` / `make govulncheck` (no SQL or
dependency change); DevNet (test-only instrumentation, no consensus, block
production, chain selection, mempool or network code touched); Postgres/MySQL
conformance backends (no DSNs configured; entry points do not vary by backend).

## Corrections to the issue text

`TestRulesConformanceVectorsWithResults`, named in the acceptance criteria, does
not exist. It was removed when the corpus replay was memoized; `WithResults`
survives only as the harness method `RunAllVectorsWithResults`. The real test is
`TestRulesConformanceVectors`.

AC #1's "each applicable vector for its era" resolves to Conway only, since the
corpus has no multi-era vector set. Era resolution is implemented generically
anyway, with the other seven eras covered through the registry detector.

Resolves #3443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEJSNPB6bA7CVW5EgXxNni

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conformance tests that exercise Dingo's era validation entry points, closing the gap where a bypassed validator still reported 315/315 vectors passing.

- Replays each corpus vector through the production entry point for its era and asserts per vector that the transaction's declared inputs were resolved via live ledger state; verdicts are not compared since Dingo's rule set is a superset of the corpus rules.
- Holds all eight eras (Byron through Dijkstra) to rejecting an input-less transaction and detects missing or no-op validators with the same execution-fault predicate.
- The SQLite-only replay is memoized per process and runs at ~22s added wall clock (23.8s → 46.1s), within test timeouts.
- A rollback following an epoch boundary is reported as an error, and synthetic-corpus traversal errors are now surfaced rather than swallowed; no corpus vector exercises either path today.

The acceptance criteria name `TestRulesConformanceVectorsWithResults`, which no longer exists; the real test is `TestRulesConformanceVectors`. Corpus coverage resolves to Conway only (the corpus has no multi-era vectors), with the other seven eras covered by the registry detector.

Resolves #3443

<sup>Written for commit 5341b397c95000e4e3903f0440225277d96c9e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

