### PR TITLE
test(eras): pin the Conway rule indexes gouroboros actually composes

### DIFF
--- a/ledger/eras/conway_utxo_divergence_test.go
+++ b/ledger/eras/conway_utxo_divergence_test.go
@@ -85,13 +85,20 @@ func newConwayDivergenceTx(
 // ValidateTxConway). The indexes are positions in the gouroboros
 // conway.UtxoValidationRules slice, so an upstream insertion silently
 // renumbers every operator-visible diagnostic and every issue report written
-// against the old numbering. UtxoValidateRequiredRedeemers was inserted at 31
-// in gouroboros v0.202.5, which moved value-not-conserved from 31 to 32.
+// against the old numbering.
+//
+// The pinned values are the positions gouroboros actually composes, confirmed
+// against the emitted diagnostic rather than derived by counting: a genuinely
+// missing input reports "conway utxo validation rule 30" and an unbalanced
+// transaction reports "rule 33". They were first committed as 29 and 32, which
+// matched no gouroboros version dingo has used — the composed list is
+// identical at v0.202.8 and v0.202.9 (60 rules) — so the guard failed from the
+// commit that introduced it (issue #3976).
 func TestConwayUtxoValidationRuleIndexesArePinned(t *testing.T) {
 	rules := conway.UtxoValidationRules
 	for idx, want := range map[int]string{
-		29: "UtxoValidateBadInputsUtxo",
-		32: "UtxoValidateValueNotConservedUtxo",
+		30: "UtxoValidateBadInputsUtxo",
+		33: "UtxoValidateValueNotConservedUtxo",
 	} {
 		require.Greater(t, len(rules), idx)
 		name := utxoValidationRuleName(rules[idx])
@@ -127,7 +134,7 @@ func TestValidateTxConwayGenuinelyMissingInputStillRejected(t *testing.T) {
 	require.ErrorAs(t, err, &badInputs)
 	require.Len(t, badInputs.Inputs, 1)
 	assert.Equal(t, tx.Inputs()[0].String(), badInputs.Inputs[0].String())
-	assert.Contains(t, err.Error(), "conway utxo validation rule 29:")
+	assert.Contains(t, err.Error(), "conway utxo validation rule 30:")
 }
 
 // TestValidateTxConwayGenuinelyUnbalancedStillRejected is the negative case for
@@ -159,7 +166,7 @@ func TestValidateTxConwayGenuinelyUnbalancedStillRejected(t *testing.T) {
 		"consumed should be the resolved input value",
 	)
 	assert.Equal(t, big.NewInt(400_000), notConserved.Produced)
-	assert.Contains(t, err.Error(), "conway utxo validation rule 32:")
+	assert.Contains(t, err.Error(), "conway utxo validation rule 33:")
 
 	// The input resolved, so bad-inputs must NOT also fire. This is what
 	// separates a genuinely unbalanced transaction from the single-cause


### PR DESCRIPTION
Fixes #3976.

## Why

Three tests in `ledger/eras` fail on unmodified `main`, so every branch that
merges `main` inherits red CI for a defect it did not introduce. That is
currently affecting at least #3838, #3843, #3853, #3916, #3924 and #3940.

## The pins never matched

`TestConwayUtxoValidationRuleIndexesArePinned` pinned positions 29 and 32.
Enumerating the composed `conway.UtxoValidationRules` at both gouroboros
versions this repository has used:

```
        v0.202.8                         v0.202.9
[28]  UtxoValidateCollateralEqBalance    (identical)
[29]  UtxoValidateNoCollateralInputs     (identical)
[30]  UtxoValidateBadInputsUtxo          (identical)
[32]  UtxoValidateRequiredRedeemers      (identical)
[33]  UtxoValidateValueNotConservedUtxo  (identical)
      60 rules                           60 rules
```

Identical, so no upstream insertion occurred across the v0.202.9 bump. The
test was added by #3818, which landed **after** that bump, and it fails at its
own commit — it was merged already red.

## The emitted diagnostic is the authority

This is what decides which numbering is correct, rather than counting the
slice. `ValidateTxConway` reports the runtime index to operators, and a
genuinely missing input produces:

```
conway utxo validation rule 30: bad input(s): aa00…#0
conway utxo validation rule 32: failed to resolve input aa00…#0: UTxO not found
conway utxo validation rule 33: value not conserved: consumed 0, produced 200000
```

So the operator-visible numbering was never wrong — only the expectations
were. Correcting the pins to 30 and 33 restores the guard rather than
suppressing it; the two `ValidateTxConway…` tests assert the same strings and
fail for the same reason.

## Checks

The guard still guards: changing a pin to 31 fails
`TestConwayUtxoValidationRuleIndexesArePinned`, so it detects a shift rather
than matching anything.

`go test ./ledger/... -count=1` — 9 packages pass. `make lint` — 0
golangci-lint issues across all module dirs and the Windows target.
`nilaway` is unavailable, not clean: the installed binary is built against
go1.26 and cannot analyse the go1.27.1 toolchain, so it emits
`failed prerequisites:` and exits 0.

`DATABASE.md` and `ARCHITECTURE.md` checked and not affected — this changes
test expectations only, no schema, query, storage, or component-boundary
change.

## Note

Separately, `./bin`'s `TestEntrypointForwardsSignalsDuringMithrilBootstrap`
and `TestEntrypointSignalHandlingSurvivesBootstrapToServeHandoff` also fail on
`main` under full-suite load and pass in isolation. That is a different defect,
tracked in #3930 and #3574, and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Conway rule index pins in `ledger/eras` tests to match the indices gouroboros actually composes, unblocking CI on branches that merge `main`. The pins were set to 29 and 32, which matched no gouroboros version, so the tests failed from the start. Corrected them to 30 and 33 and updated the corresponding diagnostic assertions.

<sup>Written for commit 8f101bcaf8160494d33884d74380af289f24a5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

