### PR TITLE
fix(forging): forge an alternative block on an equal-slot battle

### DIFF
--- a/chain/add_block_admit_test.go
+++ b/chain/add_block_admit_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chain"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// TestAddBlockWithPointDeferredIfRefusesWithoutMutating pins the fail-closed
+// half of the admission predicate: a false answer abandons the add before the
+// chain is read or written, and says so with a distinguishable error rather
+// than one that looks like an invalid block.
+func TestAddBlockWithPointDeferredIfRefusesWithoutMutating(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	tipBefore := c.Tip()
+
+	next := testBlocks[3]
+	point := ocommon.NewPoint(next.MockSlot, next.Hash().Bytes())
+	calls := 0
+	_, err = c.AddBlockWithPointDeferredIf(next, point, nil, func() bool {
+		calls++
+		return false
+	})
+	if !errors.Is(err, chain.ErrBlockAddNotAdmitted) {
+		t.Fatalf("expected ErrBlockAddNotAdmitted, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("admit must be evaluated exactly once, got %d", calls)
+	}
+	if got := c.Tip(); !bytes.Equal(got.Point.Hash, tipBefore.Point.Hash) {
+		t.Fatalf(
+			"a refused add must not move the tip: %x -> %x",
+			tipBefore.Point.Hash,
+			got.Point.Hash,
+		)
+	}
+
+	// The same block is added once the predicate admits it, so the refusal
+	// above was the predicate's doing and not an unrelated rejection.
+	if _, err := c.AddBlockWithPointDeferredIf(
+		next, point, nil, func() bool { return true },
+	); err != nil {
+		t.Fatalf("unexpected error adding admitted block: %s", err)
+	}
+	if got := c.Tip(); !bytes.Equal(got.Point.Hash, next.Hash().Bytes()) {
+		t.Fatalf("admitted block did not become the tip: %x", got.Point.Hash)
+	}
+}
+
+// TestAddBlockWithPointDeferredIfEvaluatesAdmitUnderTheChainMutex is the
+// property the predicate exists for. A caller that tests its own precondition
+// and then calls an ordinary add has released nothing but holds nothing
+// either: a concurrent mutation can land in between and make the test stale.
+// Evaluating the predicate inside the add, under the mutex that serializes
+// every chain mutation, is what makes the test and the mutation it guards one
+// atomic step.
+//
+// Proven by observing that another goroutine's add cannot make progress while
+// the predicate is running: if the predicate ran outside the lock, that add
+// would complete immediately.
+func TestAddBlockWithPointDeferredIfEvaluatesAdmitUnderTheChainMutex(
+	t *testing.T,
+) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+
+	next := testBlocks[3]
+	point := ocommon.NewPoint(next.MockSlot, next.Hash().Bytes())
+	competitor := &MockBlock{
+		MockBlockNumber: next.MockBlockNumber,
+		MockSlot:        next.MockSlot + 1,
+		MockHash:        testHashPrefix + "00fd",
+		MockPrevHash:    testBlocks[2].MockHash,
+	}
+	competitorDone := make(chan struct{})
+	blockedDuringAdmit := false
+
+	_, err = c.AddBlockWithPointDeferredIf(next, point, nil, func() bool {
+		go func() {
+			defer close(competitorDone)
+			_ = c.AddBlock(competitor, nil)
+		}()
+		// The competing add must be parked on the chain mutex we are
+		// holding. A generous window keeps this from depending on
+		// scheduling speed: the assertion is that it does NOT finish.
+		select {
+		case <-competitorDone:
+			blockedDuringAdmit = false
+		case <-time.After(250 * time.Millisecond):
+			blockedDuringAdmit = true
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatalf("unexpected error adding block: %s", err)
+	}
+	<-competitorDone
+	if !blockedDuringAdmit {
+		t.Fatal(
+			"a concurrent add completed while the admission predicate was " +
+				"running, so the predicate is not evaluated under the chain mutex",
+		)
+	}
+}

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -329,7 +329,7 @@ func (c *Chain) AddBlock(
 	block ledger.Block,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true, false)
+	evt, err := c.addBlockInternal(block, ocommon.Point{}, txn, true, false, nil)
 	if err != nil {
 		return err
 	}
@@ -356,6 +356,7 @@ func (c *Chain) AddLocalBlock(block ledger.Block) error {
 		nil,
 		false,
 		false,
+		nil,
 	)
 	if err != nil {
 		return err
@@ -385,6 +386,7 @@ func (c *Chain) AddLocalBlockDeferred(
 		nil,
 		false,
 		true,
+		nil,
 	)
 }
 
@@ -396,7 +398,7 @@ func (c *Chain) AddBlockWithPoint(
 	point ocommon.Point,
 	txn *database.Txn,
 ) error {
-	evt, err := c.addBlockInternal(block, point, txn, true, false)
+	evt, err := c.addBlockInternal(block, point, txn, true, false, nil)
 	if err != nil {
 		return err
 	}
@@ -426,7 +428,33 @@ func (c *Chain) AddBlockWithPointDeferred(
 	point ocommon.Point,
 	txn *database.Txn,
 ) (event.Event, error) {
-	return c.addBlockInternal(block, point, txn, true, true)
+	return c.addBlockInternal(block, point, txn, true, true, nil)
+}
+
+// AddBlockWithPointDeferredIf is AddBlockWithPointDeferred with a caller
+// supplied admission predicate, evaluated while the chain mutex is held and
+// before any chain state is read or written. When admit reports false the add
+// is abandoned and ErrBlockAddNotAdmitted is returned; nothing is mutated and
+// no event is queued.
+//
+// It exists because a precondition checked by the caller before calling is
+// not a precondition of the mutation. The blockfetch drain holds
+// chainsyncBlockfetchMutex, not the chainsyncMutex the equal-slot alternative
+// adoption holds, so a rollback can publish a new generation and truncate the
+// chain in the window between the drain testing its batch and this add taking
+// the chain mutex. Passing the test as a predicate closes that window: the
+// generation comparison and the tip mutation it guards become one atomic step
+// under the same lock every other chain mutation takes.
+//
+// admit must not acquire the chain or manager mutex, and must not block: it
+// runs on the chain's own write path.
+func (c *Chain) AddBlockWithPointDeferredIf(
+	block ledger.Block,
+	point ocommon.Point,
+	txn *database.Txn,
+	admit func() bool,
+) (event.Event, error) {
+	return c.addBlockInternal(block, point, txn, true, true, admit)
 }
 
 // queueDeferredEventLocked appends evt to the chain-level sequencer. The caller
@@ -483,6 +511,7 @@ func (c *Chain) addBlockInternal(
 	txn *database.Txn,
 	matchPendingHeader bool,
 	deferred bool,
+	admit func() bool,
 ) (event.Event, error) {
 	if c == nil {
 		return event.Event{}, errors.New("chain is nil")
@@ -492,6 +521,14 @@ func (c *Chain) addBlockInternal(
 	// We get a write lock on the manager to cover the integrity checks and adding the block below
 	c.manager.mutex.Lock()
 	defer c.manager.mutex.Unlock()
+	// Ask the caller, under the same lock that serializes every chain
+	// mutation, whether this add is still wanted. Evaluating it here is the
+	// point: a caller that checks its own precondition before calling has
+	// already released whatever it inspected, so a rollback landing in
+	// between would leave that check stale. See AddBlockWithPointDeferredIf.
+	if admit != nil && !admit() {
+		return event.Event{}, ErrBlockAddNotAdmitted
+	}
 	// Verify chain integrity
 	if err := c.reconcile(); err != nil {
 		return event.Event{}, fmt.Errorf("reconcile chain: %w", err)

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -143,6 +143,61 @@ func (c *Chain) HeaderTip() ochainsync.Tip {
 	return c.headerTip()
 }
 
+// TipPredecessor reports the block context an alternative to the current chain
+// tip must be built on: the tip itself (the block that would be competed with)
+// and the point of the tip's immediate predecessor, which becomes the
+// alternative block's parent.
+//
+// This is the data ouroboros-consensus' mkCurrentBlockContext returns for its
+// EQ case, where a leader whose slot is already occupied forges an alternative
+// with the same block number as the occupant and the occupant's predecessor as
+// parent (Ouroboros/Consensus/NodeKernel/Forge.hs).
+//
+// ok is false whenever that context cannot be established: an empty chain, a
+// tip that is the first block on the chain (its parent is genesis, which is not
+// a rollback target here), or a predecessor the chain can no longer resolve.
+// Callers must treat that as "no alternative can be built" and must not fall
+// back to the live tip: binding the tip itself as parent produces a block whose
+// parent slot equals its own, which envelope validation and every Praos peer
+// reject.
+func (c *Chain) TipPredecessor() (
+	parent ocommon.Point,
+	tip ochainsync.Tip,
+	ok bool,
+) {
+	if c == nil {
+		return ocommon.Point{}, ochainsync.Tip{}, false
+	}
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	c.manager.mutex.RLock()
+	defer c.manager.mutex.RUnlock()
+	// initialBlockIndex is the first block; it has no predecessor on this
+	// chain, and neither does an empty chain.
+	if c.tipBlockIndex <= initialBlockIndex {
+		return ocommon.Point{}, ochainsync.Tip{}, false
+	}
+	tipBlock, err := c.blockByIndexLocked(c.tipBlockIndex)
+	if err != nil {
+		return ocommon.Point{}, ochainsync.Tip{}, false
+	}
+	parentBlock, err := c.blockByIndexLocked(c.tipBlockIndex - 1)
+	if err != nil {
+		return ocommon.Point{}, ochainsync.Tip{}, false
+	}
+	// Cross-check the two records against each other and against the tip this
+	// chain advertises. The chain maintains all three invariants, but a caller
+	// of this function is about to sign a block against the answer, so a
+	// disagreement is reported as "no context" rather than resolved.
+	if !bytes.Equal(tipBlock.Hash, c.currentTip.Point.Hash) ||
+		!bytes.Equal(tipBlock.PrevHash, parentBlock.Hash) {
+		return ocommon.Point{}, ochainsync.Tip{}, false
+	}
+	return ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash),
+		c.currentTip,
+		true
+}
+
 // blockNumberContiguous reports whether a block number legitimately follows its
 // parent's. Shelley-era and later increment by exactly one per block. Byron
 // epoch-boundary blocks reuse the parent's block number (they do not increment),
@@ -296,6 +351,28 @@ func (c *Chain) AddLocalBlock(block ledger.Block) error {
 		c.eventBus.Publish(ChainUpdateEventType, evt)
 	}
 	return nil
+}
+
+// AddLocalBlockDeferred adds a locally forged block exactly like AddLocalBlock
+// but, instead of publishing the resulting chain.update inline, enqueues it on
+// the chain-level sequencer under c.mutex and returns it. This is the entry
+// point for a forged block adopted from a path that holds a ledger mutex --
+// specifically the equal-slot alternative, which rolls the chain back to the
+// contested block's parent under chainsyncMutex and then adopts the local
+// sibling. Publishing inline from there is the drain deadlock described on
+// AddBlockWithPointDeferred; enqueuing under c.mutex also keeps this add
+// ordered behind the rollback that preceded it. A returned event with an empty
+// Type means there is nothing to publish.
+func (c *Chain) AddLocalBlockDeferred(
+	block ledger.Block,
+) (event.Event, error) {
+	return c.addBlockInternal(
+		block,
+		ocommon.Point{},
+		nil,
+		false,
+		true,
+	)
 }
 
 // AddBlockWithPoint adds a block using a caller-supplied point. This avoids

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -170,8 +170,15 @@ func (c *Chain) TipPredecessor() (
 	}
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	c.manager.mutex.RLock()
-	defer c.manager.mutex.RUnlock()
+	// Both lookups below go through blockByIndexLocked, which resolves a
+	// common-prefix index against the primary chain when this chain is an
+	// in-memory fork. That read needs the primary-chain lock as well as the
+	// manager lock, in the chain -> primary -> manager order this helper
+	// establishes; taking manager.mutex directly would let a concurrent
+	// primary-chain mutation move the common prefix between the two lookups
+	// and yield a tip and a parent that never sat next to each other.
+	unlockBlockIndexReadLocks := c.lockBlockIndexReadLocks()
+	defer unlockBlockIndexReadLocks()
 	// initialBlockIndex is the first block; it has no predecessor on this
 	// chain, and neither does an empty chain.
 	if c.tipBlockIndex <= initialBlockIndex {
@@ -189,8 +196,14 @@ func (c *Chain) TipPredecessor() (
 	// chain advertises. The chain maintains all three invariants, but a caller
 	// of this function is about to sign a block against the answer, so a
 	// disagreement is reported as "no context" rather than resolved.
+	//
+	// The parent must also sit strictly below the tip's slot. That is the
+	// ordering contract this function's doc comment states, and the caller
+	// signs against the answer: a parent whose slot is at or above the
+	// contested slot produces a block Praos and envelope validation reject.
 	if !bytes.Equal(tipBlock.Hash, c.currentTip.Point.Hash) ||
-		!bytes.Equal(tipBlock.PrevHash, parentBlock.Hash) {
+		!bytes.Equal(tipBlock.PrevHash, parentBlock.Hash) ||
+		parentBlock.Slot >= tipBlock.Slot {
 		return ocommon.Point{}, ochainsync.Tip{}, false
 	}
 	return ocommon.NewPoint(parentBlock.Slot, parentBlock.Hash),

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -27,7 +27,14 @@ import (
 const DefaultMaxQueuedHeaders = 10_000
 
 var (
-	ErrIntersectNotFound            = errors.New("chain intersect not found")
+	ErrIntersectNotFound = errors.New("chain intersect not found")
+	// ErrBlockAddNotAdmitted is returned by AddBlockWithPointDeferredIf when
+	// the caller's admit predicate, evaluated under the chain mutex, declines
+	// the block. It means the add was abandoned before any chain state was
+	// read or written, not that the block was invalid.
+	ErrBlockAddNotAdmitted = errors.New(
+		"block add was not admitted by the caller's predicate",
+	)
 	ErrRollbackBeyondEphemeralChain = errors.New(
 		"cannot rollback ephemeral chain beyond memory buffer",
 	)

--- a/chain/tip_predecessor_test.go
+++ b/chain/tip_predecessor_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// TestTipPredecessorReportsAlternativeBlockContext covers the context an
+// equal-slot alternative is built on: the tip that would be competed with, and
+// the tip's immediate predecessor as the alternative's parent. This is what
+// ouroboros-consensus' mkCurrentBlockContext returns for its EQ case.
+func TestTipPredecessorReportsAlternativeBlockContext(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+
+	parent, tip, ok := c.TipPredecessor()
+	if !ok {
+		t.Fatal("expected a resolvable tip predecessor")
+	}
+	wantParent := testBlocks[1]
+	wantTip := testBlocks[2]
+	if parent.Slot != wantParent.MockSlot ||
+		!bytes.Equal(parent.Hash, wantParent.Hash().Bytes()) {
+		t.Fatalf(
+			"parent = %d.%x, want %d.%s",
+			parent.Slot,
+			parent.Hash,
+			wantParent.MockSlot,
+			wantParent.MockHash,
+		)
+	}
+	if tip.BlockNumber != wantTip.MockBlockNumber ||
+		!bytes.Equal(tip.Point.Hash, wantTip.Hash().Bytes()) {
+		t.Fatalf(
+			"tip = %d/%x, want %d/%s",
+			tip.BlockNumber,
+			tip.Point.Hash,
+			wantTip.MockBlockNumber,
+			wantTip.MockHash,
+		)
+	}
+	// The whole point of the context: our block's parent slot is strictly
+	// below the slot we would forge at, which is exactly what binding the
+	// live tip as parent fails to give at an equal slot.
+	if parent.Slot >= tip.Point.Slot {
+		t.Fatalf(
+			"parent slot %d must be below the contested slot %d",
+			parent.Slot,
+			tip.Point.Slot,
+		)
+	}
+}
+
+// TestTipPredecessorRefusesWithoutAResolvablePredecessor pins the fail-closed
+// contract. A caller that treated !ok as "use the live tip" would sign a block
+// whose parent slot equals its own.
+func TestTipPredecessorRefusesWithoutAResolvablePredecessor(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+
+	if _, _, ok := c.TipPredecessor(); ok {
+		t.Fatal("empty chain must not report a tip predecessor")
+	}
+
+	if err := c.AddBlock(testBlocks[0], nil); err != nil {
+		t.Fatalf("unexpected error adding block to chain: %s", err)
+	}
+	if _, _, ok := c.TipPredecessor(); ok {
+		t.Fatal(
+			"first block on the chain must not report a tip predecessor",
+		)
+	}
+}
+
+// TestAddLocalBlockDeferredAdoptsSiblingAfterRollback exercises the two chain
+// operations an equal-slot alternative needs in sequence: roll the contested
+// block off the tip, then adopt the locally forged sibling that shares its
+// parent and block number. The sibling is not an extension of the tip the
+// chain had when it was forged, which is precisely why AddLocalBlock's
+// extend-only path cannot take it.
+func TestAddLocalBlockDeferredAdoptsSiblingAfterRollback(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	cm, err := chain.NewManager(nil, eventBus)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	mustSetLedger(t, cm, 100)
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	rival := testBlocks[2]
+	parent, tip, ok := c.TipPredecessor()
+	if !ok {
+		t.Fatal("expected a resolvable tip predecessor")
+	}
+
+	// Our alternative: same slot and block number as the rival at the tip,
+	// the rival's predecessor as parent.
+	sibling := &MockBlock{
+		MockBlockNumber: tip.BlockNumber,
+		MockSlot:        tip.Point.Slot,
+		MockHash:        testHashPrefix + "0aa1",
+		MockPrevHash:    testBlocks[1].MockHash,
+	}
+
+	// Extending the live tip is refused, which is the blocker this pair of
+	// operations exists to get past.
+	if err := c.AddLocalBlock(sibling); err == nil {
+		t.Fatal("expected the sibling to be refused as a tip extension")
+	}
+
+	if _, err := c.RollbackDeferred(parent); err != nil {
+		t.Fatalf("unexpected error rolling back to the sibling parent: %s", err)
+	}
+	evt, err := c.AddLocalBlockDeferred(sibling)
+	if err != nil {
+		t.Fatalf("unexpected error adopting local sibling: %s", err)
+	}
+	if evt.Type == "" {
+		t.Fatal("expected a chain.update event for the adopted sibling")
+	}
+
+	newTip := c.Tip()
+	if !bytes.Equal(newTip.Point.Hash, sibling.Hash().Bytes()) {
+		t.Fatalf(
+			"tip = %x, want the adopted sibling %s",
+			newTip.Point.Hash,
+			sibling.MockHash,
+		)
+	}
+	if newTip.BlockNumber != rival.MockBlockNumber {
+		t.Fatalf(
+			"adopted sibling block number = %d, want the rival's %d",
+			newTip.BlockNumber,
+			rival.MockBlockNumber,
+		)
+	}
+	if newTip.Point.Slot != rival.MockSlot {
+		t.Fatalf(
+			"adopted sibling slot = %d, want the contested slot %d",
+			newTip.Point.Slot,
+			rival.MockSlot,
+		)
+	}
+
+	// The context now describes the newly adopted tip, so a second contest
+	// at the same slot would build on the same parent again.
+	parentAfter, tipAfter, ok := c.TipPredecessor()
+	if !ok {
+		t.Fatal("expected a resolvable tip predecessor after adoption")
+	}
+	if !bytes.Equal(parentAfter.Hash, parent.Hash) {
+		t.Fatalf(
+			"parent after adoption = %x, want the unchanged fork point %x",
+			parentAfter.Hash,
+			parent.Hash,
+		)
+	}
+	if !bytes.Equal(tipAfter.Point.Hash, sibling.Hash().Bytes()) {
+		t.Fatalf(
+			"tip after adoption = %x, want %s",
+			tipAfter.Point.Hash,
+			sibling.MockHash,
+		)
+	}
+	// Both mutations were deferred, so nothing was published inline; the
+	// caller drains them once its ledger mutex is released.
+	c.PublishPendingChainUpdates()
+}

--- a/chain/tip_predecessor_test.go
+++ b/chain/tip_predecessor_test.go
@@ -100,6 +100,48 @@ func TestTipPredecessorRefusesWithoutAResolvablePredecessor(t *testing.T) {
 	}
 }
 
+// TestTipPredecessorRefusesAParentAtOrAboveTheContestedSlot pins the strict
+// slot-ordering half of the contract. The alternative built on this context is
+// signed against the parent it names, so a parent whose slot is not strictly
+// below the contested tip's would produce a block that Praos ordering and
+// ledger envelope validation both reject. The chain does not enforce
+// increasing slots on add, so this state is reachable; the answer is "no
+// context", never a context the signer cannot use.
+func TestTipPredecessorRefusesAParentAtOrAboveTheContestedSlot(t *testing.T) {
+	cm, err := chain.NewManager(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating chain manager: %s", err)
+	}
+	c := cm.PrimaryChain()
+	for _, testBlock := range testBlocks[:3] {
+		if err := c.AddBlock(testBlock, nil); err != nil {
+			t.Fatalf("unexpected error adding block to chain: %s", err)
+		}
+	}
+	if _, _, ok := c.TipPredecessor(); !ok {
+		t.Fatal("expected a resolvable tip predecessor before the same-slot tip")
+	}
+	// A tip that reuses its parent's slot. Its predecessor is resolvable and
+	// the hash linkage is intact, so only the slot check can reject it.
+	sameSlotTip := &MockBlock{
+		MockBlockNumber: testBlocks[2].MockBlockNumber + 1,
+		MockSlot:        testBlocks[2].MockSlot,
+		MockHash:        testHashPrefix + "00fe",
+		MockPrevHash:    testBlocks[2].MockHash,
+	}
+	if err := c.AddBlock(sameSlotTip, nil); err != nil {
+		t.Fatalf("unexpected error adding same-slot block: %s", err)
+	}
+	if parent, tip, ok := c.TipPredecessor(); ok {
+		t.Fatalf(
+			"expected no context for a tip at its parent's slot, got parent %d.%x tip %d",
+			parent.Slot,
+			parent.Hash,
+			tip.Point.Slot,
+		)
+	}
+}
+
 // TestAddLocalBlockDeferredAdoptsSiblingAfterRollback exercises the two chain
 // operations an equal-slot alternative needs in sequence: roll the contested
 // block off the tip, then adopt the locally forged sibling that shares its

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4468,6 +4468,13 @@ func (ls *LedgerState) startQueuedBlockfetchLockedWithWaitSignal(
 	ls.activeBlockfetchStart = time.Now()
 	ls.firstBlockReceived = false
 	headerStart, headerEnd := ls.chain.HeaderRange(blockfetchBatchSize)
+	// Tag the batch with the rollback generation current at request time.
+	// The blocks it delivers are only valid for the chain segment these
+	// queued headers describe; a rollback that abandons that segment
+	// publishes a newer generation before truncating, and the flush below
+	// discards anything still carrying this one. See
+	// blockfetchRollbackGeneration.
+	ls.blockfetchBatchRollbackGeneration = ls.blockfetchRollbackGeneration.Load()
 	ls.blockfetchRequestGeneration++
 	primaryRequestGeneration := ls.blockfetchRequestGeneration
 	ls.blockfetchPrimaryRequestGeneration = primaryRequestGeneration
@@ -4719,6 +4726,38 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 	}()
 }
 
+// discardStaleBlockfetchBatch drops blocks delivered for a batch that a
+// rollback has since superseded, releasing the deferred-header-validation
+// bookkeeping each of them registered on arrival. It performs the same cleanup
+// the flush does for a block the chain declines, minus the add.
+//
+// Nothing is lost by dropping them: the rollback cleared the queued headers
+// these blocks were fetched against, so the chain would reject every one of
+// them anyway (their parent is no longer on the chain), and any block still
+// wanted after the rollback is re-offered by chainsync and re-fetched by the
+// next batch.
+func (ls *LedgerState) discardStaleBlockfetchBatch(
+	pending []BlockfetchEvent,
+) error {
+	for _, pendingEvent := range pending {
+		ls.clearDeferredHeaderValidation(pendingEvent.Point)
+		if err := ls.clearPersistentDeferredHeaderValidation(
+			pendingEvent.Point,
+			nil,
+		); err != nil {
+			return err
+		}
+	}
+	ls.config.Logger.Warn(
+		"discarding blockfetch blocks fetched before a chain rollback",
+		"component", "ledger",
+		"block_count", len(pending),
+		"batch_generation", ls.blockfetchBatchRollbackGeneration,
+		"rollback_generation", ls.blockfetchRollbackGeneration.Load(),
+	)
+	return nil
+}
+
 // flushPendingBlockfetchBlocksDeferred is flushPendingBlockfetchBlocks that
 // queues each committed block's chain.update onto pubs instead of letting the
 // chain publish it inline. The blockfetch drain runs under
@@ -4737,6 +4776,19 @@ func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
 	}
 	pending := ls.pendingBlockfetchEvents
 	ls.pendingBlockfetchEvents = ls.pendingBlockfetchEvents[:0]
+	// A rollback published a newer generation after this batch was
+	// requested, so these blocks were fetched for a chain segment that no
+	// longer exists. Discard them rather than offering them to the chain:
+	// the batch was requested against the abandoned segment's queued
+	// headers, which the rollback cleared, and the winner that replaced it
+	// is already on the chain. See blockfetchRollbackGeneration.
+	if ls.blockfetchBatchRollbackGeneration !=
+		ls.blockfetchRollbackGeneration.Load() {
+		if err := ls.discardStaleBlockfetchBatch(pending); err != nil {
+			return err
+		}
+		return nil
+	}
 	// Commit each block before exposing it on the primary chain. The chain tip
 	// is used immediately by fork detection, so batching blob writes behind an
 	// already-advanced in-memory tip can strand the node on a fork when ancestor

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4729,6 +4729,22 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 	}()
 }
 
+// blockfetchBatchStillCurrent reports whether the batch the pending blockfetch
+// events belong to was requested against the chain segment the chain still
+// holds -- that is, whether no rollback has published a newer generation since
+// the request. See blockfetchRollbackGeneration.
+//
+// It is passed to the chain as an admission predicate so the comparison and
+// the tip mutation it guards happen under one lock; it is also used directly
+// as a fast path, to drop a whole superseded batch without offering any of it
+// to the chain. Callers must hold chainsyncBlockfetchMutex, which is what
+// guards blockfetchBatchRollbackGeneration; the chain calls it while holding
+// its own mutex, and takes neither of the ledger's.
+func (ls *LedgerState) blockfetchBatchStillCurrent() bool {
+	return ls.blockfetchBatchRollbackGeneration ==
+		ls.blockfetchRollbackGeneration.Load()
+}
+
 // discardStaleBlockfetchBatch drops blocks delivered for a batch that a
 // rollback has since superseded, releasing the deferred-header-validation
 // bookkeeping each of them registered on arrival. It performs the same cleanup
@@ -4791,8 +4807,7 @@ func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
 	// the batch was requested against the abandoned segment's queued
 	// headers, which the rollback cleared, and the winner that replaced it
 	// is already on the chain. See blockfetchRollbackGeneration.
-	if ls.blockfetchBatchRollbackGeneration !=
-		ls.blockfetchRollbackGeneration.Load() {
+	if !ls.blockfetchBatchStillCurrent() {
 		if err := ls.discardStaleBlockfetchBatch(pending); err != nil {
 			return err
 		}
@@ -4802,12 +4817,29 @@ func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
 	// is used immediately by fork detection, so batching blob writes behind an
 	// already-advanced in-memory tip can strand the node on a fork when ancestor
 	// lookups hit uncommitted state.
-	for _, pendingEvent := range pending {
-		evt, addBlockErr := ls.chain.AddBlockWithPointDeferred(
+	for i, pendingEvent := range pending {
+		// The generation test above is a fast path, not the guarantee. It
+		// releases nothing, but it also holds nothing: a rollback can publish
+		// its generation and truncate between that test and this add, because
+		// the adoption that does so holds chainsyncMutex while this drain
+		// holds chainsyncBlockfetchMutex. Passing the same comparison as an
+		// admission predicate makes it atomic with the tip mutation it
+		// guards -- the chain evaluates it under the mutex that serializes
+		// every chain mutation, so no rollback can interleave between the
+		// two.
+		evt, addBlockErr := ls.chain.AddBlockWithPointDeferredIf(
 			pendingEvent.Block,
 			pendingEvent.Point,
 			nil,
+			ls.blockfetchBatchStillCurrent,
 		)
+		if errors.Is(addBlockErr, chain.ErrBlockAddNotAdmitted) {
+			// A rollback superseded this batch after the fast path let it
+			// through. Every event still unprocessed belongs to that same
+			// batch, so drop the remainder in one go instead of offering
+			// each one to a chain that will decline it for the same reason.
+			return ls.discardStaleBlockfetchBatch(pending[i:])
+		}
 		if addBlockErr == nil {
 			// Defer this block's chain.update past chainsyncBlockfetchMutex
 			// rather than publishing inline. AddBlockWithPointDeferred has

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4115,9 +4115,12 @@ func (ls *LedgerState) handleEventBlockfetchBlockDeferred(
 	}
 	ls.pendingBlockfetchEvents = append(ls.pendingBlockfetchEvents, e)
 	ls.batchBlocksReceived++
-	// If this block is the one a tracked range was failing to obtain, that
-	// range is fetchable after all and its failure record is stale.
-	ls.noteBlockfetchRangeProgress(e.Point)
+	// Range progress is noted where the block actually extends the chain,
+	// not here. Arrival alone is not progress: a block from a batch a
+	// rollback has superseded is discarded unapplied, and one that no
+	// longer fits the tip is declined, yet either would clear the failure
+	// record for the range that is stuck. See
+	// flushPendingBlockfetchBlocksDeferred.
 	if len(ls.pendingBlockfetchEvents) >= blockfetchCommitBatchSize {
 		if err := ls.flushPendingBlockfetchBlocksDeferred(pubs); err != nil {
 			return err
@@ -4736,6 +4739,12 @@ func (ls *LedgerState) startQueuedBlockfetchFromEventLocked(
 // them anyway (their parent is no longer on the chain), and any block still
 // wanted after the rollback is re-offered by chainsync and re-fetched by the
 // next batch.
+//
+// The blockfetch range-failure record is deliberately left alone. These blocks
+// never reached the chain, so they are not evidence that the range which is
+// currently stuck can be obtained; clearing it here would reset the count that
+// eventually drops an unservable queued header -- the header that blocks local
+// forging, and the routine aftermath of the slot battle this path resolves.
 func (ls *LedgerState) discardStaleBlockfetchBatch(
 	pending []BlockfetchEvent,
 ) error {
@@ -4818,6 +4827,16 @@ func (ls *LedgerState) flushPendingBlockfetchBlocksDeferred(
 			validationEnabled, _ := ls.validationStateSnapshot()
 			ls.auditContinuationBlock(pendingEvent, validationEnabled)
 			ls.checkSlotBattle(pendingEvent, nil)
+			// The block extended the chain, so the range it belongs to
+			// is fetchable after all and any failure record for it is
+			// stale. Noting it here rather than on arrival is what keeps
+			// the count meaningful: the record exists to unstick a
+			// queued header whose body cannot be applied, which is
+			// exactly the state a delivered-but-never-applied block
+			// leaves the queue in -- and, per
+			// noteBlockfetchRangeUnavailable, the routine aftermath of a
+			// tip slot battle, which is the case this path creates.
+			ls.noteBlockfetchRangeProgress(pendingEvent.Point)
 			continue
 		}
 		ls.clearDeferredHeaderValidation(pendingEvent.Point)

--- a/ledger/envelope_validation_test.go
+++ b/ledger/envelope_validation_test.go
@@ -792,3 +792,57 @@ func substituteByronEbbBody(t *testing.T, blockCbor []byte) []byte {
 	require.NoError(t, err)
 	return tampered
 }
+
+// TestValidateBlockOrderPinsTheEqualSlotAlternativeShape pins, from the
+// validator's side, exactly which of the two possible equal-slot blocks may
+// ever be built.
+//
+// When a rival occupies the slot this node is about to forge, there are two
+// candidate shapes. Binding the parent to the live chain tip -- what
+// DefaultBlockBuilder does for an uncontested slot -- names the rival as
+// parent, so the block's parent slot equals its own and this validator rejects
+// it; so does every Praos peer. Binding the rival's predecessor instead (the
+// alternative-block context, mirroring ouroboros-consensus
+// mkCurrentBlockContext) is a well-ordered sibling of the rival and passes.
+//
+// DefaultBlockBuilder refuses to construct the first shape at all
+// (TestBuildBlockRefusesAParentAtItsOwnSlot in ledger/forging); this test
+// documents why it must, and fails if either side of the rule ever moves.
+func TestValidateBlockOrderPinsTheEqualSlotAlternativeShape(t *testing.T) {
+	const (
+		predecessorSlot   = uint64(999)
+		predecessorNumber = uint64(99)
+		contestedSlot     = uint64(1000)
+		rivalNumber       = predecessorNumber + 1
+	)
+
+	// The block a live-tip-bound builder would produce at a contested slot:
+	// the rival is the parent, so parent slot == block slot.
+	sameSlotParent := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   contestedSlot,
+			number: rivalNumber + 1,
+			era:    shelley.EraShelley,
+		},
+	}
+	err := validateBlockOrder(sameSlotParent, envelopeParent{
+		slot:        contestedSlot,
+		blockNumber: rivalNumber,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not follow parent slot")
+
+	// The alternative: same block number as the rival, the rival's
+	// predecessor as parent.
+	alternative := &envelopeTestBlock{
+		header: &envelopeTestHeader{
+			slot:   contestedSlot,
+			number: rivalNumber,
+			era:    shelley.EraShelley,
+		},
+	}
+	require.NoError(t, validateBlockOrder(alternative, envelopeParent{
+		slot:        predecessorSlot,
+		blockNumber: predecessorNumber,
+	}))
+}

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -193,6 +193,11 @@ func (b *DefaultBlockBuilder) BuildBlock(
 
 // BuildBlockOnContext creates a new block on an explicitly named parent
 // instead of the live chain tip. See BlockContext.
+//
+// leios must be empty: an equal-slot alternative is a plain ranking block, and
+// a non-empty value is rejected rather than carried. The block also carries no
+// mempool transactions, because no validator here can select them against the
+// state at blockCtx.Parent. Both are explained at their guards in buildBlock.
 func (b *DefaultBlockBuilder) BuildBlockOnContext(
 	slot uint64,
 	kesPeriod uint64,
@@ -256,6 +261,15 @@ var errParentSlotNotBelowBlock = errors.New(
 	"parent slot is not below the forged slot",
 )
 
+// errLeiosDataOnAlternative indicates Leios data was supplied together with an
+// explicit block context. An equal-slot alternative is a plain ranking block:
+// see the guard in buildBlock for why certificate and announcement data
+// resolved against the live tip cannot be carried by a block that does not
+// build on it.
+var errLeiosDataOnAlternative = errors.New(
+	"an alternative block cannot carry leios data",
+)
+
 // tipsEqual reports whether two chain tips reference the same point and
 // block number. Slot and hash are both required: a rollback can restore a
 // prior slot, and two forged blocks never share a hash.
@@ -316,6 +330,18 @@ func (b *DefaultBlockBuilder) buildBlock(
 	// ouroboros-consensus mkCurrentBlockContext's EQ branch, which forges
 	// "an alternative to @hdr@: same block no and same predecessor".
 	if blockCtx != nil {
+		// An alternative is a plain ranking block. Leios data is resolved
+		// against "the parent", which the providers answer from the live tip
+		// -- here the rival, which is precisely the block this one does not
+		// build on. A certificate selected that way certifies an endorser
+		// block announced by a chain this block is not on, and a new
+		// announcement would introduce an endorser block whose announcing
+		// chain may be the one that loses the battle. The forger already
+		// omits both; refuse here too so the exported entrypoint cannot be
+		// called into that state.
+		if !leios.empty() {
+			return nil, nil, errLeiosDataOnAlternative
+		}
 		// The candidate only makes sense against the tip it was derived
 		// from. If the chain has already moved, the contest is over;
 		// abandon before doing any work rather than after signing.
@@ -404,6 +430,28 @@ func (b *DefaultBlockBuilder) buildBlock(
 	)
 
 	mempoolTxs := b.mempool.Transactions()
+	if blockCtx != nil {
+		// An alternative is built on the rival's predecessor, but every
+		// transaction validator reachable from here answers against the
+		// ledger's live state -- which has the rival applied. A mempool
+		// transaction spending a UTxO the rival created passes that check
+		// and would be selected, and adoption then rolls the rival back
+		// before applying this block: the transaction's input no longer
+		// exists, so applying our own adopted block fails and the node is
+		// left wedged at the fork point.
+		//
+		// Selecting against a validation snapshot taken at blockCtx.Parent
+		// is the fix, but no validator exposes one: LedgerState's
+		// WithTxValidationSession and ValidateTxWithOverlay both read the
+		// current UTxO set, and the overlay can only add pending state, not
+		// un-apply the block at the tip. Until such a snapshot exists, fail
+		// closed and forge the alternative with no transactions at all. An
+		// empty ranking block is valid against the parent state whatever
+		// the rival did, and it still carries the VRF and opcert that
+		// decide the battle, which is the whole purpose of forging it. The
+		// transactions stay in the mempool for the next block.
+		mempoolTxs = nil
+	}
 	if leiosCert != nil {
 		// A prototype CertRB carries the Leios certificate and no Dijkstra
 		// transactions; node-to-client later inlines the certified EB txs.

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -180,15 +180,28 @@ func NewDefaultBlockBuilder(
 	}, nil
 }
 
-// BuildBlock creates a new block for the given slot.
-// Returns the block and its CBOR encoding.
+// BuildBlock creates a new block for the given slot, extending the live chain
+// tip. Returns the block and its CBOR encoding.
 func (b *DefaultBlockBuilder) BuildBlock(
 	slot uint64,
 	kesPeriod uint64,
 ) (ledger.Block, []byte, error) {
 	generation := b.creds.acquireCredentialGeneration()
 	defer generation.release()
-	return b.buildBlock(slot, kesPeriod, LeiosBlockData{}, generation)
+	return b.buildBlock(slot, kesPeriod, LeiosBlockData{}, generation, nil)
+}
+
+// BuildBlockOnContext creates a new block on an explicitly named parent
+// instead of the live chain tip. See BlockContext.
+func (b *DefaultBlockBuilder) BuildBlockOnContext(
+	slot uint64,
+	kesPeriod uint64,
+	leios LeiosBlockData,
+	blockCtx BlockContext,
+) (ledger.Block, []byte, error) {
+	generation := b.creds.acquireCredentialGeneration()
+	defer generation.release()
+	return b.buildBlock(slot, kesPeriod, leios, generation, &blockCtx)
 }
 
 // BlockForger.buildBlock discovers the Leios capability with a runtime type
@@ -198,6 +211,7 @@ func (b *DefaultBlockBuilder) BuildBlock(
 // this one is loud, but it is the same class of defect the guard prevents.
 var (
 	_ LeiosBlockBuilder                = (*DefaultBlockBuilder)(nil)
+	_ AlternativeBlockBuilder          = (*DefaultBlockBuilder)(nil)
 	_ credentialGenerationBlockBuilder = (*DefaultBlockBuilder)(nil)
 )
 
@@ -210,7 +224,7 @@ func (b *DefaultBlockBuilder) BuildBlockWithLeios(
 ) (ledger.Block, []byte, error) {
 	generation := b.creds.acquireCredentialGeneration()
 	defer generation.release()
-	return b.buildBlock(slot, kesPeriod, leios, generation)
+	return b.buildBlock(slot, kesPeriod, leios, generation, nil)
 }
 
 func (b *DefaultBlockBuilder) buildBlockWithCredentialGeneration(
@@ -218,8 +232,9 @@ func (b *DefaultBlockBuilder) buildBlockWithCredentialGeneration(
 	kesPeriod uint64,
 	leios LeiosBlockData,
 	generation *credentialGeneration,
+	blockCtx *BlockContext,
 ) (ledger.Block, []byte, error) {
-	return b.buildBlock(slot, kesPeriod, leios, generation)
+	return b.buildBlock(slot, kesPeriod, leios, generation, blockCtx)
 }
 
 // errParentChangedDuringBuild indicates the chain tip moved while
@@ -229,6 +244,16 @@ func (b *DefaultBlockBuilder) buildBlockWithCredentialGeneration(
 // adoption would reject anyway once it re-checks the parent.
 var errParentChangedDuringBuild = errors.New(
 	"selected parent changed during block assembly",
+)
+
+// errParentSlotNotBelowBlock indicates the resolved parent does not sit
+// strictly below the slot being forged. Praos requires strictly increasing
+// slots and ledger.validateBlockOrder enforces it, so such a block would be
+// rejected after signing -- by this node and by every peer. The live-tip path
+// hits this exactly when the tip already holds the slot being forged, which is
+// the contested case an explicit BlockContext exists to serve.
+var errParentSlotNotBelowBlock = errors.New(
+	"parent slot is not below the forged slot",
 )
 
 // tipsEqual reports whether two chain tips reference the same point and
@@ -245,6 +270,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 	kesPeriod uint64,
 	leios LeiosBlockData,
 	credentials *credentialGeneration,
+	blockCtx *BlockContext,
 ) (ledger.Block, []byte, error) {
 	// Keep the protocol lifetime guard inside the generation-backed path so
 	// both exported builder entrypoints and BlockForger fail before reading the
@@ -266,10 +292,14 @@ func (b *DefaultBlockBuilder) buildBlock(
 	// Get current chain tip
 	currentTip := b.chainTip.Tip()
 
+	// Resolve the block context: the parent this block names and the block
+	// number it carries. Default (blockCtx nil) is to extend the live tip.
+	parentPoint := currentTip.Point
+
 	// Block numbers are 0-indexed in Cardano: the first block after
 	// genesis is BlockNo 0. When the tip is genesis (empty hash), the
 	// chain has no blocks yet so the next block number is 0.
-	isGenesis := len(currentTip.Point.Hash) == 0
+	isGenesis := len(parentPoint.Hash) == 0
 
 	var nextBlockNumber uint64
 	if !isGenesis {
@@ -279,6 +309,45 @@ func (b *DefaultBlockBuilder) buildBlock(
 			)
 		}
 		nextBlockNumber = currentTip.BlockNumber + 1
+	}
+
+	// An explicit context replaces both, naming the contested tip's
+	// predecessor as parent and reusing the contested tip's block number --
+	// ouroboros-consensus mkCurrentBlockContext's EQ branch, which forges
+	// "an alternative to @hdr@: same block no and same predecessor".
+	if blockCtx != nil {
+		// The candidate only makes sense against the tip it was derived
+		// from. If the chain has already moved, the contest is over;
+		// abandon before doing any work rather than after signing.
+		if !tipsEqual(currentTip, blockCtx.Rival) {
+			return nil, nil, fmt.Errorf(
+				"%w: contested tip %x/%d is no longer the chain tip (%x/%d)",
+				errParentChangedDuringBuild,
+				blockCtx.Rival.Point.Hash,
+				blockCtx.Rival.BlockNumber,
+				currentTip.Point.Hash,
+				currentTip.BlockNumber,
+			)
+		}
+		if len(blockCtx.Parent.Hash) == 0 {
+			return nil, nil, errors.New(
+				"explicit block context requires a resolved parent",
+			)
+		}
+		parentPoint = blockCtx.Parent
+		nextBlockNumber = blockCtx.BlockNumber
+		isGenesis = false
+	}
+
+	// Whichever way the parent was resolved, it must sit strictly below the
+	// slot being forged. See errParentSlotNotBelowBlock.
+	if !isGenesis && parentPoint.Slot >= slot {
+		return nil, nil, fmt.Errorf(
+			"%w: parent slot %d, forged slot %d",
+			errParentSlotNotBelowBlock,
+			parentPoint.Slot,
+			slot,
+		)
 	}
 
 	// Get protocol parameters for the slot being forged. This
@@ -666,8 +735,9 @@ func (b *DefaultBlockBuilder) buildBlock(
 		)
 	}
 
-	// currentTip, captured above, is already baked into nextBlockNumber
-	// and will be baked into prevHash below. If a concurrent block
+	// The chain tip captured above is what nextBlockNumber and prevHash were
+	// resolved from -- directly on the live-tip path, and as the contested
+	// block on the explicit-context path. If a concurrent block
 	// advanced the chain while transactions were being selected above,
 	// binding to that stale parent would only be caught later, after VRF
 	// and KES signing, when chain adoption re-checks the parent and
@@ -854,13 +924,13 @@ func (b *DefaultBlockBuilder) buildBlock(
 	// Cardano protocol).
 	var prevHash *lcommon.Blake2b256
 	if !isGenesis {
-		if len(currentTip.Point.Hash) != 32 {
+		if len(parentPoint.Hash) != 32 {
 			return nil, nil, fmt.Errorf(
-				"invalid tip hash length: expected 32 (Blake2b-256), got %d",
-				len(currentTip.Point.Hash),
+				"invalid parent hash length: expected 32 (Blake2b-256), got %d",
+				len(parentPoint.Hash),
 			)
 		}
-		h := lcommon.NewBlake2b256(currentTip.Point.Hash)
+		h := lcommon.NewBlake2b256(parentPoint.Hash)
 		prevHash = &h
 	}
 

--- a/ledger/forging/builder_block_context_test.go
+++ b/ledger/forging/builder_block_context_test.go
@@ -249,3 +249,144 @@ func TestBuildBlockStillExtendsTheLiveTipByDefault(t *testing.T) {
 	assert.Equal(t, uint64(101), block.BlockNumber())
 	assert.Equal(t, tipHash, block.PrevHash().Bytes())
 }
+
+// TestBuildBlockOnContextCarriesNoMempoolTransactions is the state-mismatch
+// half of the equal-slot alternative. Every transaction validator reachable
+// from the builder answers against the ledger's live state, which has the
+// rival applied; the alternative is built on the rival's predecessor and
+// adoption rolls the rival back before applying it. A mempool transaction
+// spending a UTxO the rival created therefore passes validation, gets
+// selected, and then fails to apply after adoption -- wedging the node at the
+// fork point with neither candidate on the chain.
+//
+// The validator here accepts everything, exactly as a live-state validator
+// would for such a transaction. The live-tip build shows it is admitted there;
+// the context build must not consult the validator at all.
+func TestBuildBlockOnContextCarriesNoMempoolTransactions(t *testing.T) {
+	const (
+		contestedSlot   = uint64(1000)
+		parentSlot      = uint64(999)
+		rivalBlockNumbr = uint64(100)
+	)
+	rivalHash := testHash32(0xAA)
+	parentHash := testHash32(0xBB)
+	rival := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: contestedSlot, Hash: rivalHash},
+		BlockNumber: rivalBlockNumbr,
+	}
+	// A UTxO that only exists because the rival block created it.
+	rivalCreatedTxHash := testHash32(0xCC)
+	mempool := &mockMempool{
+		transactions: []MempoolTransaction{
+			{
+				Hash: "spends_rival_output",
+				Cbor: makeMinimalTxCborWithInput(t, rivalCreatedTxHash, 0),
+				Type: conway.TxTypeConway,
+			},
+		},
+	}
+	validator := &sessionMockTxValidator{}
+	builder := newSelectionTestBuilder(
+		t,
+		mempool,
+		&mockChainTip{tip: rival},
+		validator,
+	)
+
+	// Live-tip control: the validator admits the transaction, so a normal
+	// build selects it. This is the state the alternative must not inherit.
+	control, _, err := builder.BuildBlock(contestedSlot+1, 0)
+	require.NoError(t, err)
+	require.Len(
+		t,
+		control.Transactions(),
+		1,
+		"control: the live-state validator admits this transaction",
+	)
+	require.Equal(t, 1, validator.validateCalls)
+
+	block, _, err := builder.BuildBlockOnContext(
+		contestedSlot,
+		0,
+		LeiosBlockData{},
+		BlockContext{
+			Parent:      ocommon.Point{Slot: parentSlot, Hash: parentHash},
+			BlockNumber: rivalBlockNumbr,
+			Rival:       rival,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	assert.Empty(
+		t,
+		block.Transactions(),
+		"an alternative must carry no transaction selected against the rival's state",
+	)
+	assert.Equal(
+		t,
+		1,
+		validator.validateCalls,
+		"no mempool transaction may be offered to a live-state validator for an alternative",
+	)
+}
+
+// TestBuildBlockOnContextRejectsLeiosData pins the fail-closed guard on the
+// exported entrypoint. Leios certificate and announcement data is resolved
+// against the live tip -- the rival -- so a block that does not build on the
+// rival must not carry it. The forger omits it already; the builder refuses it
+// rather than trusting every caller to.
+func TestBuildBlockOnContextRejectsLeiosData(t *testing.T) {
+	const (
+		contestedSlot   = uint64(1000)
+		parentSlot      = uint64(999)
+		rivalBlockNumbr = uint64(100)
+	)
+	rival := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: contestedSlot,
+			Hash: testHash32(0xAA),
+		},
+		BlockNumber: rivalBlockNumbr,
+	}
+	builder := newBlockContextTestBuilder(t, rival)
+	blockCtx := BlockContext{
+		Parent: ocommon.Point{
+			Slot: parentSlot,
+			Hash: testHash32(0xBB),
+		},
+		BlockNumber: rivalBlockNumbr,
+		Rival:       rival,
+	}
+
+	for name, leios := range map[string]LeiosBlockData{
+		"announcement": {
+			Announcement: &LeiosEndorserBlockAnnouncement{},
+		},
+		"certificate": {
+			Certificate: &lcommon.LeiosEbCertificate{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			block, blockCbor, err := builder.BuildBlockOnContext(
+				contestedSlot,
+				0,
+				leios,
+				blockCtx,
+			)
+			require.ErrorIs(t, err, errLeiosDataOnAlternative)
+			assert.Nil(t, block)
+			assert.Nil(t, blockCbor)
+		})
+	}
+
+	// Empty Leios data on the same context still builds, so the guard is
+	// rejecting the data and not the context.
+	block, _, err := builder.BuildBlockOnContext(
+		contestedSlot,
+		0,
+		LeiosBlockData{},
+		blockCtx,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+}

--- a/ledger/forging/builder_block_context_test.go
+++ b/ledger/forging/builder_block_context_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testHash32(b byte) []byte {
+	h := make([]byte, 32)
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// newBlockContextTestBuilder returns a builder whose live chain tip is the
+// contested block: slot contestedSlot, block number contestedBlockNumber.
+func newBlockContextTestBuilder(
+	t *testing.T,
+	tip ochainsync.Tip,
+) *DefaultBlockBuilder {
+	t.Helper()
+	builder, err := NewDefaultBlockBuilder(BlockBuilderConfig{
+		Mempool: &mockMempool{transactions: []MempoolTransaction{}},
+		PParamsProvider: &mockPParamsProvider{
+			pparams: &conway.ConwayProtocolParameters{
+				MaxTxSize:        16384,
+				MaxBlockBodySize: 90112,
+				MaxBlockExUnits: lcommon.ExUnits{
+					Memory: 62000000,
+					Steps:  20000000000,
+				},
+			},
+		},
+		ChainTip:    &mockChainTip{tip: tip},
+		EpochNonce:  &mockEpochNonceProvider{epoch: 1, nonce: make([]byte, 32)},
+		Credentials: setupTestCredentials(t),
+	})
+	require.NoError(t, err)
+	return builder
+}
+
+// TestBuildBlockOnContextForgesAnAlternativeToTheTip is the builder half of the
+// equal-slot alternative. The live tip is a rival block at the slot being
+// forged; the explicit context names the rival's predecessor as parent and the
+// rival's own block number, so the two blocks are siblings that chain selection
+// arbitrates between. This is ouroboros-consensus mkCurrentBlockContext's EQ
+// branch: "forge an alternative to @hdr@: same block no and same predecessor".
+func TestBuildBlockOnContextForgesAnAlternativeToTheTip(t *testing.T) {
+	const (
+		contestedSlot   = uint64(1000)
+		parentSlot      = uint64(999)
+		rivalBlockNumbr = uint64(100)
+	)
+	rivalHash := testHash32(0xAA)
+	parentHash := testHash32(0xBB)
+	rival := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: contestedSlot, Hash: rivalHash},
+		BlockNumber: rivalBlockNumbr,
+	}
+	builder := newBlockContextTestBuilder(t, rival)
+
+	block, blockCbor, err := builder.BuildBlockOnContext(
+		contestedSlot,
+		0,
+		LeiosBlockData{},
+		BlockContext{
+			Parent: ocommon.Point{
+				Slot: parentSlot,
+				Hash: parentHash,
+			},
+			BlockNumber: rivalBlockNumbr,
+			Rival:       rival,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	assert.NotEmpty(t, blockCbor)
+
+	assert.Equal(t, contestedSlot, block.SlotNumber())
+	// Same block number as the rival, not the rival's plus one: the
+	// alternative competes with it, it does not extend it.
+	assert.Equal(t, rivalBlockNumbr, block.BlockNumber())
+	assert.Equal(
+		t,
+		parentHash,
+		block.PrevHash().Bytes(),
+		"alternative must name the rival's predecessor as parent",
+	)
+	assert.NotEqual(
+		t,
+		rivalHash,
+		block.PrevHash().Bytes(),
+		"alternative must not name the rival itself as parent",
+	)
+}
+
+// TestBuildBlockRefusesAParentAtItsOwnSlot is the negative half: the default
+// live-tip path must never produce the block the equal-slot case would
+// otherwise ask it for. Binding the tip as parent when the tip is already at
+// the forged slot yields a block whose parent slot equals its own, which
+// ledger.validateBlockOrder rejects ("block slot %d does not follow parent slot
+// %d") and every Praos peer rejects for the same reason. The builder refuses
+// before signing rather than emitting it.
+func TestBuildBlockRefusesAParentAtItsOwnSlot(t *testing.T) {
+	const contestedSlot = uint64(1000)
+	rival := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: contestedSlot, Hash: testHash32(0xAA)},
+		BlockNumber: 100,
+	}
+	builder := newBlockContextTestBuilder(t, rival)
+
+	t.Run("live tip path", func(t *testing.T) {
+		block, blockCbor, err := builder.BuildBlock(contestedSlot, 0)
+		require.ErrorIs(t, err, errParentSlotNotBelowBlock)
+		assert.Nil(t, block)
+		assert.Nil(t, blockCbor)
+	})
+
+	t.Run("explicit context naming the rival", func(t *testing.T) {
+		block, blockCbor, err := builder.BuildBlockOnContext(
+			contestedSlot,
+			0,
+			LeiosBlockData{},
+			BlockContext{
+				Parent:      rival.Point,
+				BlockNumber: rival.BlockNumber,
+				Rival:       rival,
+			},
+		)
+		require.ErrorIs(t, err, errParentSlotNotBelowBlock)
+		assert.Nil(t, block)
+		assert.Nil(t, blockCbor)
+	})
+
+	t.Run("explicit context with a parent above the forged slot", func(t *testing.T) {
+		block, _, err := builder.BuildBlockOnContext(
+			contestedSlot,
+			0,
+			LeiosBlockData{},
+			BlockContext{
+				Parent: ocommon.Point{
+					Slot: contestedSlot + 1,
+					Hash: testHash32(0xBB),
+				},
+				BlockNumber: rival.BlockNumber,
+				Rival:       rival,
+			},
+		)
+		require.ErrorIs(t, err, errParentSlotNotBelowBlock)
+		assert.Nil(t, block)
+	})
+}
+
+// TestBuildBlockOnContextAbandonsAStaleContest pins that a candidate bound to a
+// rival which is no longer the chain tip is dropped before any signing work.
+// The contest is over: either the rival was rolled back, or the chain moved on
+// past it, and in both cases the alternative is meaningless.
+func TestBuildBlockOnContextAbandonsAStaleContest(t *testing.T) {
+	const contestedSlot = uint64(1000)
+	liveTip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: contestedSlot,
+			Hash: testHash32(0xCC),
+		},
+		BlockNumber: 100,
+	}
+	builder := newBlockContextTestBuilder(t, liveTip)
+
+	staleRival := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: contestedSlot,
+			Hash: testHash32(0xAA),
+		},
+		BlockNumber: 100,
+	}
+	block, _, err := builder.BuildBlockOnContext(
+		contestedSlot,
+		0,
+		LeiosBlockData{},
+		BlockContext{
+			Parent: ocommon.Point{
+				Slot: contestedSlot - 1,
+				Hash: testHash32(0xBB),
+			},
+			BlockNumber: staleRival.BlockNumber,
+			Rival:       staleRival,
+		},
+	)
+	require.ErrorIs(t, err, errParentChangedDuringBuild)
+	assert.Nil(t, block)
+}
+
+// TestBuildBlockOnContextRequiresAResolvedParent pins the fail-closed contract
+// shared with chain.TipPredecessor: a context with no parent must not silently
+// fall back to a genesis-shaped (null prevHash) block.
+func TestBuildBlockOnContextRequiresAResolvedParent(t *testing.T) {
+	const contestedSlot = uint64(1000)
+	rival := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: contestedSlot, Hash: testHash32(0xAA)},
+		BlockNumber: 100,
+	}
+	builder := newBlockContextTestBuilder(t, rival)
+
+	block, _, err := builder.BuildBlockOnContext(
+		contestedSlot,
+		0,
+		LeiosBlockData{},
+		BlockContext{BlockNumber: rival.BlockNumber, Rival: rival},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved parent")
+	assert.Nil(t, block)
+}
+
+// TestBuildBlockStillExtendsTheLiveTipByDefault guards the unchanged path: an
+// uncontested slot builds on the live tip with the tip's block number plus one.
+func TestBuildBlockStillExtendsTheLiveTipByDefault(t *testing.T) {
+	tipHash := testHash32(0xAA)
+	builder := newBlockContextTestBuilder(t, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 1000, Hash: tipHash},
+		BlockNumber: 100,
+	})
+
+	block, _, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	assert.Equal(t, uint64(1001), block.SlotNumber())
+	assert.Equal(t, uint64(101), block.BlockNumber())
+	assert.Equal(t, tipHash, block.PrevHash().Bytes())
+}

--- a/ledger/forging/forge_alternative_test.go
+++ b/ledger/forging/forge_alternative_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -385,4 +387,77 @@ func TestEqualSlotAlternativeRecoversAdopterPanic(t *testing.T) {
 		float64(1),
 		testutil.ToFloat64(forger.metrics.forgeCouldNot),
 	)
+}
+
+// TestEqualSlotAlternativeCarriesNoLeiosData pins a deliberate limitation. An
+// alternative is built on the contested block's predecessor, but
+// ParentLeiosAnnouncement resolves "the parent" from the live tip -- the
+// rival. A certificate chosen from that answer would certify an endorser
+// block announced by a ranking block the alternative is not built on, so the
+// alternative is forged as a plain ranking block: the parent-announcement
+// provider is not consulted at all, and no new endorser block is announced
+// either.
+func TestEqualSlotAlternativeCarriesNoLeiosData(t *testing.T) {
+	ebHash := lcommon.NewBlake2b256(
+		[]byte(strings.Repeat("e", 32)),
+	)
+	rbHash := lcommon.NewBlake2b256(
+		[]byte(strings.Repeat("r", 32)),
+	)
+	parent := &forgerTestLeiosParentAnnouncement{
+		rbHash: rbHash,
+		hash:   ebHash,
+		ok:     true,
+	}
+	leiosCerts := &forgerTestLeiosCerts{
+		eligible: []LeiosCertifiedEndorserBlock{
+			{
+				SlotNo:            9,
+				EndorserBlockHash: ebHash,
+				Certificate: &lcommon.LeiosEbCertificate{
+					EndorserBlockHash: ebHash,
+				},
+				AnnouncingRbHash: rbHash,
+			},
+		},
+		txHashesOK: true,
+	}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	adopter := &forgerTestSiblingAdopter{adopted: true}
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    &forgerCountingLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		ChainContext:                    newAltTestChainContext(10),
+		SiblingAdopter:                  adopter,
+		LeiosCertificateProvider:        leiosCerts,
+		LeiosParentAnnouncementProvider: parent,
+		PromRegistry:                    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	require.Equal(t, 1, builder.contextCalls)
+	assert.Zero(
+		t,
+		parent.calls,
+		"the parent announcement provider must not be consulted for an "+
+			"alternative: it answers for the tip, not for our parent",
+	)
+	assert.Nil(t, builder.leiosData.Certificate)
+	assert.Nil(t, builder.leiosData.Announcement)
+	assert.True(t, builder.leiosData.empty())
 }

--- a/ledger/forging/forge_alternative_test.go
+++ b/ledger/forging/forge_alternative_test.go
@@ -358,6 +358,81 @@ func TestCheckAndForgeProductionEqualSlotDeclinesWithoutTheAlternativePath(
 	}
 }
 
+// TestEqualSlotAlternativeRequiresADurableFence pins the anti-equivocation
+// precondition for contesting a slot at all. This path cannot tell a rival's
+// block from one of our own: it reads "the tip is at my slot" and forges an
+// alternative to whatever is there.
+//
+// Without a durable fence store, lastForgedSlot is in-memory only and
+// fenceLoaded is false after a restart, so the "slot already has our own
+// block" gate cannot fire. A producer restarted inside a slot it has already
+// forged for would therefore find its OWN block at the tip, treat it as a
+// rival, sign a second different block for that slot -- equivocation, against
+// a first block that may already have reached peers -- and roll its own good
+// block off the tip to adopt it.
+//
+// Everything wired here is wired correctly: chain context, sibling adopter,
+// context-capable builder, a tip genuinely at the contested slot. Only the
+// fence is missing, and that alone must decline the contest. The node
+// binary refuses to start a producer without a fence store at all
+// (node_forging.go), so this guards embedders and dev-mode wiring, which the
+// forging package still admits.
+func TestEqualSlotAlternativeRequiresADurableFence(t *testing.T) {
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	broadcaster := &forgerTestBroadcaster{}
+	adopter := &forgerTestSiblingAdopter{adopted: true}
+	published := 0
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		// No ForgeFence: the case this test exists for.
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		ChainContext:   newAltTestChainContext(10),
+		SiblingAdopter: adopter,
+		BlockForged: func(ledger.Block, []byte, time.Duration) {
+			published++
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	// The slot is still observable as a contested one that was declined,
+	// exactly as any other missing part of the capability is.
+	assert.Equal(t, 1, leader.callCount())
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+	// Nothing signed, nothing adopted, nothing diffused.
+	assert.Zero(t, builder.contextCalls, "no alternative may be built")
+	assert.Zero(t, builder.calls)
+	assert.Zero(t, builder.leiosCalls)
+	assert.Zero(t, adopter.calls, "nothing may be offered to chain selection")
+	assert.Zero(t, broadcaster.calls)
+	assert.Zero(t, published)
+}
+
 // TestEqualSlotAlternativeRecoversAdopterPanic keeps a misbehaving adopter
 // from taking down the forge loop goroutine, matching addBlockSafe.
 func TestEqualSlotAlternativeRecoversAdopterPanic(t *testing.T) {
@@ -375,7 +450,7 @@ func TestEqualSlotAlternativeRecoversAdopterPanic(t *testing.T) {
 		&forgerCountingLeader{},
 		builder,
 		&forgerTestBroadcaster{},
-		nil,
+		&fenceTestStore{},
 		newAltTestChainContext(10),
 		&forgerTestSiblingAdopter{panics: true},
 	)
@@ -440,6 +515,7 @@ func TestEqualSlotAlternativeCarriesNoLeiosData(t *testing.T) {
 			chainTipSlot:      10,
 			slotsPerKESPeriod: 100,
 		},
+		ForgeFence:                      &fenceTestStore{},
 		ChainContext:                    newAltTestChainContext(10),
 		SiblingAdopter:                  adopter,
 		LeiosCertificateProvider:        leiosCerts,

--- a/ledger/forging/forge_alternative_test.go
+++ b/ledger/forging/forge_alternative_test.go
@@ -1,0 +1,388 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const altTestRivalBlockNumber = uint64(42)
+
+func altTestParentPoint() ocommon.Point {
+	return ocommon.NewPoint(9, []byte("fork-point-hash"))
+}
+
+func altTestRivalTip(slot uint64) ochainsync.Tip {
+	return ochainsync.Tip{
+		Point:       ocommon.NewPoint(slot, []byte("rival-block-hash")),
+		BlockNumber: altTestRivalBlockNumber,
+	}
+}
+
+// forgerTestChainContext implements AlternativeChainContextProvider over a
+// fixed answer, standing in for chain.Chain.
+type forgerTestChainContext struct {
+	parent ocommon.Point
+	tip    ochainsync.Tip
+	ok     bool
+	calls  int
+}
+
+func newAltTestChainContext(tipSlot uint64) *forgerTestChainContext {
+	return &forgerTestChainContext{
+		parent: altTestParentPoint(),
+		tip:    altTestRivalTip(tipSlot),
+		ok:     true,
+	}
+}
+
+func (c *forgerTestChainContext) TipPredecessor() (
+	ocommon.Point,
+	ochainsync.Tip,
+	bool,
+) {
+	c.calls++
+	return c.parent, c.tip, c.ok
+}
+
+// forgerTestSiblingAdopter implements SiblingBlockAdopter with a fixed
+// chain-selection outcome.
+type forgerTestSiblingAdopter struct {
+	adopted bool
+	err     error
+	panics  bool
+	calls   int
+	block   ledger.Block
+}
+
+func (a *forgerTestSiblingAdopter) AdoptLocalForgedSibling(
+	block ledger.Block,
+) (bool, error) {
+	a.calls++
+	a.block = block
+	if a.panics {
+		panic("sibling adopter panic")
+	}
+	return a.adopted, a.err
+}
+
+// newAlternativeTestForger is newGateTestForger plus the two optional
+// providers that enable equal-slot alternative forging, and an observer count
+// so a test can assert that a losing alternative is never published.
+func newAlternativeTestForger(
+	t *testing.T,
+	clock forgerTestSlotClock,
+	leader LeaderChecker,
+	builder BlockBuilder,
+	broadcaster BlockBroadcaster,
+	fence ForgeFenceStore,
+	chainContext AlternativeChainContextProvider,
+	adopter SiblingBlockAdopter,
+) *BlockForger {
+	t.Helper()
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		ForgeFence:       fence,
+		SlotClock:        clock,
+		ChainContext:     chainContext,
+		SiblingAdopter:   adopter,
+		PromRegistry:     prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+	return forger
+}
+
+// TestEqualSlotAlternativeLosingChainSelectionIsNotPublished pins the losing
+// half of a slot battle. Chain selection kept the block already at the tip, so
+// our block was never adopted and must not be diffused, must not clear its
+// transactions from the mempool, and must not count as adopted.
+//
+// The fence, by contrast, must stay burned: the block was signed, and a second
+// signature for the same slot is equivocation whether or not the first one won.
+func TestEqualSlotAlternativeLosingChainSelectionIsNotPublished(
+	t *testing.T,
+) {
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	broadcaster := &forgerTestBroadcaster{}
+	adopter := &forgerTestSiblingAdopter{adopted: false}
+	fence := &fenceTestStore{}
+	published := 0
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    leader,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		ForgeFence:       fence,
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		ChainContext:   newAltTestChainContext(10),
+		SiblingAdopter: adopter,
+		BlockForged: func(ledger.Block, []byte, time.Duration) {
+			published++
+		},
+		PromRegistry: prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	assert.Equal(t, 1, builder.contextCalls, "the alternative is still built")
+	assert.Equal(t, 1, adopter.calls)
+	assert.Zero(t, published, "a losing alternative must not be published")
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeForged),
+		"the block was forged, which is what forgeForged counts",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.forgeAdopted),
+		"a losing alternative was not adopted",
+	)
+	assert.Equal(
+		t,
+		[]uint64{10},
+		fence.stored,
+		"the slot stays burned: the block was signed either way",
+	)
+}
+
+// TestEqualSlotAlternativeReservesTheFenceBeforeSigning pins the ordering the
+// #3734 fence depends on. The slot must be recorded durably before the builder
+// is asked for a block, so a crash between signing and adoption still leaves
+// the slot unusable.
+func TestEqualSlotAlternativeReservesTheFenceBeforeSigning(t *testing.T) {
+	fence := &fenceTestStore{}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	// Observed at the moment the builder runs.
+	var fenceAtBuild []uint64
+	builder.onBuild = func() { fenceAtBuild = append([]uint64(nil), fence.stored...) }
+
+	forger := newAlternativeTestForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		&forgerCountingLeader{},
+		builder,
+		&forgerTestBroadcaster{},
+		fence,
+		newAltTestChainContext(10),
+		&forgerTestSiblingAdopter{adopted: true},
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+	require.Equal(t, 1, builder.contextCalls)
+	assert.Equal(
+		t,
+		[]uint64{10},
+		fenceAtBuild,
+		"the fence must be reserved before the block is signed",
+	)
+}
+
+// TestEqualSlotAlternativeRefusesASlotWeAlreadyForged is the anti-equivocation
+// companion with the alternative path fully wired. Our own block at the tip,
+// or a fence already at the slot, must not produce a second signature for it.
+func TestEqualSlotAlternativeRefusesASlotWeAlreadyForged(t *testing.T) {
+	leader := &forgerCountingLeader{}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	adopter := &forgerTestSiblingAdopter{adopted: true}
+	fence := &fenceTestStore{slot: 10, present: true}
+	forger := newAlternativeTestForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		leader,
+		builder,
+		&forgerTestBroadcaster{},
+		fence,
+		newAltTestChainContext(10),
+		adopter,
+	)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	assert.Zero(t, builder.contextCalls, "must not forge a second block")
+	assert.Zero(t, builder.calls)
+	assert.Zero(t, adopter.calls)
+	assert.Empty(t, fence.stored, "must not advance the fence")
+	assert.Zero(
+		t,
+		leader.callCount(),
+		"our own block at our own slot needs no leader selection",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+		"our own block is not a rival",
+	)
+}
+
+// TestCheckAndForgeProductionEqualSlotDeclinesWithoutTheAlternativePath keeps
+// the pre-alternative behaviour observable for any node that is not wired for
+// it: the contested slot still reaches leader selection, is still counted as a
+// leader slot, a slot battle and a could-not-forge, and is still logged rather
+// than dropped in silence. Nothing is built and nothing is signed.
+func TestCheckAndForgeProductionEqualSlotDeclinesWithoutTheAlternativePath(
+	t *testing.T,
+) {
+	tests := []struct {
+		name         string
+		chainContext AlternativeChainContextProvider
+		adopter      SiblingBlockAdopter
+	}{
+		{name: "nothing wired"},
+		{
+			name:         "no sibling adopter",
+			chainContext: newAltTestChainContext(10),
+		},
+		{
+			name:    "no chain context",
+			adopter: &forgerTestSiblingAdopter{adopted: true},
+		},
+		{
+			name: "tip has no resolvable predecessor",
+			chainContext: &forgerTestChainContext{
+				ok: false,
+			},
+			adopter: &forgerTestSiblingAdopter{adopted: true},
+		},
+		{
+			name:         "tip is no longer at the contested slot",
+			chainContext: newAltTestChainContext(9),
+			adopter:      &forgerTestSiblingAdopter{adopted: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leader := &forgerCountingLeader{}
+			builder := &forgerTestBuilder{}
+			broadcaster := &forgerTestBroadcaster{}
+			fence := &fenceTestStore{}
+			forger := newAlternativeTestForger(
+				t,
+				forgerTestSlotClock{
+					currentSlot:       10,
+					chainTipSlot:      10,
+					slotsPerKESPeriod: 100,
+				},
+				leader,
+				builder,
+				broadcaster,
+				fence,
+				tt.chainContext,
+				tt.adopter,
+			)
+
+			require.NoError(
+				t,
+				forger.checkAndForgeProduction(context.Background()),
+			)
+
+			assert.Equal(t, 1, leader.callCount())
+			assert.Equal(
+				t,
+				float64(1),
+				testutil.ToFloat64(forger.metrics.slotBattlesTotal),
+			)
+			assert.Equal(
+				t,
+				float64(1),
+				testutil.ToFloat64(forger.metrics.forgeCouldNot),
+			)
+			assert.Zero(t, builder.calls)
+			assert.Zero(t, builder.contextCalls)
+			assert.Zero(t, broadcaster.calls)
+			assert.Empty(
+				t,
+				fence.stored,
+				"a declined battle must not burn the slot",
+			)
+		})
+	}
+}
+
+// TestEqualSlotAlternativeRecoversAdopterPanic keeps a misbehaving adopter
+// from taking down the forge loop goroutine, matching addBlockSafe.
+func TestEqualSlotAlternativeRecoversAdopterPanic(t *testing.T) {
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
+	forger := newAlternativeTestForger(
+		t,
+		forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      10,
+			slotsPerKESPeriod: 100,
+		},
+		&forgerCountingLeader{},
+		builder,
+		&forgerTestBroadcaster{},
+		nil,
+		newAltTestChainContext(10),
+		&forgerTestSiblingAdopter{panics: true},
+	)
+
+	err := forger.checkAndForgeProduction(context.Background())
+	require.ErrorContains(t, err, "sibling block adopter panic")
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeCouldNot),
+	)
+}

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -63,20 +63,30 @@ func newGateTestForger(
 // the propagation race puts the chain tip AT the current slot, not past
 // it. ouroboros-consensus treats that as a contested slot rather than a
 // reason to stop: mkCurrentBlockContext declines only for GT
-// (TraceBlockFromFuture) and, for EQ, builds a block context on the
-// tip's predecessor so the node still participates.
+// (TraceBlockFromFuture) and, for EQ, forges an alternative to the block
+// at the tip -- same block number, the tip's predecessor as parent -- so
+// the leader VRF and chain selection arbitrate.
 //
-// Dingo instead folded EQ into the GT skip with `currentSlot <=
-// tipSlot`, which returns before checkLeaderSafe. The slot never
-// reaches leader selection, so no leadership counter moves and the only
-// trace is a Debug line: the loss is invisible on every dashboard.
+// Dingo folded EQ into the GT skip with `currentSlot <= tipSlot`, which
+// returns before checkLeaderSafe. The slot never reached leader
+// selection, so no leadership counter moved and the only trace was a
+// Debug line.
 //
-// The slot must at minimum reach leader selection and be accounted for.
+// With the alternative path wired, the contested slot must reach leader
+// selection, be counted as a leader slot and a slot battle, and produce
+// a block built on the tip's predecessor rather than on the tip.
+// TestCheckAndForgeProductionEqualSlotDeclinesWithoutTheAlternativePath
+// covers the unwired case, which still declines and still accounts for
+// the battle.
 func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
 	leader := &forgerCountingLeader{}
-	builder := &forgerTestBuilder{}
+	builder := &forgerTestBuilder{
+		block: newForgerTestBlock(10, altTestRivalBlockNumber),
+		cbor:  []byte{0x01},
+	}
 	broadcaster := &forgerTestBroadcaster{}
-	forger := newGateTestForger(
+	adopter := &forgerTestSiblingAdopter{adopted: true}
+	forger := newAlternativeTestForger(
 		t,
 		forgerTestSlotClock{
 			currentSlot:       10,
@@ -87,6 +97,8 @@ func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
 		builder,
 		broadcaster,
 		nil,
+		newAltTestChainContext(10),
+		adopter,
 	)
 
 	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
@@ -112,27 +124,61 @@ func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		float64(1),
+		float64(0),
 		testutil.ToFloat64(forger.metrics.forgeCouldNot),
-		"a leader slot we did not produce for must be visible as a "+
-			"could-not-forge, not as silence",
+		"a contested slot we did forge for is not a could-not-forge",
 	)
 
-	// The block must NOT be built. BuildBlock binds the parent to the
-	// live chain tip, which here is the rival's block at this same
-	// slot; the resulting block would carry a parent whose slot equals
-	// its own and be rejected by ledger.validateBlockOrder. Forging a
-	// valid alternative needs the tip's predecessor as parent, which
-	// the builder cannot express yet.
+	// The block must be built on the tip's PREDECESSOR. Binding the live
+	// tip -- the rival's block at this same slot -- would carry a parent
+	// whose slot equals its own and be rejected by
+	// ledger.validateBlockOrder and by every Praos peer.
+	require.Equal(
+		t,
+		1,
+		builder.contextCalls,
+		"a contested slot must build on an explicit block context",
+	)
 	assert.Zero(
 		t,
 		builder.calls,
 		"must not bind a same-slot parent",
 	)
+	assert.Equal(
+		t,
+		altTestParentPoint(),
+		builder.blockCtx.Parent,
+		"the alternative's parent is the tip's predecessor",
+	)
+	assert.Equal(
+		t,
+		altTestRivalBlockNumber,
+		builder.blockCtx.BlockNumber,
+		"the alternative carries the rival's block number, not one past it",
+	)
+	assert.Equal(
+		t,
+		altTestRivalTip(10),
+		builder.blockCtx.Rival,
+		"the alternative names the tip it competes with",
+	)
+
+	// It goes to chain selection, not to the extend-only add path.
+	assert.Equal(t, 1, adopter.calls)
 	assert.Zero(t, broadcaster.calls)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeForged),
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(forger.metrics.forgeAdopted),
+	)
 }
 
-// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the
+// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the
 // anti-equivocation companion to the test above. The slot-aligned loop
 // can re-enter a slot it already committed to (a clock that has not
 // advanced, or a NextSlotTime already in the past), and after a

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -96,7 +96,7 @@ func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
 		leader,
 		builder,
 		broadcaster,
-		nil,
+		&fenceTestStore{},
 		newAltTestChainContext(10),
 		adopter,
 	)

--- a/ledger/forging/forge_gates_test.go
+++ b/ledger/forging/forge_gates_test.go
@@ -178,7 +178,7 @@ func TestCheckAndForgeProductionEqualSlotReachesLeaderCheck(t *testing.T) {
 	)
 }
 
-// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the
+// TestCheckAndForgeProductionEqualSlotDoesNotReForgeOurOwnSlot is the
 // anti-equivocation companion to the test above. The slot-aligned loop
 // can re-enter a slot it already committed to (a clock that has not
 // advanced, or a NextSlotTime already in the past), and after a

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -83,6 +83,13 @@ type BlockForger struct {
 	opCertLedgerView LedgerView
 	eraParams        ProtocolParamsProvider
 
+	// Equal-slot alternative forging. Both are optional and both must be
+	// present, alongside a BlockBuilder that implements
+	// AlternativeBlockBuilder, for a contested slot to be contested rather
+	// than conceded.
+	chainContext   AlternativeChainContextProvider
+	siblingAdopter SiblingBlockAdopter
+
 	// Slot battle detection
 	slotTracker *SlotTracker
 
@@ -219,6 +226,29 @@ type credentialGenerationBlockBuilder interface {
 type BlockBroadcaster interface {
 	// AddBlock adds a block to the local chain and propagates to peers.
 	AddBlock(block ledger.Block, cbor []byte) error
+}
+
+// AlternativeChainContextProvider reports the context needed to forge an
+// alternative to the block already at the chain tip: the tip itself and the
+// point of its immediate predecessor, which becomes the alternative's parent.
+// chain.Chain implements it directly.
+//
+// ok must be false whenever the context cannot be established. The forger then
+// declines the contested slot rather than falling back to the live tip, which
+// would produce a block whose parent slot equals its own.
+type AlternativeChainContextProvider interface {
+	TipPredecessor() (parent ocommon.Point, tip ochainsync.Tip, ok bool)
+}
+
+// SiblingBlockAdopter offers a locally forged block that competes with the
+// current chain tip -- rather than extending it -- to chain selection, and
+// reports whether it was adopted. ledger.LedgerState implements it as
+// AdoptLocalForgedSibling.
+//
+// Losing is a normal outcome, not an error: the block at the tip keeps the
+// slot and the forged block is discarded without being diffused.
+type SiblingBlockAdopter interface {
+	AdoptLocalForgedSibling(block ledger.Block) (adopted bool, err error)
 }
 
 // ConfirmedTxRemover removes transactions after the block containing them has
@@ -382,6 +412,14 @@ type ForgerConfig struct {
 	// rejects one that skips ahead of the last-seen value by more than
 	// one. Required whenever OpCertLedgerView is set.
 	EraParams ProtocolParamsProvider
+	// ChainContext and SiblingAdopter enable forging an alternative when the
+	// chain tip already holds a rival block at the slot this node leads --
+	// ouroboros-consensus mkCurrentBlockContext's EQ case. Both are
+	// optional; with either unset, or with a BlockBuilder that does not
+	// implement AlternativeBlockBuilder, a contested slot is declined and
+	// counted exactly as it was before this capability existed.
+	ChainContext   AlternativeChainContextProvider
+	SiblingAdopter SiblingBlockAdopter
 
 	// ForgeFence persists the last-forged-slot fence so a restart cannot
 	// sign a second block for a slot this node already used. Nil
@@ -456,6 +494,8 @@ func NewBlockForger(cfg ForgerConfig) (*BlockForger, error) {
 		fenceStore:       cfg.ForgeFence,
 		opCertLedgerView: cfg.OpCertLedgerView,
 		eraParams:        cfg.EraParams,
+		chainContext:     cfg.ChainContext,
+		siblingAdopter:   cfg.SiblingAdopter,
 	}
 	if cfg.ForgeSyncToleranceSlots == 0 {
 		cfg.ForgeSyncToleranceSlots = forgeSyncToleranceSlots
@@ -1028,17 +1068,12 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 
 	// A rival block already occupies this leader slot. This is a slot
 	// battle, not a reason to treat the slot as spent: the reference
-	// implementation forges an alternative here (same block number, the
-	// tip's predecessor as parent) and lets the leader VRF and chain
-	// selection arbitrate.
+	// implementation forges an alternative here -- same block number as the
+	// rival, the rival's predecessor as parent -- and lets the leader VRF
+	// and chain selection arbitrate (mkCurrentBlockContext's EQ branch).
 	//
-	// Dingo cannot build that alternative yet. BlockBuilder binds the
-	// parent to the live chain tip, so a block forged now would name a
-	// parent whose slot equals its own and be rejected by
-	// ledger.validateBlockOrder; binding the tip's predecessor instead
-	// needs a block that does not extend the local tip, which
-	// chain.addBlockLocked refuses. Until that path exists, record the
-	// battle we are declining rather than dropping the slot silently.
+	// altBlockContext is nil for every uncontested slot, which leaves the
+	// build and adoption below on their original live-tip paths.
 	//
 	// Unlike the rival-under-fence case in the equal-slot gate above,
 	// counting the battle here does not double up with
@@ -1050,19 +1085,31 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// exist without a fence. checkSlotBattle returns early when
 	// WasForgedByUs says we never forged the slot, so this is the only
 	// place the battle is counted.
+	var altBlockContext *BlockContext
 	if currentSlot == tipSlot {
 		if f.metrics != nil {
 			f.metrics.slotBattlesTotal.Inc()
 		}
-		f.incCouldNotForge()
-		f.logger.Warn(
-			"forge skip: leader slot already holds another block; forging an alternative is not supported",
-			"current_slot",
-			currentSlot,
-			"tip_slot",
-			tipSlot,
+		blockCtx, ok := f.alternativeBlockContext(currentSlot)
+		if !ok {
+			// Nothing to build the alternative on. Record the battle
+			// being declined rather than dropping the slot silently.
+			f.incCouldNotForge()
+			f.logger.Warn(
+				"forge skip: leader slot already holds another block and no alternative can be built",
+				"current_slot", currentSlot,
+				"tip_slot", tipSlot,
+			)
+			return nil
+		}
+		altBlockContext = &blockCtx
+		f.logger.Info(
+			"leader slot already holds another block; forging an alternative",
+			"current_slot", currentSlot,
+			"rival_hash", hex.EncodeToString(blockCtx.Rival.Point.Hash),
+			"fork_point_slot", blockCtx.Parent.Slot,
+			"block_number", blockCtx.BlockNumber,
 		)
-		return nil
 	}
 
 	// Commit to this slot before any signing happens for it, including
@@ -1154,7 +1201,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		kesPeriod,
 		leiosBlockData,
 		generation,
-		nil,
+		altBlockContext,
 	)
 	if err != nil {
 		f.incCouldNotForge()
@@ -1222,7 +1269,34 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	// Attempt local adoption immediately after building and validation. Keep
 	// observability callbacks out of this critical path: subscribers may be
 	// slow, while the block's parent must still be the active chain tip.
-	if addErr := f.addBlockSafe(block, blockCbor); addErr != nil {
+	//
+	// An alternative does not extend the tip, so it goes to chain selection
+	// instead: it is adopted only if it beats the block already there, by
+	// the same comparison a peer's competing block goes through. Losing is
+	// an outcome, not a failure -- the rival keeps the slot and this block
+	// is never diffused, so the observer, mempool cleanup and adoption
+	// counters below must not run for it.
+	if altBlockContext != nil {
+		adopted, addErr := f.adoptSiblingBlockSafe(block, blockCbor)
+		if addErr != nil {
+			f.incCouldNotForge()
+			return fmt.Errorf(
+				"failed to adopt alternative block: %w",
+				addErr,
+			)
+		}
+		if !adopted {
+			f.logger.Info(
+				"forged alternative lost the slot battle; the block at the tip stands",
+				"slot", currentSlot,
+				"hash", hex.EncodeToString(block.Hash().Bytes()),
+				"rival_hash", hex.EncodeToString(
+					altBlockContext.Rival.Point.Hash,
+				),
+			)
+			return nil
+		}
+	} else if addErr := f.addBlockSafe(block, blockCbor); addErr != nil {
 		f.incCouldNotForge()
 		return fmt.Errorf("failed to add block: %w", addErr)
 	}
@@ -1674,6 +1748,60 @@ func (f *BlockForger) validateForgedBlockSafe(
 		}
 	}()
 	return f.blockValidator.ValidateForgedBlock(block, blockCbor)
+}
+
+// alternativeBlockContext resolves the context for forging an alternative to
+// the block already at the tip: the tip's block number, and the tip's
+// predecessor as parent. This is what ouroboros-consensus'
+// mkCurrentBlockContext returns for EQ.
+//
+// It reports false -- and the caller declines the contested slot -- whenever
+// any part of the capability is missing: an unwired chain context or sibling
+// adopter, a BlockBuilder that cannot take an explicit context, a tip with no
+// resolvable predecessor, a tip that is no longer at the contested slot, or a
+// predecessor that does not sit strictly below it. Declining costs one block;
+// guessing a parent here costs a signature over a block no peer will accept.
+func (f *BlockForger) alternativeBlockContext(
+	slot uint64,
+) (BlockContext, bool) {
+	if f.chainContext == nil || f.siblingAdopter == nil {
+		return BlockContext{}, false
+	}
+	if _, ok := f.blockBuilder.(AlternativeBlockBuilder); !ok {
+		return BlockContext{}, false
+	}
+	parent, tip, ok := f.chainContext.TipPredecessor()
+	if !ok {
+		return BlockContext{}, false
+	}
+	// Read from the chain rather than trusting the slot-clock snapshot the
+	// gate above used: the tip must still be a block at the contested slot,
+	// and its parent must sit strictly below that slot.
+	if tip.Point.Slot != slot || parent.Slot >= slot {
+		return BlockContext{}, false
+	}
+	return BlockContext{
+		Parent:      parent,
+		BlockNumber: tip.BlockNumber,
+		Rival:       tip,
+	}, true
+}
+
+// adoptSiblingBlockSafe offers a forged alternative to chain selection,
+// recovering any panic from the pluggable adopter for the same reason
+// addBlockSafe does. A recovered panic is treated as an adoption failure.
+func (f *BlockForger) adoptSiblingBlockSafe(
+	block ledger.Block,
+	_ []byte,
+) (adopted bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			adopted = false
+			err = fmt.Errorf("sibling block adopter panic: %v", r)
+			f.reportForgeCallbackPanic("publication", r)
+		}
+	}()
+	return f.siblingAdopter.AdoptLocalForgedSibling(block)
 }
 
 // addBlockSafe calls the pluggable BlockBroadcaster, recovering any

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1145,9 +1145,25 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			"slot", currentSlot,
 		)
 	}
+	var (
+		leiosParentRb    lcommon.Blake2b256
+		leiosParentKnown bool
+	)
 	if forgeLeiosData {
+		// The parent announcement every piece of Leios data below is
+		// resolved against, captured before resolution so it can be
+		// re-checked after; see the guard ahead of the build. Only read on
+		// the live-tip path: an alternative carries no Leios data, and the
+		// provider answers for the tip, which on that path is the rival.
+		var leiosParentEb lcommon.Blake2b256
+		leiosParentRb, leiosParentEb, leiosParentKnown = f.leiosParentAnnouncement(
+			currentSlot,
+		)
 		leiosBlockData, embeddedEb, embeddedEbSlot = f.leiosBlockDataForSlot(
 			currentSlot,
+			leiosParentRb,
+			leiosParentEb,
+			leiosParentKnown,
 		)
 	}
 	if forgeLeiosData && f.leiosChecker != nil {
@@ -1192,6 +1208,38 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 			} else if announcement != nil {
 				leiosBlockData.Announcement = announcement
 			}
+		}
+	}
+	// Every piece of Leios data resolved above is parent-dependent. The
+	// certificate is chosen for the endorser block the parent ranking block
+	// announced, and an announcement is built against that same parent. The
+	// builder does not inherit any of that: it binds the block's parent from
+	// its own fresh chain-tip read. A tip that moved while the Leios work
+	// above ran therefore yields a block whose certificate belongs to a
+	// different parent's endorser-block lineage -- a block no peer accepts,
+	// signed with this slot's credentials.
+	//
+	// Re-check the parent announcement and, if it moved, drop the Leios data
+	// and the embedded-endorser-block bookkeeping that goes with it, then
+	// forge a plain ranking block. Dropping is the fail-closed answer:
+	// re-resolving here would have to re-run endorser-block production for
+	// the new parent, and a second endorser block for one slot is not a thing
+	// this loop may do. Clearing embeddedEb matters as much as clearing the
+	// data -- left set, MarkEndorserBlockEmbedded would record an endorser
+	// block as embedded in a block that does not carry it.
+	if !leiosBlockData.empty() && leiosParentKnown {
+		if rb, _, ok := f.leiosParentAnnouncement(currentSlot); !ok ||
+			rb != leiosParentRb {
+			f.logger.Warn(
+				"leios data dropped: parent announcement changed while the block was being prepared",
+				"slot", currentSlot,
+				"resolved_parent_rb", leiosParentRb.String(),
+			)
+			leiosBlockData = LeiosBlockData{}
+			// embeddedEb alone: embeddedEbSlot has already served its
+			// only purpose (resolving the certified closure for the
+			// mempool rebase above) and is not read again.
+			embeddedEb = nil
 		}
 	}
 	// Leios providers, mempool access, transaction validation, and broadcaster
@@ -1377,11 +1425,17 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 	return nil
 }
 
-func (f *BlockForger) leiosBlockDataForSlot(
-	slot uint64,
-) (LeiosBlockData, *lcommon.Blake2b256, uint64) {
-	if f.leiosCerts == nil {
-		return LeiosBlockData{}, nil, 0
+// leiosParentAnnouncement resolves the parent ranking block and the endorser
+// block it announced. Every parent-dependent Leios selection is made against
+// this answer, and the pre-build guard re-reads it to detect a chain tip that
+// moved underneath that selection.
+func (f *BlockForger) leiosParentAnnouncement(slot uint64) (
+	parentRbHash lcommon.Blake2b256,
+	parentHash lcommon.Blake2b256,
+	ok bool,
+) {
+	if f.leiosParent == nil {
+		return lcommon.Blake2b256{}, lcommon.Blake2b256{}, false
 	}
 	parentRbHash, parentHash, ok, err := f.leiosParent.ParentLeiosAnnouncement()
 	if err != nil {
@@ -1392,7 +1446,7 @@ func (f *BlockForger) leiosBlockDataForSlot(
 			"error",
 			err,
 		)
-		return LeiosBlockData{}, nil, 0
+		return lcommon.Blake2b256{}, lcommon.Blake2b256{}, false
 	}
 	if !ok {
 		f.logger.Debug(
@@ -1400,6 +1454,18 @@ func (f *BlockForger) leiosBlockDataForSlot(
 			"slot",
 			slot,
 		)
+		return lcommon.Blake2b256{}, lcommon.Blake2b256{}, false
+	}
+	return parentRbHash, parentHash, true
+}
+
+func (f *BlockForger) leiosBlockDataForSlot(
+	slot uint64,
+	parentRbHash lcommon.Blake2b256,
+	parentHash lcommon.Blake2b256,
+	parentKnown bool,
+) (LeiosBlockData, *lcommon.Blake2b256, uint64) {
+	if f.leiosCerts == nil || !parentKnown {
 		return LeiosBlockData{}, nil, 0
 	}
 	eligible := f.leiosCerts.EligibleCertifiedEndorserBlocks()

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -151,6 +153,43 @@ type BlockBuilder interface {
 	BuildBlock(slot uint64, kesPeriod uint64) (ledger.Block, []byte, error)
 }
 
+// BlockContext names the parent a forged block is built on. It mirrors
+// ouroboros-consensus' BlockContext (NodeKernel/Forge.hs): a block number and
+// the point the block extends.
+//
+// A nil *BlockContext means "extend the live chain tip", which is what every
+// uncontested slot uses and what BuildBlock does. An explicit context exists
+// for the equal-slot case, where the tip already holds a rival block at the
+// slot being forged: there the alternative carries the rival's block number
+// and names the rival's predecessor as parent, so the two blocks are siblings
+// that chain selection arbitrates between.
+type BlockContext struct {
+	// Parent is the point the forged block names as its parent. It must sit
+	// strictly below the forged slot.
+	Parent ocommon.Point
+	// BlockNumber is the block number the forged block carries. For an
+	// equal-slot alternative this is the rival's own block number, not the
+	// rival's plus one.
+	BlockNumber uint64
+	// Rival is the chain tip this block is an alternative to. The builder
+	// re-checks it against the live tip and abandons the candidate if the
+	// chain has moved, so a contest that is already over costs nothing.
+	Rival ochainsync.Tip
+}
+
+// AlternativeBlockBuilder constructs a block on an explicitly named parent
+// rather than on the live chain tip. A BlockBuilder that does not implement it
+// cannot forge the equal-slot alternative, and the forger declines contested
+// slots for such a builder exactly as it did before this capability existed.
+type AlternativeBlockBuilder interface {
+	BuildBlockOnContext(
+		slot uint64,
+		kesPeriod uint64,
+		leios LeiosBlockData,
+		blockCtx BlockContext,
+	) (ledger.Block, []byte, error)
+}
+
 // LeiosBlockBuilder constructs Dijkstra blocks with Leios prototype header/body
 // extensions. Builders that do not implement it cannot safely announce or
 // certify Leios endorser blocks.
@@ -172,6 +211,7 @@ type credentialGenerationBlockBuilder interface {
 		kesPeriod uint64,
 		leios LeiosBlockData,
 		generation *credentialGeneration,
+		blockCtx *BlockContext,
 	) (ledger.Block, []byte, error)
 }
 
@@ -1114,6 +1154,7 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		kesPeriod,
 		leiosBlockData,
 		generation,
+		nil,
 	)
 	if err != nil {
 		f.incCouldNotForge()
@@ -1292,6 +1333,7 @@ func (f *BlockForger) buildBlock(
 	kesPeriod uint64,
 	leiosData LeiosBlockData,
 	generation *credentialGeneration,
+	blockCtx *BlockContext,
 ) (ledger.Block, []byte, error) {
 	var (
 		block     ledger.Block
@@ -1304,6 +1346,23 @@ func (f *BlockForger) buildBlock(
 			kesPeriod,
 			leiosData,
 			generation,
+			blockCtx,
+		)
+	} else if blockCtx != nil {
+		// Only reachable for a custom builder, and only when the forger has
+		// already confirmed it implements AlternativeBlockBuilder before
+		// committing to the contested slot.
+		altBuilder, ok := f.blockBuilder.(AlternativeBlockBuilder)
+		if !ok {
+			return nil, nil, errors.New(
+				"an explicit block context requires an AlternativeBlockBuilder",
+			)
+		}
+		block, blockCbor, err = altBuilder.BuildBlockOnContext(
+			slot,
+			kesPeriod,
+			leiosData,
+			*blockCtx,
 		)
 	} else if leiosData.empty() {
 		block, blockCbor, err = f.blockBuilder.BuildBlock(slot, kesPeriod)

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1778,14 +1778,35 @@ func (f *BlockForger) validateForgedBlockSafe(
 // mkCurrentBlockContext returns for EQ.
 //
 // It reports false -- and the caller declines the contested slot -- whenever
-// any part of the capability is missing: an unwired chain context or sibling
-// adopter, a BlockBuilder that cannot take an explicit context, a tip with no
-// resolvable predecessor, a tip that is no longer at the contested slot, or a
-// predecessor that does not sit strictly below it. Declining costs one block;
-// guessing a parent here costs a signature over a block no peer will accept.
+// any part of the capability is missing: no durable forge fence, an unwired
+// chain context or sibling adopter, a BlockBuilder that cannot take an
+// explicit context, a tip with no resolvable predecessor, a tip that is no
+// longer at the contested slot, or a predecessor that does not sit strictly
+// below it. Declining costs one block; guessing a parent here costs a
+// signature over a block no peer will accept.
 func (f *BlockForger) alternativeBlockContext(
 	slot uint64,
 ) (BlockContext, bool) {
+	// A durable fence is a precondition for contesting a slot at all,
+	// because this path cannot tell a rival's block from our own.
+	//
+	// The caller's "slot already has our own block" gate reads fenceLoaded,
+	// and lastForgedSlot is in-memory only when no store is wired. Restart a
+	// producer inside a slot it has already forged for and that gate cannot
+	// fire: the tip is our own block, the slot equals the tip's, and this
+	// function would hand back a context naming our own block as the rival.
+	// Forging that alternative signs a second, different block for a slot
+	// whose first block may already have reached peers -- equivocation, and
+	// the adoption would roll our own good block off the tip to do it.
+	//
+	// A wired store makes the situation unreachable: the fence is loaded at
+	// construction, so the gate refuses the slot before this is called and
+	// reserveForgeSlot would refuse it again. Conceding a genuinely
+	// contested slot is one block; equivocating is a slashable-class
+	// protocol violation, so decline rather than guess.
+	if f.fenceStore == nil {
+		return BlockContext{}, false
+	}
 	if f.chainContext == nil || f.siblingAdopter == nil {
 		return BlockContext{}, false
 	}

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -1125,10 +1125,32 @@ func (f *BlockForger) checkAndForgeProduction(_ context.Context) error {
 		return nil
 	}
 
-	leiosBlockData, embeddedEb, embeddedEbSlot := f.leiosBlockDataForSlot(
-		currentSlot,
+	var (
+		leiosBlockData LeiosBlockData
+		embeddedEb     *lcommon.Blake2b256
+		embeddedEbSlot uint64
 	)
-	if f.leiosChecker != nil {
+	// An alternative is built on the contested block's predecessor, not on
+	// the contested block, but ParentLeiosAnnouncement resolves "the parent"
+	// from the live tip -- which here is the rival. A certificate selected
+	// from that answer would certify an endorser block announced by a ranking
+	// block this one is not built on. Forge the alternative as a plain
+	// ranking block: no certificate, and no new announcement either, so a
+	// contested slot cannot also introduce an endorser block whose announcing
+	// chain may be the one that loses.
+	forgeLeiosData := altBlockContext == nil
+	if !forgeLeiosData {
+		f.logger.Debug(
+			"leios data omitted from an equal-slot alternative",
+			"slot", currentSlot,
+		)
+	}
+	if forgeLeiosData {
+		leiosBlockData, embeddedEb, embeddedEbSlot = f.leiosBlockDataForSlot(
+			currentSlot,
+		)
+	}
+	if forgeLeiosData && f.leiosChecker != nil {
 		var excludedTxHashes map[string]struct{}
 		canAnnounce := true
 		if embeddedEb != nil {

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -1099,6 +1099,12 @@ type forgerTestLeiosParentAnnouncement struct {
 	ok     bool
 	err    error
 	calls  int
+	// rbHashAfterFirst, when set, is returned from the second call onward.
+	// This is how a test moves the chain tip underneath an already-resolved
+	// Leios selection: the forger resolves the parent once and re-reads it
+	// before building, so a different second answer is exactly a tip that
+	// advanced while the Leios work was running.
+	rbHashAfterFirst *lcommon.Blake2b256
 }
 
 func (p *forgerTestLeiosParentAnnouncement) ParentLeiosAnnouncement() (
@@ -1108,6 +1114,9 @@ func (p *forgerTestLeiosParentAnnouncement) ParentLeiosAnnouncement() (
 	error,
 ) {
 	p.calls++
+	if p.calls > 1 && p.rbHashAfterFirst != nil {
+		return *p.rbHashAfterFirst, p.hash, p.ok, p.err
+	}
 	return p.rbHash, p.hash, p.ok, p.err
 }
 
@@ -1610,7 +1619,10 @@ func TestCheckAndForgeProductionCertifiesLeiosEBAfterAdoption(t *testing.T) {
 			}
 			require.Equal(t, []lcommon.Blake2b256{ebHash}, leiosCerts.marked)
 			require.Equal(t, []uint64{9}, leiosCerts.markedSlots)
-			require.Equal(t, 1, parent.calls)
+			// Twice: once to resolve the parent the certificate is
+			// selected for, once to re-check it has not moved before the
+			// block is built against it.
+			require.Equal(t, 2, parent.calls)
 			// CertifiedEndorserBlockTxHashes must be called with the
 			// eligible certificate's own slot (9, from eb.SlotNo above), not
 			// the forged ranking block's slot (10) or zero: the manifest is
@@ -1704,5 +1716,99 @@ func TestCheckAndForgeProductionCertifiesOnlyParentAnnouncedLeiosEB(
 	require.Same(t, parentCert, builder.leiosData.Certificate)
 	require.Equal(t, []lcommon.Blake2b256{parentHash}, leiosCerts.marked)
 	require.Equal(t, []uint64{9}, leiosCerts.markedSlots)
-	require.Equal(t, 1, parent.calls)
+	// Resolve, then re-check before the build. See leiosParentAnnouncement.
+	require.Equal(t, 2, parent.calls)
+}
+
+// TestCheckAndForgeProductionDropsLeiosDataWhenTheParentMoves covers the gap
+// between resolving parent-dependent Leios data and building the block that
+// carries it.
+//
+// The certificate is selected for the endorser block the parent ranking block
+// announced. The builder inherits none of that: it binds the block's parent
+// from its own fresh chain-tip read. If the tip advances while the Leios work
+// runs -- endorser-block production and mempool rebasing are not instant --
+// the block ends up built on a new parent while carrying a certificate from
+// the old parent's endorser-block lineage. No peer accepts that block, and
+// this node has spent the slot's credentials signing it.
+//
+// The parent is therefore re-read immediately before the build. When it has
+// moved, the Leios data is dropped and a plain ranking block is forged, and
+// the embedded-endorser-block bookkeeping is dropped with it: leaving it set
+// would record an endorser block as embedded in a block that does not carry
+// it.
+func TestCheckAndForgeProductionDropsLeiosDataWhenTheParentMoves(t *testing.T) {
+	block := newForgerTestBlock(10, 2)
+	builder := &forgerTestBuilder{block: block, cbor: block.cbor}
+	parentHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x33}, 32))
+	parentRbHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x44}, 32))
+	// The tip the builder will actually bind, different from the one the
+	// certificate was selected for.
+	movedRbHash := lcommon.NewBlake2b256(bytes.Repeat([]byte{0x66}, 32))
+	parentCert := &lcommon.LeiosEbCertificate{
+		SlotNo:              9,
+		EndorserBlockHash:   parentHash,
+		Signers:             []byte{0x80},
+		AggregatedSignature: make([]byte, lcommon.LeiosBlsSignatureSize),
+	}
+	leiosCerts := &forgerTestLeiosCerts{
+		eligible: []LeiosCertifiedEndorserBlock{
+			{
+				SlotNo:            9,
+				EndorserBlockHash: parentHash,
+				Certificate:       parentCert,
+				AnnouncingRbHash:  parentRbHash,
+			},
+		},
+	}
+	parent := &forgerTestLeiosParentAnnouncement{
+		rbHash:           parentRbHash,
+		hash:             parentHash,
+		ok:               true,
+		rbHashAfterFirst: &movedRbHash,
+	}
+
+	forger, err := NewBlockForger(ForgerConfig{
+		Mode:             ModeProduction,
+		Logger:           slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Credentials:      setupTestCredentials(t),
+		LeaderChecker:    &forgerTestLeader{},
+		BlockBuilder:     builder,
+		BlockBroadcaster: &forgerTestBroadcaster{},
+		ForgeFence:       &fenceTestStore{},
+		SlotClock: forgerTestSlotClock{
+			currentSlot:       10,
+			chainTipSlot:      9,
+			slotsPerKESPeriod: 100,
+		},
+		LeiosCertificateProvider:        leiosCerts,
+		LeiosParentAnnouncementProvider: parent,
+		PromRegistry:                    prometheus.NewRegistry(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, forger.checkAndForgeProduction(context.Background()))
+
+	// The parent was resolved once and re-checked once.
+	require.Equal(t, 2, parent.calls)
+	// A block was still forged -- dropping the Leios data costs the
+	// certificate, not the slot.
+	require.Equal(t, 1, builder.calls, "a plain ranking block is still built")
+	require.Zero(
+		t,
+		builder.leiosCalls,
+		"the Leios build path must not be taken with data resolved for the abandoned parent",
+	)
+	require.Nil(
+		t,
+		builder.leiosData.Certificate,
+		"a certificate selected for the abandoned parent must not be carried",
+	)
+	require.Nil(t, builder.leiosData.Announcement)
+	// The embedded-endorser-block bookkeeping went with it.
+	require.Empty(
+		t,
+		leiosCerts.marked,
+		"no endorser block may be recorded as embedded in a block that omits it",
+	)
 }

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -779,6 +779,7 @@ func (b *forgerTestBuilder) BuildBlockWithLeios(
 	leiosData LeiosBlockData,
 ) (ledger.Block, []byte, error) {
 	b.leiosCalls++
+	b.noteBuild()
 	b.leiosData = leiosData
 	return b.block, b.cbor, nil
 }

--- a/ledger/forging/forger_test.go
+++ b/ledger/forging/forger_test.go
@@ -746,11 +746,22 @@ func TestNewBlockForgerRejectsInvalidOpCertGeneration(t *testing.T) {
 }
 
 type forgerTestBuilder struct {
-	block      ledger.Block
-	cbor       []byte
-	calls      int
-	leiosCalls int
-	leiosData  LeiosBlockData
+	block        ledger.Block
+	cbor         []byte
+	calls        int
+	leiosCalls   int
+	contextCalls int
+	blockCtx     BlockContext
+	leiosData    LeiosBlockData
+	// onBuild, when set, runs at the moment a build entry point is
+	// invoked, so a test can observe state as of block assembly.
+	onBuild func()
+}
+
+func (b *forgerTestBuilder) noteBuild() {
+	if b.onBuild != nil {
+		b.onBuild()
+	}
 }
 
 func (b *forgerTestBuilder) BuildBlock(
@@ -758,6 +769,7 @@ func (b *forgerTestBuilder) BuildBlock(
 	uint64,
 ) (ledger.Block, []byte, error) {
 	b.calls++
+	b.noteBuild()
 	return b.block, b.cbor, nil
 }
 
@@ -767,6 +779,23 @@ func (b *forgerTestBuilder) BuildBlockWithLeios(
 	leiosData LeiosBlockData,
 ) (ledger.Block, []byte, error) {
 	b.leiosCalls++
+	b.leiosData = leiosData
+	return b.block, b.cbor, nil
+}
+
+// BuildBlockOnContext makes forgerTestBuilder an AlternativeBlockBuilder, so
+// tests can wire the equal-slot alternative path. It records the context it
+// was handed; the forger only reaches it when a test also supplies a
+// ChainContext and a SiblingAdopter.
+func (b *forgerTestBuilder) BuildBlockOnContext(
+	_ uint64,
+	_ uint64,
+	leiosData LeiosBlockData,
+	blockCtx BlockContext,
+) (ledger.Block, []byte, error) {
+	b.contextCalls++
+	b.noteBuild()
+	b.blockCtx = blockCtx
 	b.leiosData = leiosData
 	return b.block, b.cbor, nil
 }

--- a/ledger/local_sibling.go
+++ b/ledger/local_sibling.go
@@ -199,10 +199,19 @@ func (ls *LedgerState) AdoptLocalForgedSibling(
 }
 
 // validateLocalSibling checks that block genuinely competes with the tip:
-// same parent, same block number, and a slot strictly above the parent's. Only
-// a block that satisfies all three can be adopted by rolling back exactly one
-// block, and only such a block is an equal-length candidate for the Praos
-// comparison that follows.
+// the tip's slot, the tip's parent, the tip's block number, and a slot strictly
+// above the parent's. Only a block that satisfies all four can be adopted by
+// rolling back exactly one block, and only such a block is an equal-length
+// candidate for the Praos comparison that follows.
+//
+// Slot equality is the admission boundary for this path, not merely the
+// forger's precondition. This is the equal-slot (EQ) case of
+// mkCurrentBlockContext and nothing else: a same-block-number competitor at a
+// different slot is an ordinary fork, which belongs to chainsync's fork
+// resolution with its ancestor search and rollback-depth accounting, not to a
+// one-block rollback driven from the forge loop. Enforcing it here keeps the
+// ledger gate closed even if a future caller reaches it without the forger's
+// own currentSlot == tipSlot check.
 func validateLocalSibling(
 	block gledger.Block,
 	parent ocommon.Point,
@@ -238,6 +247,14 @@ func validateLocalSibling(
 			ErrNotChainTipSibling,
 			block.SlotNumber(),
 			parent.Slot,
+		)
+	}
+	if block.SlotNumber() != incumbentTip.Point.Slot {
+		return fmt.Errorf(
+			"%w: block slot %d is not the chain tip's slot %d",
+			ErrNotChainTipSibling,
+			block.SlotNumber(),
+			incumbentTip.Point.Slot,
 		)
 	}
 	return nil

--- a/ledger/local_sibling.go
+++ b/ledger/local_sibling.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/consensus/praos"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// ErrNotChainTipSibling reports a block offered to AdoptLocalForgedSibling
+// that does not in fact compete with the current chain tip: it does not share
+// the tip's parent, does not carry the tip's block number, or the chain has no
+// resolvable predecessor to fork from. Such a block is never adopted, because
+// the rollback that adoption performs is only ever one block deep and only
+// ever to the block the two candidates already agree on.
+var ErrNotChainTipSibling = errors.New(
+	"block does not compete with the current chain tip",
+)
+
+// praosPrefersCandidateSibling reports whether an equal-length candidate beats
+// the incumbent tip under the standard Praos rule: higher block number, then
+// the reference implementation's opcert-issue-number and VRF tiebreakers when
+// they are armed.
+//
+// It deliberately has no notion of whose block is whose. ComparePraosTips
+// answers ChainEqual whenever no reference implementation rule applies -- an
+// unarmed tiebreaker, an unresolvable select view, identical VRF -- and
+// ChainEqual keeps the incumbent. A locally forged block therefore has to win
+// on the same evidence a peer's block would need, and a tie leaves the chain
+// exactly where it was.
+func praosPrefersCandidateSibling(
+	candidateTip, incumbentTip ochainsync.Tip,
+	candidateView, incumbentView praos.PraosTiebreakerView,
+) bool {
+	return praos.ComparePraosTips(
+		candidateTip,
+		incumbentTip,
+		candidateView,
+		incumbentView,
+	) == praos.ChainABetter
+}
+
+// AdoptLocalForgedSibling offers a locally forged block that competes with the
+// current chain tip, rather than extending it, to chain selection.
+//
+// This is the local counterpart of what a peer-delivered competing block does
+// today. When a peer sends a header that does not fit our tip, chainsync's
+// tryResolveFork compares it against the local tip with
+// praos.ComparePraosTips, and if it wins, rolls the chain and ledger back to
+// the common ancestor and adopts the peer's chain from there. A block this
+// node forges itself at a slot a rival already occupies is the same situation
+// with the same arbitration, but it arrives through the forger rather than
+// through a connection, so it cannot enter that path: tryResolveFork is keyed
+// on a ChainsyncEvent, a peer connection, that peer's retained header history
+// and a blockfetch restart, none of which exist here.
+//
+// What is shared is the decision and the mutation:
+//
+//   - The decision is praos.ComparePraosTips on the two tips and their select
+//     views, the same comparison tryResolveFork makes, with no preference for
+//     the local block. A candidate that does not strictly win is dropped.
+//   - The mutation is rollbackChainAndStateDeferred to the common parent
+//     followed by the adoption of the winner, the same sequence tryResolveFork
+//     performs. It runs under chainsyncMutex, which is the lock that path
+//     holds, so a rollback driven from the forge loop is serialized against
+//     concurrent chainsync header handling exactly as one driven from a peer
+//     is.
+//
+// The rollback is always exactly one block deep, to the block both candidates
+// name as parent, and it is only reached after the candidate has been checked
+// to be a genuine sibling of the tip.
+//
+// It reports whether the block was adopted. Losing chain selection is a normal
+// outcome and returns (false, nil): the rival keeps the slot and the forged
+// block is discarded undiffused.
+func (ls *LedgerState) AdoptLocalForgedSibling(
+	block gledger.Block,
+) (bool, error) {
+	if ls == nil || ls.chain == nil {
+		return false, errors.New("ledger state unavailable")
+	}
+	if block == nil {
+		return false, errors.New("proposed block is nil")
+	}
+	// Registered before the mutex is taken so defer's LIFO order runs it
+	// after the unlock: publishing under ls.chainsyncMutex deadlocks the
+	// node. See pendingPublishes.
+	var pending pendingPublishes
+	defer pending.flush()
+	ls.chainsyncMutex.Lock()
+	defer ls.chainsyncMutex.Unlock()
+
+	parent, incumbentTip, ok := ls.chain.TipPredecessor()
+	if !ok {
+		return false, fmt.Errorf(
+			"%w: chain tip has no resolvable predecessor",
+			ErrNotChainTipSibling,
+		)
+	}
+	if err := validateLocalSibling(block, parent, incumbentTip); err != nil {
+		return false, err
+	}
+	// Only compete for a tip the ledger has actually applied. While the
+	// pipeline is still replaying, the primary chain runs ahead of committed
+	// ledger state, and a rollback there would rewind a tip the ledger never
+	// reached. The forger's own sync gates normally keep this unreachable.
+	if appliedTip := ls.Tip(); !bytes.Equal(
+		appliedTip.Point.Hash,
+		incumbentTip.Point.Hash,
+	) {
+		return false, fmt.Errorf(
+			"%w: ledger tip %x has not caught up to chain tip %x",
+			ErrNotChainTipSibling,
+			appliedTip.Point.Hash,
+			incumbentTip.Point.Hash,
+		)
+	}
+
+	blockHash := block.Hash().Bytes()
+	candidateTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(block.SlotNumber(), blockHash),
+		BlockNumber: block.BlockNumber(),
+	}
+	candidateView, _ := praos.GetPraosTiebreakerView(block.Header())
+	incumbentView := ls.localTipPraosView(incumbentTip)
+	if !praosPrefersCandidateSibling(
+		candidateTip,
+		incumbentTip,
+		candidateView,
+		incumbentView,
+	) {
+		ls.config.Logger.Info(
+			"locally forged block lost chain selection to the block already at the tip",
+			"component", "ledger",
+			"slot", block.SlotNumber(),
+			"forged_hash", hex.EncodeToString(blockHash),
+			"tip_hash", hex.EncodeToString(incumbentTip.Point.Hash),
+			"block_number", block.BlockNumber(),
+		)
+		return false, nil
+	}
+
+	ls.config.Logger.Info(
+		"locally forged block won chain selection; replacing the block at the tip",
+		"component", "ledger",
+		"slot", block.SlotNumber(),
+		"forged_hash", hex.EncodeToString(blockHash),
+		"replaced_hash", hex.EncodeToString(incumbentTip.Point.Hash),
+		"fork_point_slot", parent.Slot,
+		"block_number", block.BlockNumber(),
+	)
+	if err := ls.rollbackChainAndStateDeferred(parent, &pending); err != nil {
+		return false, fmt.Errorf(
+			"roll back to fork point %x for locally forged sibling: %w",
+			parent.Hash,
+			err,
+		)
+	}
+	if _, err := ls.chain.AddLocalBlockDeferred(block); err != nil {
+		// The chain is now at the fork point with neither candidate on it.
+		// That is recoverable -- chainsync re-offers the rival's header,
+		// which no longer conflicts with our tip -- but it is not a state
+		// to pass over quietly.
+		ls.config.Logger.Error(
+			"locally forged sibling could not be adopted after the fork-point rollback",
+			"component", "ledger",
+			"slot", block.SlotNumber(),
+			"forged_hash", hex.EncodeToString(blockHash),
+			"fork_point_slot", parent.Slot,
+			"error", err,
+		)
+		return false, fmt.Errorf(
+			"adopt locally forged sibling %x: %w",
+			blockHash,
+			err,
+		)
+	}
+	pending.drainChain(ls.chain)
+	return true, nil
+}
+
+// validateLocalSibling checks that block genuinely competes with the tip:
+// same parent, same block number, and a slot strictly above the parent's. Only
+// a block that satisfies all three can be adopted by rolling back exactly one
+// block, and only such a block is an equal-length candidate for the Praos
+// comparison that follows.
+func validateLocalSibling(
+	block gledger.Block,
+	parent ocommon.Point,
+	incumbentTip ochainsync.Tip,
+) error {
+	blockHash := block.Hash().Bytes()
+	if bytes.Equal(blockHash, incumbentTip.Point.Hash) {
+		return fmt.Errorf(
+			"%w: block %x is already the chain tip",
+			ErrNotChainTipSibling,
+			blockHash,
+		)
+	}
+	if !bytes.Equal(block.PrevHash().Bytes(), parent.Hash) {
+		return fmt.Errorf(
+			"%w: block parent %x is not the chain tip's parent %x",
+			ErrNotChainTipSibling,
+			block.PrevHash().Bytes(),
+			parent.Hash,
+		)
+	}
+	if block.BlockNumber() != incumbentTip.BlockNumber {
+		return fmt.Errorf(
+			"%w: block number %d is not the chain tip's %d",
+			ErrNotChainTipSibling,
+			block.BlockNumber(),
+			incumbentTip.BlockNumber,
+		)
+	}
+	if block.SlotNumber() <= parent.Slot {
+		return fmt.Errorf(
+			"%w: block slot %d does not follow parent slot %d",
+			ErrNotChainTipSibling,
+			block.SlotNumber(),
+			parent.Slot,
+		)
+	}
+	return nil
+}

--- a/ledger/local_sibling.go
+++ b/ledger/local_sibling.go
@@ -168,6 +168,18 @@ func (ls *LedgerState) AdoptLocalForgedSibling(
 		"fork_point_slot", parent.Slot,
 		"block_number", block.BlockNumber(),
 	)
+	// Publish the rollback before performing it. A blockfetch batch requested
+	// against the queued headers that descend from the block about to be
+	// rolled off is still in flight, and its delivery runs under
+	// chainsyncBlockfetchMutex, not the chainsyncMutex held here -- so it can
+	// flush at any point during or after the truncation below. The chainsync
+	// rollback paths supersede such a batch by re-queueing the winning fork's
+	// headers and restarting blockfetch; this path does neither, so the batch
+	// is invalidated by generation instead. Bumping here, before
+	// rollbackChainAndStateDeferred truncates, is what makes the ordering
+	// sound: a batch tagged with the older generation can only have been
+	// requested for the segment this rollback abandons.
+	ls.blockfetchRollbackGeneration.Add(1)
 	if err := ls.rollbackChainAndStateDeferred(parent, &pending); err != nil {
 		return false, fmt.Errorf(
 			"roll back to fork point %x for locally forged sibling: %w",

--- a/ledger/local_sibling_blockfetch_test.go
+++ b/ledger/local_sibling_blockfetch_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stageInFlightBlockfetchBatch puts the fixture in the state that exists while
+// a blockfetch batch requested for the rival's continuation is in flight: the
+// batch carries the rollback generation current at request time, and one
+// fetched block is waiting to be flushed onto the chain.
+func stageInFlightBlockfetchBatch(
+	ls *LedgerState,
+	block gledger.Block,
+) {
+	ls.blockfetchBatchRollbackGeneration = ls.blockfetchRollbackGeneration.Load()
+	ls.pendingBlockfetchEvents = []BlockfetchEvent{
+		{
+			Block: block,
+			Point: ocommon.NewPoint(
+				block.SlotNumber(),
+				block.Hash().Bytes(),
+			),
+			Type: uint(block.Type()),
+		},
+	}
+}
+
+// TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption covers the race
+// between an equal-slot alternative winning chain selection and a blockfetch
+// batch that was already in flight for the chain the alternative displaces.
+//
+// The adoption rolls the rival off the tip while that batch is still being
+// delivered, and delivery runs under chainsyncBlockfetchMutex rather than the
+// chainsyncMutex the adoption holds, so the flush can land at any point during
+// or after the truncation. Its blocks were fetched for headers descending from
+// the rival -- the segment the rollback abandoned -- and must not be applied.
+//
+// The chainsync rollback paths supersede such a batch by re-queueing the
+// winning fork's headers and restarting blockfetch. This path does neither, so
+// the batch is invalidated by generation: the rollback publishes a newer one
+// before truncating, and the flush drops anything still carrying the old one.
+func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
+	t *testing.T,
+) {
+	// The block the in-flight batch is delivering: the rival's continuation.
+	newContinuation := func(t *testing.T, f *siblingFixture) gledger.Block {
+		t.Helper()
+		return newSiblingTestBlock(
+			t,
+			f.rival.BlockNumber()+1,
+			f.rival.SlotNumber()+10,
+			f.rival.Hash(),
+			0x44,
+			0x44,
+			1,
+		)
+	}
+
+	t.Run("control: the batch lands with no rollback", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		continuation := newContinuation(t, f)
+		stageInFlightBlockfetchBatch(f.ls, continuation)
+
+		require.NoError(t, f.ls.flushPendingBlockfetchBlocksDeferred(nil))
+		assert.Equal(
+			t,
+			continuation.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"without a rollback the fetched block extends the chain",
+		)
+	})
+
+	t.Run("stale batch after the alternative wins", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		continuation := newContinuation(t, f)
+		stageInFlightBlockfetchBatch(f.ls, continuation)
+		before := f.ls.blockfetchRollbackGeneration.Load()
+
+		// Lower VRF output wins, so the alternative replaces the rival.
+		ours := f.newSibling(t, siblingRivalVrfSeed-1)
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.NoError(t, err)
+		require.True(t, adopted)
+		require.Greater(
+			t,
+			f.ls.blockfetchRollbackGeneration.Load(),
+			before,
+			"the adoption must publish a new rollback generation",
+		)
+
+		// The batch flushes only now, after the rollback and the adoption.
+		require.NoError(t, f.ls.flushPendingBlockfetchBlocksDeferred(nil))
+
+		assert.Equal(
+			t,
+			ours.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"a superseded batch must not move the tip off the adopted alternative",
+		)
+		assert.Empty(
+			t,
+			f.ls.pendingBlockfetchEvents,
+			"the discarded batch must not be left queued for a later flush",
+		)
+	})
+
+	t.Run("stale batch inside the rollback window", func(t *testing.T) {
+		// The window the generation exists for. The adoption publishes
+		// the generation before it truncates, and the flush holds a
+		// different mutex, so it can land while the chain is still the
+		// one the batch was fetched for. Here the truncation is refused
+		// after the generation is published (the fork point is below the
+		// Mithril boundary), which leaves the chain at the rival with
+		// the batch's block still fitting its tip perfectly.
+		//
+		// Without the generation the block lands and re-extends a chain
+		// the node has already decided to abandon; the tip-fit check
+		// cannot see anything wrong with it.
+		f := newSiblingFixture(t)
+		continuation := newContinuation(t, f)
+		stageInFlightBlockfetchBatch(f.ls, continuation)
+		f.ls.mithrilLedgerSlot = siblingParentSlot + 1
+		before := f.ls.blockfetchRollbackGeneration.Load()
+
+		ours := f.newSibling(t, siblingRivalVrfSeed-1)
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.ErrorIs(t, err, ErrRollbackExceedsMithrilBoundary)
+		require.False(t, adopted)
+		require.Greater(
+			t,
+			f.ls.blockfetchRollbackGeneration.Load(),
+			before,
+			"the generation must be published before the truncation",
+		)
+		require.Equal(
+			t,
+			f.rival.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"precondition: the chain still holds the rival, so the "+
+				"batch's block fits its tip",
+		)
+
+		require.NoError(t, f.ls.flushPendingBlockfetchBlocksDeferred(nil))
+		assert.Equal(
+			t,
+			f.rival.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"a batch superseded by a published rollback generation must "+
+				"not extend the chain even when its block still fits",
+		)
+	})
+
+	t.Run("stale batch after the alternative loses", func(t *testing.T) {
+		// A losing alternative performs no rollback, so the batch it
+		// raced is still valid and must still land. Invalidating on the
+		// attempt rather than on the truncation would stall the chain
+		// every time a slot battle is lost.
+		f := newSiblingFixture(t)
+		continuation := newContinuation(t, f)
+		stageInFlightBlockfetchBatch(f.ls, continuation)
+		before := f.ls.blockfetchRollbackGeneration.Load()
+
+		// Higher VRF output loses.
+		ours := f.newSibling(t, siblingRivalVrfSeed+1)
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.NoError(t, err)
+		require.False(t, adopted)
+		require.Equal(
+			t,
+			before,
+			f.ls.blockfetchRollbackGeneration.Load(),
+			"a lost slot battle truncates nothing and must not invalidate a batch",
+		)
+
+		require.NoError(t, f.ls.flushPendingBlockfetchBlocksDeferred(nil))
+		assert.Equal(
+			t,
+			continuation.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"the batch the losing alternative raced must still land",
+		)
+	})
+}

--- a/ledger/local_sibling_blockfetch_test.go
+++ b/ledger/local_sibling_blockfetch_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"testing"
 
+	"github.com/blinklabs-io/dingo/chain"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -210,6 +211,60 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 			1,
 			f.ls.blockfetchRangeFailure.count,
 			"a discarded block is not range progress",
+		)
+	})
+
+	t.Run("rollback lands after the fast path passes", func(t *testing.T) {
+		// The window the early generation test cannot cover. That test
+		// releases nothing, but it holds nothing either: the adoption
+		// that publishes a generation and truncates holds chainsyncMutex
+		// while this drain holds chainsyncBlockfetchMutex, so a rollback
+		// can land between the drain testing its batch and the chain add
+		// taking the chain mutex.
+		//
+		// Expressed sequentially -- fast path would pass, generation then
+		// moves, add is attempted -- because the guarantee under test is
+		// that the same predicate is re-evaluated at add time. That it is
+		// evaluated under the chain mutex, and so cannot itself be raced,
+		// is pinned by
+		// TestAddBlockWithPointDeferredIfEvaluatesAdmitUnderTheChainMutex.
+		f := newSiblingFixture(t)
+		continuation := newContinuation(t, f)
+		point := ocommon.NewPoint(
+			continuation.SlotNumber(),
+			continuation.Hash().Bytes(),
+		)
+		f.ls.blockfetchBatchRollbackGeneration = f.ls.blockfetchRollbackGeneration.Load()
+		require.True(
+			t,
+			f.ls.blockfetchBatchStillCurrent(),
+			"precondition: the drain's own fast path would admit this batch",
+		)
+
+		// The rollback publishes its generation, as AdoptLocalForgedSibling
+		// does before it truncates.
+		f.ls.blockfetchRollbackGeneration.Add(1)
+
+		// The block still fits the tip perfectly, so nothing the chain
+		// checks for itself can reject it.
+		require.Equal(
+			t,
+			f.rival.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+		)
+		_, err := f.ls.chain.AddBlockWithPointDeferredIf(
+			continuation,
+			point,
+			nil,
+			f.ls.blockfetchBatchStillCurrent,
+		)
+		require.ErrorIs(t, err, chain.ErrBlockAddNotAdmitted)
+		assert.Equal(
+			t,
+			f.rival.Hash().Bytes(),
+			f.ls.chain.Tip().Point.Hash,
+			"a batch superseded after the fast path must still be refused "+
+				"at the moment of the add",
 		)
 	})
 

--- a/ledger/local_sibling_blockfetch_test.go
+++ b/ledger/local_sibling_blockfetch_test.go
@@ -26,22 +26,47 @@ import (
 // stageInFlightBlockfetchBatch puts the fixture in the state that exists while
 // a blockfetch batch requested for the rival's continuation is in flight: the
 // batch carries the rollback generation current at request time, and one
-// fetched block is waiting to be flushed onto the chain.
+// fetched block has been delivered and is waiting to be flushed onto the
+// chain.
+//
+// The block is delivered through the real arrival handler rather than pushed
+// onto the pending slice, so the test covers what arrival itself is allowed to
+// conclude. A range-failure record is seeded for that exact range first, as
+// noteBlockfetchRangeUnavailable would leave it after a miss: arrival must not
+// clear it, because a delivered block that is never applied leaves the queued
+// header just as stuck as one that was never delivered.
 func stageInFlightBlockfetchBatch(
+	t *testing.T,
 	ls *LedgerState,
 	block gledger.Block,
 ) {
+	t.Helper()
+	point := ocommon.NewPoint(block.SlotNumber(), block.Hash().Bytes())
 	ls.blockfetchBatchRollbackGeneration = ls.blockfetchRollbackGeneration.Load()
-	ls.pendingBlockfetchEvents = []BlockfetchEvent{
-		{
-			Block: block,
-			Point: ocommon.NewPoint(
-				block.SlotNumber(),
-				block.Hash().Bytes(),
-			),
-			Type: uint(block.Type()),
-		},
+	ls.blockfetchRangeFailure = blockfetchRangeFailureState{
+		slot:  point.Slot,
+		hash:  string(point.Hash),
+		count: 1,
 	}
+	connId := testRecycleConnId()
+	ls.activeBlockfetchConnId = connId
+	ls.chainsyncBlockfetchReadyChan = make(chan struct{})
+	require.NoError(t, ls.handleEventBlockfetchBlockDeferred(
+		BlockfetchEvent{
+			ConnectionId: connId,
+			Block:        block,
+			Point:        point,
+			Type:         uint(block.Type()),
+		},
+		nil,
+	))
+	require.Len(t, ls.pendingBlockfetchEvents, 1)
+	require.Equal(
+		t,
+		1,
+		ls.blockfetchRangeFailure.count,
+		"arrival is not range progress: the block has not been applied yet",
+	)
 }
 
 // TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption covers the race
@@ -78,7 +103,7 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 	t.Run("control: the batch lands with no rollback", func(t *testing.T) {
 		f := newSiblingFixture(t)
 		continuation := newContinuation(t, f)
-		stageInFlightBlockfetchBatch(f.ls, continuation)
+		stageInFlightBlockfetchBatch(t, f.ls, continuation)
 
 		require.NoError(t, f.ls.flushPendingBlockfetchBlocksDeferred(nil))
 		assert.Equal(
@@ -87,12 +112,17 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 			f.ls.chain.Tip().Point.Hash,
 			"without a rollback the fetched block extends the chain",
 		)
+		assert.Zero(
+			t,
+			f.ls.blockfetchRangeFailure.count,
+			"a block that extends the chain clears the range failure record",
+		)
 	})
 
 	t.Run("stale batch after the alternative wins", func(t *testing.T) {
 		f := newSiblingFixture(t)
 		continuation := newContinuation(t, f)
-		stageInFlightBlockfetchBatch(f.ls, continuation)
+		stageInFlightBlockfetchBatch(t, f.ls, continuation)
 		before := f.ls.blockfetchRollbackGeneration.Load()
 
 		// Lower VRF output wins, so the alternative replaces the rival.
@@ -121,6 +151,14 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 			f.ls.pendingBlockfetchEvents,
 			"the discarded batch must not be left queued for a later flush",
 		)
+		assert.Equal(
+			t,
+			1,
+			f.ls.blockfetchRangeFailure.count,
+			"a discarded block is not range progress: clearing the record "+
+				"would reset the count that unsticks the queued header "+
+				"blocking local forging",
+		)
 	})
 
 	t.Run("stale batch inside the rollback window", func(t *testing.T) {
@@ -137,7 +175,7 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 		// cannot see anything wrong with it.
 		f := newSiblingFixture(t)
 		continuation := newContinuation(t, f)
-		stageInFlightBlockfetchBatch(f.ls, continuation)
+		stageInFlightBlockfetchBatch(t, f.ls, continuation)
 		f.ls.mithrilLedgerSlot = siblingParentSlot + 1
 		before := f.ls.blockfetchRollbackGeneration.Load()
 
@@ -167,6 +205,12 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 			"a batch superseded by a published rollback generation must "+
 				"not extend the chain even when its block still fits",
 		)
+		assert.Equal(
+			t,
+			1,
+			f.ls.blockfetchRangeFailure.count,
+			"a discarded block is not range progress",
+		)
 	})
 
 	t.Run("stale batch after the alternative loses", func(t *testing.T) {
@@ -176,7 +220,7 @@ func TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption(
 		// every time a slot battle is lost.
 		f := newSiblingFixture(t)
 		continuation := newContinuation(t, f)
-		stageInFlightBlockfetchBatch(f.ls, continuation)
+		stageInFlightBlockfetchBatch(t, f.ls, continuation)
 		before := f.ls.blockfetchRollbackGeneration.Load()
 
 		// Higher VRF output loses.

--- a/ledger/local_sibling_test.go
+++ b/ledger/local_sibling_test.go
@@ -292,6 +292,25 @@ func TestAdoptLocalForgedSiblingRejectsNonSiblings(t *testing.T) {
 		assert.False(t, adopted)
 	})
 
+	t.Run("same block number at a different slot", func(t *testing.T) {
+		// A same-block-number competitor one slot above the tip is an
+		// ordinary fork, not the equal-slot (EQ) case this path serves.
+		// It would win or lose the Praos tiebreak on its merits, but
+		// arbitrating it here would adopt a fork through a one-block
+		// rollback driven from the forge loop instead of through
+		// chainsync's fork resolution.
+		f := newSiblingFixture(t)
+		offSlot := newSiblingTestBlock(
+			t, f.rival.BlockNumber(), f.rival.SlotNumber()+1,
+			f.parent.Hash(), 0x33, 0x33, 1,
+		)
+		require.Greater(t, offSlot.SlotNumber(), siblingParentSlot)
+		adopted, err := f.ls.AdoptLocalForgedSibling(offSlot)
+		require.ErrorIs(t, err, ErrNotChainTipSibling)
+		require.ErrorContains(t, err, "is not the chain tip's slot")
+		assert.False(t, adopted)
+	})
+
 	t.Run("the block already at the tip", func(t *testing.T) {
 		f := newSiblingFixture(t)
 		adopted, err := f.ls.AdoptLocalForgedSibling(f.rival)

--- a/ledger/local_sibling_test.go
+++ b/ledger/local_sibling_test.go
@@ -1,0 +1,396 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/consensus/praos"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func siblingTestBytes(size int, seed byte) []byte {
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = seed
+	}
+	return b
+}
+
+// newSiblingTestBlock builds a wire-decodable Conway block with a chosen
+// issuer, opcert sequence number and VRF output, so the Praos select view the
+// chain-selection comparison reads is real rather than synthesized.
+func newSiblingTestBlock(
+	t *testing.T,
+	blockNumber, slot uint64,
+	prevHash lcommon.Blake2b256,
+	issuerSeed, vrfSeed byte,
+	opCertSeqNo uint64,
+) gledger.Block {
+	t.Helper()
+	emptyTxsCbor, err := cbor.Encode([]conway.ConwayTransactionBody{})
+	require.NoError(t, err)
+	emptyWitsCbor, err := cbor.Encode([]conway.ConwayTransactionWitnessSet{})
+	require.NoError(t, err)
+	emptyAuxCbor, err := cbor.Encode(lcommon.TransactionMetadataSet{})
+	require.NoError(t, err)
+	emptyInvalidCbor, err := cbor.Encode([]uint{})
+	require.NoError(t, err)
+
+	var issuer lcommon.IssuerVkey
+	copy(issuer[:], siblingTestBytes(32, issuerSeed))
+
+	block := &conway.ConwayBlock{
+		BlockHeader: &conway.ConwayBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: blockNumber,
+					Slot:        slot,
+					PrevHash:    prevHash,
+					IssuerVkey:  issuer,
+					VrfKey:      siblingTestBytes(32, issuerSeed),
+					VrfResult: lcommon.VrfResult{
+						Output: siblingTestBytes(64, vrfSeed),
+						Proof:  siblingTestBytes(80, vrfSeed),
+					},
+					BlockBodySize: uint64(
+						len(emptyTxsCbor) + len(emptyWitsCbor) +
+							len(emptyAuxCbor) + len(emptyInvalidCbor),
+					),
+					BlockBodyHash: fixtures.ComputeBlockBodyHash(
+						emptyTxsCbor,
+						emptyWitsCbor,
+						emptyAuxCbor,
+						emptyInvalidCbor,
+					),
+					OpCert: babbage.BabbageOpCert{
+						HotVkey:        siblingTestBytes(32, issuerSeed),
+						SequenceNumber: opCertSeqNo,
+						Signature:      siblingTestBytes(64, issuerSeed),
+					},
+					ProtoVersion: babbage.BabbageProtoVersion{Major: 9},
+				},
+				Signature: siblingTestBytes(64, issuerSeed),
+			},
+		},
+	}
+	blockCbor, err := cbor.Encode(block)
+	require.NoError(t, err)
+	decoded, err := conway.NewConwayBlockFromCbor(blockCbor)
+	require.NoError(t, err)
+	return decoded
+}
+
+type siblingFixture struct {
+	ls     *LedgerState
+	parent gledger.Block
+	rival  gledger.Block
+}
+
+const (
+	siblingParentSlot = uint64(10)
+	siblingSlot       = uint64(20)
+	// The rival's VRF output. A candidate seeded below this wins the
+	// tiebreak (lower VRF wins); one seeded above loses.
+	siblingRivalVrfSeed = byte(0x80)
+)
+
+func newSiblingFixture(t *testing.T) *siblingFixture {
+	t.Helper()
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: 2}),
+	)
+
+	parent := newSiblingTestBlock(
+		t, 1, siblingParentSlot, lcommon.Blake2b256{}, 0x11, 0x11, 1,
+	)
+	rival := newSiblingTestBlock(
+		t, 2, siblingSlot, parent.Hash(), 0x22, siblingRivalVrfSeed, 1,
+	)
+	require.NoError(t, cm.PrimaryChain().AddBlock(parent, nil))
+	require.NoError(t, cm.PrimaryChain().AddBlock(rival, nil))
+
+	ls, err := NewLedgerState(LedgerStateConfig{
+		Database:          db,
+		ChainManager:      cm,
+		CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+		Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	parentTip := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			parent.SlotNumber(),
+			parent.Hash().Bytes(),
+		),
+		BlockNumber: parent.BlockNumber(),
+	}
+	rivalTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(rival.SlotNumber(), rival.Hash().Bytes()),
+		BlockNumber: rival.BlockNumber(),
+	}
+	require.NoError(t, db.SetBlockNonce(
+		parentTip.Point.Hash, parentTip.Point.Slot,
+		[]byte("nonce-parent"), true, nil,
+	))
+	require.NoError(t, db.SetBlockNonce(
+		rivalTip.Point.Hash, rivalTip.Point.Slot,
+		[]byte("nonce-rival"), false, nil,
+	))
+	require.NoError(t, db.SetTip(rivalTip, nil))
+	ls.currentTip = rivalTip
+	ls.currentTipBlockNonce = []byte("nonce-rival")
+	ls.chainsyncState = SyncingChainsyncState
+	ls.publishSnapshotsLocked()
+
+	return &siblingFixture{ls: ls, parent: parent, rival: rival}
+}
+
+// newSibling builds our own alternative to the rival: same slot and block
+// number, the rival's parent as parent, a different issuer, and a VRF output
+// seeded to win or lose the tiebreak.
+func (f *siblingFixture) newSibling(
+	t *testing.T,
+	vrfSeed byte,
+) gledger.Block {
+	t.Helper()
+	return newSiblingTestBlock(
+		t,
+		f.rival.BlockNumber(),
+		f.rival.SlotNumber(),
+		f.parent.Hash(),
+		0x33,
+		vrfSeed,
+		1,
+	)
+}
+
+// TestAdoptLocalForgedSiblingAdoptsTheWinnerOfChainSelection covers the two
+// outcomes of a slot battle a locally forged alternative can have. Nothing in
+// either case is decided by the block being ours: the same Praos comparison a
+// peer's competing block goes through picks the winner, and the loser is
+// discarded.
+func TestAdoptLocalForgedSiblingAdoptsTheWinnerOfChainSelection(
+	t *testing.T,
+) {
+	t.Run("ours wins the VRF tiebreak", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		// Lower VRF output wins.
+		ours := f.newSibling(t, siblingRivalVrfSeed-1)
+
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.NoError(t, err)
+		require.True(t, adopted, "lower VRF output must win the tiebreak")
+
+		tip := f.ls.chain.Tip()
+		assert.Equal(t, ours.Hash().Bytes(), tip.Point.Hash)
+		assert.Equal(t, f.rival.BlockNumber(), tip.BlockNumber)
+		assert.Equal(t, f.rival.SlotNumber(), tip.Point.Slot)
+		// The rollback was exactly one block deep: the fork point is still
+		// on the chain and is our block's parent.
+		parent, _, ok := f.ls.chain.TipPredecessor()
+		require.True(t, ok)
+		assert.Equal(t, f.parent.Hash().Bytes(), parent.Hash)
+	})
+
+	t.Run("the rival wins the VRF tiebreak", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		// Higher VRF output loses.
+		ours := f.newSibling(t, siblingRivalVrfSeed+1)
+
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.NoError(t, err)
+		require.False(t, adopted, "higher VRF output must lose the tiebreak")
+
+		tip := f.ls.chain.Tip()
+		assert.Equal(
+			t,
+			f.rival.Hash().Bytes(),
+			tip.Point.Hash,
+			"a losing local block must leave the incumbent tip alone",
+		)
+	})
+
+	t.Run("an identical view does not prefer ours", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		// Same VRF output as the rival: ComparePraosTips answers
+		// ChainEqual, which keeps the incumbent. A "prefer ours" rule
+		// would adopt here.
+		ours := f.newSibling(t, siblingRivalVrfSeed)
+
+		adopted, err := f.ls.AdoptLocalForgedSibling(ours)
+		require.NoError(t, err)
+		require.False(t, adopted)
+		assert.Equal(t, f.rival.Hash().Bytes(), f.ls.chain.Tip().Point.Hash)
+	})
+}
+
+// TestAdoptLocalForgedSiblingRejectsNonSiblings pins the structural
+// precondition. The adoption path rolls the chain back one block, so a block
+// that is not a genuine competitor for the tip must never reach it.
+func TestAdoptLocalForgedSiblingRejectsNonSiblings(t *testing.T) {
+	t.Run("extends the tip rather than competing with it", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		extension := newSiblingTestBlock(
+			t, f.rival.BlockNumber()+1, f.rival.SlotNumber()+1,
+			f.rival.Hash(), 0x33, 0x33, 1,
+		)
+		adopted, err := f.ls.AdoptLocalForgedSibling(extension)
+		require.ErrorIs(t, err, ErrNotChainTipSibling)
+		assert.False(t, adopted)
+	})
+
+	t.Run("wrong block number", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		wrong := newSiblingTestBlock(
+			t, f.rival.BlockNumber()+1, f.rival.SlotNumber(),
+			f.parent.Hash(), 0x33, 0x33, 1,
+		)
+		adopted, err := f.ls.AdoptLocalForgedSibling(wrong)
+		require.ErrorIs(t, err, ErrNotChainTipSibling)
+		assert.False(t, adopted)
+	})
+
+	t.Run("slot at or below the fork point", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		wrong := newSiblingTestBlock(
+			t, f.rival.BlockNumber(), siblingParentSlot,
+			f.parent.Hash(), 0x33, 0x33, 1,
+		)
+		adopted, err := f.ls.AdoptLocalForgedSibling(wrong)
+		require.ErrorIs(t, err, ErrNotChainTipSibling)
+		assert.False(t, adopted)
+	})
+
+	t.Run("the block already at the tip", func(t *testing.T) {
+		f := newSiblingFixture(t)
+		adopted, err := f.ls.AdoptLocalForgedSibling(f.rival)
+		require.ErrorIs(t, err, ErrNotChainTipSibling)
+		assert.False(t, adopted)
+	})
+}
+
+// TestPraosPrefersCandidateSiblingUsesTheStandardRule exercises the decision
+// itself, including the cases the fixture cannot reach: it must be
+// length-first, must never invent a preference, and must keep the incumbent
+// whenever no reference implementation rule applies.
+func TestPraosPrefersCandidateSiblingUsesTheStandardRule(t *testing.T) {
+	const slot = uint64(20)
+	incumbentTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(slot, siblingTestBytes(32, 0x01)),
+		BlockNumber: 2,
+	}
+	candidateTip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(slot, siblingTestBytes(32, 0x02)),
+		BlockNumber: 2,
+	}
+	viewWith := func(
+		tip ochainsync.Tip,
+		issuerSeed, vrfSeed byte,
+		issueNo uint64,
+		cfg praos.PraosTiebreakerConfig,
+	) praos.PraosTiebreakerView {
+		return praos.NewPraosTiebreakerViewFull(
+			tip,
+			siblingTestBytes(32, issuerSeed),
+			issueNo,
+			siblingTestBytes(64, vrfSeed),
+			cfg,
+		)
+	}
+	conwayCfg := praos.PraosTiebreakerConfigConway()
+
+	tests := []struct {
+		name                      string
+		candidate, incumbent      ochainsync.Tip
+		candidateView, incumbView praos.PraosTiebreakerView
+		want                      bool
+	}{
+		{
+			name:      "lower VRF wins",
+			candidate: candidateTip, incumbent: incumbentTip,
+			candidateView: viewWith(candidateTip, 0x33, 0x40, 1, conwayCfg),
+			incumbView:    viewWith(incumbentTip, 0x22, 0x80, 1, conwayCfg),
+			want:          true,
+		},
+		{
+			name:      "higher VRF loses",
+			candidate: candidateTip, incumbent: incumbentTip,
+			candidateView: viewWith(candidateTip, 0x33, 0xC0, 1, conwayCfg),
+			incumbView:    viewWith(incumbentTip, 0x22, 0x80, 1, conwayCfg),
+			want:          false,
+		},
+		{
+			name:      "identical VRF keeps the incumbent",
+			candidate: candidateTip, incumbent: incumbentTip,
+			candidateView: viewWith(candidateTip, 0x33, 0x80, 1, conwayCfg),
+			incumbView:    viewWith(incumbentTip, 0x22, 0x80, 1, conwayCfg),
+			want:          false,
+		},
+		{
+			name:      "unarmed tiebreaker keeps the incumbent",
+			candidate: candidateTip, incumbent: incumbentTip,
+			candidateView: viewWith(
+				candidateTip, 0x33, 0x40, 1,
+				praos.PraosTiebreakerConfigUnknown(),
+			),
+			incumbView: viewWith(
+				incumbentTip, 0x22, 0x80, 1,
+				praos.PraosTiebreakerConfigUnknown(),
+			),
+			want: false,
+		},
+		{
+			name: "shorter candidate loses regardless of VRF",
+			candidate: ochainsync.Tip{
+				Point:       candidateTip.Point,
+				BlockNumber: 1,
+			},
+			incumbent:     incumbentTip,
+			candidateView: viewWith(candidateTip, 0x33, 0x00, 1, conwayCfg),
+			incumbView:    viewWith(incumbentTip, 0x22, 0xFF, 1, conwayCfg),
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := praosPrefersCandidateSibling(
+				tt.candidate,
+				tt.incumbent,
+				tt.candidateView,
+				tt.incumbView,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -977,8 +977,29 @@ type LedgerState struct {
 	// primary request. A timeout may fire while the request is blocked in the
 	// protocol client; keeping its generation lets the timeout wait instead of
 	// issuing a duplicate request on the same batch.
-	blockfetchRequestGeneration         uint64
-	blockfetchPrimaryRequestGeneration  uint64
+	blockfetchRequestGeneration        uint64
+	blockfetchPrimaryRequestGeneration uint64
+	// blockfetchRollbackGeneration counts rollbacks that abandon the chain
+	// segment an in-flight blockfetch batch was requested for, without also
+	// superseding that batch. It is published before the truncation, so any
+	// batch that observed an older value was requested against a chain
+	// segment the rollback has since discarded and its blocks must not be
+	// applied.
+	//
+	// Only the locally forged sibling adoption bumps it. The chainsync
+	// rollback paths (handleEventChainsyncRollback, tryResolveFork) re-queue
+	// the winning fork's headers and restart blockfetch under
+	// chainsyncBlockfetchMutex, which supersedes the in-flight batch by
+	// itself; AdoptLocalForgedSibling does neither -- it rolls back and
+	// adopts from the forge loop, holding only chainsyncMutex.
+	//
+	// Atomic because the bump happens under chainsyncMutex while the read
+	// happens under chainsyncBlockfetchMutex.
+	blockfetchRollbackGeneration atomic.Uint64
+	// blockfetchBatchRollbackGeneration is blockfetchRollbackGeneration as
+	// observed when the current batch was requested. Guarded by
+	// chainsyncBlockfetchMutex, like the rest of the per-batch state.
+	blockfetchBatchRollbackGeneration   uint64
 	blockfetchRequestsInFlight          map[string]chan struct{}
 	blockfetchShadowRequestsInFlight    map[string]struct{}
 	blockfetchInFlightTimeoutGeneration uint64

--- a/node_forging.go
+++ b/node_forging.go
@@ -369,15 +369,24 @@ func (n *Node) initBlockForger(
 
 	// Create the block forger with the real leader election
 	forger, err := forging.NewBlockForger(forging.ForgerConfig{
-		Mode:                            forging.ModeProduction,
-		Logger:                          n.config.logger,
-		Credentials:                     creds,
-		LeaderChecker:                   election,
-		BlockBuilder:                    builder,
-		BlockBroadcaster:                broadcaster,
-		ConfirmedTxs:                    mempoolAdapter,
-		BlockForged:                     blockForged,
-		SlotClock:                       slotClock,
+		Mode:             forging.ModeProduction,
+		Logger:           n.config.logger,
+		Credentials:      creds,
+		LeaderChecker:    election,
+		BlockBuilder:     builder,
+		BlockBroadcaster: broadcaster,
+		ConfirmedTxs:     mempoolAdapter,
+		BlockForged:      blockForged,
+		SlotClock:        slotClock,
+		// Equal-slot alternative forging. When a rival block already
+		// occupies the slot this node leads, the forger builds an
+		// alternative on the rival's predecessor and offers it to chain
+		// selection instead of conceding the slot -- ouroboros-consensus
+		// mkCurrentBlockContext's EQ case. The primary chain supplies the
+		// fork context; LedgerState arbitrates with the same Praos
+		// comparison a peer's competing block goes through.
+		ChainContext:                    n.chainManager.PrimaryChain(),
+		SiblingAdopter:                  n.ledgerState,
 		ForgeSyncToleranceSlots:         n.config.forgeSyncToleranceSlots,
 		ForgeStaleGapThresholdSlots:     n.config.forgeStaleGapThresholdSlots,
 		BlockValidator:                  blockValidator,
@@ -486,6 +495,18 @@ func (a *forgingMempoolAdapter) Transactions() []forging.MempoolTransaction {
 func (a *forgingMempoolAdapter) RemoveTxsByHash(hashes []string) {
 	a.source.RemoveTxsByHash(hashes)
 }
+
+// The equal-slot alternative path is wired from two existing components
+// rather than from adapters, so these assertions are what keeps that wiring
+// honest: chain.Chain answers the fork context the alternative is built on,
+// and LedgerState arbitrates between the alternative and the block already at
+// the tip. A signature change on either side fails the build here instead of
+// silently reverting block producers to conceding contested slots, which is
+// what a nil provider does.
+var (
+	_ forging.AlternativeChainContextProvider = (*chain.Chain)(nil)
+	_ forging.SiblingBlockAdopter             = (*ledger.LedgerState)(nil)
+)
 
 // blockBroadcaster implements forging.BlockBroadcaster through synchronous
 // local chain admission. Block proposals are requests, not notifications, so


### PR DESCRIPTION
## Summary

PR #3955 narrowed the tip gate so a contested slot reaches leader selection,
and made the declined battle visible. It stopped there on purpose: the slot was
still conceded, because two things outside the forger made the alternative
impossible to build and impossible to adopt. This PR builds those two things and
forges the alternative.

Depends on #3955 and is stacked on it. It is five commits, each independently
reviewable.

## Rebase status

Rebased onto `upstream/main` at `680e65e5` (`ec7166b3` -> `1598f7b3`, 15 commits).
Two files conflicted; both resolutions keep both behaviours.

- `ledger/envelope_validation_test.go` — add/add at end of file against #3881's
  new Byron proof/size helpers. Kept both, upstream's helpers first.
- `ledger/forging/forger.go` — upstream's equal-slot branch is the concede path
  this PR replaces, so the code is ours. Of the comment above it, the paragraph
  saying "Dingo cannot build that alternative yet ... `chain.addBlockLocked`
  refuses" is exactly what this PR removes and was dropped; the paragraph
  explaining why counting `slotBattlesTotal` here does not double up with
  `LedgerState.checkSlotBattle` still describes live code and was carried over
  verbatim.
- `ledger/forging/forger_test.go` (two hunks) — #4123 added
  `require.Equal(t, []uint64{9}, leiosCerts.markedSlots)` beside the
  `parent.calls` assertion this PR changes from 1 to 2. Kept both.

One non-conflict fix the new base forces: gouroboros v0.204.0 widened
`babbage.BabbageOpCert.SequenceNumber` from `uint32` to `uint64`, so the
`newSiblingTestBlock` helper in `ledger/local_sibling_test.go` no longer
compiled. Widened to `uint64`, matching upstream's own
`chainsync_praos_dijkstra_test.go` helper, and squashed into the commit that
introduced the file. Nothing else of this PR was dropped: no commit in
`31dd4a8a..680e65e5` implements equal-slot alternative forging — upstream's own
comment on the concede path still said "Dingo cannot build that alternative yet"
at `680e65e5`.

Range-diff: 11 of 15 patches byte-identical; the four that differ are the four
changes listed above.

## Reference implementation

`ouroboros-consensus`, `mkCurrentBlockContext`
(`ouroboros-consensus-diffusion/src/ouroboros-consensus-diffusion/Ouroboros/Consensus/NodeKernel/Forge.hs`,
checked at `1820edf5e`):

```haskell
  c' :> hdr -> case blockSlot hdr `compare` currentSlot of
    LT -> Right $ blockContextFromPrevHeader hdr
    GT -> Left $ TraceBlockFromFuture currentSlot (blockSlot hdr)
    -- The block at the tip has the same slot as the block we're going to
    -- produce (@currentSlot@).
    EQ ->
      Right $
        if isJust (headerIsEBB hdr)
          then blockContextFromPrevHeader hdr
          -- If @hdr@ is not an EBB, then forge an alternative to @hdr@: same
          -- block no and same predecessor.
          else BlockContext (blockNo hdr) $ castPoint $ AF.headPoint c'
```

`BlockContext (blockNo hdr) (headPoint c')` is the whole design: the block
number of the block at the tip, and the point of the chain *without* that block
— i.e. its predecessor. The forged block is then a sibling of the rival, not a
descendant of it, and consensus resolves the two by ordinary chain selection.

## The two blockers, and what replaces them

**1. The builder derived parentage from the live tip.**
`DefaultBlockBuilder.BuildBlock` read `b.chainTip.Tip()` and used it for both
`prevHash` and `blockNumber + 1`. At an equal slot the live tip *is* the rival at
that slot, so the block would name a parent whose slot equals its own —
`ledger.validateBlockOrder` rejects it ("block slot %d does not follow parent
slot %d") and so does every Praos peer.

`BlockContext` makes the parentage explicit and mirrors the reference type. A nil
context is the unchanged live-tip path; an explicit context names a parent point
and a block number. `BuildBlockOnContext` is the entry point,
`AlternativeBlockBuilder` the capability interface.

Two guards come with it, both before any signing:

- The context carries the tip it was derived from. If the live tip has moved by
  build time, the contest is over and the candidate is abandoned. (This is the
  existing mid-assembly `errParentChangedDuringBuild` check, hoisted to the start
  for the contested path.)
- The resolved parent must sit strictly below the forged slot —
  `errParentSlotNotBelowBlock`. This is new on the **live-tip path too**: a
  builder asked to forge at a slot the tip already holds previously produced the
  invalid block described above and only found out after KES signing. It now
  fails first.

**2. There was no local-fork adoption path.**
`Chain.addBlockLocked` is extend-only, so a block that names the tip's
predecessor is refused with `BlockNotFitChainTipError`.

Dingo already resolves exactly this situation — for peers. A header that does not
fit the tip reaches `LedgerState.tryResolveFork`, which compares it to the local
tip with `praos.ComparePraosTips` and, if it wins, rolls chain and ledger back to
the common ancestor and adopts the winner. What it cannot take is a block that
arrived through the forger: `tryResolveFork` is keyed on a `ChainsyncEvent`, a
peer connection, that peer's retained header history and a blockfetch restart.

`LedgerState.AdoptLocalForgedSibling` is the same arbitration and the same
mutation, entered from the forge loop:

- **Decision:** `praos.ComparePraosTips` on the two tips and their select views,
  read from the real block headers. No preference of any kind for the local
  block. `ComparePraosTips` answers `ChainEqual` whenever no reference
  implementation rule applies — unarmed tiebreaker, unresolvable select view,
  identical VRF — and `ChainEqual` keeps the incumbent. A locally forged block
  must therefore win on the same evidence a peer's would need, and a tie changes
  nothing.
- **Mutation:** `rollbackChainAndStateDeferred` to the shared parent, then
  `Chain.AddLocalBlockDeferred`, under `chainsyncMutex` — the same sequence and
  the same lock `tryResolveFork` uses. The rollback is always exactly one block
  deep and always to the block both candidates already name as parent.

Siblinghood is checked, never assumed: the candidate must name the tip's parent
as its own, carry the tip's block number, sit strictly above the fork point, and
not already be the tip; and the *applied* ledger tip must have caught up to the
chain tip, so a rollback can never rewind past what the pipeline actually
applied. Anything else is `ErrNotChainTipSibling`, before anything is rolled back.

Losing is a normal outcome, not an error. The rival keeps the slot, and the
forged block is discarded without ever being diffused.

## Fail-closed by construction

Both new providers are optional on `ForgerConfig`. `alternativeBlockContext`
declines the contested slot when *any* of these holds: `ChainContext` unset,
`SiblingAdopter` unset, a `BlockBuilder` that is not an
`AlternativeBlockBuilder`, a tip with no resolvable predecessor, a tip no longer
at the contested slot, or a predecessor not strictly below it.
`Chain.TipPredecessor` itself reports `ok=false` for an empty chain, a tip that
is the chain's first block, an unresolvable predecessor, or any disagreement
between the two block records and the advertised tip.

A node with none of this wired behaves exactly as it did after #3955: the battle
is counted and logged at `Warn`, and nothing is signed. That path stays pinned by
`TestCheckAndForgeProductionEqualSlotDeclinesWithoutTheAlternativePath`.

Declining costs one block. Guessing a parent costs a signature over a block no
peer will accept.

## Equivocation safety

Unchanged, and now covered on this path too.

- `reserveForgeSlot` (the #3734 fence) still runs before *any* signing for the
  slot, which is before the alternative is built.
  `TestEqualSlotAlternativeReservesTheFenceBeforeSigning` asserts the fence is
  already written at the moment the builder is invoked.
- A slot whose tip is our **own** block still takes the quiet early skip and
  never reaches leader selection, with the alternative path fully wired
  (`TestEqualSlotAlternativeRefusesASlotWeAlreadyForged`).
- **Losing keeps the slot burned.** The block was signed; a second signature for
  the same slot is equivocation regardless of which block the network kept.
- A declined battle still returns before `reserveForgeSlot`, so it does not burn
  the slot.

## Leios: alternatives are plain ranking blocks

`leiosBlockDataForSlot` picks a certificate by matching eligible endorser blocks
against `ParentLeiosAnnouncement()`, which resolves "the parent" from the live
tip. That is correct for every uncontested slot and wrong for an alternative,
whose parent is the tip's *predecessor*: the certificate would attest to an
endorser block announced by a ranking block the alternative does not descend
from.

Rather than teach the prototype's announcement lookup about explicit block
contexts, an alternative is forged with no Leios data at all — no certificate,
and no new announcement either, so a contested slot cannot also introduce an
endorser block whose announcing chain may be the one that loses. The
parent-announcement provider is not consulted on this path. Uncontested slots are
untouched. This is a deliberate limitation of the alternative path and is pinned
by a test.

## Commits

1. **`feat(chain): expose the alternative-block context and a deferred local
   add`** — `Chain.TipPredecessor` (the reference implementation's EQ context,
   fail-closed) and `Chain.AddLocalBlockDeferred` (`AddLocalBlock` with deferred
   publication, because adoption runs under `chainsyncMutex` where an inline
   `chain.update` publish is the drain deadlock documented on
   `AddBlockWithPointDeferred`). No existing path changes.

2. **`feat(forging): let the builder forge on an explicit block context`** —
   `BlockContext`, `BuildBlockOnContext`, `AlternativeBlockBuilder`, the
   stale-contest guard and `errParentSlotNotBelowBlock`. Also adds
   `TestValidateBlockOrderPinsTheEqualSlotAlternativeShape`, which pins both
   halves of the validator rule the builder is now obeying.

3. **`feat(ledger): adopt a locally forged sibling through Praos chain
   selection`** — `AdoptLocalForgedSibling`, `ErrNotChainTipSibling`, and the
   preference-free decision helper.

4. **`feat(forging): forge an alternative block on an equal-slot battle`** — the
   forger wiring, `alternativeBlockContext`, `adoptSiblingBlockSafe`, and the
   flipped expectation on
   `TestCheckAndForgeProductionEqualSlotReachesLeaderCheck`.

5. **`feat(node): wire equal-slot alternative forging into the block producer`** —
   the primary chain and `LedgerState` satisfy the two provider interfaces
   directly, with compile-time assertions so a signature change fails the build
   rather than silently reverting producers to conceding contested slots.

6. **`fix(forging): forge an equal-slot alternative as a plain ranking block`** —
   the Leios limitation above.

## How tested

Go 1.26.7, `GOFLAGS=-mod=mod`.

Re-run in full on the current base `680e65e5`.

- `go build ./...` — clean.
- `go vet ./ledger/... ./chain/... .` — clean.
- `gofmt -l` — clean over every file this PR touches. (`chain/chain_test.go` is
  gofmt-unclean at `680e65e5` itself; inherited, not touched here.)
- `golangci-lint run ./ledger/... ./chain/...` — **0 issues**.
- `go test ./ledger/forging/... ./chain/... ./ledger/ . -count=1` — all pass
  (`ledger/forging` 2.6s, `chain` 15.1s, `ledger` 38.3s, root 9.2s).
- `go test -race ./ledger/forging/... ./chain/... ./ledger/` — all pass
  (24.9s / 19.4s / 205.9s).

All eight mutation checks re-run on the rebased tree; each went red and was then
restored from a copy-aside, with `git status` clean after every one:
the parent-slot-order guard (`TestBuildBlockRefusesAParentAtItsOwnSlot`),
mempool exclusion (`TestBuildBlockOnContextCarriesNoMempoolTransactions`),
the Leios-data refusal (`TestBuildBlockOnContextRejectsLeiosData`),
the durable-fence precondition (`TestEqualSlotAlternativeRequiresADurableFence`),
sibling slot equality (`TestAdoptLocalForgedSiblingRejectsNonSiblings`),
range progress on apply rather than arrival
(`TestStaleBlockfetchBatchIsDiscardedAfterLocalSiblingAdoption`),
the chain admission predicate
(`TestAddBlockWithPointDeferredIfRefusesWithoutMutating`, and
`TestAddBlockWithPointDeferredIfEvaluatesAdmitUnderTheChainMutex` which does not
merely fail but never completes), and the Leios drop when the parent moves
(`TestCheckAndForgeProductionDropsLeiosDataWhenTheParentMoves`).

Worth recording for #6: adding an extra arrival-side call while leaving the
apply-side one in place does **not** go red — a superseded batch is dropped by
the drain's fast path before the loop body runs. Only the full revert (call back
on arrival, removed from apply) exercises the invariant, and that is what was
run.

New tests:

- **chain** (`chain/tip_predecessor_test.go`) — the EQ context on a real chain;
  fail-closed on an empty chain and on a first block; and the rollback-then-adopt
  sequence, including an assertion that `AddLocalBlock` refuses the sibling first,
  so the test cannot pass vacuously.
- **builder** (`ledger/forging/builder_block_context_test.go`) — the
  alternative's shape (parent is the predecessor, block number is the rival's,
  *not* the rival's plus one); all three ways to name a parent that is not below
  the block, including the live-tip path (this is the negative test that we never
  build a same-slot parent); a stale contest; a context with no resolved parent;
  and that the default path still extends the live tip.
- **ledger** (`ledger/local_sibling_test.go`) — wire-decodable Conway blocks so
  the select views are real, covering **both** outcomes end to end: ours adopted
  with the fork point intact behind it, and the rival left alone when it wins.
  Plus identical views not preferring ours, every non-sibling shape, and the
  decision function's length-first and unarmed-tiebreaker cases.
- **forger** (`ledger/forging/forge_alternative_test.go`) — a losing alternative
  is not published and does not move `forgeAdopted` but keeps the fence burned;
  the fence is reserved before signing; a slot we already forged is refused with
  the path wired; five unwired/unresolvable configurations all decline without
  burning the slot; a panicking adopter is recovered; and the Leios omission.
- **envelope validation** (`ledger/envelope_validation_test.go`) —
  `TestValidateBlockOrderPinsTheEqualSlotAlternativeShape`.

### CI on `1598f7b3`

Green: `go-test (Linux, race)` (19m30s), `go-test (Windows)` (10m9s),
`docker`, `lint`, `govulncheck`, `Conventional Commits`, `DCO`.

Two red jobs, both the same pre-existing flake pair and neither touched by this
PR:

- `go-test (Linux)` — `TestCanonicalPeersWithCrossingFrontiersDoNotFlap`
  (`chainselection`), "only the initial selection may publish a chain switch".
- `go-test (macOS)` — `TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip`
  (`ledger/chainsync_frontier_flap_test.go`), "the scenario must publish at
  least the initial selection event".

Reproduced on clean `upstream/main` at `680e65e5` with nothing from this branch
applied, same assertions and same messages:

```
go test ./chainselection/ -run TestCanonicalPeersWithCrossingFrontiersDoNotFlap -count=300
  33/300 FAIL
go test ./ledger/ -run TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip -count=300
  36/300 FAIL
```

Both are the #4048 frontier-flap tests, fixed in #4144. Nothing to fix on this
branch; stating it once rather than repeating it per run.

## Open questions for maintainers

These are the parts I would most want a second opinion on.

1. **Should this be behind a config flag?** It changes what a block producer
   signs in a situation it previously declined. It is the reference
   implementation's behaviour and I have left it always-on for a wired producer,
   but a `--forge-equal-slot-alternative` opt-in would be easy to add if you
   would rather ship it dark first.

2. **The rollback/add pair is not atomic against a concurrent blockfetch add.**
   `AdoptLocalForgedSibling` holds `chainsyncMutex`, which serializes it against
   chainsync header handling — the same lock `tryResolveFork` holds — but the
   blockfetch drain is serialized by `chainsyncBlockfetchMutex` instead. If a
   fetched block lands between the rollback and the add, the add fails and the
   chain is left at the fork point with neither candidate on it; that is logged
   at `Error` and recovers when chainsync re-offers the rival's header (which no
   longer conflicts). This is the same window class the existing peer path has —
   `tryResolveFork` rolls back and then *waits for blockfetch*, a much wider one —
   so I did not introduce a new lock-order edge to close it. Taking both mutexes
   would be a new composition across `drainBlockPipelineBeforeRollback`, and I
   did not want to add an edge to that lock graph without a maintainer's read.

3. **Post-adoption resync churn.** `ls.rollback` publishes a "local ledger
   rollback" `ChainsyncResyncEvent`, which drives `RecoverAfterLocalRollback`.
   After a won battle the primary chain tip is *above* the rollback point, so
   that path takes its `SkipConnectionClose` branch and connections are not
   closed; peer header history is replayed, the rival's header arrives again, and
   `tryResolveFork` re-runs the same comparison and declines it. Converges, but
   it is one rollback event per won slot battle and I would like that confirmed
   as acceptable.

4. **`ComparePraosTips` returning `ChainEqual` is a decline.** This means a node
   whose incumbent tip block cannot be decoded, or whose era has no armed VRF
   tiebreaker, never adopts its own alternative. That is the conservative
   direction and matches "keep the incumbent", but it does mean the capability is
   silently inert in those cases.

Refs #3954 (the declined-battle finding). Completes what #3955 explicitly
scoped out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forges a competing sibling block when a rival already occupies the slot this node is about to forge, so the node wins via ordinary Praos chain selection instead of conceding the slot. Previously, contested slots never reached leader selection; now they do, and a won battle rolls back to the shared parent and adopts the local block.

**Key changes**
- Alternatives are built on the rival's predecessor with the rival's block number via `BlockContext`/`BuildBlockOnContext`; a guard rejects any parent not strictly below the forged slot before signing.
- `AdoptLocalForgedSibling` arbitrates with `praos.ComparePraosTips` and rolls back/adopts when the local block wins; losing discards it undiffused and is not an error.
- Both providers are optional and fail closed, so unwired nodes concede exactly as before with `Warn` logged; the durable forge fence is required without it.
- Alternatives carry no transactions or Leios data; the tip gate narrowed to `currentSlot < tipSlot` so contested slots reach leader selection.
- A won adoption invalidates in-flight blockfetch batches for the rival's segment atomically under the chain mutex, and blockfetch range progress is noted on apply, not arrival.

<sup>Written for commit 198c82bd9c28030c455eada1ce8544bfd0779344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for forging and evaluating alternative blocks when competing blocks are produced at the same slot.
  * Winning alternatives can now be adopted through normal chain-selection rules; losing alternatives are not published.
  * Alternative blocks exclude unsupported transaction and announcement data.

* **Bug Fixes**
  * Prevented stale block-fetch results from being applied after a rollback.
  * Improved handling and visibility of forging skips, including scheduled leader slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->