### PR TITLE
fix(ledger): carry the sign through the MIR pipeline

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -880,7 +880,7 @@ PostgreSQL/MySQL repeatable-read read-only transactions.
 | `genesis_delegation` | `id`, `genesis_hash`, `genesis_delegate_hash`, `vrf_key_hash`, `added_slot`, `block_index`, `cert_index`, `certificate_id` | PK `id`; lookup index `(genesis_hash, added_slot, block_index, cert_index)`; index `genesis_delegate_hash`; unique index `certificate_id` | Shelley genesis-key delegation certificates. Header validation resolves the latest row with `added_slot < block_slot`, ordered by slot/block/certificate position, and falls back to Shelley genesis only when no on-chain update exists. |
 
 | `move_instantaneous_rewards` | `id`, `pot`, `certificate_id`, `added_slot`, `other_pot` | PK `id`; indexes `pot`, `certificate_id`, `added_slot` | MIR certificate header. `pot`: 0 = Reserves, 1 = Treasury. `other_pot` is non-zero for pot-to-pot transfer certs (no child rows); zero for credential distribution certs (child rows in `move_instantaneous_rewards_reward`). Applied at each epoch boundary by the Shelley INSTANT rule. |
-| `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `credential_tag`, `amount` | PK `id`; index `mir_id`; composite index `(credential_tag, credential)` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. `credential_tag` distinguishes key (0) vs script (1) stake credentials sharing a hash; `GetAccountSumsByCredential` filters on `(credential_tag, credential)` to attribute reserves/treasury totals to an account. |
+| `move_instantaneous_rewards_reward` | `id`, `mir_id`, `credential`, `credential_tag`, `amount` | PK `id`; index `mir_id`; composite index `(credential_tag, credential)` | MIR reward rows. Join `mir_id -> move_instantaneous_rewards.id`. `credential_tag` distinguishes key (0) vs script (1) stake credentials sharing a hash; `GetAccountSumsByCredential` filters on `(credential_tag, credential)` to attribute reserves/treasury totals to an account. `amount` is signed decimal text: the wire format types a MIR reward as `delta_coin`, so a certificate may reduce a reward scheduled earlier in the same epoch. `other_pot` on the parent row is `coin` and stays non-negative. |
 
 #### Reward Withdrawal Persistence
 
@@ -2382,6 +2382,12 @@ FROM move_instantaneous_rewards_reward r
 JOIN move_instantaneous_rewards mir ON mir.id = r.mir_id
 WHERE mir.pot = $pot AND r.credential_tag = $1 AND r.credential = decode($2, 'hex');
 ```
+
+A withdrawal is `coin`, so `withdrawals_sum` is unsigned. A MIR reward is
+`delta_coin`, so `reserves_sum` and `treasury_sum` are summed as signed values
+and are rendered with their sign. The rows are summed in Go rather than by the
+engine: the amount columns are decimal text, and `SUM` over them differs across
+SQLite, PostgreSQL, and MySQL.
 
 ### `GetStakeRegistrationsByCredential`
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2370,24 +2370,28 @@ Backs the Blockfrost account `withdrawals_sum`, `reserves_sum`, and
 `treasury_sum` fields. All three totals are reconstructed from rollback-aware
 persisted rows rather than stored as running counters:
 
+Each total selects its rows and adds them in Go rather than asking the engine
+for a `SUM`: the amount columns are decimal text, and coercing them to a signed
+engine integer differs across SQLite, PostgreSQL, and MySQL and cannot span the
+full `uint64` range.
+
 ```sql
 -- withdrawals_sum
-SELECT COALESCE(SUM(amount), 0)
+SELECT amount
 FROM account_reward_delta
 WHERE withdrawal = true AND credential_tag = $1 AND staking_key = decode($2, 'hex');
 
 -- reserves_sum (pot = 0) / treasury_sum (pot = 1)
-SELECT COALESCE(SUM(r.amount), 0)
+SELECT r.amount
 FROM move_instantaneous_rewards_reward r
 JOIN move_instantaneous_rewards mir ON mir.id = r.mir_id
 WHERE mir.pot = $pot AND r.credential_tag = $1 AND r.credential = decode($2, 'hex');
 ```
 
-A withdrawal is `coin`, so `withdrawals_sum` is unsigned. A MIR reward is
-`delta_coin`, so `reserves_sum` and `treasury_sum` are summed as signed values
-and are rendered with their sign. The rows are summed in Go rather than by the
-engine: the amount columns are decimal text, and `SUM` over them differs across
-SQLite, PostgreSQL, and MySQL.
+A withdrawal is `coin`, so `withdrawals_sum` is accumulated as `uint64` and a
+negative row is an error. A MIR reward is `delta_coin`, so `reserves_sum` and
+`treasury_sum` are accumulated as signed unbounded values and are rendered with
+their sign.
 
 ### `GetStakeRegistrationsByCredential`
 

--- a/api/blockfrost/account_mir_sums_test.go
+++ b/api/blockfrost/account_mir_sums_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfrost
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSignedSumText pins the rendering of the account reserves_sum and
+// treasury_sum fields. Both aggregate delta_coin rows, so a net negative total
+// has to reach the response with its sign rather than as its magnitude, and an
+// account with no MIR history has to render as "0" rather than an empty string.
+func TestSignedSumText(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name  string
+		value *big.Int
+		want  string
+	}{
+		{name: "nil renders as zero", value: nil, want: "0"},
+		{name: "zero", value: big.NewInt(0), want: "0"},
+		{name: "positive", value: big.NewInt(1_200), want: "1200"},
+		{name: "negative keeps its sign", value: big.NewInt(-200), want: "-200"},
+		{
+			name:  "beyond int64",
+			value: new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 70)),
+			want:  "-1180591620717411303424",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, signedSumText(test.value))
+		})
+	}
+}

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -2361,13 +2361,23 @@ func (a *NodeAdapter) Account(
 		ControlledAmount:   strconv.FormatUint(controlledAmount, 10),
 		RewardsSum:         reward,
 		WithdrawalsSum:     strconv.FormatUint(sums.WithdrawalsSum, 10),
-		ReservesSum:        strconv.FormatUint(sums.ReservesSum, 10),
-		TreasurySum:        strconv.FormatUint(sums.TreasurySum, 10),
+		ReservesSum:        signedSumText(sums.ReservesSum),
+		TreasurySum:        signedSumText(sums.TreasurySum),
 		WithdrawableAmount: reward,
 		PoolID:             poolID,
 		DrepID:             accountDrepID(account.Drep, account.DrepType),
 		Registered:         account.Active,
 	}, nil
+}
+
+// signedSumText renders a signed MIR pot total. The aggregate is summed over
+// delta_coin rows, so it carries a sign; a nil total is rendered as zero so a
+// stake account with no MIR history reports "0" rather than an empty field.
+func signedSumText(value *big.Int) string {
+	if value == nil {
+		return "0"
+	}
+	return value.String()
 }
 
 // accountDrepID renders the Bech32 DRep ID a stake account is delegated to,
@@ -4373,7 +4383,7 @@ func (a *NodeAdapter) TransactionMIRs(
 		case uint(lcommon.MirSourceTreasury):
 			pot = "treasury"
 		}
