### PR TITLE
fix(forging): stop dropping contested and scheduled leader slots before the leader check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -679,9 +679,12 @@ not durably adopted:
   stays observable through the `Forge_forged_int` and
   `Forge_could_not_forge_int` counters. `Forge_could_not_forge_int` also
   counts leader slots declined because a rival block already occupies the
-  slot, so it no longer means "local build or sign failure" alone and its
-  rate overlaps `dingo_metrics_slotBattlesTotal_int`; subtract or inspect
-  that counter when alerting on it.
+  slot, so it no longer means "local build or sign failure" alone. Its
+  rate only *partially* overlaps `dingo_metrics_slotBattlesTotal_int`,
+  which `ledger/chainsync.go` raises for battles detected outside the
+  forge path as well, so the two are not a clean decomposition of one
+  another: inspect `dingo_metrics_slotBattlesTotal_int` alongside when
+  alerting rather than subtracting it exactly.
 - **Duplicate-slot fence.** The chain-tip check (`currentSlot < tipSlot`)
   cannot see a slot whose block was signed and diffused but never adopted,
   and it forgets slots entirely when the tip rolls back or the process

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -677,8 +677,12 @@ not durably adopted:
   `AddBlock` accepts the block. A rejected block is never advertised, so
   peers cannot fetch a block this node does not have. Build-versus-adopt
   stays observable through the `Forge_forged_int` and
-  `Forge_could_not_forge_int` counters.
-- **Duplicate-slot fence.** The chain-tip check (`currentSlot <= tipSlot`)
+  `Forge_could_not_forge_int` counters. `Forge_could_not_forge_int` also
+  counts leader slots declined because a rival block already occupies the
+  slot, so it no longer means "local build or sign failure" alone and its
+  rate overlaps `dingo_metrics_slotBattlesTotal_int`; subtract or inspect
+  that counter when alerting on it.
+- **Duplicate-slot fence.** The chain-tip check (`currentSlot < tipSlot`)
   cannot see a slot whose block was signed and diffused but never adopted,
   and it forgets slots entirely when the tip rolls back or the process
   restarts. `ForgeFenceStore` (`ledger/forging/store.go`, persisted in

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -795,7 +795,13 @@ func (c *forgerMovingTipSlotClock) reads() (int, int) {
 // What must change is that the loss stops being silent. Reporting it as
 // "slot already has our own block" at Debug is both false and exactly
 // the invisible leader-slot loss this PR exists to remove, so the
-// declined battle is counted and logged at Warn with both hashes.
+// declined leader slot is counted as a could-not-forge and logged at
+// Warn with both hashes.
+//
+// slotBattlesTotal stays where it is: LedgerState.checkSlotBattle
+// already counted this battle when the rival block was accepted, over
+// the same SlotTracker and the same recorder, so the forger counting it
+// again would double it.
 func TestEqualSlotLostBattleUnderTheFenceIsNotSilent(t *testing.T) {
 	const slot = uint64(10)
 	ourHash := bytes.Repeat([]byte{0xa1}, 32)
@@ -833,13 +839,24 @@ func TestEqualSlotLostBattleUnderTheFenceIsNotSilent(t *testing.T) {
 		"a slot the fence has already spent needs no leader selection",
 	)
 
-	// But the loss is accounted for and visible.
+	// The battle itself is counted by LedgerState.checkSlotBattle, not
+	// here. Reaching this case means a block other than ours was
+	// accepted at a slot SlotTracker says we forged, and the only path
+	// that accepts a peer's block already ran checkSlotBattle over the
+	// same tracker and the same recorder — the node wiring points
+	// ForgedBlockChecker at this forger's SlotTracker and
+	// SlotBattleRecorder at the forger itself. Incrementing again here
+	// would double the count, so the forger must leave it alone.
 	assert.Equal(
 		t,
-		float64(1),
+		float64(0),
 		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
-		"a rival's block at a slot we forged is a slot battle we lost",
+		"chainsync owns the slot-battle count for a rival block that "+
+			"was accepted at a slot we forged; the forger must not "+
+			"count it a second time",
 	)
+
+	// The declined leader slot is still visible, which is the point.
 	assert.Equal(
 		t,
 		float64(1),

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -535,3 +535,180 @@ func TestForgeStaleGapSkipMarksScheduledLeaderSlots(t *testing.T) {
 		})
 	}
 }
+
+// newOwnTipGateForger builds a production forger with NO fence store, so
+// the duplicate-slot fence is in-memory only and starts unloaded, and
+// captures its logs at Debug so a test can assert on the level a skip was
+// emitted at.
+func newOwnTipGateForger(
+	t *testing.T,
+	clock forgerTestSlotClock,
+	leader LeaderChecker,
+	builder BlockBuilder,
+	broadcaster BlockBroadcaster,
+) (*BlockForger, *bytes.Buffer) {
+	t.Helper()
+	logs := &bytes.Buffer{}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode: ModeProduction,
+		Logger: slog.New(slog.NewJSONHandler(
+			logs,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		// Deliberately no ForgeFence.
+		SlotClock:    clock,
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	require.False(
+		t,
+		forger.fenceLoaded,
+		"a forger with no fence store must start with an unloaded fence",
+	)
+	// Construction itself warns that no fence store is wired. Drop it so
+	// the buffer holds only what the forge cycle under test emitted.
+	logs.Reset()
+	return forger, logs
+}
+
+// TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence pins that "the block
+// at the tip is ours" is decided by identity, not by the fence
+// bookkeeping alone.
+//
+// The fence is a high-water mark over slots this node committed to, and
+// it is only guaranteed to be present when a durable ForgeFenceStore is
+// wired: without one it is in-memory (see BlockForger.fenceStore), so
+// there are wirings in which the forger holds proof that the block at the
+// tip is its own — SlotTracker recorded the hash it forged for that slot
+// — while the fence signal says nothing. Keying the quiet skip solely on
+// the fence sends that slot to the contested-slot branch, where the node
+// records a slot battle at Warn against its own block and reports a
+// could-not-forge for a slot it did in fact forge.
+//
+// Both subtests run with no fence store at all, leaving the hash as the
+// only signal, and require the forger to tell its own block from a
+// rival's using it.
+func TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence(t *testing.T) {
+	const slot = uint64(10)
+	ourHash := bytes.Repeat([]byte{0xa1}, 32)
+	rivalHash := bytes.Repeat([]byte{0xb2}, 32)
+
+	t.Run("our own block at the tip is a quiet skip", func(t *testing.T) {
+		leader := &forgerCountingLeader{}
+		builder := &forgerTestBuilder{}
+		broadcaster := &forgerTestBroadcaster{}
+		forger, logs := newOwnTipGateForger(
+			t,
+			forgerTestSlotClock{
+				currentSlot:       slot,
+				chainTipSlot:      slot,
+				chainTipHash:      ourHash,
+				slotsPerKESPeriod: 100,
+			},
+			leader,
+			builder,
+			broadcaster,
+		)
+		// We forged this slot and the block was adopted: the tip is
+		// byte-for-byte our block.
+		forger.slotTracker.RecordForgedBlock(slot, ourHash)
+
+		require.NoError(
+			t,
+			forger.checkAndForgeProduction(context.Background()),
+		)
+
+		assert.Zero(
+			t,
+			leader.callCount(),
+			"our own block at our own slot needs no leader selection",
+		)
+		assert.Zero(t, builder.calls, "must not forge a second block")
+		assert.Zero(t, broadcaster.calls)
+		assert.Equal(
+			t,
+			float64(0),
+			testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+			"our own block is not a rival, so this is not a slot battle",
+		)
+		assert.Equal(
+			t,
+			float64(0),
+			testutil.ToFloat64(forger.metrics.forgeCouldNot),
+			"a slot we forged must not report could-not-forge",
+		)
+		assert.NotContains(
+			t,
+			logs.String(),
+			`"level":"WARN"`,
+			"re-entering a slot whose tip block is ours is routine and "+
+				"must not warn",
+		)
+		assert.Contains(
+			t,
+			logs.String(),
+			"forge skip: slot already has our own block",
+		)
+		assert.Contains(
+			t,
+			logs.String(),
+			`"matched_by":"forged_block_hash"`,
+			"the skip must be attributed to the hash match, not to a "+
+				"fence that was never loaded",
+		)
+	})
+
+	t.Run(
+		"a rival block at the tip is still a slot battle",
+		func(t *testing.T) {
+			leader := &forgerCountingLeader{}
+			builder := &forgerTestBuilder{}
+			broadcaster := &forgerTestBroadcaster{}
+			forger, logs := newOwnTipGateForger(
+				t,
+				forgerTestSlotClock{
+					currentSlot:       slot,
+					chainTipSlot:      slot,
+					chainTipHash:      rivalHash,
+					slotsPerKESPeriod: 100,
+				},
+				leader,
+				builder,
+				broadcaster,
+			)
+			// A tracker record for the slot must not be mistaken for
+			// ownership of the block at the tip: we forged for this
+			// slot, but a rival's block is what the chain adopted.
+			forger.slotTracker.RecordForgedBlock(slot, ourHash)
+
+			require.NoError(
+				t,
+				forger.checkAndForgeProduction(context.Background()),
+			)
+
+			assert.Equal(
+				t,
+				1,
+				leader.callCount(),
+				"a rival's block at our slot is a contested slot",
+			)
+			assert.Equal(
+				t,
+				float64(1),
+				testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+			)
+			assert.Zero(t, builder.calls, "must not bind a same-slot parent")
+			assert.Zero(t, broadcaster.calls)
+			assert.Contains(
+				t,
+				logs.String(),
+				`"level":"WARN"`,
+				"a leader slot lost to a rival must be visible",
+			)
+		},
+	)
+}

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -15,6 +15,7 @@
 package forging
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -297,6 +298,166 @@ func TestForgeSkipsLeaderSlotWhenUpstreamTargetUnknownEvenAtTip(
 				float64(1),
 				testutil.ToFloat64(forger.metrics.forgeSyncSkip),
 			)
+		})
+	}
+}
+
+// forgerScheduleAwareLeader reports a fixed set of scheduled leader
+// slots through NextLeaderSlot, the way Election answers from its
+// precomputed VRF schedule, so a test can distinguish a skipped slot
+// this node was due to lead from an ordinary one.
+type forgerScheduleAwareLeader struct {
+	scheduled map[uint64]struct{}
+}
+
+func (l *forgerScheduleAwareLeader) ShouldProduceBlock(slot uint64) bool {
+	_, ok := l.scheduled[slot]
+	return ok
+}
+
+func (l *forgerScheduleAwareLeader) NextLeaderSlot(
+	fromSlot uint64,
+) (uint64, bool) {
+	if _, ok := l.scheduled[fromSlot]; ok {
+		return fromSlot, true
+	}
+	return 0, false
+}
+
+// newGateSkipLogForger builds a production forger whose logs are
+// captured, over a leader checker that answers NextLeaderSlot from a
+// fixed schedule, so a test can read back the level a pre-leader gate
+// skip was logged at.
+func newGateSkipLogForger(
+	t *testing.T,
+	clock forgerTestSlotClock,
+	scheduled map[uint64]struct{},
+) (*BlockForger, *bytes.Buffer) {
+	t.Helper()
+	logs := &bytes.Buffer{}
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode: ModeProduction,
+		Logger: slog.New(slog.NewJSONHandler(
+			logs,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		)),
+		Credentials: setupTestCredentials(t),
+		LeaderChecker: &forgerScheduleAwareLeader{
+			scheduled: scheduled,
+		},
+		BlockBuilder:     &forgerTestBuilder{},
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock:        clock,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	return forger, logs
+}
+
+// TestForgeGateSkipWarnsOnlyForScheduledLeaderSlots pins the log level
+// of both gates that run before leader selection. Such a gate returns
+// from checkAndForgeProduction before checkLeaderSafe, so the slot it
+// drops moves about_to_lead and nothing else: no Forge_node_is_leader,
+// no Forge_node_not_leader, no Forge_could_not_forge. A dropped
+// scheduled leader slot is therefore indistinguishable at INFO from "we
+// were simply not the leader", which is how a producer can decline its
+// own leader slots while every standard SPO dashboard shows it healthy.
+//
+// A gate skip on an ordinary slot is routine and stays at Debug. A gate
+// skip that swallows a slot this node was scheduled to lead is a lost
+// block that nothing downstream will ever mention again, so it is
+// raised to Warn and marked leader_slot=true.
+func TestForgeGateSkipWarnsOnlyForScheduledLeaderSlots(t *testing.T) {
+	// The leader slot under test is slot 10 in both gates.
+	const leaderSlot = uint64(10)
+	for _, gate := range []struct {
+		name  string
+		clock forgerTestSlotClock
+		msg   string
+	}{
+		{
+			// The chain tip has moved past the slot we would
+			// produce for.
+			name: "tip ahead",
+			clock: forgerTestSlotClock{
+				currentSlot:       leaderSlot,
+				chainTipSlot:      leaderSlot + 1,
+				slotsPerKESPeriod: 100,
+			},
+			msg: "forge skip: chain tip is ahead of the current slot",
+		},
+		{
+			// The corroborated upstream target is unknown, so the
+			// node is treated as still syncing even though it is at
+			// its own tip.
+			name: "upstream syncing",
+			clock: forgerTestSlotClock{
+				currentSlot:       leaderSlot,
+				chainTipSlot:      leaderSlot - 1,
+				upstreamTipSlot:   0,
+				upstreamActive:    true,
+				slotsPerKESPeriod: 100,
+			},
+			msg: "chain syncing from peer, skipping forge",
+		},
+	} {
+		t.Run(gate.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name       string
+				scheduled  map[uint64]struct{}
+				wantLevel  string
+				wantMarker bool
+			}{
+				{
+					name:      "ordinary slot stays at debug",
+					scheduled: map[uint64]struct{}{},
+					wantLevel: "DEBUG",
+				},
+				{
+					name: "scheduled leader slot warns",
+					scheduled: map[uint64]struct{}{
+						leaderSlot: {},
+					},
+					wantLevel:  "WARN",
+					wantMarker: true,
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					forger, logs := newGateSkipLogForger(
+						t,
+						gate.clock,
+						tc.scheduled,
+					)
+
+					require.NoError(
+						t,
+						forger.checkAndForgeProduction(
+							context.Background(),
+						),
+					)
+
+					out := logs.String()
+					require.Contains(t, out, gate.msg)
+					assert.Contains(
+						t,
+						out,
+						`"level":"`+tc.wantLevel+`"`,
+					)
+					if tc.wantMarker {
+						assert.Contains(
+							t,
+							out,
+							`"leader_slot":true`,
+						)
+					} else {
+						assert.NotContains(
+							t,
+							out,
+							`"leader_slot":true`,
+						)
+					}
+				})
+			}
 		})
 	}
 }

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -185,3 +185,118 @@ func TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot(
 		"a slot we forged must not report could-not-forge",
 	)
 }
