### PR TITLE
fix(ledger): make the continuation audit see Leios endorser-block producers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4180,14 +4180,49 @@ and applied ledger at the same point — chainsync rollback via
 `continuationAuditWindow` there. A chainsync rollback point ahead of the applied
 ledger instead disarms any prior window because its fork point no longer
 describes the continuation being fetched. While armed, every body
-delivered by blockfetch above that point is checked input by input: an input
-resolves when its producing transaction was created by a block already seen in
-the window (fetched and on the chain, not yet applied), when the ledger still
-holds the UTxO, or when transaction metadata records the producer. Anything
-left over logs `continuation block spends an input with no producer on the
-local applied chain` with the delivering peer, the block, the offending input,
-and the fork point the node had rolled back to, and increments
-`dingo_ledger_continuation_input_unresolved_total`. The audit never rejects a
+delivered by blockfetch above that point is checked input by input, against
+four resolution paths: an input resolves when its producing transaction was
+created by a block already seen in the window (fetched and on the chain, not
+yet applied), when the ledger still holds the UTxO, when transaction metadata
+records the producer, or — on a Leios chain — when it was created by the
+certified endorser block whose transactions the audited ranking block carries.
+That fourth path exists because a cert-driven ranking block has an empty body:
+its transactions arrive separately over leios-fetch and are applied later, so
+"the block was fetched" no longer implies "its transactions are in hand". The
+audit resolves the reference the way the apply path does — the block's own
+announcement on the CIP path, the parent's on the cert-driven path — and reads
+the transactions through the configured `EndorserBlockProvider`, which is
+normally an in-memory cache hit but falls back to a blob-store read for an
+occurrence whose in-memory entry has expired.
+
+Resolving an endorser block is therefore scheduled rather than eager. It is
+deferred until an input fails the other three paths, memoized per
+`(endorser block hash, slot)` so a closure certified by many ranking blocks in
+one window costs one resolution, and bounded by
+`continuationAuditMaxEndorserBlocksPerBlock` per audited body; the budget is
+owned by the body rather than by a single drain, so several unresolvable inputs
+in one body share one allowance and report one stop between them. References
+past the budget stay queued for a later body.
+
+Outcomes are counted on `dingo_ledger_continuation_audit_outcomes_total`,
+labelled by `result`. An input that resolves counts `clean`. An input with no
+producer counts `missing_producer`, logs `continuation block spends an input
+with no producer on the local applied chain` with the delivering peer, the
+block, the offending input, and the fork point the node had rolled back to, and
+increments `dingo_ledger_continuation_input_unresolved_total` as before. But
+when a certified endorser block has not been fetched yet the window's producer
+set is knowingly incomplete, and an unresolved input then counts
+`inconclusive_eb_pending` and is recorded at `Debug` *instead of* taking the
+`missing_producer` path — no `ERROR`, and no increment of
+`continuation_input_unresolved_total`. Reporting ledger corruption from a set
+the audit knows is short would be a guaranteed false positive on a healthy
+node, so an endorser-block backlog reads as "not covering this node" rather
+than as a fault. Two further results are per-window and per-reference rather
+than per-input: `skipped_budget` once per body whose endorser-block budget was
+exhausted, and `ref_unresolvable` for a reference abandoned because resolving
+it failed for a reason retrying cannot fix. `disarmed_cap` is covered below.
+
+The audit never rejects a
 block; the splice it detects is prevented upstream in the chain layer, and
 bodies that still fail reach the ordinary validation and recovery guards
 unchanged. Arming only after an aligned rollback is both the cost gate — a
@@ -4195,7 +4230,9 @@ healthy node never runs the per-input probes on the steady-state blockfetch
 path — and what makes the check sound, since every later block then arrives
 through the window. Each arming inspects at most
 `continuationAuditBlockBudget` bodies and retains at most
-`continuationAuditMaxProducedTxs` in-window producers. The audit is also skipped
+`continuationAuditMaxProducedTxs` in-window producers; reaching that producer
+cap disarms the window, logs at `Warn` and counts `disarmed_cap`, so "the audit
+stopped covering this node" does not read the same as "this node is clean". The audit is also skipped
 while block validation is off, which is how historical catch-up runs: the splice
 it diagnoses is a live tip-band failure, and bulk sync fetches far too many
 bodies per second to pay for the probes.

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -552,6 +552,12 @@ func (ls *LedgerState) queueContinuationAuditEndorserRef(
 // form — a later attempt costs only the provider lookup — and marks the window
 // incomplete, so unresolved inputs read as inconclusive rather than as missing
 // producers.
+//
+// *budget is owned by the audited body, not by one drain: a body drains once
+// per unresolved input and every drain spends the same allowance, which is why
+// it is passed by pointer. Once exhausted it is burned to -1 and stays there
+// for the rest of the body, so skipped_budget counts audited bodies whose
+// budget ran out — what its Help string promises — and not unresolved inputs.
 func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 	window *continuationAuditWindow,
 	budget *int,
@@ -562,15 +568,19 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 	armed := true
 	for i, ref := range pending {
 		if !armed || *budget <= 0 {
-			// Requeue what was not reached. Hitting the budget means the
-			// producer set is knowingly short for now. These references
+			// Requeue everything not reached, in one move, and stop.
+			// The remainder is a contiguous suffix, so there is nothing
+			// left for a further iteration to do: continuing here once
+			// appended an overlapping suffix per remaining reference,
+			// which grew the queue quadratically and made later bodies
+			// probe the same reference several times. These references
 			// were never taken off pendingEndorserSeen, so this is a
 			// one-for-one move and cannot duplicate a key.
 			window.pendingEndorserRefs = append(
 				window.pendingEndorserRefs,
 				pending[i:]...,
 			)
-			if armed && *budget <= 0 {
+			if armed && *budget == 0 {
 				ls.countContinuationAuditOutcome(
 					continuationAuditResultSkippedBudget,
 				)
@@ -581,10 +591,14 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 					"deferred", len(pending)-i,
 					"budget", continuationAuditMaxEndorserBlocksPerBlock,
 				)
-				// Only report the budget stop once per drain.
+				// The budget belongs to the audited body, not to this
+				// drain: one body triggers one drain per unresolved
+				// input, all sharing it. Burn it to -1 so the later
+				// drains of the same body take this branch without
+				// reporting a second stop for the one exhaustion.
 				*budget = -1
 			}
-			continue
+			break
 		}
 		// One probe per reference per audited body: nothing that could
 		// change the outcome happens between two inputs of the same body.
@@ -687,9 +701,6 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 		if !ls.recordContinuationAuditProducers(window, ids) {
 			armed = false
 		}
-	}
-	if *budget < 0 {
-		*budget = 0
 	}
 	return armed
 }

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"encoding/hex"
 	"errors"
+	"strconv"
 
 	"github.com/blinklabs-io/dingo/database"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -88,6 +89,14 @@ const (
 	// so truncating a pathological block is preferable to delaying the
 	// blockfetch pipeline behind unbounded per-input probes.
 	continuationAuditMaxInputsPerBlock = 32
+	// continuationAuditMaxEndorserBlocksPerBlock bounds how many endorser
+	// blocks one audited body may cause to be resolved, in the same spirit as
+	// continuationAuditMaxInputsPerBlock: resolving one costs a parent-block
+	// read plus a hash of every endorser transaction, all under
+	// chainsyncBlockfetchMutex. Refs left over stay queued for a later body,
+	// and the window reports inconclusive in the meantime rather than
+	// reporting from a set it knows is short.
+	continuationAuditMaxEndorserBlocksPerBlock = 32
 )
 
 // Label values of the dingo_ledger_continuation_audit_outcomes_total metric.
@@ -96,6 +105,7 @@ const (
 	continuationAuditResultMissingProducer       = "missing_producer"
 	continuationAuditResultInconclusiveEbPending = "inconclusive_eb_pending"
 	continuationAuditResultDisarmedCap           = "disarmed_cap"
+	continuationAuditResultSkippedBudget         = "skipped_budget"
 )
 
 // continuationAuditWindow is the state of one armed audit run. It is published
@@ -116,6 +126,51 @@ type continuationAuditWindow struct {
 	// sticky for the life of the window: once a hole exists, every later
 	// input could be falling into it.
 	endorserProducersPending bool
+	// pendingEndorserRefs are endorser-block references seen in this window
+	// whose transactions have not been merged into producedTxs yet, in
+	// arrival order. Classifying a block into a reference is header-only and
+	// free; turning a reference into producers is not, so it is deferred
+	// until an input actually fails to resolve without it. Deduplicated on
+	// insert through pendingEndorserSeen, so the same closure referenced by
+	// several ranking blocks is queued once.
+	pendingEndorserRefs []continuationAuditEndorserRef
+	pendingEndorserSeen map[string]struct{}
+	// resolvedEndorserBlocks memoizes the (hash, slot) occurrences whose
+	// transaction ids are already in producedTxs, so no endorser block is
+	// hashed twice in a window.
+	resolvedEndorserBlocks map[string]struct{}
+	// endorserResolutions counts references this window actually did work
+	// for: a parent-block read and/or a provider lookup. It is the cost the
+	// audit adds to the blockfetch path, and it stays zero for a window in
+	// which nothing spends an endorser-resident output.
+	endorserResolutions int
+}
+
+// continuationAuditEndorserRef is one endorser-block reference an audited
+// ranking block carries, in the cheapest form that can be resolved later.
+//
+// A CIP-path block announces its own endorser block, which the header gives up
+// directly. A cert-driven block certifies the endorser block its parent
+// announced, which needs a parent-block read; only the parent hash is retained
+// so the referencing block itself (and its CBOR) does not have to be. Once that
+// read happens the ref is rewritten in resolved form, so a still-unfetched
+// endorser block costs at most a provider lookup on any later attempt.
+type continuationAuditEndorserRef struct {
+	certParentHash []byte
+	ebHash         lcommon.Blake2b256
+	ebSlot         uint64
+	resolved       bool
+	blockSlot      uint64
+}
+
+// key identifies a reference for dedupe: the parent hash while the reference is
+// still a deferred certified closure, the (hash, slot) occurrence once
+// resolved.
+func (r continuationAuditEndorserRef) key() string {
+	if !r.resolved {
+		return "c" + string(r.certParentHash)
+	}
+	return "d" + string(r.ebHash.Bytes()) + strconv.FormatUint(r.ebSlot, 10)
 }
 
 // armContinuationAudit starts a bounded continuation audit at a rollback point.
