### PR TITLE
fix(ledger,chainsync): don't collapse intersect points to origin during an in-flight rollback

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -324,6 +324,12 @@ func New(config *Config, stores Stores) (*Database, error) {
 				"error", err,
 			)
 		}
+		if err := RegisterTruncateMetrics(configCopy.PromRegistry); err != nil {
+			configCopy.Logger.Warn(
+				"failed to register rollback truncation metrics",
+				"error", err,
+			)
+		}
 	}
 	// Register database size metrics
 	if configCopy.PromRegistry != nil {

--- a/database/truncate.go
+++ b/database/truncate.go
@@ -15,11 +15,62 @@
 package database
 
 import (
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+// truncateAfterSlotDuration records how long a full TruncateAfterSlot sweep
+// takes. The sweep's cost is a function of table size rather than rollback
+// depth, so on a large metadata database a single depth-1 rollback can hold the
+// ledger write lock for tens of seconds. That window is not otherwise
+// observable: the ledger simply goes silent between "rolling back to X" and
+// "chain rolled back", and chainsync cannot make progress for its duration.
+//
+// The histogram is a package-level singleton rather than a promauto
+// registration so that registering the same or multiple registries never
+// panics; see RegisterBlockByHashMetrics for the same reasoning.
+var (
+	truncateAfterSlotDurationOnce sync.Once
+	truncateAfterSlotDuration     prometheus.Histogram
+)
+
+func truncateAfterSlotDurationHistogram() prometheus.Histogram {
+	truncateAfterSlotDurationOnce.Do(func() {
+		truncateAfterSlotDuration = prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "dingo_database_truncate_after_slot_duration_seconds",
+				Help: "Duration of TruncateAfterSlot metadata rollback sweeps",
+				// 1ms to ~65s: a healthy rollback is milliseconds,
+				// a large-database sweep is tens of seconds.
+				Buckets: prometheus.ExponentialBuckets(0.001, 2, 17),
+			},
+		)
+	})
+	return truncateAfterSlotDuration
+}
+
+// RegisterTruncateMetrics exposes the rollback-truncation duration histogram on
+// the given Prometheus registry. Registering the same registry more than once
+// is a no-op.
+func RegisterTruncateMetrics(reg prometheus.Registerer) error {
+	if reg == nil {
+		return nil
+	}
+	err := reg.Register(truncateAfterSlotDurationHistogram())
+	if err == nil {
+		return nil
+	}
+	if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); !ok {
+		return err
+	}
+	return nil
+}
 
 // TruncateAfterSlot reverts all metadata rows and blob-referenced UTxO/
 // transaction CBOR added strictly after point.Slot: certificates, account
@@ -56,6 +107,23 @@ func (d *Database) TruncateAfterSlot(
 	mithrilFloor uint64,
 	txn *Txn,
 ) (ochainsync.Tip, []byte, error) {
+	started := time.Now()
+	defer func() {
+		elapsed := time.Since(started)
+		truncateAfterSlotDurationHistogram().Observe(elapsed.Seconds())
+		// Logged unconditionally at Info: the ledger holds its write lock
+		// across this call, so its duration is the length of a chain-freeze
+		// window and needs to be visible without enabling Debug.
+		if d.logger != nil {
+			d.logger.Info(
+				"metadata rollback truncation complete",
+				"component", "database",
+				"rollback_slot", point.Slot,
+				"duration", elapsed.String(),
+				"duration_seconds", elapsed.Seconds(),
+			)
+		}
+	}()
 	owned := false
 	if txn == nil {
 		txn = d.Transaction(true)

--- a/database/truncate.go
+++ b/database/truncate.go
@@ -37,12 +37,22 @@ import (
 // panics; see RegisterBlockByHashMetrics for the same reasoning.
 var (
 	truncateAfterSlotDurationOnce sync.Once
-	truncateAfterSlotDuration     prometheus.Histogram
+	truncateAfterSlotDuration     *prometheus.HistogramVec
 )
 
-func truncateAfterSlotDurationHistogram() prometheus.Histogram {
+// truncateResultSuccess and truncateResultFailure are the values of the
+// histogram's "result" label. A failed sweep can have a very different
+// duration profile from a successful one (it aborts at whichever sweep
+// failed), so mixing them into one distribution would misreport the
+// chain-freeze cost.
+const (
+	truncateResultSuccess = "success"
+	truncateResultFailure = "failure"
+)
+
+func truncateAfterSlotDurationHistogram() *prometheus.HistogramVec {
 	truncateAfterSlotDurationOnce.Do(func() {
-		truncateAfterSlotDuration = prometheus.NewHistogram(
+		truncateAfterSlotDuration = prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: "dingo_database_truncate_after_slot_duration_seconds",
 				Help: "Duration of TruncateAfterSlot metadata rollback sweeps",
@@ -50,6 +60,7 @@ func truncateAfterSlotDurationHistogram() prometheus.Histogram {
 				// a large-database sweep is tens of seconds.
 				Buckets: prometheus.ExponentialBuckets(0.001, 2, 17),
 			},
+			[]string{"result"},
 		)
 	})
 	return truncateAfterSlotDuration
@@ -106,23 +117,54 @@ func (d *Database) TruncateAfterSlot(
 	point ocommon.Point,
 	mithrilFloor uint64,
 	txn *Txn,
-) (ochainsync.Tip, []byte, error) {
+) (retTip ochainsync.Tip, retNonce []byte, retErr error) {
 	started := time.Now()
+	// Set only when this call opened and committed its own transaction.
+	// Distinct from `owned`, which is also false when the caller supplied
+	// txn and therefore cannot express "durably committed here".
+	committedInternally := false
 	defer func() {
 		elapsed := time.Since(started)
-		truncateAfterSlotDurationHistogram().Observe(elapsed.Seconds())
-		// Logged unconditionally at Info: the ledger holds its write lock
-		// across this call, so its duration is the length of a chain-freeze
-		// window and needs to be visible without enabling Debug.
-		if d.logger != nil {
-			d.logger.Info(
-				"metadata rollback truncation complete",
+		// The duration is recorded either way -- a sweep that failed still
+		// held the ledger write lock for that long -- but under a label so
+		// success and failure are distinguishable.
+		result := truncateResultSuccess
+		if retErr != nil {
+			result = truncateResultFailure
+		}
+		truncateAfterSlotDurationHistogram().
+			WithLabelValues(result).
+			Observe(elapsed.Seconds())
+		if d.logger == nil {
+			return
+		}
+		// Logged at Info: the ledger holds its write lock across this call,
+		// so its duration is the length of a chain-freeze window and needs
+		// to be visible without enabling Debug.
+		//
+		// Note this reports the sweep, not the commit. When the caller
+		// supplies txn, it owns the commit and can still roll back after
+		// this returns, so the message deliberately says the sweep
+		// completed rather than claiming the truncation was durable.
+		if retErr != nil {
+			d.logger.Warn(
+				"metadata rollback truncation failed",
 				"component", "database",
 				"rollback_slot", point.Slot,
 				"duration", elapsed.String(),
 				"duration_seconds", elapsed.Seconds(),
+				"error", retErr,
 			)
+			return
 		}
+		d.logger.Info(
+			"metadata rollback truncation sweep complete",
+			"component", "database",
+			"rollback_slot", point.Slot,
+			"duration", elapsed.String(),
+			"duration_seconds", elapsed.Seconds(),
+			"committed", committedInternally,
+		)
 	}()
 	owned := false
 	if txn == nil {
@@ -390,6 +432,7 @@ func (d *Database) TruncateAfterSlot(
 			)
 		}
 		owned = false
+		committedInternally = true
 	}
 	return newTip, newNonce, nil
 }

--- a/database/truncate_metrics_test.go
+++ b/database/truncate_metrics_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruncateAfterSlotObservesDuration verifies the rollback-truncation sweep
+// is measured. Without this the only symptom of a multi-second truncation is
+// the ledger going silent, which is what made a ~90s chain freeze invisible.
+func TestTruncateAfterSlotObservesDuration(t *testing.T) {
+	db := newTestDB(t)
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterTruncateMetrics(reg))
+	// Registering a second registry must not panic or error.
+	require.NoError(t, RegisterTruncateMetrics(prometheus.NewRegistry()))
+
+	before := collectHistogramCount(t, reg)
+
+	targetBlock := testIndexedBlock(1500, 1, 0x15)
+	require.NoError(t, db.BlockCreate(targetBlock, nil))
+	point := ocommon.Point{Slot: 1500, Hash: targetBlock.Hash}
+	_, _, err := db.TruncateAfterSlot(point, 0, nil)
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		before+1,
+		collectHistogramCount(t, reg),
+		"TruncateAfterSlot must record its duration",
+	)
+}
+
+// TestRegisterTruncateMetricsNilRegistry verifies a nil registry is tolerated,
+// matching the other database metric registrations.
+func TestRegisterTruncateMetricsNilRegistry(t *testing.T) {
+	require.NoError(t, RegisterTruncateMetrics(nil))
+}
+
+func collectHistogramCount(t *testing.T, reg *prometheus.Registry) uint64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() !=
+			"dingo_database_truncate_after_slot_duration_seconds" {
+			continue
+		}
+		require.NotEmpty(t, family.GetMetric())
+		return family.GetMetric()[0].GetHistogram().GetSampleCount()
+	}
+	t.Fatal("truncation duration histogram not registered")
+	return 0
+}

--- a/database/truncate_metrics_test.go
+++ b/database/truncate_metrics_test.go
@@ -15,10 +15,12 @@
 package database
 
 import (
+	"bytes"
 	"testing"
 
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +35,7 @@ func TestTruncateAfterSlotObservesDuration(t *testing.T) {
 	// Registering a second registry must not panic or error.
 	require.NoError(t, RegisterTruncateMetrics(prometheus.NewRegistry()))
 
-	before := collectHistogramCount(t, reg)
+	before := collectHistogramCount(t, reg, truncateResultSuccess)
 
 	targetBlock := testIndexedBlock(1500, 1, 0x15)
 	require.NoError(t, db.BlockCreate(targetBlock, nil))
@@ -44,8 +46,43 @@ func TestTruncateAfterSlotObservesDuration(t *testing.T) {
 	require.Equal(
 		t,
 		before+1,
-		collectHistogramCount(t, reg),
+		collectHistogramCount(t, reg, truncateResultSuccess),
 		"TruncateAfterSlot must record its duration",
+	)
+}
+
+// TestTruncateAfterSlotRecordsFailureSeparately verifies a failed sweep is not
+// reported as a completed truncation. The duration is still observed -- a sweep
+// that failed held the ledger write lock for that long -- but under the failure
+// label, and the log line says failed rather than complete.
+func TestTruncateAfterSlotRecordsFailureSeparately(t *testing.T) {
+	db := newTestDB(t)
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterTruncateMetrics(reg))
+	beforeOK := collectHistogramCount(t, reg, truncateResultSuccess)
+	beforeFail := collectHistogramCount(t, reg, truncateResultFailure)
+
+	// A rollback point above slot 0 whose block row does not exist makes
+	// TruncateAfterSlot fail when it looks the block up for the new tip.
+	point := ocommon.Point{
+		Slot: 4242,
+		Hash: bytes.Repeat([]byte{0x99}, 32),
+	}
+	_, _, err := db.TruncateAfterSlot(point, 0, nil)
+	require.Error(t, err)
+
+	assert.Equal(
+		t,
+		beforeOK,
+		collectHistogramCount(t, reg, truncateResultSuccess),
+		"a failed sweep must not be counted as a success",
+	)
+	assert.Equal(
+		t,
+		beforeFail+1,
+		collectHistogramCount(t, reg, truncateResultFailure),
+		"a failed sweep must still record its duration under the failure label",
 	)
 }
 
@@ -55,7 +92,11 @@ func TestRegisterTruncateMetricsNilRegistry(t *testing.T) {
 	require.NoError(t, RegisterTruncateMetrics(nil))
 }
 
-func collectHistogramCount(t *testing.T, reg *prometheus.Registry) uint64 {
+func collectHistogramCount(
+	t *testing.T,
+	reg *prometheus.Registry,
+	result string,
+) uint64 {
 	t.Helper()
 	families, err := reg.Gather()
 	require.NoError(t, err)
@@ -64,9 +105,16 @@ func collectHistogramCount(t *testing.T, reg *prometheus.Registry) uint64 {
 			"dingo_database_truncate_after_slot_duration_seconds" {
 			continue
 		}
-		require.NotEmpty(t, family.GetMetric())
-		return family.GetMetric()[0].GetHistogram().GetSampleCount()
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "result" &&
+					label.GetValue() == result {
+					return metric.GetHistogram().GetSampleCount()
+				}
+			}
+		}
 	}
-	t.Fatal("truncation duration histogram not registered")
+	// A labelled child that has never been observed is absent from the
+	// gathered output, which is a legitimate count of zero.
 	return 0
 }

--- a/ledger/intersect_points_rollback_window_test.go
+++ b/ledger/intersect_points_rollback_window_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rollbackWindowFixture reproduces the state a node holds while a rollback's
+// metadata truncation is still in flight.
+//
+// rollbackChainAndStateDeferred rewinds ls.chain (which physically removes the
+// rolled-away block rows) before calling ls.rollback, and ls.rollback only
+// assigns ls.currentTip once TruncateAfterSlot has committed. On a large
+// metadata database that truncation takes tens of seconds, and for that whole
+// window the chain tip is the rollback point while ls.currentTip still names
+// the block the chain rollback already deleted.
+type rollbackWindowFixture struct {
+	ls          *LedgerState
+	blocks      []models.Block
+	rollbackTo  models.Block
+	staleLedger ochainsync.Tip
+}
+
+func newRollbackWindowFixture(t *testing.T) *rollbackWindowFixture {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+
+	blocks := make([]models.Block, 0, 5)
+	for slot := uint64(1); slot <= 5; slot++ {
+		block := makeTestBlock(slot, slot)
+		if len(blocks) > 0 {
+			block.PrevHash = append([]byte(nil), blocks[len(blocks)-1].Hash...)
+		}
+		blocks = append(blocks, block)
+		require.NoError(t, db.BlockCreate(block, nil))
+	}
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 5}))
+
+	tipBlock := blocks[len(blocks)-1]
+	ledgerTip := ochainsync.Tip{
+		Point:       makeTestPoint(tipBlock),
+		BlockNumber: tipBlock.Number,
+	}
+	require.NoError(t, db.SetTip(ledgerTip, nil))
+
+	ls := &LedgerState{
+		db:    db,
+		chain: cm.PrimaryChain(),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+	ls.currentTip = ledgerTip
+
+	// Rewind the chain exactly as rollbackChainAndStateDeferred does, and
+	// deliberately do NOT run ls.rollback: this is the in-flight-truncation
+	// window.
+	rollbackTo := blocks[2]
+	require.NoError(t, ls.chain.Rollback(makeTestPoint(rollbackTo)))
+
+	return &rollbackWindowFixture{
+		ls:          ls,
+		blocks:      blocks,
+		rollbackTo:  rollbackTo,
+		staleLedger: ledgerTip,
+	}
+}
+
+// TestRollbackWindowPreconditions pins the exact state the bug depends on, so
+// a future change that makes the window unreachable fails here loudly rather
+// than silently turning the regression tests below into tautologies.
+func TestRollbackWindowPreconditions(t *testing.T) {
+	f := newRollbackWindowFixture(t)
+
+	// The chain has been rewound to the rollback point...
+	chainTip := f.ls.chain.Tip()
+	require.Equal(t, f.rollbackTo.Slot, chainTip.Point.Slot)
+
+	// ...but the ledger tip still names the block that rewind deleted.
+	f.ls.RLock()
+	ledgerTip := f.ls.currentTip
+	f.ls.RUnlock()
+	require.Equal(t, f.staleLedger.Point.Slot, ledgerTip.Point.Slot)
+	require.Greater(t, ledgerTip.Point.Slot, chainTip.Point.Slot)
+
+	// The ledger tip's block row is gone, which is what makes
+	// authoritativeRecentChainPoints bail out.
+	_, err := database.BlockByPoint(f.ls.db, ledgerTip.Point)
+	require.ErrorIs(t, err, models.ErrBlockNotFound)
+
+	// And the "chain is usable" guard is false, so IntersectPoints takes the
+	// authoritative path rather than the chain path.
+	require.False(t, f.ls.primaryChainTipAtOrAheadOfLedgerTip())
+}
+
+// TestAuthoritativeRecentChainPointsFallsBackToChainTipWhenLedgerTipMissing
+// asserts the ledger never reports "I have no chain points" while it demonstrably
+// holds a chain. Before the fix this returned an empty slice with a nil error,
+// which buildDefaultChainsyncIntersectPoints turned into an origin-only
+// MsgFindIntersect.
+func TestAuthoritativeRecentChainPointsFallsBackToChainTipWhenLedgerTipMissing(
+	t *testing.T,
+) {
+	f := newRollbackWindowFixture(t)
+
+	points, err := f.ls.authoritativeRecentChainPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(
+		t,
+		points,
+		"ledger reported no chain points while holding a chain tip at slot %d",
+		f.ls.chain.Tip().Point.Slot,
+	)
+
+	// The newest point offered must be the rollback point (the chain tip),
+	// not the deleted ledger tip.
+	assert.Equal(t, f.rollbackTo.Slot, points[0].Slot)
+	assert.Equal(t, f.rollbackTo.Hash, points[0].Hash)
+
+	// No point may name a block that no longer exists.
+	for _, point := range points {
+		assert.LessOrEqual(
+			t,
+			point.Slot,
+			f.rollbackTo.Slot,
+			"offered a point above the rollback point",
+		)
+	}
+
+	// Recent points below the tip must still be walked, so a peer that has
+	// also rewound can intersect deeper than the tip.
+	require.Greater(t, len(points), 1, "expected recent points below the tip")
+	assert.Equal(t, f.blocks[1].Slot, points[1].Slot)
+}
+
+// TestIntersectPointsDoesNotCollapseToEmptyDuringRollbackWindow is the
+// end-to-end ledger-level assertion: the entry point chainsync actually calls
+// must not return an empty set in this window.
+func TestIntersectPointsDoesNotCollapseToEmptyDuringRollbackWindow(
+	t *testing.T,
+) {
+	f := newRollbackWindowFixture(t)
+
+	points, err := f.ls.IntersectPoints(4)
+	require.NoError(t, err)
+	require.NotEmpty(
+		t,
+		points,
+		"IntersectPoints returned nothing during an in-flight rollback; "+
+			"chainsync would offer origin only",
+	)
+	assert.Equal(t, f.rollbackTo.Slot, points[0].Slot)
+	assert.Equal(t, f.rollbackTo.Hash, points[0].Hash)
+}
+
+// TestIntersectPointsStillEmptyAtOriginWithNoChain guards the fallback from
+// over-reaching: a node that genuinely has no chain must still report no
+// points, so a fresh node syncs from origin as designed.
+func TestIntersectPointsStillEmptyAtOriginWithNoChain(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(t, cm.SetLedger(testSecurityParamLedger{securityParam: 5}))
+	ls := &LedgerState{
+		db:    db,
+		chain: cm.PrimaryChain(),
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	points, err := ls.IntersectPoints(4)
+	require.NoError(t, err)
+	assert.Empty(t, points)
+}
+
+// TestAuthoritativeRecentChainPointsIgnoresChainTipAheadOfLedgerTip pins the
+// boundary of the fallback introduced for the rollback window. A chain tip at
+// or ahead of the ledger tip is unapplied forward work -- possibly a fork that
+// does not descend from the ledger tip at all -- and must NOT be offered as an
+// intersect point, which is the invariant the primary-chain ancestor check
+// (#2309) exists to protect. Only a chain tip strictly below the ledger tip,
+// the signature of an in-flight rewind, qualifies.
+func TestAuthoritativeRecentChainPointsIgnoresChainTipAheadOfLedgerTip(
+	t *testing.T,
+) {
+	f := newRollbackWindowFixture(t)
+
+	// Extend the rewound chain past the (missing) ledger tip with a fork
+	// block, so the chain tip is now ahead of the ledger tip.
+	forkHash := bytes.Repeat([]byte{0xfe}, 32)
+	require.NoError(t, f.ls.chain.AddRawBlocks([]chain.RawBlock{
+		{
+			Slot:        f.staleLedger.Point.Slot + 5,
+			Hash:        forkHash,
+			BlockNumber: f.staleLedger.BlockNumber + 1,
+			Type:        1,
+			PrevHash:    f.rollbackTo.Hash,
+			Cbor:        []byte{0x80},
+		},
+	}))
+	require.Greater(
+		t,
+		f.ls.chain.Tip().Point.Slot,
+		f.staleLedger.Point.Slot,
+	)
+
+	points, err := f.ls.authoritativeRecentChainPoints(4)
+	require.NoError(t, err)
+	assert.Empty(
+		t,
+		points,
+		"must not offer unapplied forward chain state as intersect points",
+	)
+}

--- a/ledger/intersect_points_rollback_window_test.go
+++ b/ledger/intersect_points_rollback_window_test.go
@@ -16,8 +16,10 @@ package ledger
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
@@ -241,4 +243,126 @@ func TestAuthoritativeRecentChainPointsIgnoresChainTipAheadOfLedgerTip(
 		points,
 		"must not offer unapplied forward chain state as intersect points",
 	)
+}
+
+// countingWarnHandler counts Warn records carrying a given message.
+type countingWarnHandler struct {
+	slog.Handler
+	message string
+	count   *atomic.Int64
+}
+
+func (h countingWarnHandler) Handle(
+	ctx context.Context,
+	record slog.Record,
+) error {
+	if record.Level == slog.LevelWarn && record.Message == h.message {
+		h.count.Add(1)
+	}
+	return nil
+}
+
+func (h countingWarnHandler) Enabled(
+	_ context.Context,
+	level slog.Level,
+) bool {
+	return level >= slog.LevelWarn
+}
+
+// TestRecentChainPointsFallbackAnchorPropagatesStorageError verifies a real
+// storage failure is surfaced rather than silently degraded into "no anchor".
+// Swallowing it would turn a transient database fault into an origin-only
+// intersect list, i.e. a request that the peer replay the chain from genesis.
+func TestRecentChainPointsFallbackAnchorPropagatesStorageError(t *testing.T) {
+	f := newRollbackWindowFixture(t)
+
+	// Sanity: the anchor resolves while the database is healthy.
+	block, ok, err := f.ls.recentChainPointsFallbackAnchor(f.staleLedger)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, f.rollbackTo.Slot, block.Slot)
+
+	require.NoError(t, dbtest.CloseDatabase(f.ls.db))
+
+	_, ok, err = f.ls.recentChainPointsFallbackAnchor(f.staleLedger)
+	require.Error(t, err, "storage failure must not be swallowed")
+	assert.False(t, ok)
+	assert.NotErrorIs(
+		t,
+		err,
+		models.ErrBlockNotFound,
+		"a real storage fault must not be reported as a missing block",
+	)
+}
+
+// TestAuthoritativeRecentChainPointsPropagatesAnchorStorageError verifies the
+// propagated error reaches the caller instead of becoming an empty point list.
+func TestAuthoritativeRecentChainPointsPropagatesAnchorStorageError(
+	t *testing.T,
+) {
+	f := newRollbackWindowFixture(t)
+	require.NoError(t, dbtest.CloseDatabase(f.ls.db))
+
+	points, err := f.ls.authoritativeRecentChainPoints(4)
+	require.Error(t, err)
+	assert.Nil(t, points)
+}
+
+// TestIntersectAnchorFallbackWarnIsThrottled verifies the anchor-fallback
+// warning does not flood. authoritativeRecentChainPoints runs on every
+// chainsync client start, and during the truncation window peer governance
+// reconnects roughly once a second across every peer, so an unthrottled
+// warning would emit hundreds of lines for a single rollback.
+func TestIntersectAnchorFallbackWarnIsThrottled(t *testing.T) {
+	f := newRollbackWindowFixture(t)
+
+	var warns atomic.Int64
+	f.ls.config.Logger = slog.New(countingWarnHandler{
+		Handler: slog.NewJSONHandler(io.Discard, nil),
+		message: "ledger tip block missing, anchoring intersect points on primary chain tip",
+		count:   &warns,
+	})
+
+	for range 50 {
+		points, err := f.ls.authoritativeRecentChainPoints(4)
+		require.NoError(t, err)
+		require.NotEmpty(t, points)
+	}
+
+	assert.Equal(
+		t,
+		int64(1),
+		warns.Load(),
+		"anchor-fallback warning must be throttled, not emitted per call",
+	)
+}
+
+// TestRollbackWindowIntersectAnchorReportsRollbackPoint verifies the exported
+// anchor, which chainsync relies on, names the rollback point during the
+// window.
+func TestRollbackWindowIntersectAnchorReportsRollbackPoint(t *testing.T) {
+	f := newRollbackWindowFixture(t)
+
+	point, ok := f.ls.RollbackWindowIntersectAnchor()
+	require.True(t, ok)
+	assert.Equal(t, f.rollbackTo.Slot, point.Slot)
+	assert.Equal(t, f.rollbackTo.Hash, point.Hash)
+}
+
+// TestRollbackWindowIntersectAnchorAbsentWhenLedgerTipPresent verifies the
+// anchor is offered only inside the window: a self-consistent ledger whose tip
+// row is readable needs no rescue.
+func TestRollbackWindowIntersectAnchorAbsentWhenLedgerTipPresent(t *testing.T) {
+	f := newRollbackWindowFixture(t)
+
+	// Move the ledger tip onto a block that still exists.
+	f.ls.Lock()
+	f.ls.currentTip = ochainsync.Tip{
+		Point:       makeTestPoint(f.rollbackTo),
+		BlockNumber: f.rollbackTo.Number,
+	}
+	f.ls.Unlock()
+
+	_, ok := f.ls.RollbackWindowIntersectAnchor()
+	assert.False(t, ok)
 }