+
+// TestForgeSkipsLeaderSlotWhenUpstreamTargetUnknownEvenAtTip documents
+// the cost of the upstream-sync gate's `upstreamTip == 0` disjunct on a
+// node that is NOT behind.
+//
+// LedgerState.UpstreamSyncStatus returns (0, true) for the whole window
+// between an active-connection switch and the new peer's first
+// authenticated, admitted, trusted header: publishActiveUpstream stores
+// the new connection key with targetSlot zero, and only
+// publishAdmittedUpstreamTarget makes it non-zero. A best-peer switch
+// therefore disables forging outright, independent of how fresh the
+// local tip is and independent of forgeSyncToleranceSlots.
+//
+// The clock below is a healthy steady-state producer: the chain tip is
+// the previous slot's block, i.e. the node is at tip. It is scheduled to
+// lead the current slot. It forges nothing, and the only counter that
+// moves is dingo_forge_sync_skip_total, which is shared with the
+// genuinely-behind case, so the lost leader slot is not recoverable from
+// /metrics.
+//
+// This test asserts the CURRENT behaviour, which is deliberate and is
+// already pinned by
+// TestCheckAndForgeProductionWaitsForUnknownActiveUpstreamTarget. It is
+// written to make the trade-off concrete and reviewable rather than to
+// change it; the fix is a separate discussion (see the linked issue).
+// If the gate is later keyed on local tip freshness instead of on the
+// upstream target being known, this test fails and names the decision
+// that was revisited.
+func TestForgeSkipsLeaderSlotWhenUpstreamTargetUnknownEvenAtTip(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name      string
+		tolerance uint64
+	}{
+		// The tolerance is irrelevant to this branch of the gate: the
+		// `upstreamTip == 0` disjunct is not compared against it.
+		{name: "default tolerance", tolerance: 0},
+		{name: "tolerance far wider than the lag", tolerance: 100000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			leader := &forgerCountingLeader{}
+			builder := &forgerTestBuilder{}
+			broadcaster := &forgerTestBroadcaster{}
+			forger, err := NewBlockForger(ForgerConfig{
+				Mode: ModeProduction,
+				Logger: slog.New(
+					slog.NewJSONHandler(io.Discard, nil),
+				),
+				Credentials:      setupTestCredentials(t),
+				LeaderChecker:    leader,
+				BlockBuilder:     builder,
+				BlockBroadcaster: broadcaster,
+				SlotClock: forgerTestSlotClock{
+					// At tip: the tip is the previous slot's block.
+					currentSlot:  10,
+					chainTipSlot: 9,
+					// A peer switch has just happened, so the
+					// corroborated upstream target is not yet known.
+					upstreamTipSlot:   0,
+					upstreamActive:    true,
+					slotsPerKESPeriod: 100,
+				},
+				ForgeSyncToleranceSlots: tc.tolerance,
+				PromRegistry:            prometheus.NewRegistry(),
+			})
+			require.NoError(t, err)
+
+			require.NoError(
+				t,
+				forger.checkAndForgeProduction(context.Background()),
+			)
+
+			assert.Zero(
+				t,
+				leader.callCount(),
+				"leader selection is never reached, so the node cannot "+
+					"know it just lost a leader slot",
+			)
+			assert.Zero(t, builder.calls)
+			assert.Zero(t, broadcaster.calls)
+
+			// The loss is invisible in every cardano-node-compatible
+			// counter: about_to_lead moves, nothing else does.
+			assert.Equal(
+				t,
+				float64(1),
+				testutil.ToFloat64(forger.metrics.forgeAboutToLead),
+			)
+			assert.Equal(
+				t,
+				float64(0),
+				testutil.ToFloat64(forger.metrics.forgeNotLeader),
+			)
+			assert.Equal(
+				t,
+				float64(0),
+				testutil.ToFloat64(forger.metrics.forgeNodeIsLeader),
+			)
+			assert.Equal(
+				t,
+				float64(0),
+				testutil.ToFloat64(forger.metrics.forgeCouldNot),
+			)
+			// The one series that does move cannot distinguish "upstream
+			// is ahead of us" from "we have not heard from the peer we
+			// selected a moment ago".
+			assert.Equal(
+				t,
+				float64(1),
+				testutil.ToFloat64(forger.metrics.forgeSyncSkip),
+			)
+		})
+	}
+}

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newGateTestForger builds a production forger over an explicit slot
+// clock so a test can place the chain tip ahead of, at, or behind the
+// current slot and observe which pre-leader gate in
+// checkAndForgeProduction fires.
+func newGateTestForger(
+	t *testing.T,
+	clock forgerTestSlotClock,
+	leader LeaderChecker,
+	builder BlockBuilder,
+	broadcaster BlockBroadcaster,
+	fence ForgeFenceStore,
+) *BlockForger {
+	t.Helper()
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		ForgeFence:       fence,
+		SlotClock:        clock,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	return forger
+}
+
+// TestCheckAndForgeProductionEqualSlotReachesLeaderCheck pins the EQ
+// half of the tip gate. A rival pool forging the same slot and winning
+// the propagation race puts the chain tip AT the current slot, not past
+// it. ouroboros-consensus treats that as a contested slot rather than a
+// reason to stop: mkCurrentBlockContext declines only for GT
+// (TraceBlockFromFuture) and, for EQ, builds a block context on the
+// tip's predecessor so the node still participates.
+//
+// Dingo instead folded EQ into the GT skip with `currentSlot <=
+// tipSlot`, which returns before checkLeaderSafe. The slot never
+// reaches leader selection, so no leadership counter moves and the only
+// trace is a Debug line: the loss is invisible on every dashboard.
+//
+// The slot must at minimum reach leader selection and be accounted for.
+func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{}
+	broadcaster := &forgerTestBroadcaster{}
+	forger := newGateTestForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		leader,
+		builder,
+		broadcaster,
+		nil,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	assert.Equal(
+		t,
+		1,
+		leader.callCount(),
+		"a tip at the current slot is a contested slot, not a reason "+
+			"to skip leader selection",
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeNodeIsLeader),
+		"the contested slot must be counted as a leader slot",
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+		"a rival block occupying our leader slot is a slot battle",
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+		"a leader slot we did not produce for must be visible as a "+
+			"could-not-forge, not as silence",
+	)
+
+	// The block must NOT be built. BuildBlock binds the parent to the
+	// live chain tip, which here is the rival's block at this same
+	// slot; the resulting block would carry a parent whose slot equals
+	// its own and be rejected by ledger.validateBlockOrder. Forging a
+	// valid alternative needs the tip's predecessor as parent, which
+	// the builder cannot express yet.
+	assert.Zero(
+		t,
+		builder.calls,
+		"must not bind a same-slot parent",
+	)
+	assert.Zero(t, broadcaster.calls)
+}
+
+// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the
+// anti-equivocation companion to the test above. The slot-aligned loop
+// can re-enter a slot it already committed to (a clock that has not
+// advanced, or a NextSlotTime already in the past), and after a
+// successful forge the chain tip is our OWN block at that slot, so
+// tipSlot == currentSlot there too.
+//
+// That case must stay a quiet skip: it is not a slot battle, it must
+// not build a second block for a slot this node already signed for, and
+// it must not report a could-not-forge for a slot that was in fact
+// forged.
+func TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot(
+	t *testing.T,
+) {
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{}
+	broadcaster := &forgerTestBroadcaster{}
+	// The fence records slot 10 as already committed to by this node,
+	// which is what "the block at the tip is ours" means before the
+	// block has been adopted.
+	fence := &fenceTestStore{slot: 10, present: true}
+	forger := newGateTestForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		leader,
+		builder,
+		broadcaster,
+		fence,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	assert.Zero(t, builder.calls, "must not forge a second block")
+	assert.Zero(t, broadcaster.calls)
+	assert.Empty(t, fence.stored, "must not advance the fence")
+	assert.Zero(
+		t,
+		leader.callCount(),
+		"our own block at our own slot needs no leader selection",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+		"our own block is not a rival",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+		"a slot we forged must not report could-not-forge",
+	)
+}

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -536,16 +538,18 @@ func TestForgeStaleGapSkipMarksScheduledLeaderSlots(t *testing.T) {
 	}
 }
 
