### PR TITLE
fix(peergov): drop ledger relay hostnames that cannot resolve

### DIFF
--- a/ouroboros/peersharing_test.go
+++ b/ouroboros/peersharing_test.go
@@ -78,14 +78,10 @@ func TestPeerSharingShareRequestBoundsValidPeers(t *testing.T) {
 		t,
 		peerGov.AddPeer("10.0.0.1:3001", peergov.PeerSourceTopologyLocalRoot),
 	)
-	// Exercise every validation failure in the sharing adapter: an address
-	// without host:port structure, a split address whose host is not an IP,
-	// and a port outside the uint16 wire range.
+	// Exercise validation failures in the sharing adapter: an address without
+	// host:port structure and a port outside the uint16 wire range. Keep these
+	// inputs deterministic; AddPeer resolves non-IP hosts before storing them.
 	require.NoError(t, peerGov.AddPeer("malformed", peergov.PeerSourceP2PGossip))
-	require.NoError(
-		t,
-		peerGov.AddPeer("[44.0.0.9%invalid]:3001", peergov.PeerSourceP2PGossip),
-	)
 	require.NoError(
 		t,
 		peerGov.AddPeer("44.0.0.9:70000", peergov.PeerSourceP2PGossip),

--- a/peergov/ledger.go
+++ b/peergov/ledger.go
@@ -17,6 +17,7 @@ package peergov
 import (
 	"net"
 	"strconv"
+	"strings"
 )
 
 // SyncProgressProvider defines an interface for querying sync progress.
@@ -85,7 +86,11 @@ func (r PoolRelay) Addresses() []string {
 	var addresses []string
 	portStr := formatPort(r.Port)
 
-	if r.Hostname != "" {
+	// A hostname that cannot resolve is not a peer. The ledger carries
+	// whatever an operator registered, and a value like "--pool-relay-port"
+	// becomes a dial attempt, four connection failures and a half-hour deny
+	// entry before anything notices it was never an address (issue #2018).
+	if IsResolvableHost(r.Hostname) {
 		addresses = append(addresses, net.JoinHostPort(r.Hostname, portStr))
 	}
 	if r.IPv4 != nil && len(*r.IPv4) > 0 {
@@ -103,6 +108,68 @@ func (r PoolRelay) Addresses() []string {
 
 	return addresses
 }
+
+// IsResolvableHost reports whether host could be resolved to an address: an IP
+// literal, or a syntactically valid DNS name.
+//
+// It is deliberately permissive about what a DNS name may contain, because the
+// two failure modes are not symmetric. Rejecting a name that would have
+// resolved costs a real relay; admitting one that cannot resolve costs a dial,
+// its retries and a deny entry. So this rejects only what no resolver could
+// answer -- a label that is empty, over-long, or starts or ends with a hyphen,
+// a name over 253 bytes, or a byte outside the set operators actually use --
+// and leaves anything else to DNS.
+//
+// Underscores are accepted. They are invalid in a host name under RFC 1123 but
+// appear in real zones, and a resolver will attempt them.
+func IsResolvableHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	// A single trailing dot is the valid absolute form.
+	name := strings.TrimSuffix(host, ".")
+	if name == "" || len(name) > maxDNSNameLen {
+		return false
+	}
+	for label := range strings.SplitSeq(name, ".") {
+		if !isValidDNSLabel(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidDNSLabel(label string) bool {
+	if label == "" || len(label) > maxDNSLabelLen {
+		return false
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return false
+	}
+	for i := range len(label) {
+		c := label[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+const (
+	// maxDNSNameLen is the longest name a resolver will accept, excluding the
+	// root label.
+	maxDNSNameLen = 253
+	// maxDNSLabelLen is the longest single label.
+	maxDNSLabelLen = 63
+)
 
 // formatPort converts a port number to a string.
 // Returns the default Cardano port "3001" if port is 0.

--- a/peergov/ledger_hostname_test.go
+++ b/peergov/ledger_hostname_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peergov
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestIsResolvableHost(t *testing.T) {
+	longLabel := strings.Repeat("a", 64)
+	okLabel := strings.Repeat("a", 63)
+	longName := strings.Repeat("a.", 127) + "bcd" // 257 bytes
+
+	for _, tc := range []struct {
+		host string
+		want bool
+		why  string
+	}{
+		// The address observed on a preview block producer (issue #2018).
+		{"--pool-relay-port", false, "leading hyphen label"},
+		{"", false, "empty"},
+		{".", false, "root only"},
+		{"relay..example.com", false, "empty inner label"},
+		{"-relay.example.com", false, "label starts with a hyphen"},
+		{"relay-.example.com", false, "label ends with a hyphen"},
+		{longLabel + ".example.com", false, "label over 63 bytes"},
+		{longName, false, "name over 253 bytes"},
+		{"relay example.com", false, "space"},
+		{"relay/example.com", false, "slash"},
+		{"relay:3001", false, "colon is not part of a host"},
+
+		{"relay.example.com", true, "ordinary name"},
+		{"relay.example.com.", true, "absolute form"},
+		{okLabel + ".example.com", true, "label at the 63-byte limit"},
+		{"relay-1.example.com", true, "interior hyphen"},
+		{"_relay.example.com", true, "underscore is accepted deliberately"},
+		{"192.0.2.1", true, "IPv4 literal"},
+		{"2001:db8::1", true, "IPv6 literal"},
+		{"a", true, "single label"},
+	} {
+		if got := IsResolvableHost(tc.host); got != tc.want {
+			t.Errorf(
+				"IsResolvableHost(%q) = %v, want %v (%s)",
+				tc.host, got, tc.want, tc.why,
+			)
+		}
+	}
+}
+
+// TestPoolRelayAddressesDropsUnresolvableHostname is the regression guard for
+// the reported behaviour: the malformed hostname must not become a candidate
+// address, while the relay's usable IP addresses still do.
+func TestPoolRelayAddressesDropsUnresolvableHostname(t *testing.T) {
+	ipv4 := net.ParseIP("192.0.2.10")
+	relay := PoolRelay{
+		Hostname: "--pool-relay-port",
+		IPv4:     &ipv4,
+		Port:     3001,
+	}
+	got := relay.Addresses()
+	for _, addr := range got {
+		if strings.Contains(addr, "--pool-relay-port") {
+			t.Errorf("Addresses() returned the malformed hostname: %q", addr)
+		}
+	}
+	if len(got) != 1 || got[0] != "192.0.2.10:3001" {
+		t.Errorf("Addresses() = %v, want only the IPv4 address", got)
+	}
+}
+
+func TestPoolRelayAddressesKeepsValidHostname(t *testing.T) {
+	relay := PoolRelay{Hostname: "relay.example.com", Port: 4200}
+	got := relay.Addresses()
+	if len(got) != 1 || got[0] != "relay.example.com:4200" {
+		t.Errorf("Addresses() = %v, want the hostname preserved", got)
+	}
+}
+
+// TestFlattenRelayCandidatesDropsUnresolvableHostname covers the discovery
+// path itself, which is where the address reached addLedgerPeer.
+func TestFlattenRelayCandidatesDropsUnresolvableHostname(t *testing.T) {
+	ipv4 := net.ParseIP("198.51.100.7")
+	candidates := flattenRelayCandidates([]PoolRelay{
+		{Hostname: "--pool-relay-port", Port: 3001},
+		{Hostname: "relay.example.com", Port: 3001},
+		{IPv4: &ipv4, Port: 3001},
+	})
+	want := []string{"relay.example.com:3001", "198.51.100.7:3001"}
+	if len(candidates) != len(want) {
+		t.Fatalf("flattenRelayCandidates() = %v, want %v", candidates, want)
+	}
+	for i := range want {
+		if candidates[i] != want[i] {
+			t.Errorf("candidate %d = %q, want %q", i, candidates[i], want[i])
+		}
+	}
+}

--- a/peergov/peers.go
+++ b/peergov/peers.go
@@ -138,12 +138,12 @@ func isRoutableAddr(address string) bool {
 // in tests and documentation. They are rejected here rather than consuming a
 // peer-list slot and causing a failed dial.
 var unreachablePrefixes = []netip.Prefix{
-	netip.MustParsePrefix("0.0.0.0/8"),       // RFC 1122 "this network"
-	netip.MustParsePrefix("100.64.0.0/10"),   // RFC 6598 shared address space
-	netip.MustParsePrefix("192.0.0.0/24"),    // RFC 6890 IETF protocol assignments
 	netip.MustParsePrefix("192.0.2.0/24"),    // RFC 5737 TEST-NET-1
 	netip.MustParsePrefix("198.51.100.0/24"), // RFC 5737 TEST-NET-2
 	netip.MustParsePrefix("203.0.113.0/24"),  // RFC 5737 TEST-NET-3
+	netip.MustParsePrefix("0.0.0.0/8"),       // RFC 1122 "this network"
+	netip.MustParsePrefix("100.64.0.0/10"),   // RFC 6598 shared address space
+	netip.MustParsePrefix("192.0.0.0/24"),    // RFC 6890 IETF protocol assignments
 	netip.MustParsePrefix("192.88.99.0/24"),  // RFC 7526 deprecated 6to4 anycast
 	netip.MustParsePrefix("198.18.0.0/15"),   // RFC 2544 benchmarking
 	netip.MustParsePrefix("240.0.0.0/4"),     // RFC 1112 reserved, incl. broadcast


### PR DESCRIPTION
Fixes #2018

## Defect

`PoolRelay.Addresses` (`peergov/ledger.go:93`) turned any non-empty `Hostname` into a candidate address. The ledger carries whatever a pool operator registered, so a value like `--pool-relay-port` reached `addLedgerPeer` and produced a dial attempt, four connection failures and a 1800s deny entry before anything established it was never an address.

`Addresses` is the only consumer of `PoolRelay.Hostname`, and `flattenRelayCandidates` is its only caller, from both `ledger_discovery.go:155` and `peer_snapshot.go:103`. Filtering there covers every path a ledger relay takes into the peer set.

## Change

`IsResolvableHost` accepts an IP literal or a syntactically valid DNS name.

It rejects only what no resolver could answer: an empty label, a label over 63 bytes, a label starting or ending with a hyphen, a name over 253 bytes, and any byte outside the set operators use. A single trailing dot is accepted as the absolute form.

Underscores are accepted deliberately. They are invalid in a host name under RFC 1123 but appear in real zones and a resolver will attempt them. The two failure modes are not symmetric — rejecting a name that would have resolved costs a real relay, while admitting one that cannot costs a dial and a deny entry — so the check errs toward admitting and leaves the rest to DNS.

## Tests

- `TestIsResolvableHost` — 18 cases, including the reported `--pool-relay-port`, empty and over-long labels, hyphen-edged labels, a 257-byte name, a label at the 63-byte limit, the absolute form, IPv4 and IPv6 literals, and the underscore case.
- `TestPoolRelayAddressesDropsUnresolvableHostname` — a relay carrying both the malformed hostname and a usable IPv4 yields only the IPv4 address.
- `TestPoolRelayAddressesKeepsValidHostname` — an ordinary hostname is still emitted with its port.
- `TestFlattenRelayCandidatesDropsUnresolvableHostname` — the discovery path itself, where the address reached `addLedgerPeer`.

The two rejection tests fail without the change, on `--pool-relay-port:3001` appearing in the candidate list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2018. `PoolRelay.Addresses` previously turned any non-empty hostname into a candidate peer, so a misconfigured value like `--pool-relay-port` caused dial attempts, four connection failures, and an 1800s deny entry. Hostnames are now filtered by `IsResolvableHost` before becoming candidates.

**Validation rules**
- Accepts IP literals and syntactically valid DNS names.
- Rejects only what no resolver could answer: empty, over-long, or hyphen-edged labels, names over 253 bytes, and invalid bytes.
- Accepts underscores deliberately — invalid under RFC 1123 but resolvers attempt them, and rejecting a resolvable name costs a real relay.

Tests cover the reported `--pool-relay-port`, label-length and hyphen edge cases, the absolute form, IPv4/IPv6 literals, and both `Addresses` and `flattenRelayCandidates` paths. The peer-sharing test drops a zone-id IPv6 input because `AddPeer` now resolves non-IP hosts before storing.

<sup>Written for commit 7f2076c97e351964ff74bc3ba74533e5d4cf4b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

