### PR TITLE
docs(eras): match the rule index comments to the assertions

### DIFF
--- a/ledger/eras/conway_utxo_divergence_test.go
+++ b/ledger/eras/conway_utxo_divergence_test.go
@@ -117,7 +117,7 @@ func TestConwayUtxoValidationRuleIndexesArePinned(t *testing.T) {
 // TestValidateTxConwayGenuinelyMissingInputStillRejected is the negative case
 // for the rollback restore fix in LedgerState.rollback: an input that is
 // genuinely absent from the ledger must still be rejected as a bad input, and
-// must still be reported under rule index 29. A restore fix that made input
+// must still be reported under rule index 30. A restore fix that made input
 // resolution more permissive would turn this into a consensus hazard.
 func TestValidateTxConwayGenuinelyMissingInputStillRejected(t *testing.T) {
 	tx := newConwayDivergenceTx(t, 0xaa, 200_000, 0)
@@ -140,7 +140,7 @@ func TestValidateTxConwayGenuinelyMissingInputStillRejected(t *testing.T) {
 // TestValidateTxConwayGenuinelyUnbalancedStillRejected is the negative case for
 // the value-conservation half of issue #3678: a transaction whose inputs all
 // resolve but whose consumed and produced values genuinely differ must still be
-// rejected, and must still be reported under rule index 32.
+// rejected, and must still be reported under rule index 33.
 func TestValidateTxConwayGenuinelyUnbalancedStillRejected(t *testing.T) {
 	tx := newConwayDivergenceTx(t, 0xbb, 200_000, 200_000)
 


### PR DESCRIPTION
Follow-up to #3977, which merged at `8f101bca` — one commit before this correction, so it did not land.

Cubic flagged it on that PR (`3942664994`): the two negative-case doc comments still name indexes 29 and 32 while their assertions check `rule 30:` and `rule 33:`.

```
:120  must still be reported under rule index 29.   ->  30
:143  must still be reported under rule index 32.   ->  33
```

Comment-only; no assertion or behaviour changes. I audited the rest of the file rather than only the flagged lines — the header comment at :92-93 already reads 30 and 33 correctly, and the other numeric matches (:54, :66, :69) are byte lengths, not rule indexes.

Worth doing rather than leaving: stale index numbering is exactly the defect that made the original pins wrong, so the file would otherwise contradict itself on its own subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects two stale rule index comments in `conway_utxo_divergence_test.go` so the doc comments match the assertions.

- Updates the negative-case doc comments from rule indexes 29 and 32 to 30 and 33.
- Comment-only change; no assertion or behavior changes.

<sup>Written for commit 5dc9cc176ad00da099b2853320d72de7364d817e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test comments to reference the correct pinned rule indexes for missing-input and unbalanced transaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->