-// newOwnTipGateForger builds a production forger with NO fence store, so
-// the duplicate-slot fence is in-memory only and starts unloaded, and
-// captures its logs at Debug so a test can assert on the level a skip was
-// emitted at.
+// newOwnTipGateForger builds a production forger over an explicit slot
+// clock and an optional fence store, and captures its logs at Debug so a
+// test can assert on the level a skip was emitted at. Passing a nil
+// fence leaves the duplicate-slot fence in-memory and unloaded, which is
+// how a wiring with no metadata store behaves.
 func newOwnTipGateForger(
 	t *testing.T,
-	clock forgerTestSlotClock,
+	clock SlotClockProvider,
 	leader LeaderChecker,
 	builder BlockBuilder,
 	broadcaster BlockBroadcaster,
+	fence ForgeFenceStore,
 ) (*BlockForger, *bytes.Buffer) {
 	t.Helper()
 	logs := &bytes.Buffer{}
@@ -559,15 +563,16 @@ func newOwnTipGateForger(
 		LeaderChecker:    leader,
 		BlockBuilder:     builder,
 		BlockBroadcaster: broadcaster,
-		// Deliberately no ForgeFence.
-		SlotClock:    clock,
-		PromRegistry: prometheus.NewRegistry(),
+		ForgeFence:       fence,
+		SlotClock:        clock,
+		PromRegistry:     prometheus.NewRegistry(),
 	})
 	require.NoError(t, err)
-	require.False(
+	require.Equal(
 		t,
+		fence != nil,
 		forger.fenceLoaded,
-		"a forger with no fence store must start with an unloaded fence",
+		"the fence must be loaded exactly when a fence store is wired",
 	)
 	// Construction itself warns that no fence store is wired. Drop it so
 	// the buffer holds only what the forge cycle under test emitted.
@@ -612,6 +617,7 @@ func TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence(t *testing.T) {
 			leader,
 			builder,
 			broadcaster,
+			nil,
 		)
 		// We forged this slot and the block was adopted: the tip is
 		// byte-for-byte our block.
@@ -679,6 +685,7 @@ func TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence(t *testing.T) {
 				leader,
 				builder,
 				broadcaster,
+				nil,
 			)
 			// A tracker record for the slot must not be mistaken for
 			// ownership of the block at the tip: we forged for this
@@ -710,5 +717,148 @@ func TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence(t *testing.T) {
 				"a leader slot lost to a rival must be visible",
 			)
 		},
+	)
+}
+
+// forgerMovingTipSlotClock is a slot clock whose chain tip moves between
+// the read at the top of a forge cycle and the read taken next to the
+// tip hash. The first ChainTipSlot call answers chainTipSlot, every
+// later one answers movedTipSlot, which is what a rival block landing
+// mid-cycle looks like to the forger.
+type forgerMovingTipSlotClock struct {
+	currentSlot       uint64
+	chainTipSlot      uint64
+	movedTipSlot      uint64
+	chainTipHash      []byte
+	slotsPerKESPeriod uint64
+
+	mu        sync.Mutex
+	tipReads  int
+	hashReads int
+}
+
+func (c *forgerMovingTipSlotClock) CurrentSlot() (uint64, error) {
+	return c.currentSlot, nil
+}
+
+func (c *forgerMovingTipSlotClock) SlotsPerKESPeriod() uint64 {
+	return c.slotsPerKESPeriod
+}
+
+func (c *forgerMovingTipSlotClock) ChainTipSlot() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tipReads++
+	if c.tipReads == 1 {
+		return c.chainTipSlot
+	}
+	return c.movedTipSlot
+}
+
+func (c *forgerMovingTipSlotClock) ChainTipHash() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hashReads++
+	return c.chainTipHash
+}
+
+func (*forgerMovingTipSlotClock) NextSlotTime() (time.Time, error) {
+	return time.Now(), nil
+}
+
+func (*forgerMovingTipSlotClock) UpstreamTipSlot() uint64 {
+	return 0
+}
+
+func (*forgerMovingTipSlotClock) UpstreamSyncStatus() (uint64, bool) {
+	return 0, false
+}
+
+func (c *forgerMovingTipSlotClock) reads() (int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.tipReads, c.hashReads
+}
+
+// TestEqualSlotOwnershipIsInconclusiveWhenTheTipMoves pins the tip-slot
+// re-read inside the ownership check.
+//
+// tipSlot is sampled once at the top of checkAndForgeProduction, and the
+// chain can move before ChainTipHash is read. Comparing a hash from one
+// tip against a slot from another decides ownership from two different
+// blocks: here it would read a rival's hash and conclude we lost a
+// battle at slot 10 when the tip has in fact already moved past it.
+//
+// Re-reading the tip slot next to the hash makes that disagreement
+// inconclusive instead, and the decision falls back to the fence, which
+// is the conservative answer. The reads are still not atomic, so this
+// narrows the window rather than closing it; what it guarantees is that
+// a moved tip cannot manufacture a slot-battle report.
+func TestEqualSlotOwnershipIsInconclusiveWhenTheTipMoves(t *testing.T) {
+	const slot = uint64(10)
+	ourHash := bytes.Repeat([]byte{0xa1}, 32)
+	rivalHash := bytes.Repeat([]byte{0xb2}, 32)
+
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{}
+	broadcaster := &forgerTestBroadcaster{}
+	fence := &fenceTestStore{slot: slot, present: true}
+	clock := &forgerMovingTipSlotClock{
+		currentSlot: slot,
+		// The cycle opens with the tip at the current slot...
+		chainTipSlot: slot,
+		// ...and it has moved on by the time the hash is read.
+		movedTipSlot:      slot + 1,
+		chainTipHash:      rivalHash,
+		slotsPerKESPeriod: 100,
+	}
+	forger, logs := newOwnTipGateForger(
+		t,
+		clock,
+		leader,
+		builder,
+		broadcaster,
+		fence,
+	)
+	forger.slotTracker.RecordForgedBlock(slot, ourHash)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	tipReads, hashReads := clock.reads()
+	assert.Equal(
+		t,
+		2,
+		tipReads,
+		"the tip slot must be re-read next to the hash, not reused "+
+			"from the top of the cycle",
+	)
+	assert.Equal(t, 1, hashReads)
+
+	assert.Zero(t, builder.calls)
+	assert.Zero(t, broadcaster.calls)
+	assert.Empty(t, fence.stored)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+		"a tip that moved proves nothing about who held slot 10",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+	logged := logs.String()
+	assert.NotContains(
+		t,
+		logged,
+		`"level":"WARN"`,
+		"an inconclusive comparison must not be reported as a lost battle",
+	)
+	assert.Contains(
+		t,
+		logged,
+		`"matched_by":"forge_fence"`,
+		"the decision must fall back to the fence",
 	)
 }

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -461,3 +461,77 @@ func TestForgeGateSkipWarnsOnlyForScheduledLeaderSlots(t *testing.T) {
 		})
 	}
 }
