### PR TITLE
chore(deps): bump gouroboros to v0.202.9 for Alonzo datum hash fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.8
+	github.com/blinklabs-io/gouroboros v0.202.9
 	github.com/blinklabs-io/ouroboros-mock v0.18.0
 	github.com/blinklabs-io/plutigo v0.5.1
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,12 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.202.6 h1:xIJluYjLjmtZp0tVRXviMzuLm7hNkiT7T7yNuXMwpG8=
-github.com/blinklabs-io/gouroboros v0.202.6/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
-github.com/blinklabs-io/gouroboros v0.202.7 h1:XIM5nk5zv/ZQ/ntNIZfQs5JtoDb74IW3CnEK2JIIXu0=
-github.com/blinklabs-io/gouroboros v0.202.7/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
-github.com/blinklabs-io/gouroboros v0.202.8 h1:dRw7Dpqd2C9d2WvPl8ePgTuhI3mzhu6ZpDy9fytS7bY=
-github.com/blinklabs-io/gouroboros v0.202.8/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.9 h1:eAR655rEVT2zdL7ogdBi+LKzIVpk/Qi6L98Zh3FBZr0=
+github.com/blinklabs-io/gouroboros v0.202.9/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/plutigo v0.5.1 h1:cHmv2LII0fZggrOfp6wzW9t644HzTB6s7/vzHVpHJs8=


### PR DESCRIPTION
## Summary
- Bumps `github.com/blinklabs-io/gouroboros` v0.202.8 → v0.202.9, which contains the fix from [blinklabs-io/gouroboros#2213](https://github.com/blinklabs-io/gouroboros/pull/2213).
- That fix resolves `AlonzoTransactionOutput.ToPlutusData()` silently dropping `OutputDatumHash`, which caused any PlutusV3 script inspecting a spent/reference input's datum option to see `NoOutputDatum` for legacy (pre-Babbage, array-encoded) outputs that actually carry a datum hash.
- Fixes #3860 — this was the root cause of the mainnet chain freeze at slot 196782988, where a canonical Minswap withdrawal transaction was incorrectly rejected by every node's own Plutus re-evaluation.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — full suite passes on x86_64 (matching production architecture), with one pre-existing failure (`TestApplyPreservesExplicitMidnightFieldOnResumedNetwork`) confirmed unrelated: it also fails identically against unmodified `origin/main` in a separate control worktree (environment-specific, not caused by this change)
- [x] `make lint`, `make docs-parity` — clean
- [x] Diff scoped to `go.mod`/`go.sum` only

Validated on an x86_64 host running the same toolchain as the affected mainnet block-producing node, not just built locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/blinklabs-io/gouroboros` to v0.202.9, which fixes `AlonzoTransactionOutput.ToPlutusData()` silently dropping `OutputDatumHash` on legacy pre-Babbage outputs. Previously PlutusV3 scripts inspecting spent or reference inputs saw `NoOutputDatum` even when a datum hash existed; now the hash is preserved. This was the root cause of the mainnet chain freeze at slot 196782988, where a canonical Minswap withdrawal transaction failed node-side Plutus re-evaluation. Resolves #3860.

<sup>Written for commit 9f2d393711d76b7557da82faca6a76bb019c22f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying library dependency to the latest maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->