-		for credential, amount := range c.Reward.Rewards {
+		for credential, amount := range c.Reward.RewardsAmount() {
 			address, err := stakeAddressFromCredential(*credential, networkID)
 			if err != nil {
 				return nil, fmt.Errorf(
@@ -4383,9 +4393,19 @@ func (a *NodeAdapter) TransactionMIRs(
 					err,
 				)
 			}
+			if amount == nil {
+				return nil, fmt.Errorf(
+					"MIR delta missing for transaction %x cert %d",
+					hash,
+					cert.Index,
+				)
+			}
 			ret = append(ret, TransactionMIRInfo{
-				Address:   address,
-				Amount:    strconv.FormatUint(amount, 10),
+				Address: address,
+				// delta_coin is signed, so the rendered amount
+				// keeps the sign rather than being formatted as
+				// an unsigned coin.
+				Amount:    amount.String(),
 				CertIndex: cert.Index,
 				Pot:       pot,
 			})

--- a/database/account_history.go
+++ b/database/account_history.go
@@ -295,7 +295,7 @@ func (d *Database) GetAccountSumsByCredential(
 		txn.Metadata(),
 	)
 	if err != nil {
-		return models.AccountSums{}, fmt.Errorf(
+		return models.NewAccountSums(), fmt.Errorf(
 			"get account sums: %w",
 			err,
 		)

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -130,3 +130,13 @@ type AccountSums struct {
 	// account sourced from the treasury pot. See ReservesSum.
 	TreasurySum *big.Int
 }
+
+// NewAccountSums returns an AccountSums with every total at zero and neither
+// signed total nil. Readers return it on their failure paths too, so the
+// non-nil guarantee does not depend on the caller checking the error first.
+func NewAccountSums() AccountSums {
+	return AccountSums{
+		ReservesSum: new(big.Int),
+		TreasurySum: new(big.Int),
+	}
+}

--- a/database/models/account_history.go
+++ b/database/models/account_history.go
@@ -14,6 +14,8 @@
 
 package models
 
+import "math/big"
+
 // AccountDelegationHistoryRow holds delegation history
 // query results for a stake account.
 type AccountDelegationHistoryRow struct {
@@ -116,12 +118,15 @@ type AccountTransactionAssociationRow struct {
 // account, summed from persisted withdrawal and MIR state.
 type AccountSums struct {
 	// WithdrawalsSum is the total of all reward withdrawals
-	// made by the account.
+	// made by the account. Withdrawals are coin, so this total
+	// is unsigned.
 	WithdrawalsSum uint64
-	// ReservesSum is the total of all MIR transfers to the
-	// account sourced from the reserves pot.
-	ReservesSum uint64
-	// TreasurySum is the total of all MIR transfers to the
-	// account sourced from the treasury pot.
-	TreasurySum uint64
+	// ReservesSum is the signed total of all MIR deltas for the
+	// account sourced from the reserves pot. MIR deltas are
+	// delta_coin, so individual rows may be negative and the
+	// total is summed as a signed value. Never nil.
+	ReservesSum *big.Int
+	// TreasurySum is the signed total of all MIR deltas for the
+	// account sourced from the treasury pot. See ReservesSum.
+	TreasurySum *big.Int
 }

--- a/database/models/mir.go
+++ b/database/models/mir.go
@@ -14,7 +14,11 @@
 
 package models
 
-import "github.com/blinklabs-io/dingo/database/types"
+import (
+	"math/big"
+
+	"github.com/blinklabs-io/dingo/database/types"
+)
 
 type MoveInstantaneousRewards struct {
 	Rewards       []MoveInstantaneousRewardsReward
@@ -32,28 +36,34 @@ type MoveInstantaneousRewards struct {
 // epoch-boundary application logic. One of OtherPot > 0 (pot-to-pot transfer)
 // or len(Rewards) > 0 (credential distribution) will be non-empty.
 type MIREffect struct {
-	// ID is the move_instantaneous_rewards row ID. It is used as the stable
-	// per-MIR reward-credit discriminator when applying epoch-boundary effects.
+	// ID is the move_instantaneous_rewards row ID, used to order the
+	// certificates of an ended epoch before their deltas are folded.
 	ID uint
 	// Pot is the source Ada pot: 0 = Reserves, 1 = Treasury.
 	Pot uint
 	// OtherPot is the amount for a pot-to-pot transfer (0 when distributing).
 	OtherPot uint64
-	// Rewards lists credential→amount pairs for a distribution MIR.
+	// Rewards lists credential→delta pairs for a distribution MIR.
 	Rewards []MIRReward
 }
 
-// MIRReward is a single credential→amount entry from a distribution MIR cert.
+// MIRReward is a single credential→delta entry from a distribution MIR cert.
 type MIRReward struct {
 	Credential    []byte
 	CredentialTag uint8
-	Amount        uint64
+	// Amount is the signed reward delta. The wire format types it as
+	// delta_coin (int), which the reference decodes as the signed unbounded
+	// DeltaCoin, so a later certificate in the same epoch can reduce an
+	// earlier one. Never nil on a value read from the store.
+	Amount *big.Int
 }
 
 type MoveInstantaneousRewardsReward struct {
 	Credential    []byte
 	CredentialTag uint8
-	Amount        types.Uint64
-	ID            uint
-	MIRID         uint
+	// Amount is the signed reward delta persisted for one credential of one
+	// MIR certificate. See MIRReward.Amount.
+	Amount *big.Int
+	ID     uint
+	MIRID  uint
 }

--- a/database/plugin/metadata/sqlstore/account.go
+++ b/database/plugin/metadata/sqlstore/account.go
@@ -818,10 +818,9 @@ func (s *Store) GetAccountSumsByCredential(
 	stakingKey []byte,
 	txn types.Txn,
 ) (models.AccountSums, error) {
-	ret := models.AccountSums{
-		ReservesSum: new(big.Int),
-		TreasurySum: new(big.Int),
-	}
+	// The two MIR totals are non-nil on every return, including the failure
+	// ones, so AccountSums never hands a caller a nil *big.Int.
+	ret := models.NewAccountSums()
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
@@ -845,7 +844,7 @@ WHERE withdrawal = TRUE AND credential_tag = ? AND staking_key = ?`,
 		stakingKey,
 	)
 	if err != nil {
-		return models.AccountSums{}, fmt.Errorf(
+		return models.NewAccountSums(), fmt.Errorf(
 			"query account sums: sum withdrawals: %w",
 			err,
 		)
@@ -860,7 +859,7 @@ WHERE mir.pot = 0 AND reward.credential_tag = ?
 		stakingKey,
 	)
 	if err != nil {
-		return models.AccountSums{}, fmt.Errorf(
+		return models.NewAccountSums(), fmt.Errorf(
 			"query account sums: sum reserves MIR: %w",
 			err,
 		)
@@ -875,7 +874,7 @@ WHERE mir.pot = 1 AND reward.credential_tag = ?
 		stakingKey,
 	)
 	if err != nil {
-		return models.AccountSums{}, fmt.Errorf(
+		return models.NewAccountSums(), fmt.Errorf(
 			"query account sums: sum treasury MIR: %w",
 			err,
 		)

--- a/database/plugin/metadata/sqlstore/account.go
+++ b/database/plugin/metadata/sqlstore/account.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -817,7 +818,10 @@ func (s *Store) GetAccountSumsByCredential(
 	stakingKey []byte,
 	txn types.Txn,
 ) (models.AccountSums, error) {
-	var ret models.AccountSums
+	ret := models.AccountSums{
+		ReservesSum: new(big.Int),
+		TreasurySum: new(big.Int),
+	}
 	if len(stakingKey) == 0 {
 		return ret, nil
 	}
@@ -827,6 +831,11 @@ func (s *Store) GetAccountSumsByCredential(
 	}
 	sum := func(query string, args ...any) (uint64, error) {
 		return sumUint64Rows(ctx, db, s.dialect.Rebind(query), args...)
+	}
+	// MIR amounts are delta_coin, so the two pot totals are summed as signed
+	// values. A withdrawal is coin and stays unsigned.
+	sumSigned := func(query string, args ...any) (*big.Int, error) {
+		return sumSignedRows(ctx, db, s.dialect.Rebind(query), args...)
 	}
 	ret.WithdrawalsSum, err = sum(`
 SELECT amount
@@ -841,7 +850,7 @@ WHERE withdrawal = TRUE AND credential_tag = ? AND staking_key = ?`,
 			err,
 		)
 	}
-	ret.ReservesSum, err = sum(`
+	ret.ReservesSum, err = sumSigned(`
 SELECT reward.amount
 FROM move_instantaneous_rewards_reward reward
 JOIN move_instantaneous_rewards mir ON mir.id = reward.mir_id
@@ -856,7 +865,7 @@ WHERE mir.pot = 0 AND reward.credential_tag = ?
 			err,
 		)
 	}
-	ret.TreasurySum, err = sum(`
+	ret.TreasurySum, err = sumSigned(`
 SELECT reward.amount
 FROM move_instantaneous_rewards_reward reward
 JOIN move_instantaneous_rewards mir ON mir.id = reward.mir_id

--- a/database/plugin/metadata/sqlstore/amounts.go
+++ b/database/plugin/metadata/sqlstore/amounts.go
@@ -16,8 +16,10 @@ package sqlstore
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"math/big"
 	"strconv"
 )
 
@@ -68,6 +70,11 @@ func sumUint64Rows(
 // for decimal amount columns. SQLite/MySQL may expose an INTEGER column as
 // int64 while text columns are returned as string/[]byte; all represent the
 // same non-negative decimal domain to the metadata API.
+//
+// The refusal to format a negative value is deliberate and is kept: every
+// column this reaches holds coin, which the wire format types as uint, so a
+// negative there is corrupt state rather than a representable value. Columns
+// whose domain is delta_coin use signedAmountText instead.
 func decimalAmountText(value any) (string, error) {
 	switch value := value.(type) {
 	case nil:
@@ -93,4 +100,108 @@ func decimalAmountText(value any) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported amount type %T", value)
 	}
+}
+
+// signedAmountText normalizes driver values for decimal amount columns whose
+// domain includes negative values. MIR reward deltas are delta_coin, which the
+// reference decodes as a signed unbounded integer, so decimalAmountText's
+// non-negative guard would reject a valid row here.
+func signedAmountText(value any) (string, error) {
+	switch value := value.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return value, nil
+	case []byte:
+		return string(value), nil
+	case int64:
+		return strconv.FormatInt(value, 10), nil
+	case int:
+		return strconv.Itoa(value), nil
+	case uint64:
+		return strconv.FormatUint(value, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(value), 10), nil
+	default:
+		return "", fmt.Errorf("unsupported amount type %T", value)
+	}
+}
+
+// sumSignedRows sums a signed decimal column in Go instead of asking SQL to
+// coerce it. It is the delta_coin counterpart of sumUint64Rows: the column is
+// persisted as decimal text carrying its own sign, and the total is
+// accumulated without a width bound so a row larger than any pot is summed
+// rather than silently truncated. The returned total is never nil.
+func sumSignedRows(
+	ctx context.Context,
+	db queryer,
+	query string,
+	args ...any,
+) (*big.Int, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	total := new(big.Int)
+	for rows.Next() {
+		var raw any
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		text, err := signedAmountText(raw)
+		if err != nil {
+			return nil, err
+		}
+		if text == "" {
+			continue
+		}
+		value, err := parseBigInt("amount", text)
+		if err != nil {
+			return nil, err
+		}
+		total.Add(total, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return total, nil
+}
+
+// signedDecimal renders a signed amount for a decimal text column. A nil value
+// is a programming error at the call site rather than a representable amount,
+// so it is reported instead of being written as zero.
+func signedDecimal(description string, value *big.Int) (string, error) {
+	if value == nil {
+		return "", fmt.Errorf("encode %s: no value", description)
+	}
+	return value.String(), nil
+}
+
+// parseBigInt decodes a signed decimal text column. Unlike parseUint64 it
+// imposes no width bound: the column's domain is delta_coin, and a value the
+// ledger rules would never accept still has to read back as what was written
+// rather than as a truncated or rejected row.
+func parseBigInt(description, value string) (*big.Int, error) {
+	ret, ok := new(big.Int).SetString(value, 10)
+	if !ok {
+		return nil, fmt.Errorf(
+			"decode %s: invalid decimal %q",
+			description,
+			value,
+		)
+	}
+	return ret, nil
+}
+
+// parseNullBigInt decodes a nullable signed decimal text column, treating NULL
+// and the empty string as zero. The result is never nil.
+func parseNullBigInt(
+	description string,
+	value sql.NullString,
+) (*big.Int, error) {
+	if !value.Valid || value.String == "" {
+		return new(big.Int), nil
+	}
+	return parseBigInt(description, value.String)
 }

--- a/database/plugin/metadata/sqlstore/certificates.go
+++ b/database/plugin/metadata/sqlstore/certificates.go
@@ -168,7 +168,7 @@ ORDER BY id`,
 				rewardRows.Close()
 				return nil, err
 			}
-			reward.Amount, err = parseNullUint64("MIR reward", amount)
+			reward.Amount, err = parseNullBigInt("MIR reward", amount)
 			if err != nil {
 				rewardRows.Close()
 				return nil, err

--- a/database/plugin/metadata/sqlstore/mir_signed_delta_test.go
+++ b/database/plugin/metadata/sqlstore/mir_signed_delta_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore/migrations"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var migratedStoreSequence atomic.Uint64
+
+// newMigratedTestStore opens an in-memory SQLite store carrying the checked-in
+// schema, so a test exercises the real column types rather than a hand-written
+// approximation of them.
+func newMigratedTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open(
+		"sqlite",
+		fmt.Sprintf(
+			"file:sqlstore_mir_%d?mode=memory&cache=shared",
+			migratedStoreSequence.Add(1),
+		),
+	)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	registry, err := migrations.SQLiteRegistry()
+	require.NoError(t, err)
+	store, err := New(Config{
+		WriteDB:         db,
+		Dialect:         SQLiteDialect(),
+		Migrations:      registry,
+		MigrationLocker: migrations.NewProcessLocker(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Start(t.Context()))
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+	return store
+}
+
+func mirTestCredential(seed byte) *lcommon.Credential {
+	var hash lcommon.Blake2b224
+	for i := range hash {
+		hash[i] = seed
+	}
+	return &lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+}
+
+// TestApplyMIRCertificatePersistsProjectedDeltas proves the persistence path
+// writes exactly what the certificate's reward projection returns, for every
+// credential, rather than a value it re-derives from the underlying field.
+// RewardsAmount is *big.Int on every gouroboros release, so this is the path a
+// signed delta travels once the underlying field is widened to delta_coin.
+func TestApplyMIRCertificatePersistsProjectedDeltas(t *testing.T) {
+	t.Parallel()
+	store := newMigratedTestStore(t)
+
+	first := mirTestCredential(0x21)
+	second := mirTestCredential(0x22)
+	cert := decodeMIRDistributionCertificate(
+		t,
+		uint(lcommon.MirSourceReserves),
+		map[*lcommon.Credential]uint64{
+			first:  1_200,
+			second: 450,
+		},
+	)
+	_, err := applyMIRCertificate(
+		context.Background(),
+		newDialectQueryer(store.writeDB, store.dialect.Name()),
+		cert,
+		0,
+		400,
+	)
+	require.NoError(t, err)
+
+	want := map[string]string{}
+	for credential, amount := range cert.Reward.RewardsAmount() {
+		want[string(credential.Credential[:])] = amount.String()
+	}
+	require.Len(t, want, 2)
+
+	effects, err := store.GetMIRCertsInSlotRange(0, 1_000, nil)
+	require.NoError(t, err)
+	require.Len(t, effects, 1)
+	got := map[string]string{}
+	for _, reward := range effects[0].Rewards {
+		require.NotNil(t, reward.Amount)
+		got[string(reward.Credential)] = reward.Amount.String()
+	}
+	assert.Equal(t, want, got)
+}
+
+// TestMIRRewardDeltaColumnRoundTripsSigned proves the reward amount column and
+// its encoder and decoder carry a sign. A MIR reward is delta_coin, so a
+// negative delta has to read back as the value that was written rather than
+// being refused by the coin encoder or rejected by the unsigned parser.
+//
+// The certificate type gouroboros currently exposes cannot hold a negative
+// delta, so this exercises the persistence encoding directly; the end-to-end
+// certificate path is covered by
+// TestApplyMIRCertificatePersistsProjectedDeltas.
+func TestMIRRewardDeltaColumnRoundTripsSigned(t *testing.T) {
+	t.Parallel()
+	store := newMigratedTestStore(t)
+
+	credential := mirTestCredential(0x25).Credential[:]
+	for _, delta := range []*big.Int{
+		big.NewInt(-450),
+		big.NewInt(1_200),
+		new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 70)),
+	} {
+		encoded, err := signedDecimal("MIR reward delta", delta)
+		require.NoError(t, err)
+		seedMIRRewardRow(t, store, 0, credential, encoded)
+	}
+
+	effects, err := store.GetMIRCertsInSlotRange(0, 1_000, nil)
+	require.NoError(t, err)
+	require.Len(t, effects, 3)
+	got := []string{}
+	for _, effect := range effects {
+		require.Len(t, effect.Rewards, 1)
+		require.NotNil(t, effect.Rewards[0].Amount)
+		got = append(got, effect.Rewards[0].Amount.String())
+	}
+	assert.Equal(
+		t,
+		[]string{"-450", "1200", "-1180591620717411303424"},
+		got,
+	)
+}
+
+// TestSignedDecimalRejectsMissingDelta pins that a missing delta is reported
+// rather than written as zero, so a certificate that cannot be represented
+// fails at the boundary that cannot represent it.
+func TestSignedDecimalRejectsMissingDelta(t *testing.T) {
+	t.Parallel()
+	_, err := signedDecimal("MIR reward delta", nil)
+	require.ErrorContains(t, err, "MIR reward delta")
+}
+
+// decodeMIRDistributionCertificate builds a distribution MIR certificate
+// through the CBOR decoder, so the test does not depend on the Go type of the
+// reward map.
+func decodeMIRDistributionCertificate(
+	t *testing.T,
+	source uint,
+	rewards map[*lcommon.Credential]uint64,
+) *lcommon.MoveInstantaneousRewardsCertificate {
+	t.Helper()
+	encoded, err := cbor.Encode(struct {
+		cbor.StructAsArray
+		Source  uint
+		Rewards map[*lcommon.Credential]uint64
+	}{
+		Source:  source,
+		Rewards: rewards,
+	})
+	require.NoError(t, err)
+	cert := &lcommon.MoveInstantaneousRewardsCertificate{
+		CertType: uint(lcommon.CertificateTypeMoveInstantaneousRewards),
+	}
+	require.NoError(t, cert.Reward.UnmarshalCBOR(encoded))
+	return cert
+}
+
+// TestGetAccountSumsByCredentialSumsSignedMIRDeltas proves the reserves and
+// treasury aggregate reads sum signed values. Summing them through the coin
+// helper would reject the negative row outright; ignoring the sign would report
+// a total larger than the account ever received.
+func TestGetAccountSumsByCredentialSumsSignedMIRDeltas(t *testing.T) {
+	t.Parallel()
+	store := newMigratedTestStore(t)
+
+	credential := mirTestCredential(0x23).Credential[:]
+	seedMIRRewardRow(t, store, 0, credential, "1000")
+	seedMIRRewardRow(t, store, 0, credential, "-250")
+	seedMIRRewardRow(t, store, 1, credential, "700")
+	seedMIRRewardRow(t, store, 1, credential, "-900")
+
+	sums, err := store.GetAccountSumsByCredential(0, credential, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sums.ReservesSum)
+	require.NotNil(t, sums.TreasurySum)
+	assert.Equal(t, "750", sums.ReservesSum.String())
+	assert.Equal(t, "-200", sums.TreasurySum.String())
+}
+
+// TestGetAccountSumsByCredentialWithoutMIRHistory pins the zero value the
+// aggregate reads return when there is nothing to sum, so the signed totals are
+// never handed to a caller as nil. The empty-credential case never reaches a
+// query, so it is the one that depends on the returned value being initialized.
+func TestGetAccountSumsByCredentialWithoutMIRHistory(t *testing.T) {
+	t.Parallel()
+	store := newMigratedTestStore(t)
+
+	for _, test := range []struct {
+		name       string
+		credential []byte
+	}{
+		{
+			name:       "known credential with no MIR rows",
+			credential: mirTestCredential(0x24).Credential[:],
+		},
+		{
+			name:       "empty credential short-circuits the query",
+			credential: nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sums, err := store.GetAccountSumsByCredential(
+				0,
+				test.credential,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, sums.ReservesSum)
+			require.NotNil(t, sums.TreasurySum)
+			assert.Equal(t, "0", sums.ReservesSum.String())
+			assert.Equal(t, "0", sums.TreasurySum.String())
+		})
+	}
+}
+
+func seedMIRRewardRow(
+	t *testing.T,
+	store *Store,
+	pot uint,
+	credential []byte,
+	amount string,
+) {
+	t.Helper()
+	var mirID int64
+	require.NoError(t, store.writeDB.QueryRow(`
+INSERT INTO move_instantaneous_rewards (pot, certificate_id, added_slot, other_pot)
+VALUES (?, 0, 100, '0')
+RETURNING id`,
+		pot,
+	).Scan(&mirID))
+	_, err := store.writeDB.Exec(`
+INSERT INTO move_instantaneous_rewards_reward (
+    credential, credential_tag, amount, mir_id
+) VALUES (?, 0, ?, ?)`,
+		credential,
+		amount,
+		mirID,
+	)
+	require.NoError(t, err)
+}

--- a/database/plugin/metadata/sqlstore/transaction_certificates.go
+++ b/database/plugin/metadata/sqlstore/transaction_certificates.go
@@ -1033,10 +1033,25 @@ RETURNING id`,
 	if err != nil {
 		return 0, err
 	}
-	for credential, amount := range cert.Reward.Rewards {
+	// A MIR reward is delta_coin, so the amount column carries its own sign
+	// and the delta is persisted as written. Whether a negative delta is
+	// permitted, and whether the deltas for one credential net to a
+	// creditable amount, are decided by the DELEG and INSTANT rules, not
+	// here. RewardsAmount projects the reward map to *big.Int on every
+	// gouroboros release, so the sign survives regardless of the width of
+	// the underlying field.
+	for credential, amount := range cert.Reward.RewardsAmount() {
 		tag, err := models.CredentialTagFromUint(credential.CredType)
 		if err != nil {
 			return 0, err
+		}
+		delta, err := signedDecimal("MIR reward delta", amount)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"%w for credential %x",
+				err,
+				credential.Credential[:],
+			)
 		}
 		if _, err := db.ExecContext(ctx, `
 INSERT INTO move_instantaneous_rewards_reward (
@@ -1044,7 +1059,7 @@ INSERT INTO move_instantaneous_rewards_reward (
 ) VALUES (?, ?, ?, ?)`,
 			credential.Credential[:],
 			tag,
-			decimalUint64(types.Uint64(amount)),
+			delta,
 			id,
 		); err != nil {
 			return 0, err

--- a/database/plugin/metadata/store.go
+++ b/database/plugin/metadata/store.go
@@ -2055,7 +2055,9 @@ type MetadataStore interface {
 	) (int, error)
 
 	// GetAccountSumsByCredential retrieves the aggregated withdrawal, reserves,
-	// and treasury lovelace totals for a stake credential tag/hash pair.
+	// and treasury lovelace totals for a stake credential tag/hash pair. The
+	// withdrawal total is coin and unsigned; the two MIR pot totals are
+	// delta_coin and signed, and are never returned nil.
 	GetAccountSumsByCredential(
 		uint8, // credentialTag
 		[]byte, // stakingKey

--- a/ledger/boundary_credit_visibility_test.go
+++ b/ledger/boundary_credit_visibility_test.go
@@ -16,11 +16,11 @@ package ledger
 
 import (
 	"database/sql"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,7 +72,7 @@ func TestBoundaryCreditVisibility_MIRIsIncludedInSnapshot(t *testing.T) {
 		0,
 		epochStartSlot+1,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: credential, Amount: types.Uint64(amount)},
+			{Credential: credential, Amount: new(big.Int).SetUint64(amount)},
 		},
 	)
 

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -218,21 +218,28 @@ func (b *mirBoundary) isEmpty() bool {
 // stays unsigned: every credit reaching here is the non-negative fold of the
 // epoch's deltas for one credential, so it is `fold` over cardano-ledger's
 // restricted InstantaneousRewards map.
-func (b *mirBoundary) addCredit(credit mirCredit) error {
+//
+// A total that no longer fits uint64 necessarily exceeds every Ada pot, so it
+// is reported as a discarded boundary rather than an error, exactly like a
+// single fold that does not fit. cardano-ledger folds over unbounded Coin and
+// reaches its no-op branch here; failing instead would wedge the node, since
+// the stored certificates are re-read and re-fail on every retry.
+func (b *mirBoundary) addCredit(credit mirCredit) {
 	total := &b.totalReserves
 	if credit.pot == mirPotTreasury {
 		total = &b.totalTreasury
 	}
 	if credit.amount > ^uint64(0)-*total {
-		return fmt.Errorf(
-			"MIR distribution total overflow: current=%d adding=%d",
+		b.discard = fmt.Sprintf(
+			"MIR distribution total for pot %d exceeds every Ada pot: %d plus %d",
+			credit.pot,
 			*total,
 			credit.amount,
 		)
+		return
 	}
 	*total += credit.amount
 	b.credits = append(b.credits, credit)
-	return nil
 }
 
 // addTransfer records a pot-to-pot transfer as an outflow from its source pot
@@ -344,13 +351,14 @@ func (ls *LedgerState) collectMIRBoundary(
 			)
 			return boundary, nil
 		}
-		if err := boundary.addCredit(mirCredit{
+		boundary.addCredit(mirCredit{
 			pot:           key.pot,
 			credentialTag: key.tag,
 			credential:    []byte(key.credential),
 			amount:        net.Uint64(),
-		}); err != nil {
-			return nil, err
+		})
+		if boundary.discard != "" {
+			return boundary, nil
 		}
 	}
 	return boundary, nil

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -231,7 +231,8 @@ func (b *mirBoundary) addCredit(credit mirCredit) {
 	}
 	if credit.amount > ^uint64(0)-*total {
 		b.discard = fmt.Sprintf(
-			"MIR distribution total for pot %d exceeds every Ada pot: %d plus %d",
+			"MIR distribution total for credential %x in pot %d exceeds every Ada pot: %d plus %d",
+			credit.credential,
 			credit.pot,
 			*total,
 			credit.amount,

--- a/ledger/mir.go
+++ b/ledger/mir.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
@@ -52,8 +53,16 @@ const (
 //	availableTreasury = treasury + deltaTreasury
 //	if totR <= availableReserves && totT <= availableTreasury then ... else ...
 //
-// Distribution MIR (credential→amount map):
-//   - Registered, active reward accounts are credited from the source pot.
+// Distribution MIR (credential→delta map):
+//   - A MIR delta is delta_coin, so it carries a sign. Every certificate of the
+//     ended epoch is folded per (pot, credential) before anything is credited,
+//     matching cardano-ledger's `iRReserves`/`iRTreasury` InstantaneousRewards
+//     maps, which `delegTransition` accumulates across the epoch
+//     (`Cardano.Ledger.Shelley.Rules.Deleg`) and which this rule credits once
+//     at the boundary. A negative delta therefore reduces an earlier positive
+//     one for the same credential and pot rather than being applied on its own.
+//   - Registered, active reward accounts are credited the folded total from the
+//     source pot.
 //   - Credentials without a registered account are silently skipped — unlike
 //     POOLREAP, there is no fallback routing to the treasury. They are also
 //     excluded from the pot totals, matching the `Map.intersection accountsMap`
@@ -65,6 +74,15 @@ const (
 //   - Source=1 (Treasury) moves OtherPot lovelace from treasury to reserves.
 //   - Transfers are folded into the available pot balances before the capacity
 //     check, so they fund distributions made at the same boundary.
+//
+// A folded total that is negative, or too large for the reward-account credit
+// path, discards the boundary the same way. cardano-ledger cannot reach either
+// state: DELEG rejects the transaction whose certificate would drive an
+// accumulated entry below zero (`MIRProducesNegativeUpdate` in
+// `Cardano.Ledger.Shelley.Rules.Deleg.delegTransition`), and an entry above the
+// pot fails the capacity check. Dingo does not run the DELEG
+// accumulation check, so the boundary reports the condition and discards rather
+// than crediting a debit it cannot represent.
 //
 // When either pot cannot cover its total the whole boundary is a no-op: no
 // credit, no debit and no transfer is written, and the epoch rollover still
@@ -90,6 +108,15 @@ func (ls *LedgerState) applyMIRCerts(
 	boundary, err := ls.collectMIRBoundary(txn, effects)
 	if err != nil {
 		return err
+	}
+	if boundary.discard != "" {
+		ls.config.Logger.Warn(
+			"discarding uncreditable MIR at epoch boundary",
+			"slot", boundarySlot,
+			"reason", boundary.discard,
+			"component", "ledger",
+		)
+		return nil
 	}
 	if boundary.isEmpty() {
 		return nil
@@ -140,13 +167,23 @@ func (ls *LedgerState) applyMIRCerts(
 }
 
 // mirCredit is one registered-account credit selected for application at an
-// epoch boundary.
+// epoch boundary. amount is the fold of every delta the ended epoch carried for
+// this (pot, credential), and is non-negative by construction.
 type mirCredit struct {
-	mirID         uint
 	pot           uint
 	credentialTag uint8
 	credential    []byte
 	amount        uint64
+}
+
+// mirPendingKey identifies one entry of the accumulated InstantaneousRewards
+// map. The pot is part of the key because cardano-ledger keeps `iRReserves`
+// and `iRTreasury` as two maps, so the same credential can hold an independent
+// pending amount in each.
+type mirPendingKey struct {
+	pot        uint
+	tag        uint8
+	credential string
 }
 
 // mirBoundary is the aggregate of every MIR certificate in one ended epoch,
@@ -162,6 +199,10 @@ type mirBoundary struct {
 	reservesOut   uint64
 	treasuryIn    uint64
 	treasuryOut   uint64
+	// discard, when non-empty, names why the folded boundary cannot be
+	// credited at all. It carries the same consequence as failing the
+	// capacity check: the whole boundary is dropped.
+	discard string
 }
 
 // isEmpty reports whether the boundary carries no pot movement at all, in
@@ -172,8 +213,11 @@ func (b *mirBoundary) isEmpty() bool {
 		b.treasuryIn == 0 && b.treasuryOut == 0
 }
 
-// addCredit records a credit against its source pot, keeping the per-pot total
-// that the capacity check compares against the pot.
+// addCredit records one folded credit against its source pot, keeping the
+// per-pot total that the capacity check compares against the pot. The total
+// stays unsigned: every credit reaching here is the non-negative fold of the
+// epoch's deltas for one credential, so it is `fold` over cardano-ledger's
+// restricted InstantaneousRewards map.
 func (b *mirBoundary) addCredit(credit mirCredit) error {
 	total := &b.totalReserves
 	if credit.pot == mirPotTreasury {
@@ -215,8 +259,16 @@ func (b *mirBoundary) addTransfer(sourcePot uint, amount uint64) error {
 }
 
 // collectMIRBoundary folds every effect for the ended epoch into a single
-// mirBoundary without mutating any state. Distribution credits are restricted
-// to registered, active reward accounts, resolved in one batched lookup.
+// mirBoundary without mutating any state. Distribution deltas are accumulated
+// per (pot, credential) as signed values first, then resolved into credits, so
+// a negative delta reduces an earlier positive one instead of being applied as
+// a debit the reward-account path cannot represent. Credits are restricted to
+// registered, active reward accounts, resolved in one batched lookup.
+//
+// The accumulation preserves first-appearance order. Effects arrive ordered by
+// added_slot then row ID and each certificate's rewards by row ID, so the
+// resulting credit order — and therefore the reward journal — is deterministic
+// for a given stored epoch.
 func (ls *LedgerState) collectMIRBoundary(
 	txn *database.Txn,
 	effects []models.MIREffect,
@@ -226,6 +278,8 @@ func (ls *LedgerState) collectMIRBoundary(
 		return nil, err
 	}
 	boundary := &mirBoundary{}
+	pending := make(map[mirPendingKey]*big.Int)
+	order := make([]mirPendingKey, 0, len(effects))
 	for _, effect := range effects {
 		if effect.OtherPot > 0 {
 			if err := boundary.addTransfer(
@@ -245,15 +299,58 @@ func (ls *LedgerState) collectMIRBoundary(
 			if !registered[ref.MapKey()] {
 				continue
 			}
-			if err := boundary.addCredit(mirCredit{
-				mirID:         effect.ID,
-				pot:           effect.Pot,
-				credentialTag: reward.CredentialTag,
-				credential:    reward.Credential,
-				amount:        reward.Amount,
-			}); err != nil {
-				return nil, err
+			if reward.Amount == nil {
+				return nil, fmt.Errorf(
+					"MIR %d carries no delta for credential %x",
+					effect.ID,
+					reward.Credential,
+				)
 			}
+			key := mirPendingKey{
+				pot:        effect.Pot,
+				tag:        reward.CredentialTag,
+				credential: string(reward.Credential),
+			}
+			total, ok := pending[key]
+			if !ok {
+				total = new(big.Int)
+				pending[key] = total
+				order = append(order, key)
+			}
+			total.Add(total, reward.Amount)
+		}
+	}
+	for _, key := range order {
+		net := pending[key]
+		if net.Sign() == 0 {
+			continue
+		}
+		if net.Sign() < 0 {
+			boundary.discard = fmt.Sprintf(
+				"MIR deltas for pot %d credential %x net to %s, "+
+					"which no reward account can carry",
+				key.pot,
+				key.credential,
+				net,
+			)
+			return boundary, nil
+		}
+		if !net.IsUint64() {
+			boundary.discard = fmt.Sprintf(
+				"MIR deltas for pot %d credential %x net to %s, which exceeds any Ada pot",
+				key.pot,
+				key.credential,
+				net,
+			)
+			return boundary, nil
+		}
+		if err := boundary.addCredit(mirCredit{
+			pot:           key.pot,
+			credentialTag: key.tag,
+			credential:    []byte(key.credential),
+			amount:        net.Uint64(),
+		}); err != nil {
+			return nil, err
 		}
 	}
 	return boundary, nil
@@ -319,11 +416,13 @@ func (ls *LedgerState) applyMIRCredits(
 			credit.amount,
 			boundarySlot,
 			// MIR has no transaction hash in this processed effect, so
-			// the MIR row ID is encoded as a synthetic discriminator.
-			// That keeps two MIR certs crediting the same account in
-			// one epoch as distinct journal rows while still mapping a
-			// crash-replayed boundary to the same row.
-			mirRewardSourceHash(credit.mirID),
+			// the source pot is encoded as a synthetic discriminator.
+			// One credit per (pot, credential) is written per boundary,
+			// matching the two InstantaneousRewards maps, so this keeps
+			// a reserves and a treasury credit to the same account at
+			// one boundary as distinct journal rows while still mapping
+			// a replayed boundary to the same row.
+			mirRewardSourceHash(credit.pot),
 		)
 		if err != nil {
 			return 0, 0, fmt.Errorf(
@@ -375,12 +474,12 @@ func mirAvailablePot(
 	return available - out, true, nil
 }
 
-func mirRewardSourceHash(mirID uint) []byte {
+func mirRewardSourceHash(pot uint) []byte {
 	out := make([]byte, len(mirRewardSourcePrefix)+8)
 	copy(out, mirRewardSourcePrefix)
 	binary.BigEndian.PutUint64(
 		out[len(mirRewardSourcePrefix):],
-		uint64(mirID),
+		uint64(pot),
 	)
 	return out
 }

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -217,22 +217,11 @@ func TestApplyMIRCerts_MultipleDistributionsSameAccount(t *testing.T) {
 	require.NotNil(t, state)
 	assert.Equal(t, uint64(9_250), uint64(state.Reserves))
 
-	rows, err := gdb.Query(`
-SELECT tx_hash FROM account_reward_delta
-WHERE credential_tag = ? AND staking_key = ? AND added_slot = ?
-ORDER BY id ASC`,
-		0, cred, boundarySlot,
+	require.Len(
+		t,
+		boundaryRewardSourceHashes(t, gdb, cred, boundarySlot),
+		1,
 	)
-	require.NoError(t, err)
-	defer rows.Close()
-	var hashes [][]byte
-	for rows.Next() {
-		var hash []byte
-		require.NoError(t, rows.Scan(&hash))
-		hashes = append(hashes, hash)
-	}
-	require.NoError(t, rows.Err())
-	require.Len(t, hashes, 1)
 }
 
 // TestApplyMIRCerts_ReservesAndTreasuryStayDistinct verifies that a reserves
@@ -320,7 +309,12 @@ ORDER BY id ASC`,
 	return hashes
 }
 
-func TestApplyMIRCerts_DistributionTotalOverflowRollsBack(t *testing.T) {
+// TestApplyMIRCerts_DistributionTotalBeyondEveryPotIsNoOp verifies that folded
+// credits whose per-pot total no longer fits uint64 discard the boundary rather
+// than failing it. cardano-ledger folds over unbounded Coin, so a total larger
+// than the pot reaches its no-op branch; failing would wedge the node, since
+// the stored certificates are re-read and re-fail on every retry.
+func TestApplyMIRCerts_DistributionTotalBeyondEveryPotIsNoOp(t *testing.T) {
 	ls, db, gdb := newMIRTestLedger(t)
 
 	maxUint := ^uint64(0)
@@ -346,8 +340,8 @@ func TestApplyMIRCerts_DistributionTotalOverflowRollsBack(t *testing.T) {
 	}))
 	require.NoError(t, db.Metadata().SetNetworkState(1_000, maxUint, 50, nil))
 
-	err := applyMIRCertsErr(ls, db, 0, 1_000)
-	require.ErrorContains(t, err, "MIR distribution total overflow")
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000),
+		"a total larger than every pot must not fail the epoch boundary")
 
 	accountA, err := db.GetAccountByCredential(0, credA, false, nil)
 	require.NoError(t, err)

--- a/ledger/mir_test.go
+++ b/ledger/mir_test.go
@@ -16,12 +16,12 @@ package ledger
 
 import (
 	"database/sql"
+	"math/big"
 	"strconv"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
-	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,7 +69,7 @@ INSERT INTO move_instantaneous_rewards_reward (
 			mirID,
 			rewards[i].Credential,
 			rewards[i].CredentialTag,
-			strconv.FormatUint(uint64(rewards[i].Amount), 10),
+			rewards[i].Amount.String(),
 		)
 		require.NoError(t, err)
 	}
@@ -139,7 +139,7 @@ func TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount(
 		mirPotReserves,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(mirAmount)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(mirAmount)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -166,9 +166,10 @@ func TestApplyMIRCerts_DistributionFromReserves_RegisteredAccount(
 		"treasury untouched for reserves distribution")
 }
 
-// TestApplyMIRCerts_MultipleDistributionsSameAccount verifies that distinct
-// MIR certs crediting the same account at one epoch boundary remain distinct
-// reward journal events.
+// TestApplyMIRCerts_MultipleDistributionsSameAccount verifies that distinct MIR
+// certs crediting the same account from the same pot at one epoch boundary are
+// folded into the single credit cardano-ledger's InstantaneousRewards map
+// produces, rather than one journal event per certificate.
 func TestApplyMIRCerts_MultipleDistributionsSameAccount(t *testing.T) {
 	ls, db, gdb := newMIRTestLedger(t)
 
@@ -185,7 +186,7 @@ func TestApplyMIRCerts_MultipleDistributionsSameAccount(t *testing.T) {
 		mirPotReserves,
 		200,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(firstAmount)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(firstAmount)},
 		},
 	)
 	seedMIRDistribution(
@@ -194,7 +195,7 @@ func TestApplyMIRCerts_MultipleDistributionsSameAccount(t *testing.T) {
 		mirPotReserves,
 		400,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(secondAmount)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(secondAmount)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -231,8 +232,92 @@ ORDER BY id ASC`,
 		hashes = append(hashes, hash)
 	}
 	require.NoError(t, rows.Err())
+	require.Len(t, hashes, 1)
+}
+
+// TestApplyMIRCerts_ReservesAndTreasuryStayDistinct verifies that a reserves
+// credit and a treasury credit to the same account at one epoch boundary remain
+// distinct journal events. cardano-ledger keeps iRReserves and iRTreasury as
+// separate maps, so folding is per pot and both credits must survive the
+// journal's (tx_hash, credential, slot) idempotency key.
+func TestApplyMIRCerts_ReservesAndTreasuryStayDistinct(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const (
+		epochStartSlot = uint64(0)
+		boundarySlot   = uint64(1_000)
+		reservesAmount = uint64(300)
+		treasuryAmount = uint64(450)
+	)
+	cred := mirCred28(0x1A)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: new(big.Int).SetUint64(reservesAmount)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotTreasury,
+		400,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: new(big.Int).SetUint64(treasuryAmount)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Reward:     0,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 10_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, reservesAmount+treasuryAmount, uint64(account.Reward))
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, uint64(10_000-reservesAmount), uint64(state.Reserves))
+	assert.Equal(t, uint64(1_000-treasuryAmount), uint64(state.Treasury))
+
+	hashes := boundaryRewardSourceHashes(t, gdb, cred, boundarySlot)
 	require.Len(t, hashes, 2)
 	assert.NotEqual(t, string(hashes[0]), string(hashes[1]))
+}
+
+// boundaryRewardSourceHashes returns the reward journal discriminators written
+// for a credential at one boundary slot, in insertion order.
+func boundaryRewardSourceHashes(
+	t *testing.T,
+	gdb *sql.DB,
+	credential []byte,
+	boundarySlot uint64,
+) [][]byte {
+	t.Helper()
+	rows, err := gdb.Query(`
+SELECT tx_hash FROM account_reward_delta
+WHERE credential_tag = ? AND staking_key = ? AND added_slot = ?
+ORDER BY id ASC`,
+		0, credential, boundarySlot,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var hashes [][]byte
+	for rows.Next() {
+		var hash []byte
+		require.NoError(t, rows.Scan(&hash))
+		hashes = append(hashes, hash)
+	}
+	require.NoError(t, rows.Err())
+	return hashes
 }
 
 func TestApplyMIRCerts_DistributionTotalOverflowRollsBack(t *testing.T) {
@@ -247,8 +332,8 @@ func TestApplyMIRCerts_DistributionTotalOverflowRollsBack(t *testing.T) {
 		mirPotReserves,
 		200,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: credA, Amount: types.Uint64(maxUint)},
-			{Credential: credB, Amount: types.Uint64(1)},
+			{Credential: credA, Amount: new(big.Int).SetUint64(maxUint)},
+			{Credential: credB, Amount: new(big.Int).SetUint64(1)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -295,7 +380,7 @@ func TestApplyMIRCerts_DistributionFromTreasury_RegisteredAccount(
 		mirPotTreasury,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(mirAmount)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(mirAmount)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -334,7 +419,7 @@ func TestApplyMIRCerts_DistributionUnregisteredAccount(t *testing.T) {
 		mirPotReserves,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(400)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(400)},
 		},
 	)
 	require.NoError(t, db.Metadata().SetNetworkState(1_000, 5_000, 50, nil))
@@ -437,7 +522,7 @@ func TestApplyMIRCerts_OutsideEpochRange(t *testing.T) {
 		mirPotReserves,
 		50,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(500)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(500)},
 		},
 	)
 	// addedSlot=1000 equals boundarySlot — excluded (half-open interval)
@@ -447,7 +532,7 @@ func TestApplyMIRCerts_OutsideEpochRange(t *testing.T) {
 		mirPotReserves,
 		1_000,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(300)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(300)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -490,7 +575,7 @@ func TestApplyMIRCerts_Rollback(t *testing.T) {
 		mirPotReserves,
 		200,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(mirAmount)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(mirAmount)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -567,7 +652,7 @@ func TestApplyMIRCerts_OverBudgetReservesIsNoOp(t *testing.T) {
 		mirPotReserves,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(750)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(750)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -605,7 +690,7 @@ func TestApplyMIRCerts_ExactBudgetApplies(t *testing.T) {
 		mirPotReserves,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(750)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(750)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -622,7 +707,12 @@ func TestApplyMIRCerts_ExactBudgetApplies(t *testing.T) {
 		"exact-budget distribution is applied")
 	state, err := db.Metadata().GetNetworkState(nil)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(0), uint64(state.Reserves), "reserves drained to zero")
+	assert.Equal(
+		t,
+		uint64(0),
+		uint64(state.Reserves),
+		"reserves drained to zero",
+	)
 	assert.Equal(t, uint64(1_000), state.Slot,
 		"boundary state row written at the boundary slot")
 }
@@ -644,7 +734,7 @@ func TestApplyMIRCerts_OverBudgetIsAggregateAcrossCerts(t *testing.T) {
 		mirPotReserves,
 		200,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: credA, Amount: types.Uint64(600)},
+			{Credential: credA, Amount: new(big.Int).SetUint64(600)},
 		},
 	)
 	seedMIRDistribution(
@@ -653,7 +743,7 @@ func TestApplyMIRCerts_OverBudgetIsAggregateAcrossCerts(t *testing.T) {
 		mirPotReserves,
 		300,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: credB, Amount: types.Uint64(600)},
+			{Credential: credB, Amount: new(big.Int).SetUint64(600)},
 		},
 	)
 	for _, cred := range [][]byte{credA, credB} {
@@ -695,8 +785,8 @@ func TestApplyMIRCerts_BudgetExcludesUnregisteredCredentials(t *testing.T) {
 		mirPotReserves,
 		500,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: registered, Amount: types.Uint64(400)},
-			{Credential: unregistered, Amount: types.Uint64(5_000)},
+			{Credential: registered, Amount: new(big.Int).SetUint64(400)},
+			{Credential: unregistered, Amount: new(big.Int).SetUint64(5_000)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -735,7 +825,7 @@ func TestApplyMIRCerts_OverBudgetTreasuryBlocksReservesDistribution(
 		mirPotReserves,
 		200,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: reservesCred, Amount: types.Uint64(100)},
+			{Credential: reservesCred, Amount: new(big.Int).SetUint64(100)},
 		},
 	)
 	seedMIRDistribution(
@@ -744,7 +834,7 @@ func TestApplyMIRCerts_OverBudgetTreasuryBlocksReservesDistribution(
 		mirPotTreasury,
 		300,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: treasuryCred, Amount: types.Uint64(9_000)},
+			{Credential: treasuryCred, Amount: new(big.Int).SetUint64(9_000)},
 		},
 	)
 	for _, cred := range [][]byte{reservesCred, treasuryCred} {
@@ -786,7 +876,7 @@ func TestApplyMIRCerts_PotTransferCountsTowardAvailablePot(t *testing.T) {
 		mirPotTreasury,
 		300,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(900)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(900)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -824,7 +914,7 @@ func TestApplyMIRCerts_OverBudgetDropsPotTransfer(t *testing.T) {
 		mirPotReserves,
 		300,
 		[]models.MoveInstantaneousRewardsReward{
-			{Credential: cred, Amount: types.Uint64(5_000)},
+			{Credential: cred, Amount: new(big.Int).SetUint64(5_000)},
 		},
 	)
 	require.NoError(t, db.CreateAccount(nil, &models.Account{
@@ -866,4 +956,204 @@ func TestApplyMIRCerts_PotTransferLargerThanPotIsNoOp(t *testing.T) {
 	assert.Equal(t, uint64(1_000), uint64(state.Treasury), "treasury untouched")
 	assert.Equal(t, uint64(50), state.Slot,
 		"no boundary state row written for a skipped transfer")
+}
+
+// TestApplyMIRCerts_NegativeDeltaReducesEarlierCredit proves a negative MIR
+// delta is applied rather than rejected or truncated. gouroboros decodes a MIR
+// reward as delta_coin, and cardano-ledger's DELEG rule accumulates the
+// certificates of an epoch into one InstantaneousRewards entry per credential,
+// so a later negative delta reduces an earlier positive one and the boundary
+// credits only the fold.
+func TestApplyMIRCerts_NegativeDeltaReducesEarlierCredit(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	const (
+		epochStartSlot = uint64(0)
+		boundarySlot   = uint64(1_000)
+		reserves       = uint64(10_000)
+	)
+	cred := mirCred28(0x71)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(1_000)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		400,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(-400)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(
+		t,
+		db.Metadata().SetNetworkState(1_000, reserves, 50, nil),
+	)
+
+	runApplyMIRCerts(t, ls, db, epochStartSlot, boundarySlot)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, uint64(600), uint64(account.Reward),
+		"the account is credited the fold of the epoch's deltas")
+
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, reserves-600, uint64(state.Reserves),
+		"reserves are debited only what was credited")
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury))
+
+	require.Len(
+		t,
+		boundaryRewardSourceHashes(t, gdb, cred, boundarySlot),
+		1,
+		"the folded credit is one journal event, not one per certificate",
+	)
+}
+
+// TestApplyMIRCerts_NegativeDeltaCancellingCreditWritesNothing verifies that
+// deltas netting to zero neither credit the account nor move the pot.
+func TestApplyMIRCerts_NegativeDeltaCancellingCreditWritesNothing(
+	t *testing.T,
+) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x72)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(500)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		400,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(-500)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 10_000, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(account.Reward))
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10_000), uint64(state.Reserves))
+	assert.Equal(t, uint64(50), state.Slot,
+		"no boundary state row written when nothing moves")
+	assert.Empty(t, boundaryRewardSourceHashes(t, gdb, cred, 1_000))
+}
+
+// TestApplyMIRCerts_NegativeDeltaExcludedFromBudget proves the pot capacity
+// check is computed over the signed fold. Summing the deltas as unsigned
+// magnitudes would make this boundary look over-budget and drop a distribution
+// the pot can cover.
+func TestApplyMIRCerts_NegativeDeltaExcludedFromBudget(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	cred := mirCred28(0x73)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(900)},
+		},
+	)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		400,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: cred, Amount: big.NewInt(-400)},
+		},
+	)
+	require.NoError(t, db.CreateAccount(nil, &models.Account{
+		StakingKey: cred,
+		Active:     true,
+	}))
+	// 500 fits; the 900 of the first certificate on its own does not.
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 500, 50, nil))
+
+	runApplyMIRCerts(t, ls, db, 0, 1_000)
+
+	account, err := db.GetAccountByCredential(0, cred, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(500), uint64(account.Reward))
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), uint64(state.Reserves))
+}
+
+// TestApplyMIRCerts_NetNegativeDeltaDiscardsBoundary pins the behaviour for a
+// credential whose deltas net below zero. cardano-ledger cannot reach this
+// state: DELEG rejects the transaction with MIRProducesNegativeUpdate. Dingo
+// does not run that accumulation check at transaction ingestion, so the
+// boundary discards the whole set rather than crediting a debit the reward
+// account cannot carry, and the epoch rollover still succeeds.
+func TestApplyMIRCerts_NetNegativeDeltaDiscardsBoundary(t *testing.T) {
+	ls, db, gdb := newMIRTestLedger(t)
+
+	negativeCred := mirCred28(0x74)
+	otherCred := mirCred28(0x75)
+	seedMIRDistribution(
+		t,
+		gdb,
+		mirPotReserves,
+		200,
+		[]models.MoveInstantaneousRewardsReward{
+			{Credential: negativeCred, Amount: big.NewInt(-100)},
+			{Credential: otherCred, Amount: big.NewInt(300)},
+		},
+	)
+	seedMIRPotTransfer(t, gdb, mirPotTreasury, 250, 300)
+	for _, cred := range [][]byte{negativeCred, otherCred} {
+		require.NoError(t, db.CreateAccount(nil, &models.Account{
+			StakingKey: cred,
+			Active:     true,
+		}))
+	}
+	require.NoError(t, db.Metadata().SetNetworkState(1_000, 10_000, 50, nil))
+
+	require.NoError(t, applyMIRCertsErr(ls, db, 0, 1_000),
+		"an uncreditable MIR fold must not fail the epoch boundary")
+
+	for _, cred := range [][]byte{negativeCred, otherCred} {
+		account, err := db.GetAccountByCredential(0, cred, false, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), uint64(account.Reward),
+			"the whole boundary is discarded, not just the negative entry")
+	}
+	state, err := db.Metadata().GetNetworkState(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10_000), uint64(state.Reserves))
+	assert.Equal(t, uint64(1_000), uint64(state.Treasury),
+		"the pot transfer at the same boundary is discarded too")
+	assert.Equal(t, uint64(50), state.Slot)
 }


### PR DESCRIPTION
## Defect

A MIR reward is `delta_coin`, which the reference decodes as a signed unbounded
integer. Dingo represented it as unsigned from the certificate to the reward
account, so a negative delta was unrepresentable at every layer below the
decoder and would have been rejected or truncated at persistence.

## Code path

- `database/plugin/metadata/sqlstore/transaction_certificates.go:1048` persisted
  the delta with `strconv.FormatUint`; it now formats the projected `*big.Int`
  through `signedDecimal`, which reports a missing delta rather than writing
  zero.
- `database/plugin/metadata/sqlstore/certificates.go:171` read it back with an
  unsigned parser; it now uses `parseNullBigInt`, which imposes no width bound.
- `database/models/mir.go:58` and `:66` type `MIRReward.Amount` and
  `MoveInstantaneousRewardsReward.Amount` as `*big.Int` rather than
  `types.Uint64`, so no layer between the decoder and the reward account
  narrows the value.
- `database/plugin/metadata/sqlstore/account.go:852` and `:867` summed the
  reserves and treasury aggregates as unsigned; they now use `sumSignedRows`.
  `decimalAmountText` keeps its non-negative guard, which is correct for the
  coin columns that reach it; `signedAmountText` and `sumSignedRows` are its
  `delta_coin` siblings.
- `ledger/mir.go:327` accumulated each certificate's reward as an independent
  credit. It now folds the ended epoch's deltas per `(pot, credential)` as
  `*big.Int` before crediting, matching the `iRReserves`/`iRTreasury`
  InstantaneousRewards maps that `delegTransition` accumulates across the epoch
  (`Cardano.Ledger.Shelley.Rules.Deleg`) and that the MIR rule credits once at
  the boundary. The credit that reaches the reward account is the non-negative
  total, so the account-balance path stays unsigned, which is the `coin` domain
  a reward account carries.
- `api/blockfrost/adapter.go:2364`, `:2365` and `:4386` rendered
  `reserves_sum`, `treasury_sum` and the transaction MIR amount as unsigned;
  they now keep the sign, and a nil pot total renders as `0`.

Both certificate call sites read `cert.Reward.RewardsAmount()`, which projects
to `map[*Credential]*big.Int` on every gouroboros release. The pipeline is
therefore correct against the current release and against one that widens
`MoveInstantaneousRewardsCertificateReward.Rewards`, and adopting that release
needs only the module bump. No `replace` directive and no pseudo-version is
committed here; `go.mod` and `go.sum` are unchanged from `main`.

## Boundary behaviour

A folded total that is negative, or larger than any Ada pot, discards the whole
boundary with a warning naming the credential — the same consequence the
capacity check already has for an over-budget distribution, and the same
non-wedging outcome. A per-pot distribution total that no longer fits `uint64`
takes the same path (`ledger/mir.go:227`): it necessarily exceeds every Ada pot,
so `addCredit` records the discard and `collectMIRBoundary` returns the
discarded boundary rather than an error. An error there would wedge the node,
since the stored certificates are re-read and re-fail on every deterministic
retry.

cardano-ledger cannot reach any of these states: DELEG rejects the transaction
whose certificate drives an accumulated entry below zero
(`MIRProducesNegativeUpdate`), and an entry above the pot fails the capacity
check. Dingo does not run that accumulation check at ingestion, so the boundary
reports the condition instead of crediting a debit the reward account cannot
carry.

## Schema and compatibility

No DDL change and no migration. `move_instantaneous_rewards_reward.amount` is
already a decimal text column in all three dialects; its documented domain
widens from non-negative to signed decimal, and every row written under the
previous domain is already a valid value under the new one. `other_pot` on the
parent row is `coin` and stays non-negative.

`models.AccountSums.ReservesSum` and `TreasurySum` change from `uint64` to
`*big.Int`. `models.NewAccountSums` constructs them at zero, and
`GetAccountSumsByCredential` returns it on its failure paths as well
(`account.go:823`, `:847`, `:862`, `:877`), so neither field is ever nil.
`models.MIRReward.Amount` and `models.MoveInstantaneousRewardsReward.Amount`
change to `*big.Int`. `account_content.reserves_sum` and `treasury_sum` can now
be negative strings, as db-sync's signed `reserve.amount` column already allows.

One credit is written per `(pot, credential)` per boundary instead of one per
certificate, so the reward journal discriminator is the source pot rather than
the MIR row ID. Balances, pot debits and the aggregate totals are unchanged;
only the journal row granularity changes, and only when two certificates credit
one account from one pot in one epoch.

`DATABASE.md` records the signed column domain, the signed aggregate reads, and
the queries `GetAccountSumsByCredential` actually issues: it selects the amount
rows and adds them in Go, because the amount columns are decimal text and
coercing them to a signed engine integer differs across SQLite, PostgreSQL and
MySQL and cannot span the full `uint64` range.

## Tests

- `TestApplyMIRCerts_NegativeDeltaReducesEarlierCredit` — a negative delta
  reduces an earlier positive one for the same credential and pot: the account
  is credited the fold, reserves are debited only what was credited, and one
  journal row is written.
- `TestApplyMIRCerts_NegativeDeltaCancellingCreditWritesNothing` — deltas
  netting to zero write nothing: no credit, no pot movement, no boundary state
  row.
- `TestApplyMIRCerts_NegativeDeltaExcludedFromBudget` — the pot capacity check
  is computed over the signed fold, so a boundary whose first certificate alone
  exceeds the pot still applies when a later negative delta brings the total
  within it.
- `TestApplyMIRCerts_NetNegativeDeltaDiscardsBoundary` — a credential whose
  deltas net below zero discards the whole boundary, including a pot transfer
  at the same boundary, without failing the rollover.
- `TestApplyMIRCerts_DistributionTotalBeyondEveryPotIsNoOp` — a per-pot total
  that does not fit `uint64` discards the boundary instead of failing it. Red
  against the previous `ledger/mir.go`, which returns
  `MIR distribution total overflow: current=18446744073709551615 adding=1`.
- `TestApplyMIRCerts_ReservesAndTreasuryStayDistinct` — a reserves credit and a
  treasury credit to one account at one boundary stay distinct journal rows.
- `TestApplyMIRCerts_MultipleDistributionsSameAccount` — two certificates
  crediting one account from one pot fold into a single journal row.
- `TestMIRRewardDeltaColumnRoundTripsSigned` — the reward amount column
  round-trips `-450`, `1200` and `-2^70` through the encoder and decoder.
- `TestSignedDecimalRejectsMissingDelta` — `signedDecimal` reports a missing
  delta.
- `TestGetAccountSumsByCredentialSumsSignedMIRDeltas` and
  `TestGetAccountSumsByCredentialWithoutMIRHistory` — the reserves and treasury
  aggregate reads sum mixed-sign rows to `750` and `-200`, and return zero
  rather than nil when there is nothing to sum.
- `TestSignedSumText` — nil, zero, positive, negative and beyond-`int64`
  totals.
- `TestApplyMIRCertificatePersistsProjectedDeltas` — the certificate write path
  persists what `RewardsAmount()` projects, signs included.

Fixes #3971