+
+// TestForgeStaleGapSkipMarksScheduledLeaderSlots covers the sub-branch
+// of the tip-ahead gate that the marker would otherwise miss. When the
+// tip runs further ahead than forgeStaleGapThresholdSlots the gate
+// diagnoses a stale database at Error instead of routing the skip
+// through logGateSkip, but it drops the slot just as silently and just
+// as far before leader selection. The severity and wording are the
+// operator's stale-genesis signal and stay as they are; the slot is
+// additionally marked leader_slot=true when it was one this node was
+// scheduled to lead, so a block lost this way is still attributable.
+func TestForgeStaleGapSkipMarksScheduledLeaderSlots(t *testing.T) {
+	const leaderSlot = uint64(10)
+	// Well past the default forgeStaleGapThresholdSlots of 1000, so
+	// the gate takes the stale-database branch.
+	clock := forgerTestSlotClock{
+		currentSlot:       leaderSlot,
+		chainTipSlot:      leaderSlot + 2000,
+		slotsPerKESPeriod: 100,
+	}
+	const msg = "chain tip is far ahead of slot clock; " +
+		"database may contain data from a different genesis"
+
+	for _, tc := range []struct {
+		name       string
+		scheduled  map[uint64]struct{}
+		wantMarker bool
+	}{
+		{
+			name:      "ordinary slot is not marked",
+			scheduled: map[uint64]struct{}{},
+		},
+		{
+			name: "scheduled leader slot is marked",
+			scheduled: map[uint64]struct{}{
+				leaderSlot: {},
+			},
+			wantMarker: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forger, logs := newGateSkipLogForger(
+				t,
+				clock,
+				tc.scheduled,
+			)
+
+			require.NoError(
+				t,
+				forger.checkAndForgeProduction(
+					context.Background(),
+				),
+			)
+
+			out := logs.String()
+			require.Contains(t, out, msg)
+			// The stale-genesis diagnosis keeps its severity
+			// whether or not the slot was a scheduled one.
+			assert.Contains(t, out, `"level":"ERROR"`)
+			if tc.wantMarker {
+				assert.Contains(
+					t,
+					out,
+					`"leader_slot":true`,
+				)
+			} else {
+				assert.NotContains(
+					t,
+					out,
+					`"leader_slot":true`,
+				)
+			}
+		})
+	}
+}

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -17,6 +17,7 @@ package forging
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"sync"
@@ -778,6 +779,100 @@ func (c *forgerMovingTipSlotClock) reads() (int, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.tipReads, c.hashReads
+}
+
+// TestEqualSlotLostBattleUnderTheFenceIsNotSilent covers the case where
+// the two ownership signals disagree: the fence says this node already
+// committed to the slot, and the recorded forge hash says the block that
+// actually won it belongs to someone else.
+//
+// The fence must still win the forging decision. A slot at or below the
+// fence may already have a signed, diffused block behind it, and signing
+// a second different block for it is equivocation; losing a slot battle
+// is not a licence to equivocate. So: no build, no broadcast, no
+// advance of the fence.
+//
+// What must change is that the loss stops being silent. Reporting it as
+// "slot already has our own block" at Debug is both false and exactly
+// the invisible leader-slot loss this PR exists to remove, so the
+// declined battle is counted and logged at Warn with both hashes.
+func TestEqualSlotLostBattleUnderTheFenceIsNotSilent(t *testing.T) {
+	const slot = uint64(10)
+	ourHash := bytes.Repeat([]byte{0xa1}, 32)
+	rivalHash := bytes.Repeat([]byte{0xb2}, 32)
+
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{}
+	broadcaster := &forgerTestBroadcaster{}
+	fence := &fenceTestStore{slot: slot, present: true}
+	forger, logs := newOwnTipGateForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       slot,
+			chainTipSlot:      slot,
+			chainTipHash:      rivalHash,
+			slotsPerKESPeriod: 100,
+		},
+		leader,
+		builder,
+		broadcaster,
+		fence,
+	)
+	// We forged for this slot, but the chain adopted a rival's block.
+	forger.slotTracker.RecordForgedBlock(slot, ourHash)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	// The fence still refuses the slot.
+	assert.Zero(t, builder.calls, "the fence must still forbid a second block")
+	assert.Zero(t, broadcaster.calls)
+	assert.Empty(t, fence.stored, "must not advance the fence")
+	assert.Zero(
+		t,
+		leader.callCount(),
+		"a slot the fence has already spent needs no leader selection",
+	)
+
+	// But the loss is accounted for and visible.
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+		"a rival's block at a slot we forged is a slot battle we lost",
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+		"a leader slot we did not hold must be visible as a "+
+			"could-not-forge, not as silence",
+	)
+	logged := logs.String()
+	assert.Contains(t, logged, `"level":"WARN"`)
+	assert.Contains(
+		t,
+		logged,
+		"slot battle lost: rival block at tip for a slot this node "+
+			"already forged",
+	)
+	assert.Contains(
+		t,
+		logged,
+		hex.EncodeToString(ourHash),
+		"the log must name the block we forged",
+	)
+	assert.Contains(
+		t,
+		logged,
+		hex.EncodeToString(rivalHash),
+		"the log must name the block that won the slot",
+	)
+	assert.NotContains(
+		t,
+		logged,
+		"forge skip: slot already has our own block",
+		"the block at the tip is demonstrably not ours",
+	)
 }
 
 // TestEqualSlotOwnershipIsInconclusiveWhenTheTipMoves pins the tip-slot

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -677,10 +677,12 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 
 	tipSlot := f.slotClock.ChainTipSlot()
 
-	// Skip if a block already exists at the current slot.
-	// When tipSlot >= currentSlot, the chain already has a block at
-	// this slot (possibly from a peer). Producing another would create
-	// a competing block and fork the chain.
+	// Skip if the chain has already moved PAST the current slot.
+	// A tip beyond currentSlot means any block we produced would fork
+	// the chain below its own tip. A tip AT currentSlot is the
+	// contested case and is handled after leader selection below:
+	// ouroboros-consensus mkCurrentBlockContext declines only for GT
+	// and treats EQ as a slot battle.
 	// Count every slot check (matches cardano-node
 	// Forge.about_to_lead)
 	if f.metrics != nil {
@@ -688,10 +690,10 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		f.metrics.tipGapSlots.Set(0)
 	}
 
-	if currentSlot <= tipSlot {
+	if currentSlot < tipSlot {
 		// Detect stale data: if the tip is far ahead of the slot clock,
 		// the database likely contains chain data from a different genesis.
-		// Use subtraction (safe here since tipSlot >= currentSlot from
+		// Use subtraction (safe here since tipSlot > currentSlot from
 		// the outer check) to avoid uint64 overflow on the addition.
 		gap := tipSlot - currentSlot
 		if f.metrics != nil {
@@ -709,11 +711,27 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			)
 		} else {
 			f.logger.Debug(
-				"forge skip: slot already has block",
+				"forge skip: chain tip is ahead of the current slot",
 				"current_slot", currentSlot,
 				"tip_slot", tipSlot,
 			)
 		}
+		return nil
+	}
+
+	// The tip is at the current slot and the block there is one this
+	// node already committed to forging, so the slot-aligned loop has
+	// simply re-entered a slot it already used. Leave without running
+	// leader selection: this is not a contested slot, and the fence
+	// below would refuse it anyway.
+	if currentSlot == tipSlot && f.fenceLoaded &&
+		currentSlot <= f.lastForgedSlot {
+		f.logger.Debug(
+			"forge skip: slot already has our own block",
+			"current_slot", currentSlot,
+			"tip_slot", tipSlot,
+			"last_forged_slot", f.lastForgedSlot,
+		)
 		return nil
 	}
 