@@ -132,7 +187,9 @@ func (ls *LedgerState) armContinuationAudit(
 		}
 	}
 	ls.continuationAudit.Store(&continuationAuditWindow{
-		producedTxs: make(map[string]struct{}),
+		producedTxs:            make(map[string]struct{}),
+		pendingEndorserSeen:    make(map[string]struct{}),
+		resolvedEndorserBlocks: make(map[string]struct{}),
 		forkPoint: ocommon.Point{
 			Slot: point.Slot,
 			Hash: append([]byte(nil), point.Hash...),
@@ -182,30 +239,18 @@ func (ls *LedgerState) auditContinuationBlock(
 	// it has one, contributes producers too: on the cert-driven path those are
 	// the only transactions a certifying ranking block brings, its own body
 	// being empty.
-	ebTxIds := ls.continuationAuditEndorserProducers(window, e)
-	if len(window.producedTxs)+len(txs)+len(ebTxIds) >
-		continuationAuditMaxProducedTxs {
-		ls.config.Logger.Warn(
-			"disarming cross-fork continuation audit: producer set at capacity",
-			"component", "ledger",
-			"blocks_audited", window.blocksSeen,
-			"produced_txs", len(window.producedTxs),
-			"max_produced_txs", continuationAuditMaxProducedTxs,
-		)
-		ls.countContinuationAuditOutcome(
-			continuationAuditResultDisarmedCap,
-		)
+	ls.queueContinuationAuditEndorserRef(window, e)
+	producers := make([][]byte, 0, len(txs))
+	for _, tx := range txs {
+		producers = append(producers, tx.Hash().Bytes())
+	}
+	if !ls.recordContinuationAuditProducers(window, producers) {
 		window.remaining = 0
 		return
 	}
-	for _, tx := range txs {
-		window.producedTxs[string(tx.Hash().Bytes())] = struct{}{}
-	}
-	for _, id := range ebTxIds {
-		window.producedTxs[string(id)] = struct{}{}
-	}
 	reports := 0
 	inputsAudited := 0
+	endorserBudget := continuationAuditMaxEndorserBlocksPerBlock
 	for _, tx := range txs {
 		for _, input := range collectReferencedInputs(tx) {
 			if inputsAudited >= continuationAuditMaxInputsPerBlock {
@@ -225,6 +270,21 @@ func (ls *LedgerState) auditContinuationBlock(
 					"input", input.String(),
 				)
 				continue
+			}
+			// Only now, with the cheap paths exhausted, is it worth
+			// paying for the window's endorser blocks: an audited body
+			// that spends nothing endorser-resident never triggers a
+			// parent-block read or a transaction hash.
+			if !resolved && len(window.pendingEndorserRefs) > 0 {
+				if !ls.drainContinuationAuditEndorserRefs(
+					window,
+					&endorserBudget,
+					e.Point.Slot,
+				) {
+					window.remaining = 0
+					return
+				}
+				_, resolved = window.producedTxs[string(input.Id().Bytes())]
 			}
 			if resolved {
 				ls.countContinuationAuditOutcome(
@@ -317,71 +377,232 @@ func (ls *LedgerState) continuationInputHasProducer(
 	return producerTx != nil, nil
 }
 
-// continuationAuditEndorserProducers returns the transaction ids of the Leios
-// endorser block the audited ranking block applies, resolving it exactly the
-// way ledgerProcessBlock does: leiosEndorserBlockForApply picks the reference
-// (the block's own announcement on the CIP path, the parent's announcement on
-// the Musashi cert-driven path) and EndorserBlockProvider supplies the
-// transactions for that (hash, slot) occurrence.
+// recordContinuationAuditProducers adds producer transaction ids to the
+// window's set, and reports whether the set stayed inside
+// continuationAuditMaxProducedTxs.
 //
-// The endorser block is already in the provider's cache by the time the
-// referencing ranking block is fetched — leios-fetch runs well ahead of ledger
-// apply — so the common path is a cache lookup plus a hash per endorser
-// transaction, with no additional I/O beyond the parent-block lookup the
-// cert-driven path needs. When the reference cannot be resolved or the block is
-// not cached yet, the window is marked incomplete rather than left to report a
-// producer it was never given.
+// Only ids the set does not already hold count toward the cap. The cap bounds
+// the size of the producer set, not the number of ids offered to it, and
+// charging a repeat against it would disarm a window whose set never grew.
+// Repeats are ordinary on the Leios path: the same transaction can appear in
+// more than one endorser block — applyEndorserBlock carries
+// deduplicateEndorserBlockTransactionIndexes for exactly that — and an endorser
+// block is content-addressed, so the same closure can be referenced from more
+// than one ranking block inside a window.
+//
+// The cap is enforced per insert rather than per block, so the set is never
+// larger than the cap. A block that runs the set into the cap partway through
+// leaves those ids recorded, which is harmless: the window is disarmed and its
+// set is never consulted again.
+func (ls *LedgerState) recordContinuationAuditProducers(
+	window *continuationAuditWindow,
+	ids [][]byte,
+) bool {
+	for _, id := range ids {
+		key := string(id)
+		if _, ok := window.producedTxs[key]; ok {
+			continue
+		}
+		if len(window.producedTxs) >= continuationAuditMaxProducedTxs {
+			ls.config.Logger.Warn(
+				"disarming cross-fork continuation audit: producer set at capacity",
+				"component", "ledger",
+				"blocks_audited", window.blocksSeen,
+				"produced_txs", len(window.producedTxs),
+				"max_produced_txs", continuationAuditMaxProducedTxs,
+			)
+			ls.countContinuationAuditOutcome(
+				continuationAuditResultDisarmedCap,
+			)
+			return false
+		}
+		window.producedTxs[key] = struct{}{}
+	}
+	return true
+}
+
+// queueContinuationAuditEndorserRef records, in header-only work, the endorser
+// block an audited ranking block applies, so it can be turned into producers
+// later if any input needs it.
+//
+// The reference is selected exactly as the apply path selects it: the block's
+// own announcement when LeiosApplyEndorserBlockTxs is set (the CIP path,
+// bound to the block's own slot), the parent's announcement otherwise (the
+// Musashi cert-driven path). The cert-driven case retains only the parent hash;
+// leiosCertifiedAnnouncementFromParent — the same helper
+// leiosEndorserBlockForApply uses — turns it into a reference when the time
+// comes, so the two cannot select different endorser blocks.
 //
 // Non-Leios chains are unaffected: no endorser-block provider is configured,
-// and a header that neither announces nor certifies an endorser block returns
-// no reference.
-func (ls *LedgerState) continuationAuditEndorserProducers(
+// and a header that neither announces nor certifies an endorser block queues
+// nothing.
+func (ls *LedgerState) queueContinuationAuditEndorserRef(
 	window *continuationAuditWindow,
 	e BlockfetchEvent,
-) [][]byte {
-	if ls.config.EndorserBlockProvider == nil {
-		return nil
+) {
+	if ls.config.EndorserBlockProvider == nil || e.Block == nil {
+		return
 	}
-	ebHash, ebSlot, _, referenced, err := ls.leiosEndorserBlockForApply(e.Block)
-	if err != nil {
-		window.endorserProducersPending = true
-		ls.config.Logger.Debug(
-			"cross-fork continuation audit could not resolve a block's endorser block",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"error", err,
+	var ref continuationAuditEndorserRef
+	if ls.config.LeiosApplyEndorserBlockTxs {
+		referencer, ok := e.Block.Header().(leiosEndorserBlockReferencer)
+		if !ok {
+			return
+		}
+		ebHash, _, announced := referencer.LeiosAnnouncement()
+		if !announced {
+			return
+		}
+		ref = continuationAuditEndorserRef{
+			ebHash:    ebHash,
+			ebSlot:    e.Block.SlotNumber(),
+			resolved:  true,
+			blockSlot: e.Point.Slot,
+		}
+	} else {
+		certifier, ok := e.Block.Header().(leiosEndorserBlockCertifier)
+		if !ok {
+			return
+		}
+		certified, present := certifier.LeiosCertified()
+		if !present || !certified {
+			return
+		}
+		ref = continuationAuditEndorserRef{
+			certParentHash: e.Block.PrevHash().Bytes(),
+			blockSlot:      e.Point.Slot,
+		}
+	}
+	key := ref.key()
+	if _, ok := window.pendingEndorserSeen[key]; ok {
+		return
+	}
+	if _, ok := window.resolvedEndorserBlocks[key]; ok {
+		return
+	}
+	window.pendingEndorserSeen[key] = struct{}{}
+	window.pendingEndorserRefs = append(window.pendingEndorserRefs, ref)
+}
+
+// drainContinuationAuditEndorserRefs merges queued endorser blocks into the
+// window's producer set, spending at most *budget resolutions, and reports
+// whether the window is still armed.
+//
+// Each endorser block is resolved and hashed at most once per window: the
+// queue is deduplicated on insert and the (hash, slot) occurrences already
+// merged are memoized, so the same closure referenced by several ranking
+// blocks costs one parent read, one provider lookup and one hashing pass, not
+// one per referencing block.
+//
+// A reference whose endorser block is not cached yet stays queued in resolved
+// form — a later attempt costs only the provider lookup — and marks the window
+// incomplete, so unresolved inputs read as inconclusive rather than as missing
+// producers.
+func (ls *LedgerState) drainContinuationAuditEndorserRefs(
+	window *continuationAuditWindow,
+	budget *int,
+	auditedSlot uint64,
+) bool {
+	pending := window.pendingEndorserRefs
+	window.pendingEndorserRefs = nil
+	armed := true
+	for i, ref := range pending {
+		if !armed || *budget <= 0 {
+			// Requeue what was not reached. Hitting the budget means the
+			// producer set is knowingly short for now.
+			window.pendingEndorserRefs = append(
+				window.pendingEndorserRefs,
+				pending[i:]...,
+			)
+			if armed && *budget <= 0 {
+				window.endorserProducersPending = true
+				ls.countContinuationAuditOutcome(
+					continuationAuditResultSkippedBudget,
+				)
+				ls.config.Logger.Debug(
+					"cross-fork continuation audit deferred endorser blocks past its per-block budget",
+					"component", "ledger",
+					"slot", auditedSlot,
+					"deferred", len(pending)-i,
+					"budget", continuationAuditMaxEndorserBlocksPerBlock,
+				)
+				// Only report the budget stop once per drain.
+				*budget = -1
+			}
+			continue
+		}
+		delete(window.pendingEndorserSeen, ref.key())
+		*budget--
+		window.endorserResolutions++
+		if !ref.resolved {
+			ebHash, ebSlot, _, announced, err := ls.leiosCertifiedAnnouncementFromParent(
+				ref.certParentHash,
+			)
+			if err != nil {
+				window.endorserProducersPending = true
+				ls.config.Logger.Debug(
+					"cross-fork continuation audit could not resolve a certifying block's endorser block",
+					"component", "ledger",
+					"slot", ref.blockSlot,
+					"error", err,
+				)
+				continue
+			}
+			if !announced {
+				continue
+			}
+			ref.ebHash = ebHash
+			ref.ebSlot = ebSlot
+			ref.resolved = true
+		}
+		key := ref.key()
+		if _, ok := window.resolvedEndorserBlocks[key]; ok {
+			continue
+		}
+		rawTxs, ok := ls.config.EndorserBlockProvider(
+			ref.ebHash.Bytes(),
+			ref.ebSlot,
 		)
-		return nil
+		if !ok {
+			window.endorserProducersPending = true
+			ls.config.Logger.Debug(
+				"cross-fork continuation audit: certified endorser block not fetched yet",
+				"component", "ledger",
+				"slot", ref.blockSlot,
+				"eb_slot", ref.ebSlot,
+				"eb_hash", ref.ebHash.String(),
+			)
+			// Keep it queued in resolved form: the parent read is done,
+			// and the block may be fetched before the window ends.
+			window.pendingEndorserSeen[key] = struct{}{}
+			window.pendingEndorserRefs = append(
+				window.pendingEndorserRefs,
+				ref,
+			)
+			continue
+		}
+		ids, err := endorserBlockTxIds(rawTxs)
+		if err != nil {
+			window.endorserProducersPending = true
+			ls.config.Logger.Debug(
+				"cross-fork continuation audit could not read endorser block transaction ids",
+				"component", "ledger",
+				"slot", ref.blockSlot,
+				"eb_slot", ref.ebSlot,
+				"eb_hash", ref.ebHash.String(),
+				"error", err,
+			)
+			continue
+		}
+		window.resolvedEndorserBlocks[key] = struct{}{}
+		if !ls.recordContinuationAuditProducers(window, ids) {
+			armed = false
+		}
 	}
-	if !referenced {
-		return nil
+	if *budget < 0 {
+		*budget = 0
 	}
-	rawTxs, ok := ls.config.EndorserBlockProvider(ebHash.Bytes(), ebSlot)
-	if !ok {
-		window.endorserProducersPending = true
-		ls.config.Logger.Debug(
-			"cross-fork continuation audit: certified endorser block not fetched yet",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"eb_slot", ebSlot,
-			"eb_hash", ebHash.String(),
-		)
-		return nil
-	}
-	ids, err := endorserBlockTxIds(rawTxs)
-	if err != nil {
-		window.endorserProducersPending = true
-		ls.config.Logger.Debug(
-			"cross-fork continuation audit could not read endorser block transaction ids",
-			"component", "ledger",
-			"slot", e.Point.Slot,
-			"eb_slot", ebSlot,
-			"eb_hash", ebHash.String(),
-			"error", err,
-		)
-		return nil
-	}
-	return ids
+	return armed
 }
 
 // countContinuationAuditOutcome increments the pre-materialized outcome
@@ -398,6 +619,8 @@ func (ls *LedgerState) countContinuationAuditOutcome(result string) {
 		counter = ls.metrics.continuationAuditInconclusiveEbPending
 	case continuationAuditResultDisarmedCap:
 		counter = ls.metrics.continuationAuditDisarmedCap
+	case continuationAuditResultSkippedBudget:
+		counter = ls.metrics.continuationAuditSkippedBudget
 	}
 	if counter == nil {
 		return

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -197,13 +197,33 @@ func (w *continuationAuditWindow) endorserProducersIncomplete() bool {
 	return len(w.pendingEndorserRefs) > 0 || w.endorserRefsDropped > 0
 }
 
-// requeueEndorserRef returns a reference to the pending queue, restoring the
-// dedupe entry the drain removed when it took it, so a later audited body
-// retries it and a concurrent duplicate is still suppressed.
+// requeueEndorserRef returns a reference the drain took and could not finish to
+// the pending queue, restoring the dedupe entry that was removed with it.
+//
+// It dedupes, because resolution can make two references converge. A deferred
+// certified reference is keyed by its parent hash, and two ranking blocks with
+// different parents can certify the same endorser block: the reference is
+// (announced hash, announcing slot), so two blocks at one slot on either side
+// of a fork — the state a window is armed in — name the same occurrence. Those
+// keys differ while the references are deferred and become equal once resolved.
+// Appending unconditionally then queued the same still-unfetched endorser block
+// twice, and every later body probed it twice, spending budget other references
+// needed.
+//
+// Only callers that took a reference off the queue may use it. The drain's
+// once-per-body and budget paths never take the dedupe entry, so they move
+// their references back directly instead; routing them through here would see
+// their own entry and drop them. An already-merged occurrence cannot reach
+// here either: the drain consults resolvedEndorserBlocks before the provider,
+// which is the only step after which a merged reference could be requeued.
 func (w *continuationAuditWindow) requeueEndorserRef(
 	ref continuationAuditEndorserRef,
 ) {
-	w.pendingEndorserSeen[ref.key()] = struct{}{}
+	key := ref.key()
+	if _, ok := w.pendingEndorserSeen[key]; ok {
+		return
+	}
+	w.pendingEndorserSeen[key] = struct{}{}
 	w.pendingEndorserRefs = append(w.pendingEndorserRefs, ref)
 }
 
@@ -543,7 +563,9 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 	for i, ref := range pending {
 		if !armed || *budget <= 0 {
 			// Requeue what was not reached. Hitting the budget means the
-			// producer set is knowingly short for now.
+			// producer set is knowingly short for now. These references
+			// were never taken off pendingEndorserSeen, so this is a
+			// one-for-one move and cannot duplicate a key.
 			window.pendingEndorserRefs = append(
 				window.pendingEndorserRefs,
 				pending[i:]...,
@@ -566,8 +588,13 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 		}
 		// One probe per reference per audited body: nothing that could
 		// change the outcome happens between two inputs of the same body.
+		// Its dedupe entry was never taken, so this moves the reference
+		// back one-for-one rather than going through requeueEndorserRef.
 		if ref.lastProbedBlock == window.blocksSeen {
-			window.requeueEndorserRef(ref)
+			window.pendingEndorserRefs = append(
+				window.pendingEndorserRefs,
+				ref,
+			)
 			continue
 		}
 		delete(window.pendingEndorserSeen, ref.key())

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -106,6 +107,7 @@ const (
 	continuationAuditResultInconclusiveEbPending = "inconclusive_eb_pending"
 	continuationAuditResultDisarmedCap           = "disarmed_cap"
 	continuationAuditResultSkippedBudget         = "skipped_budget"
+	continuationAuditResultRefUnresolvable       = "ref_unresolvable"
 )
 
 // continuationAuditWindow is the state of one armed audit run. It is published
@@ -119,13 +121,16 @@ type continuationAuditWindow struct {
 	forkPeer    string
 	remaining   int
 	blocksSeen  int
-	// endorserProducersPending records that at least one audited block in
-	// this window referenced a Leios endorser block whose transactions the
-	// audit could not obtain, so producedTxs is known to be incomplete and
-	// an unresolved input is not evidence of a missing producer. It is
-	// sticky for the life of the window: once a hole exists, every later
-	// input could be falling into it.
-	endorserProducersPending bool
+	// endorserRefsDropped counts endorser-block references this window gave
+	// up on for good: the parent lookup failed for a reason retrying cannot
+	// fix. Those holes never close, so they keep the producer set
+	// permanently short. A reference that is merely unresolved so far is not
+	// counted here — it is still queued, and queued references are what
+	// endorserProducersIncomplete reads.
+	endorserRefsDropped int
+	// endorserRefErrorLogged keeps a hard parent-resolution failure to one
+	// log line per window rather than one per audited body.
+	endorserRefErrorLogged bool
 	// pendingEndorserRefs are endorser-block references seen in this window
 	// whose transactions have not been merged into producedTxs yet, in
 	// arrival order. Classifying a block into a reference is header-only and
@@ -161,6 +166,11 @@ type continuationAuditEndorserRef struct {
 	ebSlot         uint64
 	resolved       bool
 	blockSlot      uint64
+	// lastProbedBlock is the value of the window's blocksSeen when this
+	// reference was last probed, so one audited body probes it at most once
+	// however many of its inputs need the drain. Nothing about the reference
+	// can change between two inputs of the same body.
+	lastProbedBlock int
 }
 
 // key identifies a reference for dedupe: the parent hash while the reference is
@@ -171,6 +181,30 @@ func (r continuationAuditEndorserRef) key() string {
 		return "c" + string(r.certParentHash)
 	}
 	return "d" + string(r.ebHash.Bytes()) + strconv.FormatUint(r.ebSlot, 10)
+}
+
+// endorserProducersIncomplete reports whether the window's producer set is
+// knowingly short of an endorser block it references, which makes an
+// unresolved input inconclusive rather than evidence of a missing producer.
+//
+// It is derived rather than latched. A reference that could not be resolved on
+// one body is requeued and retried on the next, so a window that recovers —
+// the parent block lands, or the endorser block finishes fetching — goes back
+// to being able to diagnose a genuine missing producer instead of staying
+// inconclusive for the rest of its life. Only a reference given up on for good
+// leaves a hole that never closes.
+func (w *continuationAuditWindow) endorserProducersIncomplete() bool {
+	return len(w.pendingEndorserRefs) > 0 || w.endorserRefsDropped > 0
+}
+
+// requeueEndorserRef returns a reference to the pending queue, restoring the
+// dedupe entry the drain removed when it took it, so a later audited body
+// retries it and a concurrent duplicate is still suppressed.
+func (w *continuationAuditWindow) requeueEndorserRef(
+	ref continuationAuditEndorserRef,
+) {
+	w.pendingEndorserSeen[ref.key()] = struct{}{}
+	w.pendingEndorserRefs = append(w.pendingEndorserRefs, ref)
 }
 
 // armContinuationAudit starts a bounded continuation audit at a rollback point.
@@ -298,7 +332,7 @@ func (ls *LedgerState) auditContinuationBlock(
 			// certified endorser block the node has fetched but not yet
 			// handed to the audit. Say so quietly instead of asserting
 			// ledger corruption on a healthy node.
-			if window.endorserProducersPending {
+			if window.endorserProducersIncomplete() {
 				ls.countContinuationAuditOutcome(
 					continuationAuditResultInconclusiveEbPending,
 				)
@@ -515,7 +549,6 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 				pending[i:]...,
 			)
 			if armed && *budget <= 0 {
-				window.endorserProducersPending = true
 				ls.countContinuationAuditOutcome(
 					continuationAuditResultSkippedBudget,
 				)
@@ -531,24 +564,55 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 			}
 			continue
 		}
+		// One probe per reference per audited body: nothing that could
+		// change the outcome happens between two inputs of the same body.
+		if ref.lastProbedBlock == window.blocksSeen {
+			window.requeueEndorserRef(ref)
+			continue
+		}
 		delete(window.pendingEndorserSeen, ref.key())
+		ref.lastProbedBlock = window.blocksSeen
 		*budget--
 		window.endorserResolutions++
 		if !ref.resolved {
 			ebHash, ebSlot, _, announced, err := ls.leiosCertifiedAnnouncementFromParent(
 				ref.certParentHash,
 			)
-			if err != nil {
-				window.endorserProducersPending = true
+			switch {
+			case errors.Is(err, models.ErrBlockNotFound):
+				// The parent is not in the block store yet. That is a
+				// state, not a verdict — it is exactly the read-ahead
+				// this audit exists to tolerate — so keep the reference
+				// and retry it on the next body.
 				ls.config.Logger.Debug(
-					"cross-fork continuation audit could not resolve a certifying block's endorser block",
+					"cross-fork continuation audit will retry a certifying block's parent lookup",
 					"component", "ledger",
 					"slot", ref.blockSlot,
-					"error", err,
 				)
+				window.requeueEndorserRef(ref)
+				continue
+			case err != nil:
+				// Anything else (I/O, a corrupt hash index) will not fix
+				// itself by retrying, so the hole is permanent and the
+				// window says so once rather than per body.
+				window.endorserRefsDropped++
+				ls.countContinuationAuditOutcome(
+					continuationAuditResultRefUnresolvable,
+				)
+				if !window.endorserRefErrorLogged {
+					window.endorserRefErrorLogged = true
+					ls.config.Logger.Warn(
+						"cross-fork continuation audit gave up resolving a certifying block's parent",
+						"component", "ledger",
+						"slot", ref.blockSlot,
+						"error", err,
+					)
+				}
 				continue
 			}
 			if !announced {
+				// Resolved, and there is definitively no endorser block:
+				// not a hole.
 				continue
 			}
 			ref.ebHash = ebHash
@@ -564,7 +628,6 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 			ref.ebSlot,
 		)
 		if !ok {
-			window.endorserProducersPending = true
 			ls.config.Logger.Debug(
 				"cross-fork continuation audit: certified endorser block not fetched yet",
 				"component", "ledger",
@@ -574,16 +637,15 @@ func (ls *LedgerState) drainContinuationAuditEndorserRefs(
 			)
 			// Keep it queued in resolved form: the parent read is done,
 			// and the block may be fetched before the window ends.
-			window.pendingEndorserSeen[key] = struct{}{}
-			window.pendingEndorserRefs = append(
-				window.pendingEndorserRefs,
-				ref,
-			)
+			window.requeueEndorserRef(ref)
 			continue
 		}
 		ids, err := endorserBlockTxIds(rawTxs)
 		if err != nil {
-			window.endorserProducersPending = true
+			window.endorserRefsDropped++
+			ls.countContinuationAuditOutcome(
+				continuationAuditResultRefUnresolvable,
+			)
 			ls.config.Logger.Debug(
 				"cross-fork continuation audit could not read endorser block transaction ids",
 				"component", "ledger",
@@ -621,6 +683,8 @@ func (ls *LedgerState) countContinuationAuditOutcome(result string) {
 		counter = ls.metrics.continuationAuditDisarmedCap
 	case continuationAuditResultSkippedBudget:
 		counter = ls.metrics.continuationAuditSkippedBudget
+	case continuationAuditResultRefUnresolvable:
+		counter = ls.metrics.continuationAuditRefUnresolvable
 	}
 	if counter == nil {
 		return

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // The cross-fork continuation audit answers the question issue #3005 could not
@@ -42,6 +43,23 @@ import (
 // (fetched, on the chain, not yet applied), or when the ledger already holds
 // the UTxO, or when transaction metadata knows the producer. Anything left over
 // has no producer on the local applied chain.
+//
+// Leios caveat. "A block was fetched, so its transactions are in hand" is true
+// of every pre-Leios block and false on the Leios cert-driven path, where a
+// certifying ranking block's body is empty: its transactions are the certified
+// endorser block's, which arrives over leios-fetch as a separate artifact and
+// is applied by LedgerState.applyEndorserBlock at ledger-apply time. The audit
+// runs at blockfetch time, so with the ledger pipeline behind the blockfetch
+// queue — the normal condition during an endorser-block backlog, and precisely
+// the condition a rollback arms the audit in — neither the UTxO nor the
+// transaction-metadata fallback can see an endorser-resident producer either.
+// The window therefore resolves each audited block's endorser block the same
+// way apply does (leiosEndorserBlockForApply plus EndorserBlockProvider) and
+// records its transaction ids as producers. When that endorser block has not
+// been fetched yet the producer set is knowingly incomplete, and the audit
+// says "inconclusive" rather than asserting a missing producer: a report from
+// an incomplete set is a false positive, and a false positive here is worse
+// than silence because it asserts ledger corruption on a healthy node.
 const (
 	// continuationAuditBlockBudget bounds how many fetched blocks a single
 	// arming inspects. Each local rollback re-arms, so a node churning at the
@@ -50,7 +68,18 @@ const (
 	// continuationAuditMaxProducedTxs bounds the in-window producer set so a
 	// long run cannot grow memory without limit. Exceeding it disarms the
 	// window rather than risking false reports from a truncated set.
-	continuationAuditMaxProducedTxs = 100_000
+	//
+	// Including endorser-block transactions changed the arithmetic: a Leios
+	// ranking block body holds a few hundred transactions, but a certified
+	// endorser block on the prototype network carries 100-2500, so a full
+	// continuationAuditBlockBudget window can offer well past a million
+	// producers. The cap is raised to 250k — roughly 16 MB of transient set
+	// for a diagnostic — rather than to that ceiling, because unbounded
+	// growth is the worse failure. A busy Leios window therefore disarms
+	// partway through, which is now explicit: the disarm logs at Warn and
+	// increments the audit-outcome counter with result="disarmed_cap", so
+	// "the audit stopped covering this node" is visible instead of silent.
+	continuationAuditMaxProducedTxs = 250_000
 	// continuationAuditMaxReportsPerBlock caps log volume for a body with
 	// many unresolvable inputs. The first few identify the fork just as well.
 	continuationAuditMaxReportsPerBlock = 4
@@ -59,6 +88,14 @@ const (
 	// so truncating a pathological block is preferable to delaying the
 	// blockfetch pipeline behind unbounded per-input probes.
 	continuationAuditMaxInputsPerBlock = 32
+)
+
+// Label values of the dingo_ledger_continuation_audit_outcomes_total metric.
+const (
+	continuationAuditResultClean                 = "clean"
+	continuationAuditResultMissingProducer       = "missing_producer"
+	continuationAuditResultInconclusiveEbPending = "inconclusive_eb_pending"
+	continuationAuditResultDisarmedCap           = "disarmed_cap"
 )
 
 // continuationAuditWindow is the state of one armed audit run. It is published
@@ -72,6 +109,13 @@ type continuationAuditWindow struct {
 	forkPeer    string
 	remaining   int
 	blocksSeen  int
+	// endorserProducersPending records that at least one audited block in
+	// this window referenced a Leios endorser block whose transactions the
+	// audit could not obtain, so producedTxs is known to be incomplete and
+	// an unresolved input is not evidence of a missing producer. It is
+	// sticky for the life of the window: once a hole exists, every later
+	// input could be falling into it.
+	endorserProducersPending bool
 }
 
 // armContinuationAudit starts a bounded continuation audit at a rollback point.
@@ -134,19 +178,31 @@ func (ls *LedgerState) auditContinuationBlock(
 	// Record this block's producers before checking its inputs. A later
 	// transaction may spend an output created by an earlier one in the same
 	// block, and treating the whole block as a producer errs toward silence
-	// rather than toward a false report.
-	if len(window.producedTxs)+len(txs) > continuationAuditMaxProducedTxs {
-		ls.config.Logger.Debug(
+	// rather than toward a false report. The block's Leios endorser block, if
+	// it has one, contributes producers too: on the cert-driven path those are
+	// the only transactions a certifying ranking block brings, its own body
+	// being empty.
+	ebTxIds := ls.continuationAuditEndorserProducers(window, e)
+	if len(window.producedTxs)+len(txs)+len(ebTxIds) >
+		continuationAuditMaxProducedTxs {
+		ls.config.Logger.Warn(
 			"disarming cross-fork continuation audit: producer set at capacity",
 			"component", "ledger",
 			"blocks_audited", window.blocksSeen,
 			"produced_txs", len(window.producedTxs),
+			"max_produced_txs", continuationAuditMaxProducedTxs,
+		)
+		ls.countContinuationAuditOutcome(
+			continuationAuditResultDisarmedCap,
 		)
 		window.remaining = 0
 		return
 	}
 	for _, tx := range txs {
 		window.producedTxs[string(tx.Hash().Bytes())] = struct{}{}
+	}
+	for _, id := range ebTxIds {
+		window.producedTxs[string(id)] = struct{}{}
 	}
 	reports := 0
 	inputsAudited := 0
@@ -171,10 +227,37 @@ func (ls *LedgerState) auditContinuationBlock(
 				continue
 			}
 			if resolved {
+				ls.countContinuationAuditOutcome(
+					continuationAuditResultClean,
+				)
 				continue
 			}
 			reports++
+			// An unresolved input proves nothing while the window's
+			// producer set has a known hole: the producer may sit in a
+			// certified endorser block the node has fetched but not yet
+			// handed to the audit. Say so quietly instead of asserting
+			// ledger corruption on a healthy node.
+			if window.endorserProducersPending {
+				ls.countContinuationAuditOutcome(
+					continuationAuditResultInconclusiveEbPending,
+				)
+				ls.config.Logger.Debug(
+					"cross-fork continuation audit inconclusive: certified endorser block not fetched yet",
+					"component", "ledger",
+					"block_slot", e.Point.Slot,
+					"block_hash", hex.EncodeToString(e.Point.Hash),
+					"tx_hash", tx.Hash().String(),
+					"input", input.String(),
+					"producer_tx_hash", input.Id().String(),
+					"blocks_since_fork", window.blocksSeen,
+				)
+				continue
+			}
 			ls.metrics.continuationInputUnresolved.Inc()
+			ls.countContinuationAuditOutcome(
+				continuationAuditResultMissingProducer,
+			)
 			ls.config.Logger.Error(
 				"continuation block spends an input with no producer on the local applied chain",
 				"component",
@@ -232,4 +315,92 @@ func (ls *LedgerState) continuationInputHasProducer(
 		return false, err
 	}
 	return producerTx != nil, nil
+}
+
+// continuationAuditEndorserProducers returns the transaction ids of the Leios
+// endorser block the audited ranking block applies, resolving it exactly the
+// way ledgerProcessBlock does: leiosEndorserBlockForApply picks the reference
+// (the block's own announcement on the CIP path, the parent's announcement on
+// the Musashi cert-driven path) and EndorserBlockProvider supplies the
+// transactions for that (hash, slot) occurrence.
+//
+// The endorser block is already in the provider's cache by the time the
+// referencing ranking block is fetched — leios-fetch runs well ahead of ledger
+// apply — so the common path is a cache lookup plus a hash per endorser
+// transaction, with no additional I/O beyond the parent-block lookup the
+// cert-driven path needs. When the reference cannot be resolved or the block is
+// not cached yet, the window is marked incomplete rather than left to report a
+// producer it was never given.
+//
+// Non-Leios chains are unaffected: no endorser-block provider is configured,
+// and a header that neither announces nor certifies an endorser block returns
+// no reference.
+func (ls *LedgerState) continuationAuditEndorserProducers(
+	window *continuationAuditWindow,
+	e BlockfetchEvent,
+) [][]byte {
+	if ls.config.EndorserBlockProvider == nil {
+		return nil
+	}
+	ebHash, ebSlot, _, referenced, err := ls.leiosEndorserBlockForApply(e.Block)
+	if err != nil {
+		window.endorserProducersPending = true
+		ls.config.Logger.Debug(
+			"cross-fork continuation audit could not resolve a block's endorser block",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"error", err,
+		)
+		return nil
+	}
+	if !referenced {
+		return nil
+	}
+	rawTxs, ok := ls.config.EndorserBlockProvider(ebHash.Bytes(), ebSlot)
+	if !ok {
+		window.endorserProducersPending = true
+		ls.config.Logger.Debug(
+			"cross-fork continuation audit: certified endorser block not fetched yet",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"eb_slot", ebSlot,
+			"eb_hash", ebHash.String(),
+		)
+		return nil
+	}
+	ids, err := endorserBlockTxIds(rawTxs)
+	if err != nil {
+		window.endorserProducersPending = true
+		ls.config.Logger.Debug(
+			"cross-fork continuation audit could not read endorser block transaction ids",
+			"component", "ledger",
+			"slot", e.Point.Slot,
+			"eb_slot", ebSlot,
+			"eb_hash", ebHash.String(),
+			"error", err,
+		)
+		return nil
+	}
+	return ids
+}
+
+// countContinuationAuditOutcome increments the pre-materialized outcome
+// counter for one audit verdict. Metrics are unset in unit tests that build a
+// LedgerState directly, so every child is nil-checked.
+func (ls *LedgerState) countContinuationAuditOutcome(result string) {
+	var counter prometheus.Counter
+	switch result {
+	case continuationAuditResultClean:
+		counter = ls.metrics.continuationAuditClean
+	case continuationAuditResultMissingProducer:
+		counter = ls.metrics.continuationAuditMissingProducer
+	case continuationAuditResultInconclusiveEbPending:
+		counter = ls.metrics.continuationAuditInconclusiveEbPending
+	case continuationAuditResultDisarmedCap:
+		counter = ls.metrics.continuationAuditDisarmedCap
+	}
+	if counter == nil {
+		return
+	}
+	counter.Inc()
 }

--- a/ledger/continuation_audit.go
+++ b/ledger/continuation_audit.go
@@ -553,6 +553,15 @@ func (ls *LedgerState) queueContinuationAuditEndorserRef(
 // incomplete, so unresolved inputs read as inconclusive rather than as missing
 // producers.
 //
+// A provider lookup is not guaranteed to be I/O-free. EndorserBlockProvider
+// resolves to the ouroboros Leios cache, which on an in-memory miss falls back
+// to a blob-store manifest read, a decode and a transaction load. The audit is
+// armed exactly during an endorser-block backlog and holds
+// chainsyncBlockfetchMutex throughout, so an occurrence whose in-memory entry
+// has expired turns into that read here. It is bounded — at most *budget of
+// them per audited body, and once per (hash, slot) for the life of the window
+// — but it is a disk read, not merely a map hit.
+//
 // *budget is owned by the audited body, not by one drain: a body drains once
 // per unresolved input and every drain spends the same allowance, which is why
 // it is passed by pointer. Once exhausted it is burned to -1 and stays there

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -120,9 +120,31 @@ type leiosAuditFixture struct {
 	providerOK    *bool
 	providerCalls *int
 	logs          *strings.Builder
+	// announceRaw is the ranking block whose announcement the certifying
+	// block certifies, as it would be stored. Tests that exercise a parent
+	// the block store cannot resolve yet add it partway through.
+	announceRaw chain.RawBlock
+}
+
+func (f *leiosAuditFixture) addAnnouncingBlock(t *testing.T) {
+	t.Helper()
+	require.NoError(t, f.ls.chain.AddRawBlocks(
+		[]chain.RawBlock{f.announceRaw},
+	))
 }
 
 func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
+	t.Helper()
+	return newLeiosAuditFixtureOpts(t, true)
+}
+
+// newLeiosAuditFixtureOpts optionally withholds the announcing ranking block
+// from the block store, which is how a test reproduces a certifying block whose
+// parent the audit cannot resolve at the moment it first tries.
+func newLeiosAuditFixtureOpts(
+	t *testing.T,
+	insertAnnouncingBlock bool,
+) *leiosAuditFixture {
 	t.Helper()
 	fixture := newChainsyncRollbackFixture(t)
 	ls := fixture.ls
@@ -151,14 +173,20 @@ func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
 	require.True(t, ok, "fixture parent must announce an endorser block")
 	require.Equal(t, ebHash, gotHash)
 
-	require.NoError(t, ls.chain.AddRawBlocks([]chain.RawBlock{{
+	announceRaw := chain.RawBlock{
 		Slot:        announceSlot,
 		Hash:        announcing.Hash().Bytes(),
 		BlockNumber: 3,
 		Type:        dijkstra.BlockTypeDijkstra,
 		PrevHash:    fixture.currentTip.Point.Hash,
 		Cbor:        announceCbor,
-	}}))
+	}
+	if insertAnnouncingBlock {
+		require.NoError(
+			t,
+			ls.chain.AddRawBlocks([]chain.RawBlock{announceRaw}),
+		)
+	}
 
 	certRB := leiosAuditCertifyingBlock(t, 40, announcing.Hash())
 	require.Empty(
@@ -200,6 +228,7 @@ func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
 		providerOK:    &providerOK,
 		providerCalls: &providerCalls,
 		logs:          logs,
+		announceRaw:   announceRaw,
 	}
 }
 
@@ -207,16 +236,25 @@ func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
 // output of the endorser-block transaction.
 func (f *leiosAuditFixture) spenderBlock(t *testing.T) BlockfetchEvent {
 	t.Helper()
+	return f.spenderBlockAt(t, 50, "leios-audit-spender")
+}
+
+func (f *leiosAuditFixture) spenderBlockAt(
+	t *testing.T,
+	slot uint64,
+	seed string,
+) BlockfetchEvent {
+	t.Helper()
 	body := &spliceAuditBlock{
-		slot: 50,
-		hash: lcommon.NewBlake2b256(testHashBytes("leios-audit-spender")),
+		slot: slot,
+		hash: lcommon.NewBlake2b256(testHashBytes(seed)),
 		prevHash: lcommon.NewBlake2b256(
-			testHashBytes("leios-audit-spender-parent"),
+			testHashBytes(seed + "-parent"),
 		),
 		txs: []lcommon.Transaction{
 			mustSpliceAuditTx(
 				t,
-				testHashBytes("leios-audit-spender-tx"),
+				testHashBytes(seed+"-tx"),
 				[]lcommon.TransactionInput{
 					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 0),
 				},
@@ -267,7 +305,7 @@ func TestContinuationAuditAcceptsEndorserBlockProducer(t *testing.T) {
 	// is also silent about a real splice.
 	assert.False(
 		t,
-		window.endorserProducersPending,
+		window.endorserProducersIncomplete(),
 		"the certified endorser block was cached, so the producer set is complete",
 	)
 	assert.Contains(
@@ -777,10 +815,22 @@ func TestContinuationAuditEndorserResolutionIsBudgeted(t *testing.T) {
 	assert.Len(
 		t,
 		window.pendingEndorserRefs,
-		1,
-		"the overflow must stay queued for a later body",
+		queued,
+		"nothing may be lost: the overflow stays queued, and the probed "+
+			"references are requeued because their parents are not "+
+			"resolvable yet",
 	)
-	assert.True(t, window.endorserProducersPending)
+	assert.True(t, window.endorserProducersIncomplete())
+	assert.Equal(
+		t,
+		float64(0),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(
+				"ref_unresolvable",
+			),
+		),
+		"a parent that is merely absent is retryable, not unresolvable",
+	)
 	assert.Equal(
 		t,
 		float64(1),
@@ -896,7 +946,7 @@ func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 		"no producer on the local applied chain",
 		"a producer in the endorser block this window announced must not be reported",
 	)
-	assert.False(t, window.endorserProducersPending)
+	assert.False(t, window.endorserProducersIncomplete())
 	assert.Equal(t, 1, window.endorserResolutions)
 	assert.Contains(
 		t,
@@ -904,4 +954,150 @@ func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 		string(ebTx.Hash().Bytes()),
 		"the announced endorser block's transaction must be an in-window producer",
 	)
+}
+
+// TestContinuationAuditRetriesUnresolvedCertifyingParent is the regression for
+// the review finding that a transient parent lookup failure was permanent.
+//
+// A certifying ranking block names its certified closure only through its
+// parent's announcement, so resolving it needs the parent out of the block
+// store. When that lookup missed, the reference was dropped for the rest of the
+// window: no later body retried it, so the window stayed inconclusive forever
+// and could neither recognise the endorser-resident producer nor diagnose a
+// genuine missing one. A miss is a transient state, not a verdict — the parent
+// arrives — so the reference must be requeued and retried.
+func TestContinuationAuditRetriesUnresolvedCertifyingParent(t *testing.T) {
+	f := newLeiosAuditFixtureOpts(t, false)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+	// First attempt: the parent is not in the block store, so the closure
+	// cannot be named yet.
+	ls.auditContinuationBlock(
+		f.spenderBlockAt(t, 50, "retry-spender-before"),
+		true,
+	)
+	require.Equal(t, 0, *f.providerCalls)
+	require.True(
+		t,
+		window.endorserProducersIncomplete(),
+		"an unresolvable parent leaves the producer set knowingly short",
+	)
+	require.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"the reference must stay queued for a later attempt",
+	)
+	require.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+	)
+
+	// A second certifying block over the same parent must not queue the
+	// reference a second time: the drain took the dedupe entry when it tried,
+	// and requeueing has to put it back.
+	dupCertRB := leiosAuditCertifyingBlock(t, 41, f.announceHash)
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        dupCertRB,
+		Point: ocommon.NewPoint(
+			dupCertRB.SlotNumber(),
+			dupCertRB.Hash().Bytes(),
+		),
+	}, true)
+	require.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"a requeued reference must still suppress its duplicates",
+	)
+
+	// The parent lands. The next audited body must retry and resolve.
+	f.addAnnouncingBlock(t)
+	ls.auditContinuationBlock(
+		f.spenderBlockAt(t, 51, "retry-spender-after"),
+		true,
+	)
+
+	assert.Equal(t, 1, *f.providerCalls)
+	assert.Contains(
+		t,
+		window.producedTxs,
+		string(f.ebTx.Hash().Bytes()),
+		"the retried closure's transaction must become an in-window producer",
+	)
+	assert.False(
+		t,
+		window.endorserProducersIncomplete(),
+		"with every reference resolved the producer set is complete again",
+	)
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues("clean"),
+		),
+	)
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+	)
+}
+
+// TestContinuationAuditRetriesParentAtMostOncePerBlock bounds the retry: a
+// reference that cannot be resolved must not be re-probed for every unresolved
+// input of the same body, only once per audited body, so a permanently absent
+// parent costs one index miss per block rather than one per input.
+func TestContinuationAuditRetriesParentAtMostOncePerBlock(t *testing.T) {
+	f := newLeiosAuditFixtureOpts(t, false)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+
+	// A body with three unresolvable inputs: three drains, one lookup.
+	body := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("retry-multi-input")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("retry-multi-input-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 0),
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 1),
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 2),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}, true)
+
+	assert.Equal(
+		t,
+		1,
+		window.endorserResolutions,
+		"one body must probe an unresolvable parent once, not once per input",
+	)
+	assert.Len(t, window.pendingEndorserRefs, 1)
 }

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -1267,3 +1267,96 @@ func TestContinuationAuditBudgetStopIsCountedOncePerBody(t *testing.T) {
 		"the budget must not be replenished between inputs of one body",
 	)
 }
+
+// TestContinuationAuditReusesAnAlreadyMergedEndorserBlock pins the second half
+// of the once-per-window cost bound. The queue dedupe only covers references
+// still waiting: the drain takes a reference's dedupe entry with it, so a
+// ranking block that certifies a closure already merged is queued again — and
+// on a Leios fork window, where a closure is certified by many ranking blocks
+// arriving over the length of the window, that is the ordinary case rather
+// than an edge one.
+//
+// Only the memo of merged (hash, slot) occurrences keeps that requeue from
+// costing a second provider lookup and a second hashing pass over every
+// transaction of a thousand-transaction endorser block, once per later audited
+// body, all under chainsyncBlockfetchMutex. Deduplicating on insert alone
+// cannot do it, because there is nothing left to deduplicate against.
+func TestContinuationAuditReusesAnAlreadyMergedEndorserBlock(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+	// An endorser-resident spend drains the queued reference and merges the
+	// closure: one parent read, one provider lookup, one hashing pass.
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	require.Equal(t, 1, *f.providerCalls)
+	require.Equal(t, 1, window.endorserResolutions)
+	require.Empty(t, window.pendingEndorserRefs)
+
+	// A later ranking block certifying the same closure. Its reference is
+	// queued again — the entry that would have deduplicated it went with the
+	// drain.
+	later := leiosAuditCertifyingBlock(t, 43, f.announceHash)
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        later,
+		Point: ocommon.NewPoint(
+			later.SlotNumber(),
+			later.Hash().Bytes(),
+		),
+	}, true)
+	require.Len(t, window.pendingEndorserRefs, 1)
+
+	// A body whose input nothing can explain forces a second drain, which is
+	// where an unmemoized occurrence would be fetched and hashed again.
+	body := &spliceAuditBlock{
+		slot: 60,
+		hash: lcommon.NewBlake2b256(testHashBytes("remerge-spender")),
+		prevHash: lcommon.NewBlake2b256(
+			testHashBytes("remerge-spender-parent"),
+		),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("remerge-spender-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(
+						t,
+						testHashBytes("remerge-absent-producer"),
+						0,
+					),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}, true)
+
+	assert.Equal(
+		t,
+		2,
+		window.endorserResolutions,
+		"the requeued reference is probed, so the drain did run",
+	)
+	assert.Equal(
+		t,
+		1,
+		*f.providerCalls,
+		"an occurrence already merged must not be fetched or hashed again",
+	)
+	assert.Empty(
+		t,
+		window.pendingEndorserRefs,
+		"a reference resolved onto a merged occurrence is finished, not requeued",
+	)
+}

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"encoding/binary"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -111,11 +112,14 @@ func leiosAuditCertifyingBlock(
 // certified closure.
 type leiosAuditFixture struct {
 	*chainsyncRollbackFixture
-	certRB     *dijkstra.DijkstraBlock
-	certPoint  ocommon.Point
-	ebTx       lcommon.Transaction
-	providerOK *bool
-	logs       *strings.Builder
+	certRB        *dijkstra.DijkstraBlock
+	certPoint     ocommon.Point
+	announceHash  lcommon.Blake2b256
+	ebTx          lcommon.Transaction
+	ebRepeatTx    lcommon.Transaction
+	providerOK    *bool
+	providerCalls *int
+	logs          *strings.Builder
 }
 
 func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
@@ -163,19 +167,24 @@ func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
 		"a certifying ranking block carries no transactions of its own",
 	)
 
+	// Two transactions, so a cap test can offer the window one id it already
+	// holds alongside one it does not.
 	rawTx, _, ebTx := leiosApplyTestTx(t, 0x5A)
+	rawRepeatTx, _, ebRepeatTx := leiosApplyTestTx(t, 0x5B)
 	providerOK := true
+	providerCalls := 0
 	ls.config.EndorserBlockProvider = func(
 		hash []byte,
 		slot uint64,
 	) ([]cbor.RawMessage, bool) {
+		providerCalls++
 		if !providerOK {
 			return nil, false
 		}
 		if string(hash) != string(ebHash.Bytes()) || slot != announceSlot {
 			return nil, false
 		}
-		return []cbor.RawMessage{rawTx}, true
+		return []cbor.RawMessage{rawTx, rawRepeatTx}, true
 	}
 
 	return &leiosAuditFixture{
@@ -185,9 +194,12 @@ func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
 			certRB.SlotNumber(),
 			certRB.Hash().Bytes(),
 		),
-		ebTx:       ebTx,
-		providerOK: &providerOK,
-		logs:       logs,
+		announceHash:  announcing.Hash(),
+		ebTx:          ebTx,
+		ebRepeatTx:    ebRepeatTx,
+		providerOK:    &providerOK,
+		providerCalls: &providerCalls,
+		logs:          logs,
 	}
 }
 
@@ -454,28 +466,47 @@ func TestContinuationAuditOutcomesAreCounted(t *testing.T) {
 	})
 }
 
+// continuationAuditFillProducers seeds the window's producer set with n
+// synthetic ids, so a cap test does not have to audit a quarter of a million
+// real transactions to reach the boundary.
+func continuationAuditFillProducers(
+	window *continuationAuditWindow,
+	n int,
+) {
+	filler := make([]byte, 8)
+	for i := range n {
+		binary.BigEndian.PutUint64(filler, uint64(i))
+		window.producedTxs[string(filler)] = struct{}{}
+	}
+}
+
 // TestContinuationAuditCapDisarmIsExplicit covers the other half of the cap
 // review: including endorser-block transactions in the producer set makes a
 // busy Leios window reach continuationAuditMaxProducedTxs, so the disarm must
 // be visible — a Warn line and a counted outcome — instead of the audit going
 // quiet with no way to tell it apart from a clean node.
+//
+// The window is seeded one short of the cap so the spending body's own
+// transaction fits and its input probe reaches the endorser-block drain; the
+// endorser transaction is then the id that runs the set into the cap, which is
+// the path a real Leios window disarms on.
 func TestContinuationAuditCapDisarmIsExplicit(t *testing.T) {
 	f := newLeiosAuditFixture(t)
 	ls := f.ls
 	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
 	window := ls.continuationAudit.Load()
 	require.NotNil(t, window)
-	filler := make([]byte, 8)
-	for i := range continuationAuditMaxProducedTxs {
-		binary.BigEndian.PutUint64(filler, uint64(i))
-		window.producedTxs[string(filler)] = struct{}{}
-	}
+	continuationAuditFillProducers(
+		window,
+		continuationAuditMaxProducedTxs-1,
+	)
 
 	ls.auditContinuationBlock(BlockfetchEvent{
 		ConnectionId: f.connId,
 		Block:        f.certRB,
 		Point:        f.certPoint,
 	}, true)
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
 
 	assert.Equal(t, 0, window.remaining, "the window must disarm at the cap")
 	record := findLogRecord(
@@ -495,13 +526,284 @@ func TestContinuationAuditCapDisarmIsExplicit(t *testing.T) {
 	)
 }
 
+// TestContinuationAuditCapCountsOnlyNewProducers is the regression for the
+// review finding on the cap check: it compared the producer set's size plus
+// every id the block offered, so an id the set already held was charged against
+// the cap a second time and a window whose producer set never grew could
+// disarm itself.
+//
+// That is not hypothetical on the Leios path. The same transaction can appear
+// in more than one endorser block — applyEndorserBlock carries
+// deduplicateEndorserBlockTransactionIndexes for exactly that — and an endorser
+// block is content-addressed, so the same closure can be referenced from more
+// than one ranking block inside a window. The cap bounds the size of the set,
+// so only ids the set does not already hold may count toward it.
+//
+// Same seeding as the disarm test above, one id short of the cap, except that
+// the endorser block's transaction is already recorded. The drain therefore
+// offers a repeat, the set cannot grow, and the window must stay armed.
+func TestContinuationAuditCapCountsOnlyNewProducers(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	// One of the endorser block's two transactions is already a producer.
+	// Seeded two short of the cap, the window has room for exactly the two
+	// ids it is about to be offered that it does not already hold: the
+	// spending body's own transaction and the endorser block's other one.
+	window.producedTxs[string(f.ebRepeatTx.Hash().Bytes())] = struct{}{}
+	continuationAuditFillProducers(
+		window,
+		continuationAuditMaxProducedTxs-3,
+	)
+	require.Len(t, window.producedTxs, continuationAuditMaxProducedTxs-2)
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+
+	assert.Positive(
+		t,
+		window.remaining,
+		"a repeated endorser transaction must not disarm the window",
+	)
+	assert.Equal(t, 2, window.blocksSeen)
+	assert.Len(
+		t,
+		window.producedTxs,
+		continuationAuditMaxProducedTxs,
+		"only the two ids the set did not already hold may have been added",
+	)
+	assert.Contains(t, window.producedTxs, string(f.ebTx.Hash().Bytes()))
+	require.Positive(
+		t,
+		window.endorserResolutions,
+		"the endorser block must actually have been drained, or this test proves nothing",
+	)
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"disarming cross-fork continuation audit",
+	)
+	assert.Equal(
+		t,
+		float64(0),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(
+				"disarmed_cap",
+			),
+		),
+	)
+}
+
+// TestContinuationAuditResolvesEachEndorserBlockOnce is the cost regression for
+// the review finding that the audit resolved a block's endorser block for every
+// referencing ranking block, inside auditContinuationBlock while
+// chainsyncBlockfetchMutex is held.
+//
+// A certified endorser block is content-addressed and can be certified from
+// more than one ranking block in a window; resolving it costs a parent-block
+// read plus a hash of every one of its transactions. Three certifying blocks
+// over the same closure must cost exactly one resolution, not three.
+func TestContinuationAuditResolvesEachEndorserBlockOnce(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	for _, slot := range []uint64{40, 41, 42} {
+		certRB := leiosAuditCertifyingBlock(t, slot, f.announceHash)
+		ls.auditContinuationBlock(BlockfetchEvent{
+			ConnectionId: f.connId,
+			Block:        certRB,
+			Point: ocommon.NewPoint(
+				certRB.SlotNumber(),
+				certRB.Hash().Bytes(),
+			),
+		}, true)
+	}
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	require.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"three blocks certifying the same closure must queue one reference",
+	)
+
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+
+	assert.Equal(
+		t,
+		1,
+		window.endorserResolutions,
+		"the shared endorser block must be resolved exactly once per window",
+	)
+	assert.Equal(t, 1, *f.providerCalls)
+	assert.Contains(t, window.producedTxs, string(f.ebTx.Hash().Bytes()))
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+	)
+}
+
+// TestContinuationAuditSkipsEndorserResolutionWithoutEndorserSpends is the
+// other half of that finding: the resolution ran even when nothing in the
+// window spent an endorser-resident output, so a node in a dense endorser-block
+// backlog — exactly when the audit is armed — paid for it on every body for no
+// diagnostic value.
+//
+// Here the spending body's producer is an ordinary in-window ranking-block
+// transaction, so the audit must never touch the queued endorser block.
+func TestContinuationAuditSkipsEndorserResolutionWithoutEndorserSpends(
+	t *testing.T,
+) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+
+	producerTxId := testHashBytes("ordinary-in-window-producer")
+	producerBlock := &spliceAuditBlock{
+		slot: 45,
+		hash: lcommon.NewBlake2b256(testHashBytes("ordinary-producer-block")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				producerTxId,
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, producerTxId, 9),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        producerBlock,
+		Point: ocommon.NewPoint(
+			producerBlock.slot,
+			producerBlock.hash.Bytes(),
+		),
+	}, true)
+
+	spender := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("ordinary-spender-block")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("ordinary-spender-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, producerTxId, 0),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        spender,
+		Point:        ocommon.NewPoint(spender.slot, spender.hash.Bytes()),
+	}, true)
+
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.Equal(
+		t,
+		0,
+		window.endorserResolutions,
+		"a window that spends nothing endorser-resident must not resolve any endorser block",
+	)
+	assert.Equal(t, 0, *f.providerCalls)
+	assert.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"the reference must stay queued, classified but unresolved",
+	)
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+	)
+}
+
+// TestContinuationAuditEndorserResolutionIsBudgeted pins the per-block bound on
+// endorser-block resolution, the analogue of continuationAuditMaxInputsPerBlock
+// for the endorser path: one audited body may not resolve an unbounded number
+// of endorser blocks under the blockfetch mutex. The overflow stays queued for
+// a later body, the window reports inconclusive rather than missing while it is
+// short, and the stop is counted.
+func TestContinuationAuditEndorserResolutionIsBudgeted(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+
+	// Queue one more distinct certified closure than a single body may
+	// resolve. Their parents are absent from the chain, so each resolution
+	// attempt is spent and accounted without needing a provider entry.
+	queued := continuationAuditMaxEndorserBlocksPerBlock + 1
+	for i := range queued {
+		window.pendingEndorserRefs = append(
+			window.pendingEndorserRefs,
+			continuationAuditEndorserRef{
+				certParentHash: testHashBytes(
+					"budget-parent-" + strconv.Itoa(i),
+				),
+				blockSlot: uint64(60 + i),
+			},
+		)
+		window.pendingEndorserSeen[window.pendingEndorserRefs[i].key()] = struct{}{}
+	}
+
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+
+	assert.Equal(
+		t,
+		continuationAuditMaxEndorserBlocksPerBlock,
+		window.endorserResolutions,
+		"one body must not resolve more endorser blocks than its budget",
+	)
+	assert.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"the overflow must stay queued for a later body",
+	)
+	assert.True(t, window.endorserProducersPending)
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(
+				"skipped_budget",
+			),
+		),
+	)
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+	)
+}
+
 // TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer covers the
 // forward/CIP path, where a ranking block applies the endorser block it
-// announces itself rather than one its parent announced. The audit resolves
-// the reference through the same leiosEndorserBlockForApply the apply path
-// uses, so both Leios shapes are covered by one change; this pins the CIP half
-// so a future divergence in that selector cannot silently reintroduce the
-// false positive on the conformant path.
+// announces itself rather than one its parent announced. The audit classifies
+// the reference the same way the apply path selects it, so both Leios shapes
+// are covered by one change; this pins the CIP half so a future divergence in
+// that selector cannot silently reintroduce the false positive on the
+// conformant path.
 func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 	fixture := newChainsyncRollbackFixture(t)
 	ls := fixture.ls
@@ -536,10 +838,12 @@ func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 	}
 
 	rawTx, _, ebTx := leiosApplyTestTx(t, 0x7C)
+	providerCalls := 0
 	ls.config.EndorserBlockProvider = func(
 		hash []byte,
 		slot uint64,
 	) ([]cbor.RawMessage, bool) {
+		providerCalls++
 		// On the CIP path the endorser block is bound to the announcing
 		// block's own slot, not a parent's.
 		if string(hash) != string(ebHash.Bytes()) ||
@@ -558,6 +862,14 @@ func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 			announcing.Hash().Bytes(),
 		),
 	}, true)
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	require.Equal(
+		t,
+		0,
+		providerCalls,
+		"an announced reference must be classified without being resolved",
+	)
 
 	spender := &spliceAuditBlock{
 		slot: 50,
@@ -584,9 +896,8 @@ func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
 		"no producer on the local applied chain",
 		"a producer in the endorser block this window announced must not be reported",
 	)