--- a/ledger/intersect_points_rollback_window_test.go
+++ b/ledger/intersect_points_rollback_window_test.go
@@ -343,7 +343,8 @@ func TestIntersectAnchorFallbackWarnIsThrottled(t *testing.T) {
 func TestRollbackWindowIntersectAnchorReportsRollbackPoint(t *testing.T) {
 	f := newRollbackWindowFixture(t)
 
-	point, ok := f.ls.RollbackWindowIntersectAnchor()
+	point, ok, err := f.ls.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, f.rollbackTo.Slot, point.Slot)
 	assert.Equal(t, f.rollbackTo.Hash, point.Hash)
@@ -363,6 +364,7 @@ func TestRollbackWindowIntersectAnchorAbsentWhenLedgerTipPresent(t *testing.T) {
 	}
 	f.ls.Unlock()
 
-	_, ok := f.ls.RollbackWindowIntersectAnchor()
+	_, ok, err := f.ls.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
 	assert.False(t, ok)
 }

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8912,25 +8912,40 @@ func (ls *LedgerState) recentChainPointsFallbackAnchor(
 // chain tip directly. A raw chain tip can be an unapplied fork ahead of the
 // ledger tip that does not descend from it, and advertising that would break
 // the primary-chain ancestor invariant (#2309).
-func (ls *LedgerState) RollbackWindowIntersectAnchor() (ocommon.Point, bool) {
+func (ls *LedgerState) RollbackWindowIntersectAnchor() (
+	ocommon.Point,
+	bool,
+	error,
+) {
 	ls.RLock()
 	currentTip := ls.currentTip
 	ls.RUnlock()
 	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
-		return ocommon.Point{}, false
+		return ocommon.Point{}, false, nil
 	}
 	// The window is defined by the ledger tip's row being gone. If it is
 	// readable the ledger is self-consistent and needs no rescue.
+	//
+	// A lookup failure that is not "block not found" is a storage fault, not
+	// an answer. Reporting it as "no anchor" would let a transient database
+	// error silently become an origin-only intersect list, i.e. a request
+	// that the peer replay the chain from genesis.
 	if _, err := database.BlockByPoint(ls.db, currentTip.Point); err == nil {
-		return ocommon.Point{}, false
+		return ocommon.Point{}, false, nil
 	} else if !errors.Is(err, models.ErrBlockNotFound) {
-		return ocommon.Point{}, false
+		return ocommon.Point{}, false, fmt.Errorf(
+			"look up ledger tip block for rollback intersect anchor: %w",
+			err,
+		)
 	}
 	block, ok, err := ls.recentChainPointsFallbackAnchor(currentTip)
-	if err != nil || !ok {
-		return ocommon.Point{}, false
+	if err != nil {
+		return ocommon.Point{}, false, err
 	}
-	return ocommon.NewPoint(block.Slot, block.Hash), true
+	if !ok {
+		return ocommon.Point{}, false, nil
+	}
+	return ocommon.NewPoint(block.Slot, block.Hash), true, nil
 }
 
 // intersectAnchorFallbackWarnInterval throttles the anchor-fallback warning.

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -8840,6 +8840,50 @@ func (ls *LedgerState) primaryChainTipAtOrAheadOfLedgerTip() bool {
 		bytes.Equal(chainTip.Point.Hash, ledgerTip.Point.Hash)
 }
 
+// recentChainPointsFallbackAnchor resolves the newest block row that can anchor
+// the recent-chain-point walk when the ledger tip's own row is absent from the
+// metadata database. It returns the primary chain's tip block, which during an
+// in-flight rollback is the rollback point the ledger is being rewound to.
+//
+// It reports ok=false when there is no chain, when the chain is still at
+// origin, when the chain tip is not strictly below the ledger tip (see below),
+// or when the chain tip's own row is not readable either. In all of those cases
+// the node has nothing better to offer and the caller keeps its previous
+// behaviour of returning no points.
+func (ls *LedgerState) recentChainPointsFallbackAnchor(
+	ledgerTip ochainsync.Tip,
+) (models.Block, bool) {
+	ls.RLock()
+	chain := ls.chain
+	ls.RUnlock()
+	if chain == nil {
+		return models.Block{}, false
+	}
+	chainTip := chain.Tip()
+	if chainTip.Point.Slot == 0 && len(chainTip.Point.Hash) == 0 {
+		return models.Block{}, false
+	}
+	// Only a chain tip strictly BELOW the ledger tip qualifies. That is the
+	// signature of a rewind in progress: the chain has been rolled back to a
+	// point the ledger has already applied and is being rewound to, so
+	// offering it describes chain state we hold and have validated.
+	//
+	// A chain tip at or ahead of the ledger tip is the opposite case --
+	// unapplied forward work, possibly on a fork that does not descend from
+	// the ledger tip at all. Offering that would break the ancestor
+	// invariant established in #2309 (primaryChainTipAtOrAheadOfLedgerTip
+	// exists precisely to gate it), which is why the ahead case stays with
+	// the existing behaviour of reporting no points.
+	if chainTip.Point.Slot >= ledgerTip.Point.Slot {
+		return models.Block{}, false
+	}
+	block, err := database.BlockByPoint(ls.db, chainTip.Point)
+	if err != nil {
+		return models.Block{}, false
+	}
+	return block, true
+}
+
 func (ls *LedgerState) authoritativeRecentChainPoints(
 	count int,
 ) ([]ocommon.Point, error) {
@@ -8886,10 +8930,41 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 		// (peers can't sync from us) and our own outbound
 		// chainsync setup (we ship MsgFindIntersect with these
 		// points).
-		if errors.Is(err, models.ErrBlockNotFound) {
+		if !errors.Is(err, models.ErrBlockNotFound) {
+			return nil, err
+		}
+		// Tolerating the missing row must not mean offering nothing.
+		// rollbackChainAndStateDeferred rewinds ls.chain (which removes
+		// the rolled-away block rows) before ls.rollback runs, and
+		// ls.rollback only assigns ls.currentTip once its metadata
+		// truncation has committed. For the whole truncation -- tens of
+		// seconds on a large metadata database -- ls.currentTip names a
+		// block that no longer exists while the chain already sits at the
+		// rollback point. Returning an empty slice here made
+		// IntersectPoints yield nothing, which
+		// buildDefaultChainsyncIntersectPoints turns into an origin-only
+		// MsgFindIntersect: the peer replays genesis-era headers, header
+		// verification rejects them (no epoch-0 stake entry for the
+		// genesis-era producer), and every connection is recycled until
+		// the truncation finishes.
+		//
+		// Anchor the walk on the primary chain's tip instead. During that
+		// window it is precisely the rollback point, so the points we
+		// offer describe the chain we will hold once the truncation
+		// commits.
+		fallbackBlock, ok := ls.recentChainPointsFallbackAnchor(currentTip)
+		if !ok {
 			return points, nil
 		}
-		return nil, err
+		ls.config.Logger.Warn(
+			"ledger tip block missing, anchoring intersect points on primary chain tip",
+			"component", "ledger",
+			"ledger_tip_slot", currentTip.Point.Slot,
+			"ledger_tip_hash", hex.EncodeToString(currentTip.Point.Hash),
+			"chain_tip_slot", fallbackBlock.Slot,
+			"chain_tip_hash", hex.EncodeToString(fallbackBlock.Hash),
+		)
+		tipBlock = fallbackBlock
 	}
 	appendBlock(tipBlock)
 	denseStartIndex := tipBlock.ID

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -1043,11 +1043,14 @@ type LedgerState struct {
 	// Cross-fork continuation audit (issue #3005). Armed by a local
 	// rollback and consumed by the blockfetch handler; see
 	// ledger/continuation_audit.go for the cost and soundness argument.
-	continuationAudit      atomic.Pointer[continuationAuditWindow]
-	mithrilLedgerSlot      uint64 // blocks at or below this slot are Mithril-verified; skip validation
-	mithrilLedgerHash      []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
-	lastLocalRollbackSeq   uint64
-	lastLocalRollbackPoint ocommon.Point
+	continuationAudit    atomic.Pointer[continuationAuditWindow]
+	mithrilLedgerSlot    uint64 // blocks at or below this slot are Mithril-verified; skip validation
+	mithrilLedgerHash    []byte // hash for mithrilLedgerSlot, used as a stable chainsync intersect point
+	lastLocalRollbackSeq uint64
+	// lastIntersectAnchorFallbackWarn throttles
+	// warnIntersectAnchorFallback. Unix nanoseconds; 0 means never warned.
+	lastIntersectAnchorFallbackWarn atomic.Int64
+	lastLocalRollbackPoint          ocommon.Point
 
 	// Subscription IDs for event bus unsubscribe on close
 	chainsyncSubID           event.EventSubscriberId
@@ -8852,16 +8855,16 @@ func (ls *LedgerState) primaryChainTipAtOrAheadOfLedgerTip() bool {
 // behaviour of returning no points.
 func (ls *LedgerState) recentChainPointsFallbackAnchor(
 	ledgerTip ochainsync.Tip,
-) (models.Block, bool) {
+) (models.Block, bool, error) {
 	ls.RLock()
 	chain := ls.chain
 	ls.RUnlock()
 	if chain == nil {
-		return models.Block{}, false
+		return models.Block{}, false, nil
 	}
 	chainTip := chain.Tip()
 	if chainTip.Point.Slot == 0 && len(chainTip.Point.Hash) == 0 {
-		return models.Block{}, false
+		return models.Block{}, false, nil
 	}
 	// Only a chain tip strictly BELOW the ledger tip qualifies. That is the
 	// signature of a rewind in progress: the chain has been rolled back to a
@@ -8875,13 +8878,95 @@ func (ls *LedgerState) recentChainPointsFallbackAnchor(
 	// exists precisely to gate it), which is why the ahead case stays with
 	// the existing behaviour of reporting no points.
 	if chainTip.Point.Slot >= ledgerTip.Point.Slot {
-		return models.Block{}, false
+		return models.Block{}, false, nil
 	}
 	block, err := database.BlockByPoint(ls.db, chainTip.Point)
 	if err != nil {
-		return models.Block{}, false
+		// A chain tip whose row is simply absent means there is no better
+		// anchor and the caller keeps its previous behaviour. Any other
+		// error is a storage failure and must not be silently downgraded
+		// into "offer no intersect points", which reaches the network as a
+		// request to replay from genesis.
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return models.Block{}, false, nil
+		}
+		return models.Block{}, false, fmt.Errorf(
+			"look up primary chain tip block for intersect anchor: %w",
+			err,
+		)
 	}
-	return block, true
+	return block, true, nil
+}
+
+// RollbackWindowIntersectAnchor reports the point that may safely seed a
+// chainsync intersect list while a rollback's metadata truncation is in
+// flight, and whether such a point exists.
+//
+// It is the ledger's authoritative answer to "is this node mid-rewind, and if
+// so what has it actually applied": ok is true only when the ledger tip's own
+// block row is absent (the signature of the window) AND the primary chain tip
+// sits strictly below the ledger tip (a rewind target the ledger has already
+// applied, not unapplied forward work).
+//
+// Callers outside the ledger must use this rather than reading the primary
+// chain tip directly. A raw chain tip can be an unapplied fork ahead of the
+// ledger tip that does not descend from it, and advertising that would break
+// the primary-chain ancestor invariant (#2309).
+func (ls *LedgerState) RollbackWindowIntersectAnchor() (ocommon.Point, bool) {
+	ls.RLock()
+	currentTip := ls.currentTip
+	ls.RUnlock()
+	if currentTip.Point.Slot == 0 && len(currentTip.Point.Hash) == 0 {
+		return ocommon.Point{}, false
+	}
+	// The window is defined by the ledger tip's row being gone. If it is
+	// readable the ledger is self-consistent and needs no rescue.
+	if _, err := database.BlockByPoint(ls.db, currentTip.Point); err == nil {
+		return ocommon.Point{}, false
+	} else if !errors.Is(err, models.ErrBlockNotFound) {
+		return ocommon.Point{}, false
+	}
+	block, ok, err := ls.recentChainPointsFallbackAnchor(currentTip)
+	if err != nil || !ok {
+		return ocommon.Point{}, false
+	}
+	return ocommon.NewPoint(block.Slot, block.Hash), true
+}
+
+// intersectAnchorFallbackWarnInterval throttles the anchor-fallback warning.
+// authoritativeRecentChainPoints runs on every chainsync client start, and
+// during the truncation window peer governance reconnects roughly once a
+// second across every peer, so an unthrottled warning floods the log for the
+// whole freeze.
+const intersectAnchorFallbackWarnInterval = 30 * time.Second
+
+// warnIntersectAnchorFallback logs, at most once per
+// intersectAnchorFallbackWarnInterval, that the ledger tip's block row is
+// missing and intersect points are being anchored on the primary chain tip.
+func (ls *LedgerState) warnIntersectAnchorFallback(
+	currentTip ochainsync.Tip,
+	fallbackBlock models.Block,
+) {
+	now := time.Now()
+	last := ls.lastIntersectAnchorFallbackWarn.Load()
+	if last != 0 &&
+		now.Sub(time.Unix(0, last)) < intersectAnchorFallbackWarnInterval {
+		return
+	}
+	if !ls.lastIntersectAnchorFallbackWarn.CompareAndSwap(
+		last,
+		now.UnixNano(),
+	) {
+		return
+	}
+	ls.config.Logger.Warn(
+		"ledger tip block missing, anchoring intersect points on primary chain tip",
+		"component", "ledger",
+		"ledger_tip_slot", currentTip.Point.Slot,
+		"ledger_tip_hash", hex.EncodeToString(currentTip.Point.Hash),
+		"chain_tip_slot", fallbackBlock.Slot,
+		"chain_tip_hash", hex.EncodeToString(fallbackBlock.Hash),
+	)
 }
 
 func (ls *LedgerState) authoritativeRecentChainPoints(
@@ -8952,18 +9037,16 @@ func (ls *LedgerState) authoritativeRecentChainPoints(
 		// window it is precisely the rollback point, so the points we
 		// offer describe the chain we will hold once the truncation
 		// commits.
-		fallbackBlock, ok := ls.recentChainPointsFallbackAnchor(currentTip)
+		fallbackBlock, ok, anchorErr := ls.recentChainPointsFallbackAnchor(
+			currentTip,
+		)
+		if anchorErr != nil {
+			return nil, anchorErr
+		}
 		if !ok {
 			return points, nil
 		}
-		ls.config.Logger.Warn(
-			"ledger tip block missing, anchoring intersect points on primary chain tip",
-			"component", "ledger",
-			"ledger_tip_slot", currentTip.Point.Slot,
-			"ledger_tip_hash", hex.EncodeToString(currentTip.Point.Hash),
-			"chain_tip_slot", fallbackBlock.Slot,
-			"chain_tip_hash", hex.EncodeToString(fallbackBlock.Hash),
-		)
+		ls.warnIntersectAnchorFallback(currentTip, fallbackBlock)
 		tipBlock = fallbackBlock
 	}
 	appendBlock(tipBlock)

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -366,20 +366,32 @@ const originOnlyIntersectWarnInterval = 30 * time.Second
 //
 // Returns the finalized points and whether an origin-only list had to be
 // rescued, which the caller logs (throttled).
+// intersectPointsHaveRealPoint reports whether points contains a point other
+// than origin.
+//
+// It is the sole definition of the condition the rollback anchor exists to
+// rescue, shared by finalizeChainsyncIntersectPoints and by the gate on the
+// anchor lookup in buildDefaultChainsyncIntersectPoints. Those two must agree:
+// if the gate were ever narrower than the rescue, the lookup would be skipped
+// for a list the rescue would have acted on, and the node would send the
+// origin-only request this whole path exists to prevent.
+func intersectPointsHaveRealPoint(points []ocommon.Point) bool {
+	for _, point := range points {
+		if !isOriginPoint(point) {
+			return true
+		}
+	}
+	return false
+}
+
 func finalizeChainsyncIntersectPoints(
 	intersectPoints []ocommon.Point,
 	rollbackAnchor ocommon.Point,
 	hasRollbackAnchor bool,
 ) ([]ocommon.Point, bool) {
 	rescued := false
-	hasRealPoint := false
-	for _, point := range intersectPoints {
-		if !isOriginPoint(point) {
-			hasRealPoint = true
-			break
-		}
-	}
-	if !hasRealPoint && hasRollbackAnchor && !isOriginPoint(rollbackAnchor) {
+	if !intersectPointsHaveRealPoint(intersectPoints) &&
+		hasRollbackAnchor && !isOriginPoint(rollbackAnchor) {
 		intersectPoints = normalizeIntersectPoints(
 			append(
 				[]ocommon.Point{rollbackAnchor},
@@ -541,15 +553,31 @@ func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
 		}
 	}
 	intersectPoints = normalizeIntersectPoints(intersectPoints)
-	rollbackAnchor, hasRollbackAnchor, err := o.ledgerState.RollbackWindowIntersectAnchor()
-	if err != nil {
-		// Surfaced like any other intersect-point failure above: a storage
-		// fault must fail the chainsync start so the caller retries, not be
-		// downgraded into "no anchor" and sent to the peer as origin-only.
-		return nil, fmt.Errorf(
-			"LedgerState.RollbackWindowIntersectAnchor failed: %w",
-			err,
-		)
+	// The anchor is consulted only to rescue a list with no real point, so
+	// look it up only in that case. Unconditionally is both wasted work on
+	// every chainsync client start and a way to lose a healthy peer: the
+	// common path is served from the in-memory chain without touching the
+	// database, while the anchor lookup always reads it, so a transient
+	// storage fault there would fail a start that had good points to offer
+	// and close the connection under it.
+	var (
+		rollbackAnchor    ocommon.Point
+		hasRollbackAnchor bool
+	)
+	if !intersectPointsHaveRealPoint(intersectPoints) {
+		rollbackAnchor, hasRollbackAnchor, err = o.ledgerState.RollbackWindowIntersectAnchor()
+		if err != nil {
+			// Surfaced like any other intersect-point failure above: a
+			// storage fault must fail the chainsync start so the caller
+			// retries, not be downgraded into "no anchor" and sent to the
+			// peer as origin-only. Reached only when the list is already
+			// origin-only, which is exactly when the answer decides what
+			// goes on the wire.
+			return nil, fmt.Errorf(
+				"LedgerState.RollbackWindowIntersectAnchor failed: %w",
+				err,
+			)
+		}
 	}
 	intersectPoints, rescued := finalizeChainsyncIntersectPoints(
 		intersectPoints,

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -541,7 +541,16 @@ func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
 		}
 	}
 	intersectPoints = normalizeIntersectPoints(intersectPoints)
-	rollbackAnchor, hasRollbackAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
+	rollbackAnchor, hasRollbackAnchor, err := o.ledgerState.RollbackWindowIntersectAnchor()
+	if err != nil {
+		// Surfaced like any other intersect-point failure above: a storage
+		// fault must fail the chainsync start so the caller retries, not be
+		// downgraded into "no anchor" and sent to the peer as origin-only.
+		return nil, fmt.Errorf(
+			"LedgerState.RollbackWindowIntersectAnchor failed: %w",
+			err,
+		)
+	}
 	intersectPoints, rescued := finalizeChainsyncIntersectPoints(
 		intersectPoints,
 		rollbackAnchor,

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -352,15 +352,24 @@ const originOnlyIntersectWarnInterval = 30 * time.Second
 //
 // The condition does occur on a healthy node: while a rollback's metadata
 // truncation is in flight the ledger tip names a block the chain rewind has
-// already deleted, and the ledger can return no points. When that happens the
-// primary chain still reports a real tip, so seed the list with it and let
-// origin stay the fallback it was meant to be.
+// already deleted, and the ledger can return no points. In that case the
+// ledger can still name a point it has applied, so seed the list with it and
+// let origin stay the fallback it was meant to be.
+//
+// rollbackAnchor MUST come from LedgerState.RollbackWindowIntersectAnchor,
+// never from the primary chain tip directly. An empty point list can also mean
+// the primary chain is ahead of the ledger on a fork that does not descend
+// from the applied ledger tip; seeding from that raw chain tip would advertise
+// unapplied fork state and break the primary-chain ancestor invariant (#2309).
+// The ledger returns hasRollbackAnchor=false for that case, so it stays
+// origin-only exactly as before.
 //
 // Returns the finalized points and whether an origin-only list had to be
 // rescued, which the caller logs (throttled).
 func finalizeChainsyncIntersectPoints(
 	intersectPoints []ocommon.Point,
-	primaryChainTip ochainsync.Tip,
+	rollbackAnchor ocommon.Point,
+	hasRollbackAnchor bool,
 ) ([]ocommon.Point, bool) {
 	rescued := false
 	hasRealPoint := false
@@ -370,10 +379,10 @@ func finalizeChainsyncIntersectPoints(
 			break
 		}
 	}
-	if !hasRealPoint && !isOriginPoint(primaryChainTip.Point) {
+	if !hasRealPoint && hasRollbackAnchor && !isOriginPoint(rollbackAnchor) {
 		intersectPoints = normalizeIntersectPoints(
 			append(
-				[]ocommon.Point{primaryChainTip.Point},
+				[]ocommon.Point{rollbackAnchor},
 				intersectPoints...,
 			),
 		)
@@ -395,7 +404,7 @@ func finalizeChainsyncIntersectPoints(
 // from genesis on a node that is not at genesis.
 func (o *Ouroboros) warnOriginOnlyIntersectRescued(
 	connId ouroboros.ConnectionId,
-	primaryChainTip ochainsync.Tip,
+	rollbackAnchor ocommon.Point,
 ) {
 	now := time.Now()
 	last := o.lastOriginOnlyIntersectWarn.Load()
@@ -407,12 +416,12 @@ func (o *Ouroboros) warnOriginOnlyIntersectRescued(
 		return
 	}
 	o.config.Logger.Warn(
-		"chainsync intersect points collapsed to origin on a non-origin chain, using primary chain tip instead",
+		"chainsync intersect points collapsed to origin on a non-origin chain, using rollback anchor instead",
 		"component", "ouroboros",
 		"connection_id", connId.String(),
-		"chain_tip_slot", primaryChainTip.Point.Slot,
-		"chain_tip_hash", hex.EncodeToString(primaryChainTip.Point.Hash),
-		"reason", "ledger returned no intersect points (rollback truncation in flight?)",
+		"anchor_slot", rollbackAnchor.Slot,
+		"anchor_hash", hex.EncodeToString(rollbackAnchor.Hash),
+		"reason", "ledger returned no intersect points (rollback truncation in flight)",
 	)
 }
 
@@ -532,13 +541,14 @@ func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
 		}
 	}
 	intersectPoints = normalizeIntersectPoints(intersectPoints)
-	primaryChainTip := o.ledgerState.PrimaryChainTip()
+	rollbackAnchor, hasRollbackAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
 	intersectPoints, rescued := finalizeChainsyncIntersectPoints(
 		intersectPoints,
-		primaryChainTip,
+		rollbackAnchor,
+		hasRollbackAnchor,
 	)
 	if rescued {
-		o.warnOriginOnlyIntersectRescued(connId, primaryChainTip)
+		o.warnOriginOnlyIntersectRescued(connId, rollbackAnchor)
 	}
 	return intersectPoints, nil
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -17,6 +17,7 @@ package ouroboros
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -328,6 +329,93 @@ func isOriginPoint(point ocommon.Point) bool {
 	return point.Slot == 0 && len(point.Hash) == 0
 }
 
+// originOnlyIntersectWarnInterval throttles the "intersect points collapsed to
+// origin" warning. The condition that produces it (an in-flight ledger
+// rollback) is re-evaluated on every reconnect, and peer governance reconnects
+// every second or so, so an unthrottled warning would emit hundreds of lines
+// for a single incident.
+const originOnlyIntersectWarnInterval = 30 * time.Second
+
+// finalizeChainsyncIntersectPoints appends origin as the last-resort intersect
+// point and refuses to offer origin *alone* while the local chain holds a
+// non-origin tip.
+//
+// Origin is always appended so FindIntersect still succeeds against a peer that
+// follows a divergent fork (e.g. a multi-producer DevNet) -- without it such
+// peers have no common point at all. But an origin-ONLY list is a different
+// request: it asks the peer to replay the chain from genesis. A synced node
+// cannot accept that reply. Genesis-era headers fail leader-eligibility
+// verification (the genesis-era producer has no entry in the epoch-0 stake
+// snapshot), which publishes ConnectionRecycleRequestedEvent and tears the
+// connection down milliseconds after it opened, so the node makes no chainsync
+// progress with any peer for as long as the condition lasts.
+//
+// The condition does occur on a healthy node: while a rollback's metadata
+// truncation is in flight the ledger tip names a block the chain rewind has
+// already deleted, and the ledger can return no points. When that happens the
+// primary chain still reports a real tip, so seed the list with it and let
+// origin stay the fallback it was meant to be.
+//
+// Returns the finalized points and whether an origin-only list had to be
+// rescued, which the caller logs (throttled).
+func finalizeChainsyncIntersectPoints(
+	intersectPoints []ocommon.Point,
+	primaryChainTip ochainsync.Tip,
+) ([]ocommon.Point, bool) {
+	rescued := false
+	hasRealPoint := false
+	for _, point := range intersectPoints {
+		if !isOriginPoint(point) {
+			hasRealPoint = true
+			break
+		}
+	}
+	if !hasRealPoint && !isOriginPoint(primaryChainTip.Point) {
+		intersectPoints = normalizeIntersectPoints(
+			append(
+				[]ocommon.Point{primaryChainTip.Point},
+				intersectPoints...,
+			),
+		)
+		rescued = true
+	}
+	// Always include origin as the last intersect point. This
+	// ensures FindIntersect succeeds even when the peer follows
+	// a different fork (e.g. multi-producer DevNet). Without
+	// origin, peers on divergent chains have no common point.
+	if len(intersectPoints) == 0 ||
+		!isOriginPoint(intersectPoints[len(intersectPoints)-1]) {
+		intersectPoints = append(intersectPoints, ocommon.NewPointOrigin())
+	}
+	return intersectPoints, rescued
+}
+
+// warnOriginOnlyIntersectRescued reports, at most once per
+// originOnlyIntersectWarnInterval, that we were about to ask a peer to replay
+// from genesis on a node that is not at genesis.
+func (o *Ouroboros) warnOriginOnlyIntersectRescued(
+	connId ouroboros.ConnectionId,
+	primaryChainTip ochainsync.Tip,
+) {
+	now := time.Now()
+	last := o.lastOriginOnlyIntersectWarn.Load()
+	if last != 0 &&
+		now.Sub(time.Unix(0, last)) < originOnlyIntersectWarnInterval {
+		return
+	}
+	if !o.lastOriginOnlyIntersectWarn.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+	o.config.Logger.Warn(
+		"chainsync intersect points collapsed to origin on a non-origin chain, using primary chain tip instead",
+		"component", "ouroboros",
+		"connection_id", connId.String(),
+		"chain_tip_slot", primaryChainTip.Point.Slot,
+		"chain_tip_hash", hex.EncodeToString(primaryChainTip.Point.Hash),
+		"reason", "ledger returned no intersect points (rollback truncation in flight?)",
+	)
+}
+
 func chainsyncResyncRequiresFreshConnection(reason string) bool {
 	switch reason {
 	case event.ChainsyncResyncReasonLocalTipPlateau,
@@ -444,13 +532,13 @@ func (o *Ouroboros) buildDefaultChainsyncIntersectPoints(
 		}
 	}
 	intersectPoints = normalizeIntersectPoints(intersectPoints)
-	// Always include origin as the last intersect point. This
-	// ensures FindIntersect succeeds even when the peer follows
-	// a different fork (e.g. multi-producer DevNet). Without
-	// origin, peers on divergent chains have no common point.
-	if len(intersectPoints) == 0 ||
-		!isOriginPoint(intersectPoints[len(intersectPoints)-1]) {
-		intersectPoints = append(intersectPoints, ocommon.NewPointOrigin())
+	primaryChainTip := o.ledgerState.PrimaryChainTip()
+	intersectPoints, rescued := finalizeChainsyncIntersectPoints(
+		intersectPoints,
+		primaryChainTip,
+	)
+	if rescued {
+		o.warnOriginOnlyIntersectRescued(connId, primaryChainTip)
 	}
 	return intersectPoints, nil
 }

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -336,6 +336,24 @@ func isOriginPoint(point ocommon.Point) bool {
 // for a single incident.
 const originOnlyIntersectWarnInterval = 30 * time.Second
 
+// intersectPointsHaveRealPoint reports whether points contains a point other
+// than origin.
+//
+// It is the sole definition of the condition the rollback anchor exists to
+// rescue, shared by finalizeChainsyncIntersectPoints and by the gate on the
+// anchor lookup in buildDefaultChainsyncIntersectPoints. Those two must agree:
+// if the gate were ever narrower than the rescue, the lookup would be skipped
+// for a list the rescue would have acted on, and the node would send the
+// origin-only request this whole path exists to prevent.
+func intersectPointsHaveRealPoint(points []ocommon.Point) bool {
+	for _, point := range points {
+		if !isOriginPoint(point) {
+			return true
+		}
+	}
+	return false
+}
+
 // finalizeChainsyncIntersectPoints appends origin as the last-resort intersect
 // point and refuses to offer origin *alone* while the local chain holds a
 // non-origin tip.
@@ -366,24 +384,6 @@ const originOnlyIntersectWarnInterval = 30 * time.Second
 //
 // Returns the finalized points and whether an origin-only list had to be
 // rescued, which the caller logs (throttled).
-// intersectPointsHaveRealPoint reports whether points contains a point other
-// than origin.
-//
-// It is the sole definition of the condition the rollback anchor exists to
-// rescue, shared by finalizeChainsyncIntersectPoints and by the gate on the
-// anchor lookup in buildDefaultChainsyncIntersectPoints. Those two must agree:
-// if the gate were ever narrower than the rescue, the lookup would be skipped
-// for a list the rescue would have acted on, and the node would send the
-// origin-only request this whole path exists to prevent.
-func intersectPointsHaveRealPoint(points []ocommon.Point) bool {
-	for _, point := range points {
-		if !isOriginPoint(point) {
-			return true
-		}
-	}
-	return false
-}
-
 func finalizeChainsyncIntersectPoints(
 	intersectPoints []ocommon.Point,
 	rollbackAnchor ocommon.Point,

--- a/ouroboros/chainsync_intersect_anchor_gate_test.go
+++ b/ouroboros/chainsync_intersect_anchor_gate_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildDefaultChainsyncIntersectPointsSurvivesAnchorStorageFaultWhenPointsAreGood
+// is the regression test for the rollback anchor being looked up on every
+// chainsync client start rather than only when it can matter.
+//
+// The healthy path is served from the in-memory chain: with the primary chain
+// tip at or ahead of the ledger tip, LedgerState.IntersectPoints answers out of
+// chain.IntersectPoints and never reads the database. The anchor lookup always
+// reads it. So an unconditional lookup gave a database fault a way to fail a
+// chainsync start that had a full list of real points to offer -- and since
+// this branch makes HandleOutboundConnEvent close the connection when the
+// client fails to start, a transient storage fault would tear down a healthy
+// peer over an answer that would have been discarded.
+//
+// The closed database here stands in for that transient fault. What the test
+// pins is that the fault cannot reach a start whose intersect list is already
+// good.
+func TestBuildDefaultChainsyncIntersectPointsSurvivesAnchorStorageFaultWhenPointsAreGood(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, _, connId := newOutboundStartTestOuroboros(t, logger, bus)
+	ls, db := newTestLedgerStateWithChain(t, 5)
+	o.ledgerState = ls
+
+	// A healthy node: the ledger tip is a block the chain holds, so the
+	// primary chain tip is not behind it and intersect points come from the
+	// in-memory chain.
+	chainTip := ls.PrimaryChainTip()
+	require.Equal(t, uint64(5), chainTip.Point.Slot)
+	ls.SetTipForTesting(ochainsync.Tip{
+		Point:       chainTip.Point,
+		BlockNumber: 5,
+	})
+
+	// Sanity: with the database up, the start builds real points.
+	healthy, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	require.NoError(t, err)
+	require.True(
+		t,
+		intersectPointsHaveRealPoint(healthy),
+		"fixture must produce a list with real points",
+	)
+
+	// The anchor lookup reads the database; the healthy path does not.
+	require.NoError(t, dbtest.CloseDatabase(db))
+	_, _, anchorErr := ls.RollbackWindowIntersectAnchor()
+	require.Error(
+		t,
+		anchorErr,
+		"fixture must make the anchor lookup fail",
+	)
+
+	points, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	require.NoError(
+		t,
+		err,
+		"a storage fault in a lookup that cannot affect the result must not fail the chainsync start",
+	)
+
+	// The deeper points come from the database, so the fault legitimately
+	// shortens the list. What must survive is the part that decides what
+	// goes on the wire: a real leading point, and origin only as the last
+	// resort rather than the whole request.
+	require.True(
+		t,
+		intersectPointsHaveRealPoint(points),
+		"the start must still offer a real point, not an origin-only request",
+	)
+	assert.Equal(t, chainTip.Point.Slot, points[0].Slot)
+	assert.Equal(t, chainTip.Point.Hash, points[0].Hash)
+	assert.True(
+		t,
+		isOriginPoint(points[len(points)-1]),
+		"origin must remain the appended last resort",
+	)
+	assert.Equal(t, healthy[0], points[0])
+}
+
+// TestIntersectPointsHaveRealPointMatchesTheRescueCondition pins the predicate
+// that the anchor-lookup gate and the rescue both use. They have to be the
+// same test: a gate narrower than the rescue would skip the lookup for a list
+// the rescue would have acted on, and the node would send the origin-only
+// FindIntersect this path exists to prevent.
+func TestIntersectPointsHaveRealPointMatchesTheRescueCondition(t *testing.T) {
+	anchor := testAnchorPoint(1000)
+	for _, tc := range []struct {
+		name   string
+		points []ocommon.Point
+		real   bool
+	}{
+		{"empty", nil, false},
+		{"origin only", []ocommon.Point{ocommon.NewPointOrigin()}, false},
+		{
+			"origin repeated",
+			[]ocommon.Point{
+				ocommon.NewPointOrigin(),
+				ocommon.NewPointOrigin(),
+			},
+			false,
+		},
+		{"real point", []ocommon.Point{testAnchorPoint(42)}, true},
+		{
+			"real point then origin",
+			[]ocommon.Point{
+				testAnchorPoint(42),
+				ocommon.NewPointOrigin(),
+			},
+			true,
+		},
+		{
+			"origin then real point",
+			[]ocommon.Point{
+				ocommon.NewPointOrigin(),
+				testAnchorPoint(42),
+			},
+			true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				tc.real,
+				intersectPointsHaveRealPoint(tc.points),
+			)
+			// The rescue fires exactly when the predicate is false,
+			// given a usable anchor. That equivalence is what lets the
+			// gate skip the lookup whenever the predicate is true.
+			_, rescued := finalizeChainsyncIntersectPoints(
+				tc.points,
+				anchor,
+				true,
+			)
+			require.Equal(
+				t,
+				!tc.real,
+				rescued,
+				"the rescue must fire exactly when the gate would allow the lookup",
+			)
+		})
+	}
+}

--- a/ouroboros/chainsync_intersect_origin_test.go
+++ b/ouroboros/chainsync_intersect_origin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/event"
 	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
 	"github.com/blinklabs-io/dingo/ledger"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -418,4 +419,98 @@ func TestRollbackWindowIntersectAnchorPropagatesStorageError(t *testing.T) {
 	_, hasAnchor, err := ls.RollbackWindowIntersectAnchor()
 	require.Error(t, err, "storage failure must not be reported as no anchor")
 	assert.False(t, hasAnchor)
+}
+
+// TestBuildDefaultChainsyncIntersectPointsOffersRollbackPointInWindow is the
+// end-to-end composition test for the rollback window, driven through the
+// function the chainsync client actually calls rather than through
+// finalizeChainsyncIntersectPoints directly.
+//
+// Every other test in this file supplies the intersect points and the anchor
+// itself, so none of them pins the runtime path
+// buildDefaultChainsyncIntersectPoints takes: LedgerState.IntersectPoints ->
+// finalizeChainsyncIntersectPoints -> the list handed to MsgFindIntersect. This
+// one drives a ledger genuinely in the window (ledger tip row absent, primary
+// chain tip strictly below the ledger tip) and asserts what goes on the wire.
+func TestBuildDefaultChainsyncIntersectPointsOffersRollbackPointInWindow(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, _, connId := newOutboundStartTestOuroboros(t, logger, bus)
+	ls, _ := newTestLedgerStateWithChain(t, 5)
+	o.ledgerState = ls
+
+	// The window: the chain has been rewound to slot 5 while the ledger tip
+	// still names a block at slot 9 whose row the rewind removed.
+	ls.SetTipForTesting(ochainsync.Tip{
+		Point:       ocommon.NewPoint(9, ledgerTipHashAbsentFromChain),
+		BlockNumber: 9,
+	})
+
+	chainTip := ls.PrimaryChainTip()
+	require.Equal(t, uint64(5), chainTip.Point.Slot)
+	_, err := ls.GetBlock(ocommon.NewPoint(9, ledgerTipHashAbsentFromChain))
+	require.Error(t, err, "fixture requires the ledger tip row to be absent")
+
+	points, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	require.NoError(t, err)
+
+	// What actually matters on the wire: we must not ask the peer to replay
+	// from genesis, and the newest point offered must be the rollback point.
+	require.NotEmpty(t, points)
+	require.False(
+		t,
+		len(points) == 1 && isOriginPoint(points[0]),
+		"a node holding a chain must never send an origin-only FindIntersect",
+	)
+	assert.Equal(t, chainTip.Point.Slot, points[0].Slot)
+	assert.Equal(t, chainTip.Point.Hash, points[0].Hash)
+	assert.True(
+		t,
+		isOriginPoint(points[len(points)-1]),
+		"origin must remain the appended last resort",
+	)
+
+	// No point may name a block above the rollback point.
+	for _, point := range points {
+		if isOriginPoint(point) {
+			continue
+		}
+		assert.LessOrEqual(t, point.Slot, chainTip.Point.Slot)
+	}
+}
+
+// TestBuildDefaultChainsyncIntersectPointsStaysOriginOnlyOnAheadFork drives the
+// #2309 shape through the real call site: the primary chain is ahead of the
+// ledger tip on a fork that does not contain it, and the ledger tip row is
+// missing. Nothing may be advertised, so the wire request is origin-only.
+func TestBuildDefaultChainsyncIntersectPointsStaysOriginOnlyOnAheadFork(
+	t *testing.T,
+) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, _, connId := newOutboundStartTestOuroboros(t, logger, bus)
+	ls, _ := newTestLedgerStateWithChain(t, 5)
+	o.ledgerState = ls
+
+	ls.SetTipForTesting(ochainsync.Tip{
+		Point:       ocommon.NewPoint(2, ledgerTipHashAbsentFromChain),
+		BlockNumber: 2,
+	})
+	require.Greater(t, ls.PrimaryChainTip().Point.Slot, uint64(2))
+
+	points, err := o.buildDefaultChainsyncIntersectPoints(connId)
+	require.NoError(t, err)
+
+	require.Len(t, points, 1)
+	assert.True(
+		t,
+		isOriginPoint(points[0]),
+		"unapplied ahead-fork state must not be advertised (#2309)",
+	)
 }

--- a/ouroboros/chainsync_intersect_origin_test.go
+++ b/ouroboros/chainsync_intersect_origin_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testChainTip(slot uint64) ochainsync.Tip {
+	return ochainsync.Tip{
+		Point:       ocommon.NewPoint(slot, bytes.Repeat([]byte{0xab}, 32)),
+		BlockNumber: slot,
+	}
+}
+
+// TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain is
+// the regression test for the connection-recycle loop: while a rollback's
+// metadata truncation is in flight the ledger can return no intersect points,
+// and the "always append origin" fallback then made a fully synced node ask its
+// peers to replay from genesis. Those genesis-era headers fail leader
+// verification and recycle every connection until the truncation commits.
+func TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain(
+	t *testing.T,
+) {
+	chainTip := testChainTip(2576716)
+
+	for name, points := range map[string][]ocommon.Point{
+		"nil points":      nil,
+		"empty points":    {},
+		"origin-only set": {ocommon.NewPointOrigin()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, rescued := finalizeChainsyncIntersectPoints(
+				points,
+				chainTip,
+			)
+
+			require.NotEmpty(t, got)
+			require.True(
+				t,
+				rescued,
+				"expected the origin-only collapse to be reported",
+			)
+			require.False(
+				t,
+				len(got) == 1 && isOriginPoint(got[0]),
+				"offered origin as the only intersect point while the chain tip is slot %d",
+				chainTip.Point.Slot,
+			)
+
+			// The chain tip leads, origin remains the last resort.
+			assert.Equal(t, chainTip.Point.Slot, got[0].Slot)
+			assert.Equal(t, chainTip.Point.Hash, got[0].Hash)
+			assert.True(
+				t,
+				isOriginPoint(got[len(got)-1]),
+				"origin must remain the final fallback point",
+			)
+		})
+	}
+}
+
+// TestFinalizeChainsyncIntersectPointsKeepsOriginOnlyAtOrigin guards the other
+// direction: a node that really is at origin (fresh sync) must still be allowed
+// to ask for a full replay, otherwise it could never bootstrap.
+func TestFinalizeChainsyncIntersectPointsKeepsOriginOnlyAtOrigin(t *testing.T) {
+	got, rescued := finalizeChainsyncIntersectPoints(
+		nil,
+		ochainsync.Tip{},
+	)
+
+	require.Len(t, got, 1)
+	assert.True(t, isOriginPoint(got[0]))
+	assert.False(t, rescued)
+}
+
+// TestFinalizeChainsyncIntersectPointsPreservesRealPoints verifies the normal
+// path is untouched: a healthy point list keeps its order and still gets origin
+// appended as the final fallback for divergent-fork peers.
+func TestFinalizeChainsyncIntersectPointsPreservesRealPoints(t *testing.T) {
+	points := []ocommon.Point{
+		ocommon.NewPoint(300, bytes.Repeat([]byte{0x03}, 32)),
+		ocommon.NewPoint(200, bytes.Repeat([]byte{0x02}, 32)),
+		ocommon.NewPoint(100, bytes.Repeat([]byte{0x01}, 32)),
+	}
+
+	got, rescued := finalizeChainsyncIntersectPoints(
+		points,
+		testChainTip(300),
+	)
+
+	assert.False(t, rescued)
+	require.Len(t, got, len(points)+1)
+	for idx, point := range points {
+		assert.Equal(t, point.Slot, got[idx].Slot)
+		assert.Equal(t, point.Hash, got[idx].Hash)
+	}
+	assert.True(t, isOriginPoint(got[len(got)-1]))
+}
+
+// TestFinalizeChainsyncIntersectPointsDoesNotDoubleAppendOrigin verifies a list
+// that already ends in origin is left alone.
+func TestFinalizeChainsyncIntersectPointsDoesNotDoubleAppendOrigin(
+	t *testing.T,
+) {
+	points := []ocommon.Point{
+		ocommon.NewPoint(300, bytes.Repeat([]byte{0x03}, 32)),
+		ocommon.NewPointOrigin(),
+	}
+
+	got, rescued := finalizeChainsyncIntersectPoints(
+		points,
+		testChainTip(300),
+	)
+
+	assert.False(t, rescued)
+	require.Len(t, got, 2)
+	assert.True(t, isOriginPoint(got[1]))
+}
+
+// newTestLedgerStateWithChain builds a ledger whose primary chain holds
+// blockCount blocks, so PrimaryChainTip reports a real (non-origin) tip.
+func newTestLedgerStateWithChain(
+	t *testing.T,
+	blockCount uint64,
+) *ledger.LedgerState {
+	t.Helper()
+
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) })
+
+	var prevHash []byte
+	for slot := uint64(1); slot <= blockCount; slot++ {
+		hash := bytes.Repeat([]byte{byte(slot)}, 32)
+		require.NoError(t, db.BlockCreate(models.Block{
+			ID:       slot,
+			Slot:     slot,
+			Number:   slot,
+			Hash:     hash,
+			PrevHash: prevHash,
+			Type:     1,
+			Cbor:     []byte{0x80},
+		}, nil))
+		prevHash = hash
+	}
+
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(testSecurityParamLedger{securityParam: 2160}),
+	)
+
+	ls, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:     db,
+		ChainManager: cm,
+		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	return ls
+}
+
+// TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback is the
+// composition test for the incident: a node holding a real chain whose ledger
+// tip block row has been removed (the window between the chain rewind and the
+// end of the metadata truncation) must not build an origin-only FindIntersect
+// list. It exercises both halves of the fix together -- the ledger anchoring
+// its points on the chain tip, and chainsync refusing an origin-only list --
+// because either one alone is sufficient to preserve the invariant.
+func TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback(t *testing.T) {
+	o := &Ouroboros{}
+	o.ledgerState = newTestLedgerStateWithChain(t, 5)
+
+	chainTip := o.ledgerState.PrimaryChainTip()
+	require.False(
+		t,
+		isOriginPoint(chainTip.Point),
+		"fixture must hold a non-origin chain",
+	)
+
+	// The ledger tip names a block that is not in the metadata database,
+	// which is what a chain rewind leaves behind until ls.rollback's
+	// truncation commits and reassigns ls.currentTip.
+	setTestLedgerTip(t, o, ochainsync.Tip{
+		Point:       ocommon.NewPoint(2576729, bytes.Repeat([]byte{0xe8}, 32)),
+		BlockNumber: 112915,
+	})
+
+	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
+	require.NoError(t, err)
+
+	got, _ := finalizeChainsyncIntersectPoints(
+		normalizeIntersectPoints(points),
+		o.ledgerState.PrimaryChainTip(),
+	)
+
+	require.NotEmpty(t, got)
+	require.False(
+		t,
+		len(got) == 1 && isOriginPoint(got[0]),
+		"chainsync would have asked the peer to replay from genesis while holding a chain at slot %d",
+		chainTip.Point.Slot,
+	)
+	assert.False(
+		t,
+		isOriginPoint(got[0]),
+		"the leading intersect point must be a real chain point",
+	)
+	assert.True(
+		t,
+		isOriginPoint(got[len(got)-1]),
+		"origin must remain the final fallback point",
+	)
+}

--- a/ouroboros/chainsync_intersect_origin_test.go
+++ b/ouroboros/chainsync_intersect_origin_test.go
@@ -149,7 +149,7 @@ func TestFinalizeChainsyncIntersectPointsDoesNotDoubleAppendOrigin(
 func newTestLedgerStateWithChain(
 	t *testing.T,
 	blockCount uint64,
-) *ledger.LedgerState {
+) (*ledger.LedgerState, *database.Database) {
 	t.Helper()
 
 	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
@@ -184,7 +184,7 @@ func newTestLedgerStateWithChain(
 		Logger:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
 	})
 	require.NoError(t, err)
-	return ls
+	return ls, db
 }
 
 // TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback is the
@@ -196,7 +196,7 @@ func newTestLedgerStateWithChain(
 // because either one alone is sufficient to preserve the invariant.
 func TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback(t *testing.T) {
 	o := &Ouroboros{}
-	o.ledgerState = newTestLedgerStateWithChain(t, 5)
+	o.ledgerState, _ = newTestLedgerStateWithChain(t, 5)
 
 	chainTip := o.ledgerState.PrimaryChainTip()
 	require.False(
@@ -216,7 +216,8 @@ func TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback(t *testing.T) {
 	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
 	require.NoError(t, err)
 
-	anchor, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
+	anchor, hasAnchor, err := o.ledgerState.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
 	got, _ := finalizeChainsyncIntersectPoints(
 		normalizeIntersectPoints(points),
 		anchor,
@@ -269,39 +270,65 @@ func TestFinalizeChainsyncIntersectPointsRefusesAheadForkAnchor(t *testing.T) {
 	)
 }
 
-// TestRollbackWindowIntersectAnchorRefusesChainTipAheadOfLedgerTip drives the
-// ledger's authoritative anchor decision through the exact #2309 shape: the
-// ledger tip row is missing AND the primary chain is ahead on a fork. The
-// ledger must report no anchor, which is what keeps the chainsync rescue from
-// firing.
-func TestRollbackWindowIntersectAnchorRefusesChainTipAheadOfLedgerTip(
+// ledgerTipHashAbsentFromChain is a hash that deliberately matches no block
+// built by newTestLedgerStateWithChain (whose block at slot N has hash
+// bytes.Repeat([]byte{byte(N)}, 32)). Using it as the ledger tip point makes
+// that tip's metadata row absent AND places it off the primary chain, which is
+// the state a chain rewind leaves behind.
+//
+// This distinction is load-bearing: swapping this for the real block hash
+// converts the #2309 test below into the ordinary chain-ahead test beside it,
+// which asserts the opposite outcome.
+var ledgerTipHashAbsentFromChain = bytes.Repeat([]byte{0xe8}, 32)
+
+// TestIntersectPointsChainAheadWithLedgerTipRowMissingStaysOriginOnly is the
+// #2309 case: the primary chain is AHEAD of the ledger tip, and the ledger
+// tip's own block row is missing (so the tip is not an ancestor on the primary
+// chain either). primaryChainTipAtOrAheadOfLedgerTip's ancestor check fails,
+// the authoritative path finds no tip row, and the ahead-gate refuses to anchor
+// on unapplied forward work.
+//
+// Nothing may be advertised: the list must stay origin-only, matching upstream
+// TestIntersectPointsDoesNotUsePrimaryChainWhenLedgerTipMissing.
+func TestIntersectPointsChainAheadWithLedgerTipRowMissingStaysOriginOnly(
 	t *testing.T,
 ) {
 	o := &Ouroboros{}
-	o.ledgerState = newTestLedgerStateWithChain(t, 5)
+	o.ledgerState, _ = newTestLedgerStateWithChain(t, 5)
 
-	// Ledger tip is below the chain tip and its row is absent.
+	ledgerTipPoint := ocommon.NewPoint(2, ledgerTipHashAbsentFromChain)
 	setTestLedgerTip(t, o, ochainsync.Tip{
-		Point:       ocommon.NewPoint(2, bytes.Repeat([]byte{0xe8}, 32)),
+		Point:       ledgerTipPoint,
 		BlockNumber: 2,
 	})
+
+	// Pin the preconditions, so this cannot silently become the
+	// chain-ahead-with-a-real-tip case below.
+	_, err := o.ledgerState.GetBlock(ledgerTipPoint)
+	require.Error(t, err, "fixture requires the ledger tip row to be absent")
 	require.Greater(
 		t,
 		o.ledgerState.PrimaryChainTip().Point.Slot,
-		uint64(2),
-		"fixture must have the chain ahead of the ledger tip",
+		ledgerTipPoint.Slot,
+		"fixture requires the primary chain to be ahead of the ledger tip",
 	)
 
-	_, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
-	assert.False(
+	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
+	require.NoError(t, err)
+	require.Empty(
+		t,
+		points,
+		"unapplied ahead-fork state must not be advertised (#2309)",
+	)
+
+	anchor, hasAnchor, err := o.ledgerState.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
+	require.False(
 		t,
 		hasAnchor,
 		"ledger must refuse to anchor on a chain tip ahead of its own tip",
 	)
 
-	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
-	require.NoError(t, err)
-	anchor, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
 	got, rescued := finalizeChainsyncIntersectPoints(
 		normalizeIntersectPoints(points),
 		anchor,
@@ -310,4 +337,85 @@ func TestRollbackWindowIntersectAnchorRefusesChainTipAheadOfLedgerTip(
 	assert.False(t, rescued)
 	require.Len(t, got, 1)
 	assert.True(t, isOriginPoint(got[0]))
+}
+
+// TestIntersectPointsChainAheadWithLedgerTipRowPresentAdvertisesChainPoints is
+// the complementary case, and the one that must NOT be conflated with the
+// #2309 test above: the primary chain is ahead of the ledger tip, but the
+// ledger tip is a real block on that chain. The chain is then a valid forward
+// extension, primaryChainTipAtOrAheadOfLedgerTip's ancestor check passes, and
+// the chain's real points are advertised with origin appended as the usual
+// last resort.
+//
+// No rescue is involved here: the ledger already returned real points, so the
+// rollback anchor is absent and must stay absent.
+func TestIntersectPointsChainAheadWithLedgerTipRowPresentAdvertisesChainPoints(
+	t *testing.T,
+) {
+	o := &Ouroboros{}
+	o.ledgerState, _ = newTestLedgerStateWithChain(t, 5)
+
+	// The real block-2 hash produced by the fixture, so the row exists and
+	// the tip is an ancestor on the primary chain.
+	ledgerTipPoint := ocommon.NewPoint(2, bytes.Repeat([]byte{0x02}, 32))
+	setTestLedgerTip(t, o, ochainsync.Tip{
+		Point:       ledgerTipPoint,
+		BlockNumber: 2,
+	})
+
+	_, err := o.ledgerState.GetBlock(ledgerTipPoint)
+	require.NoError(t, err, "fixture requires the ledger tip row to be present")
+
+	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
+	require.NoError(t, err)
+	require.Len(t, points, 5, "the chain's real points must be advertised")
+	assert.Equal(t, uint64(5), points[0].Slot, "newest chain point leads")
+
+	anchor, hasAnchor, err := o.ledgerState.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
+	assert.False(
+		t,
+		hasAnchor,
+		"no rollback is in flight, so no anchor may be offered",
+	)
+
+	got, rescued := finalizeChainsyncIntersectPoints(
+		normalizeIntersectPoints(points),
+		anchor,
+		hasAnchor,
+	)
+	assert.False(t, rescued, "real points need no rescue")
+	require.Len(t, got, len(points)+1)
+	assert.Equal(t, uint64(5), got[0].Slot)
+	assert.True(
+		t,
+		isOriginPoint(got[len(got)-1]),
+		"origin remains the appended last resort",
+	)
+}
+
+// TestRollbackWindowIntersectAnchorPropagatesStorageError verifies the anchor
+// lookup surfaces a storage fault instead of reporting "no anchor". The
+// chainsync call site fails the client start on this error; downgrading it
+// would send the peer an origin-only intersect list, i.e. a request to replay
+// the chain from genesis.
+func TestRollbackWindowIntersectAnchorPropagatesStorageError(t *testing.T) {
+	o := &Ouroboros{}
+	ls, db := newTestLedgerStateWithChain(t, 5)
+	o.ledgerState = ls
+
+	setTestLedgerTip(t, o, ochainsync.Tip{
+		Point:       ocommon.NewPoint(2, ledgerTipHashAbsentFromChain),
+		BlockNumber: 2,
+	})
+
+	// Sanity: healthy database answers without error.
+	_, _, err := ls.RollbackWindowIntersectAnchor()
+	require.NoError(t, err)
+
+	require.NoError(t, dbtest.CloseDatabase(db))
+
+	_, hasAnchor, err := ls.RollbackWindowIntersectAnchor()
+	require.Error(t, err, "storage failure must not be reported as no anchor")
+	assert.False(t, hasAnchor)
 }

--- a/ouroboros/chainsync_intersect_origin_test.go
+++ b/ouroboros/chainsync_intersect_origin_test.go
@@ -31,11 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testChainTip(slot uint64) ochainsync.Tip {
-	return ochainsync.Tip{
-		Point:       ocommon.NewPoint(slot, bytes.Repeat([]byte{0xab}, 32)),
-		BlockNumber: slot,
-	}
+func testAnchorPoint(slot uint64) ocommon.Point {
+	return ocommon.NewPoint(slot, bytes.Repeat([]byte{0xab}, 32))
 }
 
 // TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain is
@@ -47,7 +44,7 @@ func testChainTip(slot uint64) ochainsync.Tip {
 func TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain(
 	t *testing.T,
 ) {
-	chainTip := testChainTip(2576716)
+	anchor := testAnchorPoint(2576716)
 
 	for name, points := range map[string][]ocommon.Point{
 		"nil points":      nil,
@@ -57,7 +54,8 @@ func TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain(
 		t.Run(name, func(t *testing.T) {
 			got, rescued := finalizeChainsyncIntersectPoints(
 				points,
-				chainTip,
+				anchor,
+				true,
 			)
 
 			require.NotEmpty(t, got)
@@ -69,13 +67,13 @@ func TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain(
 			require.False(
 				t,
 				len(got) == 1 && isOriginPoint(got[0]),
-				"offered origin as the only intersect point while the chain tip is slot %d",
-				chainTip.Point.Slot,
+				"offered origin as the only intersect point while holding a rollback anchor at slot %d",
+				anchor.Slot,
 			)
 
-			// The chain tip leads, origin remains the last resort.
-			assert.Equal(t, chainTip.Point.Slot, got[0].Slot)
-			assert.Equal(t, chainTip.Point.Hash, got[0].Hash)
+			// The anchor leads, origin remains the last resort.
+			assert.Equal(t, anchor.Slot, got[0].Slot)
+			assert.Equal(t, anchor.Hash, got[0].Hash)
 			assert.True(
 				t,
 				isOriginPoint(got[len(got)-1]),
@@ -91,7 +89,8 @@ func TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain(
 func TestFinalizeChainsyncIntersectPointsKeepsOriginOnlyAtOrigin(t *testing.T) {
 	got, rescued := finalizeChainsyncIntersectPoints(
 		nil,
-		ochainsync.Tip{},
+		ocommon.Point{},
+		false,
 	)
 
 	require.Len(t, got, 1)
@@ -111,7 +110,8 @@ func TestFinalizeChainsyncIntersectPointsPreservesRealPoints(t *testing.T) {
 
 	got, rescued := finalizeChainsyncIntersectPoints(
 		points,
-		testChainTip(300),
+		testAnchorPoint(300),
+		true,
 	)
 
 	assert.False(t, rescued)
@@ -135,7 +135,8 @@ func TestFinalizeChainsyncIntersectPointsDoesNotDoubleAppendOrigin(
 
 	got, rescued := finalizeChainsyncIntersectPoints(
 		points,
-		testChainTip(300),
+		testAnchorPoint(300),
+		true,
 	)
 
 	assert.False(t, rescued)
@@ -215,9 +216,11 @@ func TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback(t *testing.T) {
 	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
 	require.NoError(t, err)
 
+	anchor, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
 	got, _ := finalizeChainsyncIntersectPoints(
 		normalizeIntersectPoints(points),
-		o.ledgerState.PrimaryChainTip(),
+		anchor,
+		hasAnchor,
 	)
 
 	require.NotEmpty(t, got)
@@ -237,4 +240,74 @@ func TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback(t *testing.T) {
 		isOriginPoint(got[len(got)-1]),
 		"origin must remain the final fallback point",
 	)
+}
+
+// TestFinalizeChainsyncIntersectPointsRefusesAheadForkAnchor is the regression
+// test for the review finding that the origin-only rescue re-introduced the
+// #2309 violation one layer up.
+//
+// When the point list is empty because the primary chain is AHEAD on a fork
+// that does not contain the applied ledger tip, the ledger deliberately reports
+// no rollback anchor. Seeding from the raw chain tip in that case would
+// advertise unapplied fork state. The list must stay origin-only, exactly as
+// before the rescue existed.
+func TestFinalizeChainsyncIntersectPointsRefusesAheadForkAnchor(t *testing.T) {
+	got, rescued := finalizeChainsyncIntersectPoints(
+		nil,
+		// A caller that wrongly passes a real ahead-fork point must still
+		// be refused when the ledger says there is no anchor.
+		testAnchorPoint(999999),
+		false,
+	)
+
+	assert.False(t, rescued, "must not rescue without a ledger-approved anchor")
+	require.Len(t, got, 1)
+	assert.True(
+		t,
+		isOriginPoint(got[0]),
+		"an ahead-fork chain tip must never seed the intersect list",
+	)
+}
+
+// TestRollbackWindowIntersectAnchorRefusesChainTipAheadOfLedgerTip drives the
+// ledger's authoritative anchor decision through the exact #2309 shape: the
+// ledger tip row is missing AND the primary chain is ahead on a fork. The
+// ledger must report no anchor, which is what keeps the chainsync rescue from
+// firing.
+func TestRollbackWindowIntersectAnchorRefusesChainTipAheadOfLedgerTip(
+	t *testing.T,
+) {
+	o := &Ouroboros{}
+	o.ledgerState = newTestLedgerStateWithChain(t, 5)
+
+	// Ledger tip is below the chain tip and its row is absent.
+	setTestLedgerTip(t, o, ochainsync.Tip{
+		Point:       ocommon.NewPoint(2, bytes.Repeat([]byte{0xe8}, 32)),
+		BlockNumber: 2,
+	})
+	require.Greater(
+		t,
+		o.ledgerState.PrimaryChainTip().Point.Slot,
+		uint64(2),
+		"fixture must have the chain ahead of the ledger tip",
+	)
+
+	_, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
+	assert.False(
+		t,
+		hasAnchor,
+		"ledger must refuse to anchor on a chain tip ahead of its own tip",
+	)
+
+	points, err := o.ledgerState.IntersectPoints(chainsyncIntersectPointCount)
+	require.NoError(t, err)
+	anchor, hasAnchor := o.ledgerState.RollbackWindowIntersectAnchor()
+	got, rescued := finalizeChainsyncIntersectPoints(
+		normalizeIntersectPoints(points),
+		anchor,
+		hasAnchor,
+	)
+	assert.False(t, rescued)
+	require.Len(t, got, 1)
+	assert.True(t, isOriginPoint(got[0]))
 }

--- a/ouroboros/chainsync_outbound_start_failure_test.go
+++ b/ouroboros/chainsync_outbound_start_failure_test.go
@@ -16,6 +16,7 @@ package ouroboros
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"runtime"
 	"testing"
@@ -34,6 +35,7 @@ import (
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 // newOutboundStartTestOuroboros builds an Ouroboros wired with every
@@ -132,9 +134,20 @@ func TestOutboundChainsyncStartFailureClosesConnection(t *testing.T) {
 	bus := event.NewEventBus(nil, logger)
 	defer bus.Close()
 
-	baselineGoroutines := runtime.NumGoroutine()
-
 	o, connManager, connId := newOutboundStartTestOuroboros(t, logger, bus)
+
+	// Snapshot AFTER the harness has started its own workers (mempool,
+	// event bus, connection manager, mock connection) so only goroutines
+	// created from here on are attributed to the code under test.
+	//
+	// IgnoreCurrent is what makes goleak usable in this package: a bare
+	// goleak call inspects the whole process and would trip on unrelated
+	// pre-existing goroutines from other tests. A NumGoroutine baseline was
+	// tried first and is not sensitive enough here -- tearing the connection
+	// down frees several goroutines, so the total lands below the baseline
+	// and a single stranded goroutine hides inside that slack.
+	leakOpt := goleak.IgnoreCurrent()
+	baselineGoroutines := runtime.NumGoroutine()
 
 	// A ledger whose database is closed makes the rollback-anchor lookup
 	// return a storage error rather than "no anchor".
@@ -177,15 +190,125 @@ func TestOutboundChainsyncStartFailureClosesConnection(t *testing.T) {
 		"failed to start chainsync client, closing outbound connection",
 	)
 
-	// The torn-down connection must not strand goroutines. A small margin
-	// absorbs the test harness's own workers (mempool, event bus).
+	// The torn-down connection must not strand goroutines. The count must
+	// come back to (or below) the post-setup baseline; teardown is
+	// asynchronous, hence the poll.
 	require.Eventually(
 		t,
-		func() bool { return runtime.NumGoroutine() <= baselineGoroutines+8 },
-		5*time.Second,
+		func() bool { return runtime.NumGoroutine() <= baselineGoroutines },
+		10*time.Second,
 		50*time.Millisecond,
-		"goroutines leaked after the failed chainsync start (baseline %d, now %d)",
+		"goroutines did not return to the post-setup baseline after the failed chainsync start (baseline %d, now %d)",
 		baselineGoroutines,
 		runtime.NumGoroutine(),
 	)
+	// And, unlike the count above, this catches a single stranded goroutine.
+	goleak.VerifyNone(t, leakOpt)
+}
+
+// TestCloseOutboundConnAfterChainsyncFailureClosesStartedConn covers the
+// ordinary case: the connection chainsync failed on is still the manager's
+// current connection for its id, so it is closed and peer governance can
+// reconnect.
+func TestCloseOutboundConnAfterChainsyncFailureClosesStartedConn(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, connManager, connId := newOutboundStartTestOuroboros(t, logger, bus)
+	startedConn := connManager.GetConnectionById(connId)
+	require.NotNil(t, startedConn)
+
+	o.closeOutboundConnAfterChainsyncFailure(connId, startedConn)
+
+	require.Eventually(
+		t,
+		func() bool { return connManager.GetConnectionById(connId) == nil },
+		2*time.Second,
+		20*time.Millisecond,
+		"the connection chainsync failed on must be closed",
+	)
+}
+
+// TestCloseOutboundConnAfterChainsyncFailureSparesReplacement is the
+// regression test for closing the wrong connection.
+//
+// ConnectionId is a (local addr, remote addr) pair, so a reconnect to the same
+// peer can produce the same id. If the connection we started on has already
+// been replaced by the time the failed start returns, closing whatever now
+// holds the id would tear down a healthy peer for its predecessor's failure.
+//
+// The replacement is modelled by handing the helper a connection that is not
+// the one the manager currently holds for that id, which is exactly the state
+// the guard has to detect.
+func TestCloseOutboundConnAfterChainsyncFailureSparesReplacement(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, connManager, connId := newOutboundStartTestOuroboros(t, logger, bus)
+	replacement := connManager.GetConnectionById(connId)
+	require.NotNil(t, replacement)
+
+	// A different connection object, standing in for the one we started on
+	// before it was replaced under the same id.
+	staleConn, err := ouroboros.New(
+		ouroboros.WithConnection(
+			ouroboros_mock.NewConnection(
+				ouroboros_mock.ProtocolRoleClient,
+				ouroboros_mock.ConversationKeepAlive,
+			),
+		),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = staleConn.Close() })
+	require.NotSame(t, replacement, staleConn)
+
+	o.closeOutboundConnAfterChainsyncFailure(connId, staleConn)
+
+	// The replacement must be left strictly alone. Removal from the manager
+	// is asynchronous, so assert the connection never disappears over a
+	// window rather than checking once: an immediate NotNil would pass even
+	// if the helper had just closed it.
+	require.Never(
+		t,
+		func() bool { return connManager.GetConnectionById(connId) == nil },
+		2*time.Second,
+		50*time.Millisecond,
+		"the replacement connection must not be closed",
+	)
+	require.Same(t, replacement, connManager.GetConnectionById(connId))
+}
+
+// TestCloseOutboundConnAfterChainsyncFailureHandlesMissingConn verifies the
+// helper is a no-op when there was no connection to start with, and when the
+// connection has already gone away entirely.
+func TestCloseOutboundConnAfterChainsyncFailureHandlesMissingConn(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	o, connManager, connId := newOutboundStartTestOuroboros(t, logger, bus)
+
+	// Nil started connection: nothing to close, must not panic.
+	require.NotPanics(t, func() {
+		o.closeOutboundConnAfterChainsyncFailure(connId, nil)
+	})
+	require.NotNil(t, connManager.GetConnectionById(connId))
+
+	// Connection already gone: the id no longer resolves, so the guard sees
+	// current == nil != startedConn and leaves well alone.
+	startedConn := connManager.GetConnectionById(connId)
+	require.NoError(t, startedConn.Close())
+	require.Eventually(
+		t,
+		func() bool { return connManager.GetConnectionById(connId) == nil },
+		2*time.Second,
+		20*time.Millisecond,
+	)
+	require.NotPanics(t, func() {
+		o.closeOutboundConnAfterChainsyncFailure(connId, startedConn)
+	})
 }

--- a/ouroboros/chainsync_outbound_start_failure_test.go
+++ b/ouroboros/chainsync_outbound_start_failure_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"testing"
+	"time"
+
+	dchainsync "github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/event"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/mempool"
+	"github.com/blinklabs-io/dingo/peergov"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// newOutboundStartTestOuroboros builds an Ouroboros wired with every
+// dependency hasDependencies() requires, so HandleOutboundConnEvent actually
+// reaches the chainsync start rather than dropping the event as unwired.
+func newOutboundStartTestOuroboros(
+	t *testing.T,
+	logger *slog.Logger,
+	bus *event.EventBus,
+) (*Ouroboros, *connmanager.ConnectionManager, ouroboros.ConnectionId) {
+	t.Helper()
+
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{
+			EventBus: bus,
+			Logger:   logger,
+		},
+	)
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer stopCancel()
+		_ = connManager.Stop(stopCtx)
+	})
+
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		ouroboros_mock.ConversationKeepAlive,
+	)
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithKeepAliveConfig(
+			keepalive.NewConfig(
+				keepalive.WithCookie(ouroboros_mock.MockKeepAliveCookie),
+				keepalive.WithPeriod(30*time.Second),
+				keepalive.WithTimeout(15*time.Second),
+			),
+		),
+	)
+	require.NoError(t, err)
+	connManager.AddConnection(oConn, false, "127.0.0.1:1234")
+
+	m, err := mempool.NewMempool(mempool.MempoolConfig{
+		Logger:          logger,
+		PromRegistry:    prometheus.NewRegistry(),
+		Validator:       txsubmissionTestValidator{},
+		MempoolCapacity: 1024 * 1024,
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, m.Stop(context.Background()))
+	})
+
+	o := newOuroboros(OuroborosConfig{
+		EventBus: bus,
+		Logger:   logger,
+	})
+	o.eventBus = bus
+	o.connManager = connManager
+	o.chainsyncState = dchainsync.NewState(bus, nil)
+	o.mempool = &mempool.FIFO{Mempool: m}
+	o.peerGov = peergov.NewPeerGovernor(peergov.PeerGovernorConfig{
+		Logger: logger,
+	})
+	return o, connManager, oConn.Id()
+}
+
+// TestOutboundChainsyncStartFailureClosesConnection is the regression test for
+// an outbound peer left half-connected.
+//
+// When chainsync fails to start, HandleOutboundConnEvent rolls back the
+// registration and returns before starting txsubmission. It used to leave the
+// TCP connection open, so peer governance still counted the peer as connected,
+// nothing retried, and the peer was effectively lost for the lifetime of the
+// connection. That matters for transient causes -- an intersect-point or
+// rollback-anchor lookup hitting a storage fault -- which are recoverable on a
+// reconnect but were never retried.
+//
+// The failure is induced here by closing the ledger's database, which makes
+// the rollback-anchor lookup return a storage error, which fails the chainsync
+// client start.
+func TestOutboundChainsyncStartFailureClosesConnection(t *testing.T) {
+	logBuf := &lockedBuffer{}
+	logger := slog.New(
+		slog.NewJSONHandler(
+			logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+	bus := event.NewEventBus(nil, logger)
+	defer bus.Close()
+
+	baselineGoroutines := runtime.NumGoroutine()
+
+	o, connManager, connId := newOutboundStartTestOuroboros(t, logger, bus)
+
+	// A ledger whose database is closed makes the rollback-anchor lookup
+	// return a storage error rather than "no anchor".
+	ls, db := newTestLedgerStateWithChain(t, 5)
+	o.ledgerState = ls
+	o.ledgerState.SetTipForTesting(ochainsync.Tip{
+		Point:       ocommon.NewPoint(2, ledgerTipHashAbsentFromChain),
+		BlockNumber: 2,
+	})
+	require.NoError(t, dbtest.CloseDatabase(db))
+	_, _, anchorErr := ls.RollbackWindowIntersectAnchor()
+	require.Error(t, anchorErr, "fixture must produce an anchor lookup error")
+
+	o.HandleOutboundConnEvent(event.NewEvent(
+		peergov.OutboundConnectionEventType,
+		peergov.OutboundConnectionEvent{ConnectionId: connId},
+	))
+
+	// The connection must not be left open: peer governance has to observe
+	// the failure to apply backoff and reconnect.
+	require.Eventually(
+		t,
+		func() bool { return connManager.GetConnectionById(connId) == nil },
+		2*time.Second,
+		20*time.Millisecond,
+		"outbound connection was left open after chainsync start failure",
+	)
+
+	// The tracked chainsync client registration must have been rolled back.
+	require.False(
+		t,
+		o.chainsyncState.HasClientConnId(connId),
+		"chainsync client registration must be rolled back",
+	)
+	require.Zero(t, o.chainsyncState.ClientConnCount())
+
+	require.Contains(
+		t,
+		logBuf.String(),
+		"failed to start chainsync client, closing outbound connection",
+	)
+
+	// The torn-down connection must not strand goroutines. A small margin
+	// absorbs the test harness's own workers (mempool, event bus).
+	require.Eventually(
+		t,
+		func() bool { return runtime.NumGoroutine() <= baselineGoroutines+8 },
+		5*time.Second,
+		50*time.Millisecond,
+		"goroutines leaked after the failed chainsync start (baseline %d, now %d)",
+		baselineGoroutines,
+		runtime.NumGoroutine(),
+	)
+}

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -981,10 +981,6 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 	}
 }
 
-// HandleInboundConnEvent starts client-side mini-protocols on full-duplex
-// inbound connections. When the remote peer negotiated InitiatorAndResponder
-// mode, a single TCP connection can carry both directions of the Ouroboros
-// protocols, matching cardano-node's connection manager behavior.
 // closeOutboundConnAfterChainsyncFailure closes the connection that chainsync
 // failed to start on, so peer governance observes the failure and applies its
 // reconnect backoff.
@@ -1021,6 +1017,10 @@ func (o *Ouroboros) closeOutboundConnAfterChainsyncFailure(
 	}
 }
 
+// HandleInboundConnEvent starts client-side mini-protocols on full-duplex
+// inbound connections. When the remote peer negotiated InitiatorAndResponder
+// mode, a single TCP connection can carry both directions of the Ouroboros
+// protocols, matching cardano-node's connection manager behavior.
 func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	e, ok := evt.Data.(connmanager.InboundConnectionEvent)
 	if !ok {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -895,6 +895,13 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 			true, // startedAsOutbound
 		)
 		if shouldStartChainsync {
+			// Capture the connection we are about to start chainsync on.
+			// The failure path below must close *this* connection, not
+			// whatever holds the id by the time the start returns: a
+			// reconnect can reuse the same local/remote address pair, and
+			// ConnectionId is exactly that pair, so a replacement can take
+			// over the id while the start is in flight.
+			startedConn := o.connManager.GetConnectionById(connId)
 			if err := o.chainsyncClientStart(connId); err != nil {
 				// Roll back the registration on failure
 				o.chainsyncState.RemoveClientConnId(connId)
@@ -919,16 +926,10 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 				//
 				// The inbound handler already closes on this same failure;
 				// this makes the outbound path consistent with it.
-				if conn := o.connManager.GetConnectionById(connId); conn != nil {
-					if closeErr := conn.Close(); closeErr != nil {
-						o.config.Logger.Debug(
-							"failed to close outbound connection after chainsync start failure",
-							"component", "network",
-							"connection_id", connId.String(),
-							"error", closeErr,
-						)
-					}
-				}
+				o.closeOutboundConnAfterChainsyncFailure(
+					connId,
+					startedConn,
+				)
 				return
 			}
 			o.config.Logger.Debug(
@@ -984,6 +985,42 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 // inbound connections. When the remote peer negotiated InitiatorAndResponder
 // mode, a single TCP connection can carry both directions of the Ouroboros
 // protocols, matching cardano-node's connection manager behavior.
+// closeOutboundConnAfterChainsyncFailure closes the connection that chainsync
+// failed to start on, so peer governance observes the failure and applies its
+// reconnect backoff.
+//
+// It closes startedConn only if that is still the connection manager's current
+// connection for this id. ConnectionId is a (local addr, remote addr) pair, so
+// a reconnect to the same peer can legitimately produce the same id: looking
+// the connection up again after the start returned could hand back a healthy
+// replacement, and closing that would tear down a good peer for a failure that
+// belonged to its predecessor.
+func (o *Ouroboros) closeOutboundConnAfterChainsyncFailure(
+	connId ouroboros.ConnectionId,
+	startedConn *ouroboros.Connection,
+) {
+	if startedConn == nil {
+		return
+	}
+	if current := o.connManager.GetConnectionById(connId); current != startedConn {
+		o.config.Logger.Debug(
+			"outbound connection no longer current after chainsync start failure, not closing",
+			"component", "network",
+			"connection_id", connId.String(),
+			"replaced", current != nil,
+		)
+		return
+	}
+	if closeErr := startedConn.Close(); closeErr != nil {
+		o.config.Logger.Debug(
+			"failed to close outbound connection after chainsync start failure",
+			"component", "network",
+			"connection_id", connId.String(),
+			"error", closeErr,
+		)
+	}
+}
+
 func (o *Ouroboros) HandleInboundConnEvent(evt event.Event) {
 	e, ok := evt.Data.(connmanager.InboundConnectionEvent)
 	if !ok {

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -899,10 +899,36 @@ func (o *Ouroboros) HandleOutboundConnEvent(evt event.Event) {
 				// Roll back the registration on failure
 				o.chainsyncState.RemoveClientConnId(connId)
 				o.config.Logger.Error(
-					"failed to start chainsync client",
-					"error",
-					err,
+					"failed to start chainsync client, closing outbound connection",
+					"component", "network",
+					"connection_id", connId.String(),
+					"error", err,
 				)
+				// Close the connection so peer governance observes the
+				// failure and applies its reconnect backoff.
+				//
+				// Returning while the connection is still open strands the
+				// peer half-connected: TCP is up and peergov still counts it
+				// as connected, but no chainsync client is tracked and this
+				// function returns before txsubmission starts, so nothing
+				// retries and the peer is never replaced. Any transient
+				// failure -- an intersect-point or rollback-anchor lookup
+				// hitting a storage fault, not just a negotiation failure --
+				// would silently cost us the peer for the lifetime of the
+				// connection.
+				//
+				// The inbound handler already closes on this same failure;
+				// this makes the outbound path consistent with it.
+				if conn := o.connManager.GetConnectionById(connId); conn != nil {
+					if closeErr := conn.Close(); closeErr != nil {
+						o.config.Logger.Debug(
+							"failed to close outbound connection after chainsync start failure",
+							"component", "network",
+							"connection_id", connId.String(),
+							"error", closeErr,
+						)
+					}
+				}
 				return
 			}
 			o.config.Logger.Debug(

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -92,6 +92,9 @@ type Ouroboros struct {
 	eventBus       *event.EventBus
 	mempool        mempool.Service
 	ledgerState    *ledger.LedgerState
+	// lastOriginOnlyIntersectWarn throttles warnOriginOnlyIntersectRescued.
+	// Unix nanoseconds; 0 means "never warned".
+	lastOriginOnlyIntersectWarn atomic.Int64
 	// leiosAnnouncementLedger is the narrow synchronous ledger view used by
 	// LeiosNotify. It returns validation facts only; this package owns peer,
 	// publication, and relay semantics.


### PR DESCRIPTION

## Problem

While a ledger rollback's metadata truncation is executing, a node can send its
peers a `MsgFindIntersect` containing **origin only**. The peer then replays the
chain's first headers. A synced node hard-rejects those genesis-era headers
(their producer has no entry in the epoch-0 stake snapshot), publishes
`ConnectionRecycleRequestedEvent`, and closes the connection ~15 ms after it
opened. Peer governance applies its short-lived-connection backoff, reconnects
into the same window, and the loop repeats until the truncation commits.

For as long as that lasts the node makes no chainsync progress with any peer.
Observed on a 1-second-slot Leios devnet: a **depth-1** rollback on a ~14 GB
SQLite metadata database took 87-90 s (four measurements on two nodes: 87.4,
89.3, 90.4, 87.2 s — flat, because the truncation's cost tracks table size, not
rollback depth). Two nodes running the same code entered the window together and
served each other origin-rooted headers, extending the outage to ~3.5 minutes
before it self-cleared.

A block producer in this window also cannot forge: the forge is skipped when the
admitted upstream frontier exceeds the frozen local tip by more than the sync
tolerance, and that skip is Debug-only, so a leader slot landing in the window is
silently lost.

### Abstracted timeline

Both nodes see the same depth-1 fork; the ledger begins rolling back one block.

```
T+0.000  chain extended, new tip: <block A> at slot S+13
T+1.009  ledger: rolling back to S
         <<< 87 s of silence: no chain extension, no ledger event >>>
T+88.37  chain rolled back, new tip: <block B> at slot S
T+88.38  local rollback had no recoverable peer history, closing connections
T+88.40  short-lived connection detected, applying backoff  duration=17.7ms
T+89.42  short-lived connection detected, applying backoff  duration=12.7ms
...      (second rollback enters the same window)
T+178.9  chainsync: excluding header from chain selection after verification
         failure slot=0
         error="producer pool <genesis-era producer> has no stake in epoch 0
                snapshot (pool is absent from the epoch distribution)"
T+178.9  recycling connection on request reason=header_verification_failure
T+180.9  chain rolled back  <-- truncation commits; the loop ends here
```

Nothing else unblocked it: no watchdog, no failover. The single unblocking event
is the truncation committing, after which `ls.currentTip` names a block that
exists, intersect points become real again, and the next connection intersects
correctly.

Slot 0 and slot 6 are the chain's first two blocks. The node was fully synced;
nothing but an origin-rooted `MsgFindIntersect` explains receiving them.

## Mechanism

1. **The chain is rewound before the ledger tip is.**
   `ledger/state.go` `rollbackChainAndStateDeferred` calls
   `ls.chain.RollbackDeferred(point)` (which removes the rolled-away block rows)
   and only then `ls.rollback(point)`. `ls.rollback` runs the truncation inside
   `SubmitAsyncDBTxn` and assigns `ls.currentTip = newTip` only after that
   transaction returns. For the whole truncation, `chain.Tip()` is the rollback
   point while `ls.currentTip` still names the deleted block.

2. **In that window the ledger returns no intersect points.**
   `IntersectPoints` takes the primary-chain path only when
   `primaryChainTipAtOrAheadOfLedgerTip()`, which is false here (the chain slot
   is *below* the ledger slot). It falls through to
   `authoritativeRecentChainPoints`, whose
   `database.BlockByPoint(ls.db, currentTip.Point)` returns
   `models.ErrBlockNotFound` — the row the chain rewind just deleted — and which
   then returns an **empty slice with a nil error**.

3. **Empty becomes origin.** `ouroboros/chainsync.go`
   `buildDefaultChainsyncIntersectPoints` appends origin as a last resort. With
   an empty list and no `IntersectTip`/configured points, origin is the *only*
   point sent.

4. **Genesis-era headers are a hard rejection that recycles the connection**, so
   every reconnect is torn down until step 2 stops holding.

## Fix

**`ledger/state.go` — anchor the point walk on the chain tip when the ledger tip
row is gone.** `authoritativeRecentChainPoints` no longer returns an empty set
on `ErrBlockNotFound`. It resolves a fallback anchor via the new
`recentChainPointsFallbackAnchor` and walks recent points from there, so the
points offered describe the chain the node will hold once the truncation
commits.

The fallback is deliberately narrow: it applies **only when the primary chain
tip is strictly below the ledger tip**, which is the signature of a rewind in
progress toward a point the ledger has already applied. A chain tip at or ahead
of the ledger tip is unapplied forward work — possibly a fork that does not
descend from the ledger tip — and must not be advertised. That is the invariant
the primary-chain ancestor check (#2309) exists to protect, and it is preserved:
`TestIntersectPointsDoesNotUsePrimaryChainWhenLedgerTipMissing` still passes
unchanged, and a new test pins the boundary explicitly.

**`ouroboros/chainsync.go` — refuse to emit origin-only when the ledger can name
an applied point.** The origin-appending logic moves into
`finalizeChainsyncIntersectPoints`, which still always appends origin as the
final fallback (divergent-fork peers need it), but when the computed list
contains no real point *and* the ledger supplies a rollback-window anchor, it
seeds the list with that anchor first. Origin stays as the tail, never the whole
request. A throttled Warn (30 s) records each occurrence.

The anchor comes from the new
`LedgerState.RollbackWindowIntersectAnchor() (ocommon.Point, bool, error)`,
which applies the same strict test as the ledger-side fix: the ledger tip's row
must be missing *and* the primary chain tip must sit strictly below the ledger
tip. A storage fault is returned as an error and fails the chainsync client
start, rather than being reported as an absent anchor.
Chainsync deliberately cannot read the primary chain tip directly here. An empty
point list can also mean the chain is *ahead* on a fork that does not descend
from the applied ledger tip, and seeding from that raw tip would advertise
unapplied fork state — re-introducing the #2309 violation one layer above the
ledger. Without an anchor the list stays origin-only, exactly as before.

Storage errors from the anchor lookup are propagated rather than reported as
"no anchor": silently degrading a database fault into an empty intersect list
would produce the very genesis-replay request this change exists to prevent.

This is defence in depth: the ledger change alone stops the loop, and the
chainsync guard makes "ask a synced node's peer to replay from genesis"
unreachable through any future path that produces an empty list.

## Observability

- `dingo_database_truncate_after_slot_duration_seconds` — histogram of
  `TruncateAfterSlot` sweep duration (1 ms to ~65 s exponential buckets),
  labelled `result="success"|"failure"`, registered alongside the other database
  metrics. A failed sweep still held the ledger write lock, so its duration is
  recorded too, but separately: it aborts at whichever sweep failed and so has a
  different profile.
- An Info line, `metadata rollback truncation sweep complete`, with the rollback
  slot, duration and whether this call committed; a failure logs at Warn with the
  error instead. The ledger holds its write lock across this call, so the
  duration *is* the length of the chain-freeze window; it needed to be visible
  without enabling Debug. Previously the only symptom was the ledger going
  silent. The message says *sweep* because a caller-supplied transaction is
  committed by the caller, which may still roll back afterwards.
- A throttled Warn when intersect points would have collapsed to origin on a
  node whose chain tip is non-origin.

## Tests

`ledger/intersect_points_rollback_window_test.go` (new) — a fixture that
reproduces the window exactly: build a 5-block chain, set the ledger tip to
block 5, then `chain.Rollback` to block 3 *without* running `ls.rollback`.

- `TestRollbackWindowPreconditions` — pins the state the bug depends on (chain
  tip below ledger tip, ledger tip row absent, `primaryChainTipAtOrAheadOfLedgerTip`
  false) so a future change that makes the window unreachable fails loudly
  instead of turning the regressions into tautologies.
- `TestAuthoritativeRecentChainPointsFallsBackToChainTipWhenLedgerTipMissing` —
  the core regression: not empty, led by the rollback point, no point above it,
  recent points still walked below it.
- `TestIntersectPointsDoesNotCollapseToEmptyDuringRollbackWindow` — same through
  the entry point chainsync actually calls.
- `TestAuthoritativeRecentChainPointsIgnoresChainTipAheadOfLedgerTip` — the
  boundary: a fork block ahead of the ledger tip must still yield no points.
- `TestIntersectPointsStillEmptyAtOriginWithNoChain` — a genuinely empty node
  still reports nothing, so fresh sync from origin is unaffected.

`ouroboros/chainsync_intersect_origin_test.go` (new):

- `TestFinalizeChainsyncIntersectPointsNeverOffersOriginAloneOnNonOriginChain` —
  table over nil / empty / origin-only input; never origin-alone, the anchor
  leads, origin remains the tail.
- `TestFinalizeChainsyncIntersectPointsRefusesAheadForkAnchor` — a caller that
  passes a real point without a ledger-approved anchor is still refused.
- `TestIntersectPointsChainAheadWithLedgerTipRowMissingStaysOriginOnly` — the
  #2309 shape: chain ahead with the ledger tip row missing must stay
  origin-only.
- `TestIntersectPointsChainAheadWithLedgerTipRowPresentAdvertisesChainPoints` —
  the complementary case: with the tip row present the chain is a valid forward
  extension and its real points are advertised, origin appended.
- `TestRollbackWindowIntersectAnchorPropagatesStorageError` — a storage fault
  fails the client start instead of becoming an origin-only request.
- `TestFinalizeChainsyncIntersectPointsKeepsOriginOnlyAtOrigin` — a node really
  at origin may still request a full replay, so bootstrap is unaffected.
- `TestFinalizeChainsyncIntersectPointsPreservesRealPoints` and
  `...DoesNotDoubleAppendOrigin` — the healthy path is unchanged.
- `TestChainsyncNeverAsksPeerToReplayFromGenesisDuringRollback` — composition
  test over a live `LedgerState` holding a real chain with a missing ledger tip
  row.

`database/truncate_metrics_test.go` (new) —
`TestTruncateAfterSlotObservesDuration`,
`TestTruncateAfterSlotRecordsFailureSeparately` and
`TestRegisterTruncateMetricsNilRegistry`.

Ledger-side additions: `TestRecentChainPointsFallbackAnchorPropagatesStorageError`
(a storage fault must not become an empty point list),
`TestIntersectAnchorFallbackWarnIsThrottled` (the warning must not flood during a
reconnect storm), and `TestRollbackWindowIntersectAnchorReportsRollbackPoint` /
`...AbsentWhenLedgerTipPresent` (the exported anchor contract).

Each new test was mutation-checked: with the corresponding fix reverted, it
fails; the guard tests keep passing.

## Follow-ups (deliberately not in this PR)

1. **Truncation cost.** `TruncateAfterSlot` runs ~15 sequential `*AfterSlot` /
   `Restore*AtSlot` sweeps whose cost tracks table size rather than rollback
   depth — hence a flat ~88 s for a single block on a 14 GB database. The new
   histogram makes this measurable; optimizing it is out of scope here. One
   untested hypothesis worth checking first: `database/models/account.go`
   declares `AddedSlot uint64` with no index tag, which would make the
   `WHERE added_slot > ?` filters full scans. That is a hypothesis, not a
   measurement — the per-sweep breakdown should be instrumented before anyone
   adds indexes.
2. **Rewind ordering.** The underlying asymmetry is that
   `rollbackChainAndStateDeferred` rewinds `ls.chain` before `ls.rollback`
   updates `ls.currentTip`, leaving the two inconsistent for the duration of the
   truncation. Reordering them, or publishing the new tip before the truncation
   commits, would remove the window entirely — but the current order exists for
   event-ordering reasons documented at length on that function, so it is not
   changed here without a proof that it is safe.
3. **Header rejection below the immutable tip.** A header at or below our own
   stable tip arguably should not be a recyclable peer fault, matching the
   existing Mithril-covered exemption. Separate change.
4. `syncChainsyncClient` retains its own `len == 0 -> origin` fallback. Both of
   its call sites now feed from the fixed builder, so it is unreachable in
   practice, but it could be hardened for symmetry.

## Related

- #3212 (closed) — same `block(s) not found` warning on the local-rollback
  recovery path. That warning fires here too and is benign; this is about the
  `closing connections for fresh chainsync` path it leads into.
- #2790 (closed) — producer/relay pair thrashing chainsync every ~15 ms with the
  same short-lived-connection backoff, entered via a different branch.
- #2309 — introduced the primary-chain ancestor check whose invariant this
  change preserves.

Fixes #3968.