@@ -880,6 +898,32 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// the pre-selection gate.
 	if f.metrics != nil {
 		f.metrics.forgeNodeIsLeader.Inc()
+	}
+
+	// A rival block already occupies this leader slot. This is a slot
+	// battle, not a reason to treat the slot as spent: the reference
+	// implementation forges an alternative here (same block number, the
+	// tip's predecessor as parent) and lets the leader VRF and chain
+	// selection arbitrate.
+	//
+	// Dingo cannot build that alternative yet. BlockBuilder binds the
+	// parent to the live chain tip, so a block forged now would name a
+	// parent whose slot equals its own and be rejected by
+	// ledger.validateBlockOrder; binding the tip's predecessor instead
+	// needs a block that does not extend the local tip, which
+	// chain.addBlockLocked refuses. Until that path exists, record the
+	// battle we are declining rather than dropping the slot silently.
+	if currentSlot == tipSlot {
+		if f.metrics != nil {
+			f.metrics.slotBattlesTotal.Inc()
+		}
+		f.incCouldNotForge()
+		f.logger.Warn(
+			"forge skip: leader slot already holds another block; forging an alternative is not supported",
+			"current_slot", currentSlot,
+			"tip_slot", tipSlot,
+		)
+		return nil
 	}
 
 	// Commit to this slot before any signing happens for it, including

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -710,7 +710,8 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 				gap,
 			)
 		} else {
-			f.logger.Debug(
+			f.logGateSkip(
+				currentSlot,
 				"forge skip: chain tip is ahead of the current slot",
 				"current_slot", currentSlot,
 				"tip_slot", tipSlot,
@@ -755,7 +756,8 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 				float64(gap),
 			)
 		}
-		f.logger.Debug(
+		f.logGateSkip(
+			currentSlot,
 			"chain syncing from peer, skipping forge",
 			"current_slot", currentSlot,
 			"tip_slot", tipSlot,
@@ -1317,6 +1319,48 @@ func (f *BlockForger) checkOpCertSequence(
 		opCert.IssueNumber,
 		!limits.era.isTPraos(),
 	)
+}
+
+// logGateSkip logs a slot dropped by a gate that runs before leader
+// selection. Such skips are routine and stay at Debug, but one that
+// swallows a slot this node was scheduled to lead is a lost block, and
+// nothing downstream will ever mention that slot again, so it is raised
+// to Warn.
+func (f *BlockForger) logGateSkip(
+	slot uint64,
+	msg string,
+	attrs ...any,
+) {
+	if f.isScheduledLeaderSlot(slot) {
+		f.logger.Warn(msg, append(attrs, "leader_slot", true)...)
+		return
+	}
+	f.logger.Debug(msg, attrs...)
+}
+
+// isScheduledLeaderSlot reports whether slot is one this node is
+// scheduled to lead, by consulting the precomputed VRF leader schedule
+// rather than running leader selection. Election.NextLeaderSlot is a
+// read-locked scan of the cached schedule for the slot's epoch, so it
+// is cheap enough to call on a skip path.
+//
+// It only decides a log level, so it fails quiet: a checker with no
+// cached schedule for that epoch reports false and the skip stays at
+// Debug. A panic in the pluggable checker is recovered for the same
+// reason checkLeaderSafe recovers one — it must not take down the
+// producer-loop goroutine.
+func (f *BlockForger) isScheduledLeaderSlot(slot uint64) (scheduled bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			scheduled = false
+			f.reportForgeCallbackPanic("schedule", r)
+		}
+	}()
+	if f.leaderChecker == nil {
+		return false
+	}
+	next, ok := f.leaderChecker.NextLeaderSlot(slot)
+	return ok && next == slot
 }
 
 // checkLeaderSafe calls the pluggable LeaderChecker, recovering any

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -700,14 +700,27 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			f.metrics.tipGapSlots.Set(float64(gap))
 		}
 		if gap > f.forgeStaleGapThresholdSlots {
-			f.logger.Error(
-				"chain tip is far ahead of slot clock; database may contain data from a different genesis",
+			// This gate also runs before leader selection, so it
+			// swallows a scheduled leader slot as silently as the
+			// skips routed through logGateSkip. The stale-genesis
+			// diagnosis stays at Error, but carry the same
+			// leader_slot marker so a lost block is still
+			// attributable. Reuse isScheduledLeaderSlot rather
+			// than repeating the schedule lookup.
+			attrs := []any{
 				"current_slot",
 				currentSlot,
 				"tip_slot",
 				tipSlot,
 				"slot_gap",
 				gap,
+			}
+			if f.isScheduledLeaderSlot(currentSlot) {
+				attrs = append(attrs, "leader_slot", true)
+			}
+			f.logger.Error(
+				"chain tip is far ahead of slot clock; database may contain data from a different genesis",
+				attrs...,
 			)
 		} else {
 			f.logGateSkip(

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -748,22 +748,60 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
-	// The tip is at the current slot and the block there is one this
-	// node produced, so the slot-aligned loop has simply re-entered a
-	// slot it already used. Leave without running leader selection:
-	// this is not a contested slot, and the fence below would refuse
-	// it anyway.
+	// The tip is at the current slot. Before treating that as a
+	// contested slot, work out whether the block sitting there is one
+	// this node produced.
 	if currentSlot == tipSlot {
-		if ours, matchedBy := f.tipBlockIsOurs(currentSlot); ours {
+		ownership, ourHash, tipHash := f.tipBlockOwnership(currentSlot)
+		fenceCovers := f.fenceLoaded && currentSlot <= f.lastForgedSlot
+		switch {
+		case ownership == tipOwnershipOurs:
+			// The slot-aligned loop has simply re-entered a slot
+			// whose block is provably ours. Not a contested slot,
+			// and the fence would refuse it anyway.
 			f.logger.Debug(
 				"forge skip: slot already has our own block",
 				"current_slot", currentSlot,
 				"tip_slot", tipSlot,
 				"last_forged_slot", f.lastForgedSlot,
-				"matched_by", matchedBy,
+				"matched_by", "forged_block_hash",
+			)
+			return nil
+		case ownership == tipOwnershipRival && fenceCovers:
+			// We committed to this slot and a rival's block is what
+			// the chain adopted for it. The fence still forbids
+			// forging: a second, different block for a slot whose
+			// first block may already have reached peers is
+			// equivocation, and losing a battle is not a licence to
+			// equivocate. But this is a slot battle we lost, not
+			// "the tip block is ours", and dropping it at Debug is
+			// exactly the silent loss this change exists to remove.
+			f.RecordSlotBattle()
+			f.incCouldNotForge()
+			f.logger.Warn(
+				"slot battle lost: rival block at tip for a slot this node already forged",
+				"current_slot", currentSlot,
+				"tip_slot", tipSlot,
+				"last_forged_slot", f.lastForgedSlot,
+				"our_block_hash", hex.EncodeToString(ourHash),
+				"tip_block_hash", hex.EncodeToString(tipHash),
+			)
+			return nil
+		case fenceCovers:
+			// Ownership is inconclusive, but the fence says this
+			// node already committed to the slot, so it is not
+			// available regardless of who holds the tip.
+			f.logger.Debug(
+				"forge skip: slot already has our own block",
+				"current_slot", currentSlot,
+				"tip_slot", tipSlot,
+				"last_forged_slot", f.lastForgedSlot,
+				"matched_by", "forge_fence",
 			)
 			return nil
 		}
+		// Neither signal claims the slot: fall through and let leader
+		// selection and the contested-slot branch account for it.
 	}
 
 	// Skip if the chain is still syncing from a peer.
@@ -1303,67 +1341,85 @@ func (f *BlockForger) reserveForgeSlot(slot uint64) (bool, error) {
 	return true, nil
 }
 
-// tipBlockIsOurs reports whether the block occupying slot at the chain
-// tip is one this node produced, and which signal decided it.
+// tipOwnership is the outcome of comparing the block sitting at the
+// chain tip against the block this node forged for a given slot.
+type tipOwnership int
+
+const (
+	// tipOwnershipUnknown means the comparison could not be made: no
+	// recorded hash for the slot, a slot clock that cannot report a tip
+	// hash, an empty hash on either side, or a tip that moved between
+	// the two reads. The caller must fall back to the fence.
+	tipOwnershipUnknown tipOwnership = iota
+	// tipOwnershipOurs means the tip block is byte-for-byte the block
+	// this node forged for the slot.
+	tipOwnershipOurs
+	// tipOwnershipRival means the tip holds a different block for a slot
+	// this node forged for: a slot battle this node lost.
+	tipOwnershipRival
+)
+
+// tipBlockOwnership reports whether the block at the chain tip for slot
+// is the one this node forged, a rival's, or indeterminate, together
+// with the two hashes it compared (nil when indeterminate).
 //
-// The primary signal is identity, not bookkeeping: SlotTracker already
-// records the hash of every block this node forged and adopted, so a tip
-// hash equal to that record proves the block at the tip is ours rather
-// than a rival's. That check is independent of whether a durable
-// ForgeFenceStore is wired, which matters because the fence is in-memory
-// only when it is not (see fenceStore above).
+// This is identity rather than bookkeeping. SlotTracker already records
+// the hash of every block this node forged and adopted, so comparing it
+// against the hash at the tip distinguishes "we re-entered our own slot"
+// from "we lost this slot to a rival". The forge fence cannot make that
+// distinction: it is a high-water mark over slots this node committed
+// to, so it reports both cases identically, and it is durable only
+// through a ForgeFenceStore, so where none is wired (see fenceStore
+// above) it can be silent about a slot this node demonstrably forged.
 //
-// The fence is kept as an additional guard, not replaced. It covers the
-// window the tracker cannot: reserveForgeSlot writes the fence *before*
-// the header for a slot is signed, while RecordForgedBlock runs only
-// after the block is adopted, so between those two points the slot is
-// already ours but has no recorded hash yet. The fence is also the only
-// signal available when the wired slot clock does not implement
-// ChainTipHashProvider.
+// The fence is not replaced by this, and the caller must keep consulting
+// it. It covers the window the tracker cannot: reserveForgeSlot writes
+// the fence *before* the header for a slot is signed, while
+// RecordForgedBlock runs only after adoption, so between those two
+// points the slot is already ours but has no recorded hash yet. More
+// importantly, a fence that covers the slot forbids forging even when
+// this function answers tipOwnershipRival — losing a slot battle is not
+// a licence to sign a second block for a slot whose first block may
+// already have reached peers.
 //
 // Neither signal survives a process restart on its own: the tracker is
-// in-memory, and the fence is durable only through a ForgeFenceStore.
-func (f *BlockForger) tipBlockIsOurs(slot uint64) (bool, string) {
-	if f.tipHashMatchesForgedBlock(slot) {
-		return true, "forged_block_hash"
-	}
-	if f.fenceLoaded && slot <= f.lastForgedSlot {
-		return true, "forge_fence"
-	}
-	return false, ""
-}
-
-// tipHashMatchesForgedBlock reports whether the current chain tip is the
-// exact block this node forged for slot. It answers false whenever any
-// input is missing (no tracker record, no tip-hash capable slot clock,
-// an empty hash on either side) or the tip has moved off slot between
-// the two reads, so the caller falls back to the fence.
-func (f *BlockForger) tipHashMatchesForgedBlock(slot uint64) bool {
+// in-memory, and the fence is durable only through a store.
+//
+// The result can only choose between skipping quietly and skipping
+// loudly; no branch of the equal-slot gate forges, so a wrong answer
+// here cannot produce a block.
+func (f *BlockForger) tipBlockOwnership(
+	slot uint64,
+) (tipOwnership, []byte, []byte) {
 	if f.slotTracker == nil {
-		return false
+		return tipOwnershipUnknown, nil, nil
 	}
 	forgedHash, ok := f.slotTracker.WasForgedByUs(slot)
 	if !ok || len(forgedHash) == 0 {
-		return false
+		return tipOwnershipUnknown, nil, nil
 	}
 	provider, hasTipHash := f.slotClock.(ChainTipHashProvider)
 	if !hasTipHash {
-		return false
+		return tipOwnershipUnknown, nil, nil
 	}
 	tipHash := provider.ChainTipHash()
 	if len(tipHash) == 0 {
-		return false
+		return tipOwnershipUnknown, nil, nil
 	}
 	// The caller's tipSlot was sampled at the top of the forge cycle and
 	// the chain can move underneath it, so this hash need not belong to
 	// the slot being decided. Re-read the tip slot next to the hash and
-	// refuse to conclude anything if the tip is no longer at this slot,
-	// which sends the caller back to the fence. The two reads are still
-	// not atomic, so this narrows the window rather than closing it.
+	// refuse to conclude anything if the tip is no longer at this slot.
+	// The two reads are still not atomic, so this narrows the window
+	// rather than closing it; every remaining disagreement resolves to
+	// tipOwnershipUnknown or to a Warn, never to a forge.
 	if f.slotClock.ChainTipSlot() != slot {
-		return false
+		return tipOwnershipUnknown, nil, nil
 	}
-	return bytes.Equal(tipHash, forgedHash)
+	if bytes.Equal(tipHash, forgedHash) {
+		return tipOwnershipOurs, forgedHash, tipHash
+	}
+	return tipOwnershipRival, forgedHash, tipHash
 }
 
 func (f *BlockForger) incCouldNotForge() {

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -776,7 +776,17 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			// equivocate. But this is a slot battle we lost, not
 			// "the tip block is ours", and dropping it at Debug is
 			// exactly the silent loss this change exists to remove.
-			f.RecordSlotBattle()
+			//
+			// slotBattlesTotal is deliberately NOT incremented here.
+			// Reaching this case means a block other than ours was
+			// accepted at a slot SlotTracker says we forged, and the
+			// only path that accepts a peer's block already ran
+			// LedgerState.checkSlotBattle over the same tracker
+			// (node wiring points ForgedBlockChecker at this
+			// forger's SlotTracker and SlotBattleRecorder at this
+			// forger), which found the same hash mismatch and
+			// counted the battle. chainsync owns that count;
+			// counting it again here would double it.
 			f.incCouldNotForge()
 			f.logger.Warn(
 				"slot battle lost: rival block at tip for a slot this node already forged",
@@ -983,6 +993,17 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// needs a block that does not extend the local tip, which
 	// chain.addBlockLocked refuses. Until that path exists, record the
 	// battle we are declining rather than dropping the slot silently.
+	//
+	// Unlike the rival-under-fence case in the equal-slot gate above,
+	// counting the battle here does not double up with
+	// LedgerState.checkSlotBattle. Reaching this point means the gate
+	// found no fence covering the slot, which in turn means
+	// reserveForgeSlot never ran for it, which means SlotTracker holds
+	// no record of it either — the fence is written before signing and
+	// RecordForgedBlock only after adoption, so a tracker record cannot
+	// exist without a fence. checkSlotBattle returns early when
+	// WasForgedByUs says we never forged the slot, so this is the only
+	// place the battle is counted.
 	if currentSlot == tipSlot {
 		if f.metrics != nil {
 			f.metrics.slotBattlesTotal.Inc()

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1336,7 +1336,8 @@ func (f *BlockForger) tipBlockIsOurs(slot uint64) (bool, string) {
 // tipHashMatchesForgedBlock reports whether the current chain tip is the
 // exact block this node forged for slot. It answers false whenever any
 // input is missing (no tracker record, no tip-hash capable slot clock,
-// an empty hash on either side) so the caller falls back to the fence.
+// an empty hash on either side) or the tip has moved off slot between
+// the two reads, so the caller falls back to the fence.
 func (f *BlockForger) tipHashMatchesForgedBlock(slot uint64) bool {
 	if f.slotTracker == nil {
 		return false
@@ -1351,6 +1352,15 @@ func (f *BlockForger) tipHashMatchesForgedBlock(slot uint64) bool {
 	}
 	tipHash := provider.ChainTipHash()
 	if len(tipHash) == 0 {
+		return false
+	}
+	// The caller's tipSlot was sampled at the top of the forge cycle and
+	// the chain can move underneath it, so this hash need not belong to
+	// the slot being decided. Re-read the tip slot next to the hash and
+	// refuse to conclude anything if the tip is no longer at this slot,
+	// which sends the caller back to the fence. The two reads are still
+	// not atomic, so this narrows the window rather than closing it.
+	if f.slotClock.ChainTipSlot() != slot {
 		return false
 	}
 	return bytes.Equal(tipHash, forgedHash)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -15,6 +15,7 @@
 package forging
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -291,6 +292,20 @@ type SlotClockProvider interface {
 	// UpstreamSyncStatus reports whether a live upstream is selected and its
 	// corroborated target.
 	UpstreamSyncStatus() (targetSlot uint64, active bool)
+}
+
+// ChainTipHashProvider is an optional extension of SlotClockProvider.
+// When the wired slot clock implements it, the forger can identify the
+// block sitting at the chain tip by hash instead of inferring ownership
+// of a slot from the forge fence alone.
+//
+// It is deliberately a separate, optional interface so that existing
+// SlotClockProvider implementations outside this repository keep
+// compiling; a clock that does not implement it falls back to the fence.
+type ChainTipHashProvider interface {
+	// ChainTipHash returns the block hash of the current chain tip, or
+	// nil when the chain is empty or the hash is unavailable.
+	ChainTipHash() []byte
 }
 
 // ForgerConfig holds configuration for the block forger.
@@ -734,19 +749,21 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	}
 
 	// The tip is at the current slot and the block there is one this
-	// node already committed to forging, so the slot-aligned loop has
-	// simply re-entered a slot it already used. Leave without running
-	// leader selection: this is not a contested slot, and the fence
-	// below would refuse it anyway.
-	if currentSlot == tipSlot && f.fenceLoaded &&
-		currentSlot <= f.lastForgedSlot {
-		f.logger.Debug(
-			"forge skip: slot already has our own block",
-			"current_slot", currentSlot,
-			"tip_slot", tipSlot,
-			"last_forged_slot", f.lastForgedSlot,
-		)
-		return nil
+	// node produced, so the slot-aligned loop has simply re-entered a
+	// slot it already used. Leave without running leader selection:
+	// this is not a contested slot, and the fence below would refuse
+	// it anyway.
+	if currentSlot == tipSlot {
+		if ours, matchedBy := f.tipBlockIsOurs(currentSlot); ours {
+			f.logger.Debug(
+				"forge skip: slot already has our own block",
+				"current_slot", currentSlot,
+				"tip_slot", tipSlot,
+				"last_forged_slot", f.lastForgedSlot,
+				"matched_by", matchedBy,
+			)
+			return nil
+		}
 	}
 
 	// Skip if the chain is still syncing from a peer.
@@ -1284,6 +1301,59 @@ func (f *BlockForger) reserveForgeSlot(slot uint64) (bool, error) {
 	f.lastForgedSlot = slot
 	f.fenceLoaded = true
 	return true, nil
+}
+
+// tipBlockIsOurs reports whether the block occupying slot at the chain
+// tip is one this node produced, and which signal decided it.
+//
+// The primary signal is identity, not bookkeeping: SlotTracker already
+// records the hash of every block this node forged and adopted, so a tip
+// hash equal to that record proves the block at the tip is ours rather
+// than a rival's. That check is independent of whether a durable
+// ForgeFenceStore is wired, which matters because the fence is in-memory
+// only when it is not (see fenceStore above).
+//
+// The fence is kept as an additional guard, not replaced. It covers the
+// window the tracker cannot: reserveForgeSlot writes the fence *before*
+// the header for a slot is signed, while RecordForgedBlock runs only
+// after the block is adopted, so between those two points the slot is
+// already ours but has no recorded hash yet. The fence is also the only
+// signal available when the wired slot clock does not implement
+// ChainTipHashProvider.
+//
+// Neither signal survives a process restart on its own: the tracker is
+// in-memory, and the fence is durable only through a ForgeFenceStore.
+func (f *BlockForger) tipBlockIsOurs(slot uint64) (bool, string) {
+	if f.tipHashMatchesForgedBlock(slot) {
+		return true, "forged_block_hash"
+	}
+	if f.fenceLoaded && slot <= f.lastForgedSlot {
+		return true, "forge_fence"
+	}
+	return false, ""
+}
+
+// tipHashMatchesForgedBlock reports whether the current chain tip is the
+// exact block this node forged for slot. It answers false whenever any
+// input is missing (no tracker record, no tip-hash capable slot clock,
+// an empty hash on either side) so the caller falls back to the fence.
+func (f *BlockForger) tipHashMatchesForgedBlock(slot uint64) bool {
+	if f.slotTracker == nil {
+		return false
+	}
+	forgedHash, ok := f.slotTracker.WasForgedByUs(slot)
+	if !ok || len(forgedHash) == 0 {
+		return false
+	}
+	provider, hasTipHash := f.slotClock.(ChainTipHashProvider)
+	if !hasTipHash {
+		return false
+	}
+	tipHash := provider.ChainTipHash()
+	if len(tipHash) == 0 {
+		return false
+	}
+	return bytes.Equal(tipHash, forgedHash)
 }
 
 func (f *BlockForger) incCouldNotForge() {

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -104,6 +104,7 @@ func (l *forgerCountingLeader) callCount() int {
 type forgerTestSlotClock struct {
 	currentSlot       uint64
 	chainTipSlot      uint64
+	chainTipHash      []byte
 	upstreamTipSlot   uint64
 	upstreamActive    bool
 	slotsPerKESPeriod uint64
@@ -123,6 +124,13 @@ func (c forgerTestSlotClock) ChainTipSlot() uint64 {
 
 func (forgerTestSlotClock) NextSlotTime() (time.Time, error) {
 	return time.Now(), nil
+}
+
+// ChainTipHash satisfies the optional ChainTipHashProvider. It returns
+// nil unless a test sets chainTipHash, so every existing test keeps the
+// fence-only behaviour.
+func (c forgerTestSlotClock) ChainTipHash() []byte {
+	return c.chainTipHash
 }
 
 func (c forgerTestSlotClock) UpstreamTipSlot() uint64 {

--- a/node_forging.go
+++ b/node_forging.go
@@ -748,6 +748,21 @@ func (a *slotClockAdapter) ChainTipSlot() uint64 {
 	return a.ledgerState.ChainTipSlot()
 }
 
+// ChainTipHash satisfies forging.ChainTipHashProvider. It lets the
+// forger tell its own block at the current slot from a rival's by hash
+// rather than inferring it from the forge fence, which is in-memory only
+// when no fence store is wired. Both this and ChainTipSlot read the same
+// tip snapshot; a tip that moves between the two reads simply fails the
+// hash match and falls back to the fence.
+func (a *slotClockAdapter) ChainTipHash() []byte {
+	return a.ledgerState.Tip().Point.Hash
+}
+
+// The forger type-asserts for this optional interface, so losing the
+// method would silently fall back to the fence rather than fail to
+// build.
+var _ forging.ChainTipHashProvider = (*slotClockAdapter)(nil)
+
 func (a *slotClockAdapter) NextSlotTime() (time.Time, error) {
 	return a.ledgerState.NextSlotTime()
 }


### PR DESCRIPTION
## Summary

`checkAndForgeProduction` has two skip gates that run **before**
`checkLeaderSafe`. Both `return nil`, neither moves a leadership counter, and both
log at `Debug`, so a scheduled leader slot they drop is indistinguishable at INFO
from "we were simply not the leader for that slot".

This PR fixes the narrower of the two problems and makes a dropped **leader** slot
visible in the log for both gates. It deliberately does **not** change the
upstream-sync gate's behaviour; that is a trade-off question for maintainers and is
documented here by a test rather than altered. It also deliberately adds **no new
metric** — see commit 4.

The tip gate is `currentSlot <= tipSlot`. The `<` half matches the reference
implementation. The `==` half does not, and it turns every contested slot into a
guaranteed loss: a rival pool that forges the same slot and wins the propagation
race puts our tip *at* the current slot, the gate matches, and we return before
ever asking whether we are the leader.

## Reference implementation

`ouroboros-consensus`, `mkCurrentBlockContext`
(`ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs`,
checked at `1820edf5e`) handles the three cases explicitly:

```haskell
  c' :> hdr -> case blockSlot hdr `compare` currentSlot of
    LT -> Right $ blockContextFromPrevHeader hdr
    GT -> Left $ TraceBlockFromFuture currentSlot (blockSlot hdr)
    -- The block at the tip has the same slot as the block we're going to
    -- produce (@currentSlot@).
    EQ ->
      Right $
        if isJust (headerIsEBB hdr)
          then blockContextFromPrevHeader hdr
          -- If @hdr@ is not an EBB, then forge an alternative to @hdr@: same
          -- block no and same predecessor.
          else BlockContext (blockNo hdr) $ castPoint $ AF.headPoint c'
```

`GT` declines — that is dingo's `<`. `EQ` forges an alternative and lets the leader
VRF and chain selection arbitrate. Dingo collapses `EQ` into the decline.

## What this PR does and does not do

It narrows the gate to `currentSlot < tipSlot` so the `EQ` case reaches leader
selection and is accounted for.

It does **not** yet forge the alternative block, and it does not pretend to. Two
things in the current code block that, and both are outside the forger:

- `DefaultBlockBuilder.BuildBlock` binds the parent to the live chain tip
  (`ledger/forging/builder.go`, `currentTip := b.chainTip.Tip()` feeding both
  `nextBlockNumber` and `prevHash`). A block forged at `EQ` would therefore name a
  parent whose slot equals its own, which `validateBlockOrder` rejects
  (`ledger/envelope_validation.go`: `block.SlotNumber() <= parent.slot` →
  `"block slot %d does not follow parent slot %d"`). Every Praos peer rejects it
  too, for the same reason.
- Binding the tip's **predecessor** instead — what `mkCurrentBlockContext` does —
  produces a block that does not extend the local tip, and `Chain.addBlockLocked`
  refuses that with `BlockNotFitChainTipError`. There is no local-fork adoption
  path for a self-forged block today.

So the alternative-block path needs a builder that can take an explicit parent and
a chain that can adopt a locally forged fork. **That is explicitly out of scope
here and will be addressed in a follow-up PR.** What this PR fixes is that the loss
was **silent**: the slot now reaches leader selection and, when we are the leader,
is counted as a leader slot, a slot battle and a could-not-forge, and logged at
`Warn`.

Maintainers who prefer to go straight to the full fix: the branch point is the same
one-line gate, and the two blockers above are the whole remaining scope.

## Commits

1. **`test(forging): pin the equal-slot tip gate as a contested slot`** — fails
   before commit 2. `TestCheckAndForgeProductionEqualSlotReachesLeaderCheck` asserts
   the contested slot reaches leader selection and is accounted for.
   `TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot` is the
   anti-equivocation companion and passes before and after: after a successful
   forge the tip is our *own* block at that slot, so `tipSlot == currentSlot` there
   too, and that case must stay a quiet skip.

2. **`fix(forging): stop dropping contested slots before leader selection`** —
   `<=` → `<`, plus an explicit split of the two `EQ` cases. "The block at the tip
   is ours" keeps the existing quiet early skip, now keyed on the last-forged-slot
   fence rather than on the tip comparison alone. "The block at the tip is a
   rival's" runs leader selection and records the declined battle. Anti-equivocation
   is unaffected: the #3734 fence is still the mechanism that prevents a second
   block for a slot this node already signed for, and the contested-slot path
   returns before `reserveForgeSlot`, so a declined battle does not burn the slot.

3. **`test(forging): document the leader slot lost to an unknown upstream target`**
   — no behaviour change. `UpstreamSyncStatus()` returns `(0, true)` for the whole
   window between an active-connection switch and the new peer's first
   authenticated, admitted, trusted header (`publishActiveUpstream` stores the new
   connection key with `targetSlot` zero; only `publishAdmittedUpstreamTarget` makes
   it non-zero). The gate's `upstreamTip == 0` disjunct therefore disables forging
   outright during that window, independent of local tip freshness and independent
   of `forgeSyncToleranceSlots` — raising the tolerance does not affect this branch
   at all, which the test pins with a subtest at 100000.

   `TestForgeSkipsLeaderSlotWhenUpstreamTargetUnknownEvenAtTip` asserts the
   **current** behaviour, on a node whose tip is the previous slot's block. It is
   written that way on purpose: the behaviour is deliberate and already pinned by
   `TestCheckAndForgeProductionWaitsForUnknownActiveUpstreamTarget`, so this PR is
   not the place to change it. A `t.Skip` would have hidden the assertions from CI
   and let them rot; a passing test that fails the moment the gate is rekeyed on
   local tip freshness names the decision being revisited.

4. **`feat(forging): warn when a pre-leader gate drops a leader slot`** — additive,
   separable, no behaviour change. Take or drop it independently of 1–3.
   - A gate skip is raised from `Debug` to `Warn`, with `leader_slot=true`, when the
     slot is one this node is scheduled to lead. Both gates route their skip line
     through `logGateSkip`; the routine case is unchanged and still logs at `Debug`.
   - `isScheduledLeaderSlot` consults the precomputed VRF schedule via
     `LeaderChecker.NextLeaderSlot` (in `Election`, a read-locked scan of the cached
     schedule for the slot's epoch) rather than running leader selection, so it is
     cheap on a skip path. It only picks a log level, so it fails quiet — no cached
     schedule means the skip stays at `Debug` — and it recovers a panic from the
     pluggable checker for the same reason `checkLeaderSafe` does.
   - **No metric is added or changed.** `ledger/forging/metrics.go` is untouched by
     this branch, so every existing series and every `docs/dashboards/*.json` panel
     is bit-for-bit unaffected. This commit only decides the severity of a line that
     was already emitted. A counter for the pre-leader gates is a reasonable
     separate request (cf. #2873) and is left to maintainers.

5. **`test(forging): pin our own block at the tip as identified by hash`** — fails
   before commit 6. `TestEqualSlotOwnBlockIsIdentifiedByHashNotByFence` wires **no**
   fence store and asserts the forger starts with an unloaded fence, so the recorded
   forged hash is the only ownership signal left. Subtest one: the tip hash equals
   the block we forged for the slot, and the cycle must be a quiet `Debug` skip —
   no leader selection, no slot battle, no could-not-forge, no `Warn`. Subtest two
   is the companion that stops subtest one being satisfied by a blanket skip: the
   tracker holds a record for the slot but the tip carries a rival's hash, and that
   must still reach leader selection and count a slot battle.

6. **`fix(forging): identify our own tip block by hash, not by the fence alone`** —
   the skip is decided by `tipBlockIsOurs`, which prefers the `SlotTracker` hash
   match and falls back to the fence. The tip hash arrives through
   `ChainTipHashProvider`, a **separate optional** extension of `SlotClockProvider`
   rather than a new method on it, so `SlotClockProvider` implementations outside
   this repository keep compiling and a clock that does not implement it behaves
   exactly as before. No block is built, signed or broadcast on either side of this
   change — both outcomes return before `reserveForgeSlot` — so anti-equivocation is
   untouched.

7. **`docs(architecture): note could_not_forge now counts declined slot battles`** —
   documentation only. Adds the metrics note below to the block-forging section of
   `ARCHITECTURE.md` and corrects the chain-tip check quoted there, which this
   branch narrowed from `currentSlot <= tipSlot` to `currentSlot < tipSlot`.

Commits 8-10 answer the automated review of 5-7:

8. **`fix(forging): re-read the tip slot beside the tip hash`** — `tipSlot` is
   sampled at the top of the cycle and `ChainTipHash` is read later, so the hash
   need not belong to the slot being decided. The tip slot is now re-read next to
   the hash, and a tip that has moved off the slot is inconclusive and falls back
   to the fence. The reads are still not atomic, so this narrows the window rather
   than closing it.

9. **`fix(forging): report an equal-slot battle lost under the fence`** — when the
   fence covers the slot but the recorded forge hash shows a rival's block won it,
   the fence still refuses the forge: a second, different block for a slot whose
   first block may already have reached peers is equivocation, and losing a battle
   is not a licence to equivocate. What changes is that the loss is no longer
   reported at `Debug` as "slot already has our own block".
   `tipHashMatchesForgedBlock` becomes `tipBlockOwnership`, a tri-state — ours, a
   rival's, or indeterminate — and the rival-under-fence case is counted through
   `RecordSlotBattle` and `incCouldNotForge` and logged at `Warn` with both hashes.
   No branch of the equal-slot gate forges, so a wrong answer there can only choose
   between skipping quietly and skipping loudly.

10. **`docs(architecture): could_not_forge only partially overlaps slot battles`** —
    corrects the note added in commit 7, which told operators to subtract
    `dingo_metrics_slotBattlesTotal_int`. That counter is also raised from
    `ledger/chainsync.go` outside the forge path, so the overlap is partial and an
    exact subtraction under-counts.

11. **`fix(forging): let chainsync own the slot-battle count for a lost equal-slot battle`** —
    the rival-at-tip-under-the-fence path no longer calls `RecordSlotBattle()`:
    `LedgerState.checkSlotBattle` already recorded that battle when the rival block
    was accepted at our slot (same `SlotTracker`, same counter, wired in
    `node_lifecycle.go`), so the forger's increment was always the second one.
    `Forge_could_not_forge_int` and the Warn stay. The no-fence contested branch
    keeps its count: no fence means no tracker record, so chainsync returns early there.

## How tested

Go 1.26.7, `GOFLAGS=-mod=mod`, base `main` @ `429dbdbb`.

- `go build ./...` — clean.
- `go vet ./ledger/forging/...` — clean.
- `golangci-lint run ./ledger/forging/...` — 0 issues.
- `gofmt -l ledger/forging/` — clean. (`golines` is not installed here; no added
  line exceeds 80 columns except log string literals, which `golines` does not
  split and for which this file already has precedent.)
- Before commit 2, at commit 1:
  `go test ./ledger/forging/... -run TestCheckAndForgeProductionEqualSlot` →
  `--- FAIL: TestCheckAndForgeProductionEqualSlotReachesLeaderCheck`
  (leader selection call count 0, expected 1; `Forge_node_is_leader_int`,
  `slotBattlesTotal` and `could_not_forge` all 0, expected 1). The companion
  anti-equivocation test passes at commit 1.
- After commit 2: both pass.
- `go test ./ledger/forging/... -count=1` — all pass, including the pre-existing
  fence, bootstrap-gate, KES and upstream-target tests.
- `go test ./ledger/forging/... ./ledger/ ./chain/... -count=1` — all pass.

## Notes for review

- The `EQ`-is-ours early skip was originally keyed on the fence alone (`fenceLoaded
  && currentSlot <= lastForgedSlot`). Review pointed out that the fence answers a
  different question — it is a high-water mark over slots this node *committed to*,
  and it is durable only through a `ForgeFenceStore`, so where none is wired
  `lastForgedSlot` is in-memory only. Commits 5–7 rekey the skip on identity:
  `SlotTracker` already records the hash of every block this node forged, so the
  skip now compares that hash against the hash at the tip, which proves whether the
  block there is ours or a rival's. The fence is kept as an additional guard for the
  window the tracker cannot cover — `reserveForgeSlot` writes the fence *before*
  signing while `RecordForgedBlock` runs only after adoption — and for slot clocks
  that cannot report a tip hash. The skip line now reports which signal decided it,
  via `matched_by`. Neither signal survives a restart on its own, so this narrows
  the window rather than closing it; the durable half is still the fence store.
- After this change the tip gate only fires when the tip is strictly past the
  current slot, so its log line was reworded from "slot already has block" to
  "chain tip is ahead of the current slot".
- Nothing here changes what is signed or diffused. The only new signing-adjacent
  behaviour is that a contested slot now runs the KES gate and leader selection
  before declining, which is where cardano-node also spends that work.

**Known window (pre-existing).** `tipSlot` is read once at the top of
`checkAndForgeProduction`, before the KES gate and before `checkLeaderSafe`, and the
chain can move while leader selection runs. A rival block that lands at
`currentSlot` inside that window is invisible to the `currentSlot == tipSlot`
comparison further down, because that comparison is evaluated against the
already-sampled `tipSlot`. The slot therefore escapes the contested-slot branch,
`reserveForgeSlot` succeeds, and `BuildBlock` binds the parent to the *live* tip —
which by then is the rival's block at the same slot. The result is a block naming a
parent whose slot equals its own, rejected by `validateBlockOrder` after the header
has already been signed. This window is pre-existing: it is neither introduced,
widened nor narrowed by this PR, and no code here addresses it. Re-reading the tip
inside the branch would only shrink it, not close it, since the tip can still move
between that read and `BuildBlock`. The follow-up explicit-parent builder — the
one described under *What this PR does and does not do* — is what closes it: a
builder that takes an explicit parent re-derives it against the tip it actually
built on, rather than against a value sampled earlier in the cycle.

**Metrics note.** `cardano_node_metrics_Forge_could_not_forge_int` now also counts
leader slots declined because a rival's block already occupies the slot. Before this
PR it meant "we were the leader and the local build or sign failed"; it now includes
a case that is neither, and that case is exactly the one that also increments
`dingo_metrics_slotBattlesTotal_int`, so the two series overlap. No metric is added,
removed or renamed, and no dashboard query changes. Anyone alerting on the rate of
`Forge_could_not_forge_int` should inspect `dingo_metrics_slotBattlesTotal_int`
alongside it. The overlap is only *partial* and the two are **not** a clean
decomposition of one another: `ledger/chainsync.go` also raises
`dingo_metrics_slotBattlesTotal_int` for battles detected outside the forge path,
so subtracting it exactly would under-count real could-not-forge events. The same
note is in the block-forging section of `ARCHITECTURE.md` (commits 7 and 10).

Closes #3954 — defect 3, the tip gate collapsing `EQ` into a decline.
Refs #3954 — defect 1 (observability) is addressed in the log only, at `Warn`, with
no new metric; defect 2 (the unknown upstream target) is documented by a test but
deliberately not changed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the forger dropping contested leader slots before leader selection, so a rival block at the current slot is now counted as a slot battle and `Warn`-logged instead of silently skipped; pre-leader gate skips that swallow scheduled leader slots warn too.

- A tip at the current slot now reaches leader selection; ownership of the tip block (ours vs. rival) is decided by hash via the optional `ChainTipHashProvider`, with the forge fence as fallback, and our own committed slot still skips quietly.
- Pre-leader gate skips (chain tip ahead, stale-gap, upstream-sync) mark scheduled leader slots with `leader_slot=true`; ordinary skips stay at `Debug`.
- `Forge_could_not_forge_int` now also counts declined rival-block battles; its partial overlap with `dingo_metrics_slotBattlesTotal_int` is documented in `ARCHITECTURE.md`.
- The upstream-sync gate behavior is unchanged and pinned by tests; forging a valid alternative block remains unsupported and is left for a follow-up.

<sup>Written for commit 3f53a6018bbb0944d4fa472e2f0057b20b1bc119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Forging now handles chain tips at the current slot correctly, allowing leader selection for contested slots.
  - Prevents re-forging slots already recorded by the local forge fence.
  - Skips forging when the upstream target is unknown, even when the node is at the chain tip.
  - Records unsupported rival-block conflicts as skipped slot battles.
  - Sync-gate warnings now distinguish scheduled leader slots from ordinary skipped slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