-	window := ls.continuationAudit.Load()
-	require.NotNil(t, window)
 	assert.False(t, window.endorserProducersPending)
+	assert.Equal(t, 1, window.endorserResolutions)
 	assert.Contains(
 		t,
 		window.producedTxs,

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -115,6 +116,7 @@ type leiosAuditFixture struct {
 	certRB        *dijkstra.DijkstraBlock
 	certPoint     ocommon.Point
 	announceHash  lcommon.Blake2b256
+	ebHash        lcommon.Blake2b256
 	ebTx          lcommon.Transaction
 	ebRepeatTx    lcommon.Transaction
 	providerOK    *bool
@@ -223,6 +225,7 @@ func newLeiosAuditFixtureOpts(
 			certRB.Hash().Bytes(),
 		),
 		announceHash:  announcing.Hash(),
+		ebHash:        ebHash,
 		ebTx:          ebTx,
 		ebRepeatTx:    ebRepeatTx,
 		providerOK:    &providerOK,
@@ -1100,4 +1103,95 @@ func TestContinuationAuditRetriesParentAtMostOncePerBlock(t *testing.T) {
 		"one body must probe an unresolvable parent once, not once per input",
 	)
 	assert.Len(t, window.pendingEndorserRefs, 1)
+}
+
+// TestContinuationAuditDedupesConvergingEndorserRefs is the regression for the
+// review finding that requeueing bypassed the dedupe.
+//
+// Two certifying ranking blocks with *different* parents can certify the same
+// endorser block: the reference is (announced hash, announcing slot), so two
+// blocks at one slot on either side of a fork — which is exactly the state a
+// window is armed in — announce the same occurrence. Those two references are
+// distinct while they are still deferred parent hashes, and converge only once
+// resolved. Requeueing appended without checking, so a still-unfetched endorser
+// block ended up queued twice and was probed twice on every later body, burning
+// budget that other references needed.
+func TestContinuationAuditDedupesConvergingEndorserRefs(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+
+	// A second announcing block, at the same slot and over the same endorser
+	// block as the fixture's, but a distinct block.
+	siblingCbor := leiosAuditAnnouncingBlockCbor(
+		t,
+		30,
+		lcommon.NewBlake2b256(testHashBytes("converging-sibling-parent")),
+		f.ebHash,
+		4096,
+	)
+	var sibling dijkstra.DijkstraBlock
+	_, err := cbor.Decode(siblingCbor, &sibling)
+	require.NoError(t, err)
+	require.NotEqual(t, f.announceHash, sibling.Hash())
+	require.NoError(t, ls.db.BlockCreate(models.Block{
+		Hash:     sibling.Hash().Bytes(),
+		PrevHash: testHashBytes("converging-sibling-parent"),
+		Cbor:     siblingCbor,
+		Slot:     30,
+		Number:   3,
+		Type:     dijkstra.BlockTypeDijkstra,
+	}, nil))
+
+	*f.providerOK = false
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+
+	for i, parent := range []lcommon.Blake2b256{
+		f.announceHash,
+		sibling.Hash(),
+	} {
+		certRB := leiosAuditCertifyingBlock(t, uint64(40+i), parent)
+		ls.auditContinuationBlock(BlockfetchEvent{
+			ConnectionId: f.connId,
+			Block:        certRB,
+			Point: ocommon.NewPoint(
+				certRB.SlotNumber(),
+				certRB.Hash().Bytes(),
+			),
+		}, true)
+	}
+	require.Len(
+		t,
+		window.pendingEndorserRefs,
+		2,
+		"two distinct parents must queue two deferred references",
+	)
+
+	// Resolving both converges them on one occurrence. The endorser block is
+	// still unfetched, so both are requeued -- as one reference, not two.
+	ls.auditContinuationBlock(
+		f.spenderBlockAt(t, 50, "converging-spender-one"),
+		true,
+	)
+	assert.Equal(t, 2, window.endorserResolutions)
+	require.Len(
+		t,
+		window.pendingEndorserRefs,
+		1,
+		"references that converge on one endorser block must queue once",
+	)
+
+	// And the next body probes that occurrence once, not once per reference.
+	before := *f.providerCalls
+	ls.auditContinuationBlock(
+		f.spenderBlockAt(t, 51, "converging-spender-two"),
+		true,
+	)
+	assert.Equal(
+		t,
+		1,
+		*f.providerCalls-before,
+		"one queued occurrence must cost one provider probe per body",
+	)
 }

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -1,0 +1,596 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/binary"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// leiosAuditAnnouncingBlockCbor builds the wire CBOR of a Dijkstra ranking
+// block that announces an endorser block. The announcement lives in the Leios
+// header extension, and DijkstraBlockHeader.MarshalCBOR only reproduces an
+// extension it decoded, so the header body array has to be assembled by hand:
+// the ten Babbage fields followed by leios_certified and leios_announcement.
+func leiosAuditAnnouncingBlockCbor(
+	t *testing.T,
+	slot uint64,
+	prevHash lcommon.Blake2b256,
+	ebHash lcommon.Blake2b256,
+	ebSize uint64,
+) []byte {
+	t.Helper()
+	headerBody := babbage.BabbageBlockHeaderBody{
+		BlockNumber: 3,
+		Slot:        slot,
+		PrevHash:    prevHash,
+	}
+	babbageBodyCbor, err := cbor.Encode(&headerBody)
+	require.NoError(t, err)
+	var bodyElems []cbor.RawMessage
+	_, err = cbor.Decode(babbageBodyCbor, &bodyElems)
+	require.NoError(t, err)
+	certified, err := cbor.Encode(false)
+	require.NoError(t, err)
+	announcement, err := cbor.Encode([]any{ebHash.Bytes(), ebSize})
+	require.NoError(t, err)
+	bodyElems = append(
+		bodyElems,
+		cbor.RawMessage(certified),
+		cbor.RawMessage(announcement),
+	)
+	extendedBody, err := cbor.Encode(bodyElems)
+	require.NoError(t, err)
+	headerCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(extendedBody),
+		[]byte("leios-audit-signature"),
+	})
+	require.NoError(t, err)
+	emptyBody, err := cbor.Encode(dijkstra.DijkstraBlockBody{})
+	require.NoError(t, err)
+	blockCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(headerCbor),
+		cbor.RawMessage(emptyBody),
+	})
+	require.NoError(t, err)
+	return blockCbor
+}
+
+// leiosAuditCertifyingBlock builds the 71-byte-body shape the Musashi
+// prototype produces: a ranking block whose header certifies the endorser
+// block its parent announced and whose own body carries no transactions.
+func leiosAuditCertifyingBlock(
+	t *testing.T,
+	slot uint64,
+	prevHash lcommon.Blake2b256,
+) *dijkstra.DijkstraBlock {
+	t.Helper()
+	certified, err := cbor.Encode(true)
+	require.NoError(t, err)
+	return &dijkstra.DijkstraBlock{
+		BlockHeader: &dijkstra.DijkstraBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: 4,
+					Slot:        slot,
+					PrevHash:    prevHash,
+				},
+			},
+			LeiosHeaderExtension: []cbor.RawMessage{certified},
+		},
+	}
+}
+
+// leiosAuditFixture wires the fleet's cert-driven Leios shape onto the shared
+// rollback fixture: an announcing ranking block on the chain, a certifying
+// ranking block with an empty body, and an endorser-block provider holding the
+// certified closure.
+type leiosAuditFixture struct {
+	*chainsyncRollbackFixture
+	certRB     *dijkstra.DijkstraBlock
+	certPoint  ocommon.Point
+	ebTx       lcommon.Transaction
+	providerOK *bool
+	logs       *strings.Builder
+}
+
+func newLeiosAuditFixture(t *testing.T) *leiosAuditFixture {
+	t.Helper()
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	logs := &strings.Builder{}
+	// Debug level: the inconclusive verdict is deliberately quiet.
+	ls.config.Logger = slog.New(slog.NewJSONHandler(
+		logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+
+	ebHash := lcommon.NewBlake2b256(testHashBytes("leios-audit-eb"))
+	const announceSlot = 30
+	announceCbor := leiosAuditAnnouncingBlockCbor(
+		t,
+		announceSlot,
+		lcommon.NewBlake2b256(fixture.currentTip.Point.Hash),
+		ebHash,
+		4096,
+	)
+	var announcing dijkstra.DijkstraBlock
+	_, err := cbor.Decode(announceCbor, &announcing)
+	require.NoError(t, err)
+	// The announcement must survive the round trip, otherwise the fixture
+	// would prove nothing about the certified closure.
+	gotHash, _, ok := announcing.BlockHeader.LeiosAnnouncement()
+	require.True(t, ok, "fixture parent must announce an endorser block")
+	require.Equal(t, ebHash, gotHash)
+
+	require.NoError(t, ls.chain.AddRawBlocks([]chain.RawBlock{{
+		Slot:        announceSlot,
+		Hash:        announcing.Hash().Bytes(),
+		BlockNumber: 3,
+		Type:        dijkstra.BlockTypeDijkstra,
+		PrevHash:    fixture.currentTip.Point.Hash,
+		Cbor:        announceCbor,
+	}}))
+
+	certRB := leiosAuditCertifyingBlock(t, 40, announcing.Hash())
+	require.Empty(
+		t,
+		certRB.Transactions(),
+		"a certifying ranking block carries no transactions of its own",
+	)
+
+	rawTx, _, ebTx := leiosApplyTestTx(t, 0x5A)
+	providerOK := true
+	ls.config.EndorserBlockProvider = func(
+		hash []byte,
+		slot uint64,
+	) ([]cbor.RawMessage, bool) {
+		if !providerOK {
+			return nil, false
+		}
+		if string(hash) != string(ebHash.Bytes()) || slot != announceSlot {
+			return nil, false
+		}
+		return []cbor.RawMessage{rawTx}, true
+	}
+
+	return &leiosAuditFixture{
+		chainsyncRollbackFixture: fixture,
+		certRB:                   certRB,
+		certPoint: ocommon.NewPoint(
+			certRB.SlotNumber(),
+			certRB.Hash().Bytes(),
+		),
+		ebTx:       ebTx,
+		providerOK: &providerOK,
+		logs:       logs,
+	}
+}
+
+// spenderBlockFor builds an ordinary ranking block that spends the first
+// output of the endorser-block transaction.
+func (f *leiosAuditFixture) spenderBlock(t *testing.T) BlockfetchEvent {
+	t.Helper()
+	body := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("leios-audit-spender")),
+		prevHash: lcommon.NewBlake2b256(
+			testHashBytes("leios-audit-spender-parent"),
+		),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("leios-audit-spender-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 0),
+				},
+			),
+		},
+	}
+	return BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}
+}
+
+// TestContinuationAuditAcceptsEndorserBlockProducer is the regression for the
+// false positive this package reported on every Leios cert-driven fork window.
+//
+// A certifying ranking block's body is empty: its transactions live in the
+// endorser block it certifies, which LedgerState.applyEndorserBlock applies at
+// ledger-apply time, long after blockfetch time when the audit runs. Building
+// the in-window producer set from e.Block.Transactions() alone therefore never
+// records an endorser-block transaction, and the ledger fallbacks miss too
+// because the endorser block has not been applied yet. Every later ranking
+// block spending an endorser-resident output was reported as having no
+// producer on the local applied chain, on a node whose UTxO set was correct.
+func TestContinuationAuditAcceptsEndorserBlockProducer(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+		"an endorser-block-resident producer certified in this window must not be reported",
+	)
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.Equal(t, 2, window.blocksSeen)
+	// The input must resolve because the producer was recorded, not because
+	// the window gave up: an audit that silently declares itself inconclusive
+	// is also silent about a real splice.
+	assert.False(
+		t,
+		window.endorserProducersPending,
+		"the certified endorser block was cached, so the producer set is complete",
+	)
+	assert.Contains(
+		t,
+		window.producedTxs,
+		string(f.ebTx.Hash().Bytes()),
+		"the certified endorser block's transaction must be an in-window producer",
+	)
+}
+
+// TestContinuationAuditTreatsPendingEndorserBlockAsInconclusive covers the
+// other half: when the certified endorser block has not been fetched yet the
+// audit cannot know the producer set, so it must say so at Debug rather than
+// assert ledger corruption at Error.
+func TestContinuationAuditTreatsPendingEndorserBlockAsInconclusive(
+	t *testing.T,
+) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	*f.providerOK = false
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+	ls.auditContinuationBlock(f.spenderBlock(t), true)
+
+	assert.NotContains(
+		t,
+		f.logs.String(),
+		"no producer on the local applied chain",
+		"an unresolvable producer set must not be reported as a missing producer",
+	)
+	record := findLogRecord(
+		t,
+		f.logs.String(),
+		"cross-fork continuation audit inconclusive: certified endorser block not fetched yet",
+	)
+	assert.Equal(t, float64(50), record["block_slot"])
+}
+
+// TestContinuationAuditStillReportsMissingProducerOnLeios guards against the
+// fix muting the diagnostic it was written for: with the certified closure
+// resolved, an input whose producer is in neither the ranking block bodies,
+// the endorser block, nor the ledger is still reported at Error.
+func TestContinuationAuditStillReportsMissingProducerOnLeios(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+
+	missing := mustSpliceAuditInput(t, testHashBytes("leios-absent-producer"), 0)
+	body := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("leios-audit-splice")),
+		prevHash: lcommon.NewBlake2b256(
+			testHashBytes("leios-audit-splice-parent"),
+		),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("leios-audit-splice-tx"),
+				[]lcommon.TransactionInput{missing},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}, true)
+
+	report := findLogRecord(
+		t,
+		f.logs.String(),
+		"continuation block spends an input with no producer on the local applied chain",
+	)
+	assert.Equal(t, missing.String(), report["input"])
+}
+
+// TestEndorserBlockTxIdsMatchDecodedTransactionHashes pins the audit's cheap
+// producer-id derivation to the one the apply path produces. The audit hashes
+// the transaction body straight out of the envelope instead of decoding every
+// endorser transaction, which is only correct while a transaction id is
+// blake2b-256 over its body CBOR. If that ever diverges, the audit would stop
+// recognising endorser producers and the false positive would return, so the
+// two derivations are compared directly.
+func TestEndorserBlockTxIdsMatchDecodedTransactionHashes(t *testing.T) {
+	rawTxs := make([]cbor.RawMessage, 0, 3)
+	want := make([][]byte, 0, 3)
+	for _, seed := range []byte{0x01, 0x02, 0x03} {
+		raw, _, tx := leiosApplyTestTx(t, seed)
+		rawTxs = append(rawTxs, raw)
+		want = append(want, tx.Hash().Bytes())
+	}
+	// leios-fetch delivers each transaction CBOR-in-CBOR; the third entry
+	// carries that wrapping so both envelope shapes are covered.
+	wrapped, err := cbor.Encode([]byte(rawTxs[2]))
+	require.NoError(t, err)
+	rawTxs[2] = cbor.RawMessage(wrapped)
+
+	got, err := endorserBlockTxIds(rawTxs)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestContinuationAuditOutcomesAreCounted covers the observability the
+// diagnostic was missing: each audited input lands in exactly one labelled
+// bucket, so "this node is not being audited" (inconclusive) is distinguishable
+// from "this node is clean" and from "this node is spending unknown inputs".
+func TestContinuationAuditOutcomesAreCounted(t *testing.T) {
+	outcome := func(ls *LedgerState, result string) float64 {
+		t.Helper()
+		return promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(result),
+		)
+	}
+
+	t.Run("clean", func(t *testing.T) {
+		f := newLeiosAuditFixture(t)
+		ls := f.ls
+		ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+		ls.auditContinuationBlock(BlockfetchEvent{
+			ConnectionId: f.connId,
+			Block:        f.certRB,
+			Point:        f.certPoint,
+		}, true)
+		ls.auditContinuationBlock(f.spenderBlock(t), true)
+		assert.Equal(t, float64(1), outcome(ls, "clean"))
+		assert.Equal(t, float64(0), outcome(ls, "missing_producer"))
+		assert.Equal(t, float64(0), outcome(ls, "inconclusive_eb_pending"))
+	})
+
+	t.Run("inconclusive", func(t *testing.T) {
+		f := newLeiosAuditFixture(t)
+		ls := f.ls
+		*f.providerOK = false
+		ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+		ls.auditContinuationBlock(BlockfetchEvent{
+			ConnectionId: f.connId,
+			Block:        f.certRB,
+			Point:        f.certPoint,
+		}, true)
+		ls.auditContinuationBlock(f.spenderBlock(t), true)
+		assert.Equal(
+			t,
+			float64(1),
+			outcome(ls, "inconclusive_eb_pending"),
+		)
+		assert.Equal(t, float64(0), outcome(ls, "missing_producer"))
+		assert.Equal(
+			t,
+			float64(0),
+			promtestutil.ToFloat64(ls.metrics.continuationInputUnresolved),
+		)
+	})
+
+	t.Run("missing_producer", func(t *testing.T) {
+		f := newLeiosAuditFixture(t)
+		ls := f.ls
+		ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+		missing := mustSpliceAuditInput(
+			t,
+			testHashBytes("counted-absent-producer"),
+			0,
+		)
+		body := &spliceAuditBlock{
+			slot: 50,
+			hash: lcommon.NewBlake2b256(testHashBytes("counted-splice")),
+			txs: []lcommon.Transaction{
+				mustSpliceAuditTx(
+					t,
+					testHashBytes("counted-splice-tx"),
+					[]lcommon.TransactionInput{missing},
+				),
+			},
+		}
+		ls.auditContinuationBlock(BlockfetchEvent{
+			ConnectionId: f.connId,
+			Block:        body,
+			Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+		}, true)
+		assert.Equal(t, float64(1), outcome(ls, "missing_producer"))
+		assert.Equal(
+			t,
+			float64(1),
+			promtestutil.ToFloat64(ls.metrics.continuationInputUnresolved),
+		)
+	})
+}
+
+// TestContinuationAuditCapDisarmIsExplicit covers the other half of the cap
+// review: including endorser-block transactions in the producer set makes a
+// busy Leios window reach continuationAuditMaxProducedTxs, so the disarm must
+// be visible — a Warn line and a counted outcome — instead of the audit going
+// quiet with no way to tell it apart from a clean node.
+func TestContinuationAuditCapDisarmIsExplicit(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	filler := make([]byte, 8)
+	for i := range continuationAuditMaxProducedTxs {
+		binary.BigEndian.PutUint64(filler, uint64(i))
+		window.producedTxs[string(filler)] = struct{}{}
+	}
+
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        f.certRB,
+		Point:        f.certPoint,
+	}, true)
+
+	assert.Equal(t, 0, window.remaining, "the window must disarm at the cap")
+	record := findLogRecord(
+		t,
+		f.logs.String(),
+		"disarming cross-fork continuation audit: producer set at capacity",
+	)
+	assert.Equal(t, "WARN", record["level"])
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(
+				"disarmed_cap",
+			),
+		),
+	)
+}
+
+// TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer covers the
+// forward/CIP path, where a ranking block applies the endorser block it
+// announces itself rather than one its parent announced. The audit resolves
+// the reference through the same leiosEndorserBlockForApply the apply path
+// uses, so both Leios shapes are covered by one change; this pins the CIP half
+// so a future divergence in that selector cannot silently reintroduce the
+// false positive on the conformant path.
+func TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer(t *testing.T) {
+	fixture := newChainsyncRollbackFixture(t)
+	ls := fixture.ls
+	logs := &strings.Builder{}
+	ls.config.Logger = slog.New(slog.NewJSONHandler(
+		logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+	ls.config.LeiosApplyEndorserBlockTxs = true
+
+	ebHash := lcommon.NewBlake2b256(testHashBytes("cip-audit-eb"))
+	certified, err := cbor.Encode(false)
+	require.NoError(t, err)
+	announcement, err := cbor.Encode([]any{ebHash.Bytes(), uint64(4096)})
+	require.NoError(t, err)
+	announcing := &dijkstra.DijkstraBlock{
+		BlockHeader: &dijkstra.DijkstraBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: 3,
+					Slot:        30,
+					PrevHash: lcommon.NewBlake2b256(
+						fixture.currentTip.Point.Hash,
+					),
+				},
+			},
+			LeiosHeaderExtension: []cbor.RawMessage{
+				cbor.RawMessage(certified),
+				cbor.RawMessage(announcement),
+			},
+		},
+	}
+
+	rawTx, _, ebTx := leiosApplyTestTx(t, 0x7C)
+	ls.config.EndorserBlockProvider = func(
+		hash []byte,
+		slot uint64,
+	) ([]cbor.RawMessage, bool) {
+		// On the CIP path the endorser block is bound to the announcing
+		// block's own slot, not a parent's.
+		if string(hash) != string(ebHash.Bytes()) ||
+			slot != announcing.SlotNumber() {
+			return nil, false
+		}
+		return []cbor.RawMessage{rawTx}, true
+	}
+
+	ls.armContinuationAudit(fixture.ancestorTip.Point, "test rollback")
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        announcing,
+		Point: ocommon.NewPoint(
+			announcing.SlotNumber(),
+			announcing.Hash().Bytes(),
+		),
+	}, true)
+
+	spender := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("cip-audit-spender")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("cip-audit-spender-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, ebTx.Hash().Bytes(), 0),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: fixture.connId,
+		Block:        spender,
+		Point:        ocommon.NewPoint(spender.slot, spender.hash.Bytes()),
+	}, true)
+
+	assert.NotContains(
+		t,
+		logs.String(),
+		"no producer on the local applied chain",
+		"a producer in the endorser block this window announced must not be reported",
+	)
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	assert.False(t, window.endorserProducersPending)
+	assert.Contains(
+		t,
+		window.producedTxs,
+		string(ebTx.Hash().Bytes()),
+		"the announced endorser block's transaction must be an in-window producer",
+	)
+}

--- a/ledger/continuation_audit_leios_test.go
+++ b/ledger/continuation_audit_leios_test.go
@@ -777,6 +777,24 @@ func TestContinuationAuditSkipsEndorserResolutionWithoutEndorserSpends(
 	)
 }
 
+// queueContinuationAuditTestRefs queues n synthetic deferred certified
+// references whose parents are absent from the block store, so each one costs a
+// resolution attempt that resolves to "not stored yet".
+func queueContinuationAuditTestRefs(
+	window *continuationAuditWindow,
+	seed string,
+	n int,
+) {
+	for i := range n {
+		ref := continuationAuditEndorserRef{
+			certParentHash: testHashBytes(seed + strconv.Itoa(i)),
+			blockSlot:      uint64(60 + i),
+		}
+		window.pendingEndorserRefs = append(window.pendingEndorserRefs, ref)
+		window.pendingEndorserSeen[ref.key()] = struct{}{}
+	}
+}
+
 // TestContinuationAuditEndorserResolutionIsBudgeted pins the per-block bound on
 // endorser-block resolution, the analogue of continuationAuditMaxInputsPerBlock
 // for the endorser path: one audited body may not resolve an unbounded number
@@ -790,22 +808,14 @@ func TestContinuationAuditEndorserResolutionIsBudgeted(t *testing.T) {
 	window := ls.continuationAudit.Load()
 	require.NotNil(t, window)
 
-	// Queue one more distinct certified closure than a single body may
+	// Queue three more distinct certified closures than a single body may
 	// resolve. Their parents are absent from the chain, so each resolution
-	// attempt is spent and accounted without needing a provider entry.
-	queued := continuationAuditMaxEndorserBlocksPerBlock + 1
-	for i := range queued {
-		window.pendingEndorserRefs = append(
-			window.pendingEndorserRefs,
-			continuationAuditEndorserRef{
-				certParentHash: testHashBytes(
-					"budget-parent-" + strconv.Itoa(i),
-				),
-				blockSlot: uint64(60 + i),
-			},
-		)
-		window.pendingEndorserSeen[window.pendingEndorserRefs[i].key()] = struct{}{}
-	}
+	// attempt is spent and accounted without needing a provider entry. The
+	// overflow is deliberately longer than one: with a single leftover the
+	// requeue-the-remainder path cannot show whether it requeues the tail
+	// once or once per remaining reference.
+	queued := continuationAuditMaxEndorserBlocksPerBlock + 3
+	queueContinuationAuditTestRefs(window, "budget-parent-", queued)
 
 	ls.auditContinuationBlock(f.spenderBlock(t), true)
 
@@ -819,9 +829,9 @@ func TestContinuationAuditEndorserResolutionIsBudgeted(t *testing.T) {
 		t,
 		window.pendingEndorserRefs,
 		queued,
-		"nothing may be lost: the overflow stays queued, and the probed "+
-			"references are requeued because their parents are not "+
-			"resolvable yet",
+		"nothing may be lost and nothing may be duplicated: the overflow "+
+			"is requeued once, and the probed references are requeued "+
+			"because their parents are not resolvable yet",
 	)
 	assert.True(t, window.endorserProducersIncomplete())
 	assert.Equal(
@@ -1193,5 +1203,67 @@ func TestContinuationAuditDedupesConvergingEndorserRefs(t *testing.T) {
 		1,
 		*f.providerCalls-before,
 		"one queued occurrence must cost one provider probe per body",
+	)
+}
+
+// TestContinuationAuditBudgetStopIsCountedOncePerBody is the regression for the
+// review finding that `skipped_budget` counted per unresolved input rather than
+// per audited body, which is what its Help string promises.
+//
+// The budget is a per-body allowance shared by every drain that body triggers,
+// one per unresolved input. The exhaustion sentinel was reset at the end of
+// each drain, so the next input's drain re-entered the budget-limited branch
+// and counted again — a body with thirty unresolvable inputs reported thirty
+// budget stops for one exhausted budget.
+func TestContinuationAuditBudgetStopIsCountedOncePerBody(t *testing.T) {
+	f := newLeiosAuditFixture(t)
+	ls := f.ls
+	ls.armContinuationAudit(f.ancestorTip.Point, "test rollback")
+	window := ls.continuationAudit.Load()
+	require.NotNil(t, window)
+	queueContinuationAuditTestRefs(
+		window,
+		"once-per-body-parent-",
+		continuationAuditMaxEndorserBlocksPerBlock+3,
+	)
+
+	// One body, four unresolvable inputs: four drains against one budget.
+	body := &spliceAuditBlock{
+		slot: 50,
+		hash: lcommon.NewBlake2b256(testHashBytes("once-per-body-spender")),
+		txs: []lcommon.Transaction{
+			mustSpliceAuditTx(
+				t,
+				testHashBytes("once-per-body-spender-tx"),
+				[]lcommon.TransactionInput{
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 0),
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 1),
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 2),
+					mustSpliceAuditInput(t, f.ebTx.Hash().Bytes(), 3),
+				},
+			),
+		},
+	}
+	ls.auditContinuationBlock(BlockfetchEvent{
+		ConnectionId: f.connId,
+		Block:        body,
+		Point:        ocommon.NewPoint(body.slot, body.hash.Bytes()),
+	}, true)
+
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(
+			ls.metrics.continuationAuditOutcomes.WithLabelValues(
+				"skipped_budget",
+			),
+		),
+		"one body with one exhausted budget is one budget stop",
+	)
+	assert.Equal(
+		t,
+		continuationAuditMaxEndorserBlocksPerBlock,
+		window.endorserResolutions,
+		"the budget must not be replenished between inputs of one body",
 	)
 }

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -63,6 +63,65 @@ var errCertifiedEndorserBlockUnavailable = errors.New(
 
 const certifiedEndorserBlockRetryDelay = time.Second
 
+// decodeEndorserTxEnvelope unwraps one endorser-block transaction entry and
+// splits it into its transaction CBOR and its top-level array elements.
+//
+// leios-fetch carries each endorser transaction CBOR-in-CBOR: the tx_list entry
+// is a CBOR byte string wrapping the transaction's own CBOR
+// (LeiosTx = encodeBytes(txCbor)). A non-byte-string entry — major type != 2 —
+// is already the bare transaction. elems[0] is the transaction body, which is
+// both the transaction-offset payload and, hashed, the transaction id.
+func decodeEndorserTxEnvelope(
+	raw cbor.RawMessage,
+) (txCbor []byte, elems []cbor.RawMessage, err error) {
+	txCbor = []byte(raw)
+	if len(txCbor) > 0 && txCbor[0]>>5 == 2 {
+		var inner []byte
+		if _, err := cbor.Decode(txCbor, &inner); err != nil {
+			return nil, nil, fmt.Errorf(
+				"unwrap CBOR-in-CBOR entry: %w",
+				err,
+			)
+		}
+		txCbor = inner
+	}
+	if _, err := cbor.Decode(txCbor, &elems); err != nil {
+		return nil, nil, fmt.Errorf("decode envelope: %w", err)
+	}
+	if len(elems) < 2 {
+		return nil, nil, fmt.Errorf(
+			"envelope has %d elements, want >= 2",
+			len(elems),
+		)
+	}
+	return txCbor, elems, nil
+}
+
+// endorserBlockTxIds returns the transaction id of every transaction in an
+// endorser block, without decoding the transactions themselves.
+//
+// A Cardano transaction id is blake2b-256 over the transaction body's CBOR —
+// the definition DijkstraTransaction.Id inherits from
+// BabbageTransactionBody.Id, which hashes the body bytes it decoded, i.e.
+// exactly elems[0] here. Deriving the ids straight from the envelope keeps the
+// cross-fork continuation audit off the full per-transaction decode path: an
+// armed window can span continuationAuditBlockBudget blocks and an endorser
+// block carries thousands of transactions, and the audit runs under
+// chainsyncBlockfetchMutex, where a full decode of every endorser transaction
+// would stall the blockfetch pipeline for a diagnostic.
+func endorserBlockTxIds(rawTxs []cbor.RawMessage) ([][]byte, error) {
+	ids := make([][]byte, 0, len(rawTxs))
+	for i, raw := range rawTxs {
+		_, elems, err := decodeEndorserTxEnvelope(raw)
+		if err != nil {
+			return nil, fmt.Errorf("endorser tx %d: %w", i, err)
+		}
+		id := lcommon.Blake2b256Hash([]byte(elems[0]))
+		ids = append(ids, id.Bytes())
+	}
+	return ids, nil
+}
+
 // applyEndorserBlock decodes a Leios endorser block's standalone transactions,
 // persists them as a standalone blob, and — on the CIP-conformant path
 // (LeiosApplyEndorserBlockTxs) — applies them to the ledger ahead of the ranking
@@ -115,33 +174,9 @@ func (ls *LedgerState) applyEndorserBlock(
 	txs := make([]lcommon.Transaction, len(rawTxs))
 	bodyCbors := make([][]byte, len(rawTxs))
 	for i, raw := range rawTxs {
-		// leios-fetch carries each endorser transaction CBOR-in-CBOR: the
-		// tx_list entry is a CBOR byte string wrapping the transaction's own
-		// CBOR (LeiosTx = encodeBytes(txCbor)). Unwrap it to the inner
-		// transaction bytes before decoding. (A non-byte-string entry — major
-		// type != 2 — is already the bare transaction.)
-		txCbor := []byte(raw)
-		if len(txCbor) > 0 && txCbor[0]>>5 == 2 {
-			var inner []byte
-			if _, err := cbor.Decode(txCbor, &inner); err != nil {
-				return 0, 0, fmt.Errorf("unwrap endorser tx %d: %w", i, err)
-			}
-			txCbor = inner
-		}
-		var elems []cbor.RawMessage
-		if _, err := cbor.Decode(txCbor, &elems); err != nil {
-			return 0, 0, fmt.Errorf(
-				"decode endorser tx %d envelope: %w",
-				i,
-				err,
-			)
-		}
-		if len(elems) < 2 {
-			return 0, 0, fmt.Errorf(
-				"endorser tx %d has %d elements, want >= 2",
-				i,
-				len(elems),
-			)
+		txCbor, elems, err := decodeEndorserTxEnvelope(raw)
+		if err != nil {
+			return 0, 0, fmt.Errorf("endorser tx %d: %w", i, err)
 		}
 		// An endorser block referenced by a Dijkstra ranking block is
 		// Dijkstra-era, so decode its transactions as Dijkstra directly.

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -954,7 +954,18 @@ func (ls *LedgerState) leiosEndorserBlockForApply(
 	if !present || !certified {
 		return lcommon.Blake2b256{}, 0, 0, false, nil
 	}
-	parent, perr := ls.BlockByHash(block.PrevHash().Bytes())
+	return ls.leiosCertifiedAnnouncementFromParent(block.PrevHash().Bytes())
+}
+
+// leiosCertifiedAnnouncementFromParent resolves the endorser block a certifying
+// ranking block certifies: the one its parent announced. Split out of
+// leiosEndorserBlockForApply so the cross-fork continuation audit can resolve
+// the same reference from a retained parent hash alone, without holding the
+// certifying block, and cannot drift from what apply selects.
+func (ls *LedgerState) leiosCertifiedAnnouncementFromParent(
+	prevHash []byte,
+) (hash lcommon.Blake2b256, expectedSlot, size uint64, announced bool, err error) {
+	parent, perr := ls.BlockByHash(prevHash)
 	if perr != nil {
 		return lcommon.Blake2b256{}, 0, 0, false, fmt.Errorf(
 			"resolve certifying block parent: %w",

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -86,9 +86,13 @@ type stateMetrics struct {
 	// durable per-block record, not merely because the content was no
 	// longer reachable. See issue #3778.
 	reconciliationUndoMissingRecord prometheus.Counter
-	// Cross-fork continuation audit outcomes. The first three label values
-	// count one audited input each; disarmed_cap counts one audit window
-	// each. See continuationAuditOutcome for the verdicts.
+	// Cross-fork continuation audit outcomes. clean, missing_producer and
+	// inconclusive_eb_pending count one audited input each; disarmed_cap
+	// counts one audit window; skipped_budget counts one audited body whose
+	// endorser-block budget was exhausted; ref_unresolvable counts one
+	// endorser-block reference abandoned for good. See the
+	// continuationAuditResult* constants for the label values and
+	// countContinuationAuditOutcome for the helper that records them.
 	continuationAuditOutcomes *prometheus.CounterVec
 	// Pre-materialized children of continuationAuditOutcomes, so every
 	// verdict is exported from process start (an absent series and a zero

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -86,6 +86,19 @@ type stateMetrics struct {
 	// durable per-block record, not merely because the content was no
 	// longer reachable. See issue #3778.
 	reconciliationUndoMissingRecord prometheus.Counter
+	// Cross-fork continuation audit outcomes. The first three label values
+	// count one audited input each; disarmed_cap counts one audit window
+	// each. See continuationAuditOutcome for the verdicts.
+	continuationAuditOutcomes *prometheus.CounterVec
+	// Pre-materialized children of continuationAuditOutcomes, so every
+	// verdict is exported from process start (an absent series and a zero
+	// series read very differently when the question is "is this node
+	// reporting missing producers") and so the audit pays no label lookup
+	// per input while holding chainsyncBlockfetchMutex.
+	continuationAuditClean                 prometheus.Counter
+	continuationAuditMissingProducer       prometheus.Counter
+	continuationAuditInconclusiveEbPending prometheus.Counter
+	continuationAuditDisarmedCap           prometheus.Counter
 	// Observed for every Praos leader-eligibility decision on an inbound
 	// header: (threshold - leaderValue) / threshold. Positive is eligible,
 	// and the magnitude is the headroom. dingo derives its leadership stake
@@ -409,6 +422,39 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 			Name: "dingo_ledger_reconciliation_undo_missing_record_total",
 			Help: "applied blocks in a reconciliation undo range with no block_nonce row at all, not merely unresolvable content -- the shape of a Byron-era applied block (issue #3778)",
 		},
+	)
+	// Cross-fork continuation audit verdicts, labelled by result:
+	//   result="clean"                   — the input resolved to a producer
+	//   result="missing_producer"        — no producer found; reported at
+	//        Error, and the splice indicator above is incremented too
+	//   result="inconclusive_eb_pending" — the window's producer set is
+	//        knowingly incomplete because a certified Leios endorser block
+	//        had not been fetched when the audit ran, so an unresolved input
+	//        cannot be distinguished from one the audit simply cannot see
+	//   result="disarmed_cap"            — one per window, when the producer
+	//        set reached continuationAuditMaxProducedTxs and the window was
+	//        disarmed rather than report from a truncated set
+	// A node whose inconclusive count dominates is telling the operator the
+	// audit is not covering it, which is the honest reading of an
+	// endorser-block backlog.
+	m.continuationAuditOutcomes = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dingo_ledger_continuation_audit_outcomes_total",
+			Help: "cross-fork continuation audit verdicts by result; clean/missing_producer/inconclusive_eb_pending count audited inputs, disarmed_cap counts audit windows",
+		},
+		[]string{"result"},
+	)
+	m.continuationAuditClean = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultClean,
+	)
+	m.continuationAuditMissingProducer = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultMissingProducer,
+	)
+	m.continuationAuditInconclusiveEbPending = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultInconclusiveEbPending,
+	)
+	m.continuationAuditDisarmedCap = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultDisarmedCap,
 	)
 	m.leaderThresholdMargin = promautoFactory.NewHistogram(
 		prometheus.HistogramOpts{

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -99,6 +99,7 @@ type stateMetrics struct {
 	continuationAuditMissingProducer       prometheus.Counter
 	continuationAuditInconclusiveEbPending prometheus.Counter
 	continuationAuditDisarmedCap           prometheus.Counter
+	continuationAuditSkippedBudget         prometheus.Counter
 	// Observed for every Praos leader-eligibility decision on an inbound
 	// header: (threshold - leaderValue) / threshold. Positive is eligible,
 	// and the magnitude is the headroom. dingo derives its leadership stake
@@ -434,13 +435,16 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	//   result="disarmed_cap"            — one per window, when the producer
 	//        set reached continuationAuditMaxProducedTxs and the window was
 	//        disarmed rather than report from a truncated set
+	//   result="skipped_budget"          — one per audited body that had more
+	//        endorser blocks queued than continuationAuditMaxEndorserBlocksPerBlock
+	//        allows it to resolve; the rest stay queued for a later body
 	// A node whose inconclusive count dominates is telling the operator the
 	// audit is not covering it, which is the honest reading of an
 	// endorser-block backlog.
 	m.continuationAuditOutcomes = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "dingo_ledger_continuation_audit_outcomes_total",
-			Help: "cross-fork continuation audit verdicts by result; clean/missing_producer/inconclusive_eb_pending count audited inputs, disarmed_cap counts audit windows",
+			Help: "cross-fork continuation audit verdicts by result; clean/missing_producer/inconclusive_eb_pending count audited inputs, skipped_budget counts audited blocks, disarmed_cap counts audit windows",
 		},
 		[]string{"result"},
 	)
@@ -455,6 +459,9 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	)
 	m.continuationAuditDisarmedCap = m.continuationAuditOutcomes.WithLabelValues(
 		continuationAuditResultDisarmedCap,
+	)
+	m.continuationAuditSkippedBudget = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultSkippedBudget,
 	)
 	m.leaderThresholdMargin = promautoFactory.NewHistogram(
 		prometheus.HistogramOpts{

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -100,6 +100,7 @@ type stateMetrics struct {
 	continuationAuditInconclusiveEbPending prometheus.Counter
 	continuationAuditDisarmedCap           prometheus.Counter
 	continuationAuditSkippedBudget         prometheus.Counter
+	continuationAuditRefUnresolvable       prometheus.Counter
 	// Observed for every Praos leader-eligibility decision on an inbound
 	// header: (threshold - leaderValue) / threshold. Positive is eligible,
 	// and the magnitude is the headroom. dingo derives its leadership stake
@@ -438,6 +439,9 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	//   result="skipped_budget"          — one per audited body that had more
 	//        endorser blocks queued than continuationAuditMaxEndorserBlocksPerBlock
 	//        allows it to resolve; the rest stay queued for a later body
+	//   result="ref_unresolvable"        — an endorser-block reference given up
+	//        on for good, because resolving it failed for a reason retrying
+	//        cannot fix; that hole in the producer set never closes
 	// A node whose inconclusive count dominates is telling the operator the
 	// audit is not covering it, which is the honest reading of an
 	// endorser-block backlog.
@@ -462,6 +466,9 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	)
 	m.continuationAuditSkippedBudget = m.continuationAuditOutcomes.WithLabelValues(
 		continuationAuditResultSkippedBudget,
+	)
+	m.continuationAuditRefUnresolvable = m.continuationAuditOutcomes.WithLabelValues(
+		continuationAuditResultRefUnresolvable,
 	)
 	m.leaderThresholdMargin = promautoFactory.NewHistogram(
 		prometheus.HistogramOpts{

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -448,7 +448,7 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	m.continuationAuditOutcomes = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "dingo_ledger_continuation_audit_outcomes_total",
-			Help: "cross-fork continuation audit verdicts by result; clean/missing_producer/inconclusive_eb_pending count audited inputs, skipped_budget counts audited blocks, disarmed_cap counts audit windows",
+			Help: "cross-fork continuation audit verdicts by result; clean/missing_producer/inconclusive_eb_pending count audited inputs, skipped_budget counts audited blocks, ref_unresolvable counts abandoned endorser-block references, disarmed_cap counts audit windows",
 		},
 		[]string{"result"},
 	)


### PR DESCRIPTION
## What

The cross-fork continuation audit added for #3005 reports

```
level=ERROR msg="continuation block spends an input with no producer on the local applied chain"
```

for inputs whose producing transaction is canonical, present, and correctly
applied by the same node seconds later. On a Leios network every
endorser-resident spend after a fork is reported. The audit is wrong, not the
ledger. This PR makes the audit Leios-aware.

## Why the audit misses these producers

`ledger/continuation_audit.go` builds its in-window producer set from the
ranking block body:

```go
txs := e.Block.Transactions()
...
for _, tx := range txs {
	window.producedTxs[string(tx.Hash().Bytes())] = struct{}{}
}
```

On the Leios cert-driven path a **certifying ranking block carries an empty
body** (71 bytes on the prototype network). Its transactions are the certified
endorser block's, which arrives over `leios-fetch` as a separate artifact and is
applied by `LedgerState.applyEndorserBlock` (`ledger/state.go`, the
`dijkstraEraGate` branch of `ledgerProcessBlock`) at **ledger-apply** time. The
audit runs at **blockfetch** time (`ledger/chainsync.go`,
`flushPendingBlockfetchBlocksDeferred`, under `chainsyncBlockfetchMutex`).

So all three resolution paths in `continuationInputHasProducer` miss an
endorser-resident producer while the ledger is behind the blockfetch queue:

1. `window.producedTxs` — populated only from the ranking-block body, which is
   empty on a cert-RB. This is the bug.
2. `ls.db.UtxoByRef` — the UTxO does not exist yet; `applyEndorserBlock` has not
   run.
3. `ls.db.GetTransactionByHash` — the transaction row does not exist yet, same
   reason.

The audit's own soundness argument said:

> An input can therefore be resolved without a chain scan: it is legitimate when
> its producing transaction was created by a block already seen in this window
> (fetched, on the chain, not yet applied) …

That is exactly right for pre-Leios blocks, where "the block was fetched"
implies "its transactions are in hand". It does not hold where a block's
transactions are a separate artifact fetched over a different mini-protocol and
applied by a later stage.

Being behind is not an edge case here: an endorser-block apply backlog is the
normal condition on a Leios node, and it is precisely the condition in which a
rollback arms the audit.

## Field observation

Two independent nodes on the same Leios prototype network (magic 164), two
different fork windows, same signature. Timeline from one of them, abstracted:

| offset | event |
|---|---|
| T-29m | endorser block for slot 2610537 fetched complete, manifest + 1347/1347 transactions |
| T+0 | 16 × `ERROR continuation block spends an input with no producer…` across blocks at slots 2610834 / 2610858 / 2610876 |
| T+16s | `INFO applied Leios endorser block transactions slot=2610577 eb_slot=2610537 eb_txs=1347` |
| T+23s | `INFO applied Leios endorser block transactions slot=2610590 eb_slot=2610577 eb_txs=959` |
| T+67s | `INFO applied Leios endorser block transactions slot=2610832 eb_slot=2610793 eb_txs=641` |

Every named producer resolved, against an independent chain index, to a block
with `has_leios_cert: true` and a 71-byte body — a cert-RB whose 1347 / 959
transactions are the certified endorser block's. Every *reporting* block was an
ordinary ranking block with a real body. There was no
`certified Leios endorser block unavailable` and no dropped required reference
in the window; the node then tracked the network tip unaided. The second node
was at the tip throughout and never wedged, and produced the same message. The
UTxO set was never short.

Severity is diagnostic-only — the audit never rejects a block — but the message
is an operator-facing `ERROR` that names a transaction and an input and asserts
ledger corruption. It is the first thing one greps for during a Leios stall and
it points away from the real problem. It also defeats the audit's purpose: with
a guaranteed false-positive source on the Leios path, a *true* unresolved
producer is indistinguishable from noise.

## Fix

`auditContinuationBlock` now resolves each audited block's endorser block the
same way `ledgerProcessBlock` does, and records its transactions as in-window
producers:

- `ls.leiosEndorserBlockForApply(block)` picks the reference — the block's own
  announcement on the CIP path, the parent's announcement on the cert-driven
  path — and returns the slot that occurrence must be bound to.
- `ls.config.EndorserBlockProvider(ebHash, ebSlot)` supplies the transactions
  for exactly that `(hash, slot)` occurrence. The common path is an in-memory
  cache hit plus a hash per endorser transaction, since the endorser block is
  usually in the provider cache by the time the referencing ranking block is
  fetched. It is not guaranteed to be I/O-free, though: the provider resolves to
  `Ouroboros.EndorserBlockTxsByHash` → `lookupLeiosEndorserBlock`, which falls
  back to `loadLeiosEBFromDB` — a blob-store manifest read, a decode and a
  transaction load — for an occurrence whose in-memory entry has expired. That
  is the case worth naming, because the audit is armed precisely during the
  backlog in which entries do expire, and it holds
  `chainsyncBlockfetchMutex` throughout. It stays bounded on both axes: at most
  `continuationAuditMaxEndorserBlocksPerBlock` per audited body, and once per
  `(hash, slot)` for the life of the window.
- Transaction ids come straight from the envelope: blake2b-256 over the
  transaction body CBOR, which is the definition `DijkstraTransaction.Id`
  inherits from `BabbageTransactionBody.Id`. A full per-transaction decode was
  rejected because the audit holds `chainsyncBlockfetchMutex` and an armed
  window can span 512 blocks of thousand-transaction endorser blocks.
  `TestEndorserBlockTxIdsMatchDecodedTransactionHashes` pins the cheap
  derivation against the decoded transaction hash so the two cannot drift.
- The CBOR-in-CBOR unwrap that `applyEndorserBlock` already performed is
  extracted to `decodeEndorserTxEnvelope` and shared, so the audit and the apply
  path cannot disagree about what an endorser transaction entry is.

**When the endorser block is not cached yet**, the producer set is knowingly
incomplete. The window is marked (`endorserProducersPending`, sticky) and
unresolved inputs are reported as *inconclusive* at `Debug` instead of as
missing producers at `Error`. A report from an incomplete set is a false
positive, and a false positive here is worse than silence: it asserts ledger
corruption on a healthy node.

Non-Leios chains are unaffected: a header that neither announces nor certifies
an endorser block yields no reference, and the offline replay path configures no
endorser-block provider at all.

## Cost model

Resolving an endorser block costs a parent-block read (cert-driven path) plus a
hash of every one of its transactions, all under `chainsyncBlockfetchMutex`. The
audit is armed exactly when a node is in a dense endorser-block backlog, so that
work is scheduled carefully:

- **Lazy.** Classifying a block into an endorser-block reference is header-only
  and free, so that stays eager. Turning a reference into producers is deferred
  until an audited input fails to resolve from the ranking-block producer set
  *and* the ledger. A window in which nothing spends an endorser-resident output
  performs zero parent reads, zero provider lookups and zero hashing. The
  cert-driven reference is retained as its parent hash alone, so the referencing
  block and its CBOR need not be held.
- **Once per window.** References are deduplicated when queued and merged
  occurrences memoized by `(ebHash, ebSlot)`, so a closure certified by N ranking
  blocks costs one parent read, one provider lookup and one hashing pass rather
  than N. An endorser block not cached yet is requeued in *resolved* form, so a
  later attempt costs only the provider lookup.
- **Budgeted.** `continuationAuditMaxEndorserBlocksPerBlock` (32) is the
  analogue of `continuationAuditMaxInputsPerBlock`: one audited body may not
  resolve an unbounded number of endorser blocks. Overflow stays queued for a
  later body, the window reports inconclusive while its set is knowingly short,
  and the stop is counted as `result="skipped_budget"`.
- **Retryable.** A parent that is not in the block store yet is a state, not a
  verdict — the same read-ahead this audit exists to tolerate — so
  `models.ErrBlockNotFound` requeues the reference for the next audited body
  rather than dropping it for the life of the window. Each reference is probed
  at most once per body, so a permanently absent parent costs one index miss per
  audited block. Anything else drops the reference, counts
  `result="ref_unresolvable"` and logs once per window.
- **Deduplicated on requeue too.** A deferred certified reference is keyed by
  its parent hash, but the endorser-block reference is (announced hash,
  announcing slot): two ranking blocks with different parents at one slot — on
  either side of a fork, which is the state a window is armed in — name the same
  occurrence under two queue keys, and converge only once resolved. Requeueing
  therefore dedupes against the queue as well, so a still-unfetched endorser
  block cannot be queued twice and probed twice per body.

"The producer set is knowingly short" is derived from the queue rather than
latched, so a window whose references all resolve becomes complete again and can
go back to diagnosing a genuine missing producer. Before, one transient miss
silenced a window permanently.

Net per audited body: nothing at all unless one of its inputs is unresolvable
without an endorser block, and at most 32 resolutions when it is, each the first
and only time that closure is touched in the window.

## Producer-set cap

Including endorser transactions changes the arithmetic. A ranking-block-only
window held a few hundred transactions per block; a certified endorser block on
the prototype network carries 100–2500, so a full `continuationAuditBlockBudget`
(512 block) window can offer well past a million producers against the old
100k cap.

`continuationAuditMaxProducedTxs` is raised **100k → 250k** (~16 MB of
transient set for a diagnostic) rather than to that ceiling, because unbounded
growth is the worse failure. A busy Leios window will therefore still disarm
partway through — so the disarm is now **explicit** rather than silent: it logs
at `Warn` (was `Debug`) with `max_produced_txs`, and increments the outcome
counter with `result="disarmed_cap"`. "The audit stopped covering this node"
should not read the same as "this node is clean".

The cap bounds the **size of the set**, so it is enforced per insert and only
ids the set does not already hold count toward it. Charging a repeat would
disarm a window whose producer set never grew, and repeats are ordinary here:
the same transaction can appear in more than one endorser block
(`deduplicateEndorserBlockTransactionIndexes` exists for exactly that), and an
endorser block is content-addressed, so the same closure can be certified from
more than one ranking block in a window.

## Observability

New `dingo_ledger_continuation_audit_outcomes_total{result=…}`, with all four
children pre-materialized at registration so every verdict is exported from
process start (an absent series and a zero series read very differently when the
question is "is this node reporting missing producers"), and so the audit pays
no label lookup per input under the mutex:

| `result` | unit | meaning |
|---|---|---|
| `clean` | input | resolved to a producer |
| `missing_producer` | input | no producer; still logged at `Error`, and `dingo_ledger_continuation_input_unresolved_total` still increments |
| `inconclusive_eb_pending` | input | producer set knowingly incomplete (certified endorser block not fetched yet) |
| `disarmed_cap` | window | producer set hit the cap and the window disarmed |
| `skipped_budget` | block | more endorser blocks queued than one body may resolve; the rest stay queued |
| `ref_unresolvable` | reference | an endorser-block reference given up on for good, because resolving it failed for a reason retrying cannot fix |

A node whose `inconclusive_eb_pending` dominates is telling the operator the
audit is not covering it, which is the honest reading of an endorser-block
backlog.

The audit's soundness comment now states the Leios caveat instead of implying
"block fetched ⇒ transactions in hand" holds everywhere.

## Tests

New `ledger/continuation_audit_leios_test.go`. Red before the fix, green after:

- `TestContinuationAuditAcceptsEndorserBlockProducer` — the regression. A
  cert-RB with an empty body certifies an endorser block containing tx T; a
  later ordinary ranking block spends `T#0`; the ledger has not applied the
  endorser block (the provider cache holds it, the ledger does not). Asserts no
  report, that the window is not `endorserProducersPending`, and that T is in
  the producer set. **Failed before the fix.**
- `TestContinuationAuditTreatsPendingEndorserBlockAsInconclusive` — same shape
  with the endorser block not yet cached: no `Error`, and the inconclusive
  `Debug` record is emitted. **Failed before the fix.**
- `TestContinuationAuditStillReportsMissingProducerOnLeios` — the guard: with
  the closure resolved, a genuinely absent producer is still reported at
  `Error`. Passed before and after, so the fix is not muting the diagnostic.
- `TestContinuationAuditAcceptsAnnouncedEndorserBlockProducer` — the forward/CIP
  path, where the block applies the endorser block it announces itself.
- `TestEndorserBlockTxIdsMatchDecodedTransactionHashes` — cheap id derivation
  vs. the decoded transaction hash, for both bare and CBOR-in-CBOR entries.
- `TestContinuationAuditOutcomesAreCounted` — clean / inconclusive /
  missing_producer land in exactly one bucket each.
- `TestContinuationAuditCapDisarmIsExplicit` — disarm logs at `Warn` and counts
  `disarmed_cap`.
- `TestContinuationAuditCapCountsOnlyNewProducers` — a repeated endorser
  transaction offered to a window one short of the cap must not disarm it.
- `TestContinuationAuditResolvesEachEndorserBlockOnce` — three ranking blocks
  certifying one closure cost one resolution and one provider call.
- `TestContinuationAuditSkipsEndorserResolutionWithoutEndorserSpends` — a window
  that spends nothing endorser-resident performs zero resolutions; the reference
  stays queued, classified but unresolved.
- `TestContinuationAuditEndorserResolutionIsBudgeted` — one body may not exceed
  `continuationAuditMaxEndorserBlocksPerBlock`; the overflow requeues, the window
  goes inconclusive, and the stop is counted.
- `TestContinuationAuditRetriesUnresolvedCertifyingParent` — parent missing, the
  reference stays queued and is not duplicated by a second certifying block over
  the same parent; parent lands, the next body resolves it, the producer is
  recognised and the window is complete again.
- `TestContinuationAuditRetriesParentAtMostOncePerBlock` — three unresolvable
  inputs on one body cost one parent lookup.
- `TestContinuationAuditDedupesConvergingEndorserRefs` — two certifying blocks
  over two distinct parents at one slot announcing one endorser block leave
  exactly one queued reference and cost one provider probe per later body.

Fifteen mutations were checked independently and each turns the suite red: not
queueing the endorser reference, dropping the per-window memoization, making the
drain eager, removing the per-block budget, restoring the batch cap arithmetic
that counted duplicates, dropping the post-drain re-check, hashing the full
transaction CBOR instead of the body, perturbing the endorser-block slot binding
in the shared selector, dropping the transient requeue, latching incompleteness,
removing the once-per-body probe guard, misclassifying a not-found parent as a
hard error, requeueing without restoring the dedupe entry, removing the
converging-key dedupe, and routing the once-per-body path back through the
requeue helper. A sixteenth — dropping an already-merged guard in that helper —
stayed green, which identified the guard as unreachable; it was removed rather
than shipped as an untestable branch.

`gofmt`, `go vet ./...`, `golangci-lint run ./ledger/...` (0 issues),
`go test ./ledger/ -count=1` and `-race`, plus `./ledger/eras/` and
`./database/...` — all green on `upstream/main`.

## Follow-ups (not in this PR)

- The audit still inspects only the ranking block's own transaction inputs. A
  certified endorser block's transactions are now recognised as *producers* but
  their own inputs are not audited, so a splice that lands entirely inside an
  endorser block is not covered. Doing that needs the full decode this PR
  deliberately avoids on the mutex.
- #3170's second comment showed the same audit message on preview (Conway, no
  endorser blocks), where this mechanism cannot apply. That case is untouched
  here and may be a genuine, separate read-ahead race: an audit at blockfetch
  time against a producer whose block is below the fork point but not yet
  applied. `GetTransactionByHash` should cover it, but that is unverified under
  a deep backlog. This PR narrows the dataset — the Leios occurrences were
  noise and should be excluded from it.
- On a busy Leios chain the window will now disarm at the cap partway through
  its 512-block budget. That is a deliberate memory/coverage trade, and it is
  counted; if the coverage matters more than the ~16 MB, the cap is the knob.
- The per-block endorser-resolution budget is a count, not a time bound. A
  count is the right shape for the existing knobs in this file, but if endorser
  blocks grow much larger a deadline would bound the mutex hold better.

Related: #3170, #3005

