### PR TITLE
fix(chainselection): register a peer from its post-intersect rollback

### DIFF
--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -35,9 +35,19 @@ type PeerChainTip struct {
 	// observedTipSet distinguishes a delivered origin/rollback frontier from
 	// legacy callers that did not provide ObservedTip and need Tip as fallback.
 	observedTipSet bool
-	VRFOutput      []byte // VRF output from tip block for tie-breaking
-	PraosView      PraosTiebreakerView
-	LastUpdated    time.Time
+	// awaitingFirstHeader marks an entry created from a chainsync rollback for
+	// a connection the selector was not tracking (the post-FindIntersect
+	// MsgRollBackward on a fresh or recycled connection). Such a peer has
+	// confirmed an intersection but has not delivered a header yet, so its
+	// ObservedTip carries the confirmed intersection point with block number 0.
+	// That zero means "nothing delivered yet", NOT "this peer is at block 0",
+	// and the two behind-filters in isPeerSelectableLocked would otherwise read
+	// it as a peer implausibly far behind and skip it until its next
+	// MsgRollForward. Cleared by the first delivered header.
+	awaitingFirstHeader bool
+	VRFOutput           []byte // VRF output from tip block for tie-breaking
+	PraosView           PraosTiebreakerView
+	LastUpdated         time.Time
 	// observedSlots is the recent observed slot frontier used for Genesis
 	// density. observedPoints is the same frontier with block hashes, used
 	// for Genesis corroboration (detecting whether other peers report the
@@ -67,6 +77,40 @@ func NewPeerChainTip(
 			PraosTiebreakerConfigUnknown(),
 		),
 		LastUpdated: time.Now(),
+	}
+}
+
+// newPeerChainTipFromRollback creates the tracked tip for a peer that reported
+// a chainsync rollback while the selector had no entry for its connection. The
+// canonical case is the post-FindIntersect MsgRollBackward that a server sends
+// on a fresh connection: it is the only chainsync traffic until the next block
+// is minted, so a peer whose entry was dropped by a connection recycle would
+// otherwise stay invisible to chain selection for a whole block interval.
+//
+// The entry deliberately records only what the exchange proved:
+//   - Tip is the peer's advertised tip, untrusted exactly as on roll forward.
+//   - ObservedTip is the intersection point the peer confirmed it holds, with
+//     block number 0 because no header has been delivered. It is never the
+//     advertised tip (mirroring ApplyRollback, which refuses that promotion).
+//   - No observed slot/point frontier is recorded, so the peer contributes no
+//     Genesis density and cannot corroborate another peer until it delivers
+//     headers.
+//
+// awaitingFirstHeader marks the zero block number as "unknown" rather than
+// "behind"; the first delivered header clears it and the peer is compared on
+// its real frontier from then on.
+func newPeerChainTipFromRollback(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) *PeerChainTip {
+	return &PeerChainTip{
+		ConnectionId:        connId,
+		Tip:                 tip,
+		ObservedTip:         ochainsync.Tip{Point: clonePoint(point)},
+		observedTipSet:      true,
+		awaitingFirstHeader: true,
+		LastUpdated:         time.Now(),
 	}
 }
 
@@ -109,6 +153,7 @@ func (p *PeerChainTip) UpdateTipWithObservedPraosView(
 	p.Tip = tip
 	p.ObservedTip = observedTip
 	p.observedTipSet = true
+	p.awaitingFirstHeader = false
 	p.VRFOutput = vrfOutput
 	p.PraosView = praosView
 	p.LastUpdated = time.Now()

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -96,6 +96,29 @@ func safeUint64ToInt64(v uint64) int64 {
 	return int64(v)
 }
 
+// RollbackRegistrationOutcome is the result of handling a chainsync rollback
+// for a connection the selector is not tracking (see
+// registerPeerFromRollbackLocked). It is reported to
+// ChainSelectorConfig.OnRollbackRegistration so the composition layer can count
+// registrations and refusals without chainselection depending on a metrics
+// library.
+type RollbackRegistrationOutcome string
+
+const (
+	// RollbackRegistrationRegistered means the peer was registered from the
+	// rollback and is now visible to chain selection.
+	RollbackRegistrationRegistered RollbackRegistrationOutcome = "registered"
+	// RollbackRegistrationClosedConnection means the rollback arrived for a
+	// connection that is no longer live, so no entry was created.
+	RollbackRegistrationClosedConnection RollbackRegistrationOutcome = "rejected_closed_connection"
+	// RollbackRegistrationImplausibleTip means the advertised tip failed the
+	// same plausibility bound the roll-forward path applies to a new peer.
+	RollbackRegistrationImplausibleTip RollbackRegistrationOutcome = "rejected_implausible_tip"
+	// RollbackRegistrationAtCapacity means the tracked-peer table was full and
+	// no peer could be evicted to make room.
+	RollbackRegistrationAtCapacity RollbackRegistrationOutcome = "rejected_at_capacity"
+)
+
 // ChainSelectorConfig holds configuration for the ChainSelector.
 type ChainSelectorConfig struct {
 	Logger             *slog.Logger
@@ -124,6 +147,11 @@ type ChainSelectorConfig struct {
 	// connection and whether any samples exist. Used only to choose a
 	// peer when two peers advertise the exact same selected block.
 	BlockfetchLatency func(ouroboros.ConnectionId) (time.Duration, bool)
+	// OnRollbackRegistration is called, outside the selector lock, with the
+	// outcome of every attempt to register a peer from a chainsync rollback for
+	// an untracked connection. Optional; the composition layer uses it to
+	// export a counter.
+	OnRollbackRegistration func(RollbackRegistrationOutcome)
 }
 
 // ChainSelector tracks chain tips from multiple peers and selects the best
@@ -466,104 +494,9 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
 
-		// Reject implausible delivered frontiers that jump too far ahead of a
-		// trusted reference point. Before any local block has been applied,
-		// retain the advertised-tip bound as well: the first peer bootstraps the
-		// reference, and later peers cannot immediately inject a far claim. Once
-		// a local tip exists, the advertisement can legitimately be arbitrarily
-		// far ahead during catch-up; only its delivered frontier drives
-		// selection and must remain plausible. Three cases:
-		//  1. Known peer: compare against the peer's own previous
-		//     observed frontier — chainsync advances incrementally so the delta
-		//     is always small. Always checked (even if prev == 0).
-		//  2. New peer with existing peers: compare against the
-		//     best observed peer frontier to prevent a malicious newcomer
-		//     from injecting an extremely high delivered block number.
-		//  3. First peer ever: no reference exists, accept to
-		//     allow bootstrap.
-		if cs.securityParam > 0 {
-			// Callers without a distinct delivered frontier pass the
-			// advertised tip for both values, as UpdatePeerTip does. An
-			// all-zero delivered frontier therefore means the peer has
-			// delivered nothing, and is bounded as block 0 rather than
-			// being credited with its untrusted advertisement.
-			observedBlock := observedTip.BlockNumber
-			observedReject := false
-			advertisedReject := false
-			hasReference := false
-			var referenceBlock uint64
-			var advertisedReferenceBlock uint64
-			var maxPlausibleBlock uint64
-			var maxPlausibleAdvertisedBlock uint64
-			if prevTip, exists := cs.peerTips[connId]; exists {
-				// Case 1: known peer — compare against the peer's own
-				// previous delivered frontier.
-				hasReference = true
-				referenceBlock = prevTip.SelectionTip().BlockNumber
-				advertisedReferenceBlock = prevTip.Tip.BlockNumber
-			} else if len(cs.peerTips) > 0 {
-				// Case 2: new peer — check against the best observed and
-				// advertised frontiers separately.
-				hasReference = true
-				for _, pt := range cs.peerTips {
-					blockNumber := pt.SelectionTip().BlockNumber
-					if blockNumber > referenceBlock {
-						referenceBlock = blockNumber
-					}
-					if pt.Tip.BlockNumber > advertisedReferenceBlock {
-						advertisedReferenceBlock = pt.Tip.BlockNumber
-					}
-				}
-			}
-			if hasReference {
-				maxPlausibleBlock = safeAddUint64(
-					referenceBlock,
-					cs.securityParam,
-				)
-				observedReject = observedBlock > maxPlausibleBlock
-				maxPlausibleAdvertisedBlock = safeAddUint64(
-					advertisedReferenceBlock,
-					cs.securityParam,
-				)
-				advertisedReject = tip.BlockNumber >
-					maxPlausibleAdvertisedBlock
-			}
-			// Catch-up relaxation: after a stall, recorded peer tips
-			// go stale while the network advances. A peer whose
-			// delta from the stale reference exceeds K looks
-			// implausible, but the network legitimately moved on.
-			// Accept the tip if it is within 2*K of the local tip
-			// AND the reference itself is stale (reference <=
-			// local tip, meaning the node hasn't updated peer
-			// records since the stall began).
-			if observedReject && cs.localTip.BlockNumber > 0 &&
-				referenceBlock <= cs.localTip.BlockNumber {
-				maxPlausibleBlock = safeAddUint64(
-					cs.localTip.BlockNumber,
-					safeAddUint64(cs.securityParam, cs.securityParam),
-				)
-				observedReject = observedBlock > maxPlausibleBlock
-			}
-			// Case 3: len(peerTips)==0 && peer not known → bootstrap
-			if observedReject ||
-				(advertisedReject && cs.localTip.BlockNumber == 0) {
-				cs.config.Logger.Warn(
-					"rejecting implausible peer tip",
-					"connection_id", connId.String(),
-					"claimed_block", tip.BlockNumber,
-					"observed_block", observedBlock,
-					"reference_block", referenceBlock,
-					"advertised_reference_block",
-					advertisedReferenceBlock,
-					"local_block", cs.localTip.BlockNumber,
-					"security_param", cs.securityParam,
-					"max_plausible_block", maxPlausibleBlock,
-					"max_plausible_advertised_block",
-					maxPlausibleAdvertisedBlock,
-				)
-				accepted = false
-				return
-			}
+		if !cs.checkPeerTipPlausibleLocked(connId, tip, observedTip) {
+			accepted = false
+			return
 		}
 
 		trackHashes := cs.genesisCorroborationActiveLocked()
@@ -584,19 +517,11 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 				safeAddUint64(cs.securityParam, 1),
 			)
 		} else {
-			// Evict the least-recently-updated peer if at capacity
-			if len(cs.peerTips) >= cs.maxTrackedPeers {
-				evictedConn = cs.evictLeastRecentPeerLocked()
-				if evictedConn == nil {
-					cs.config.Logger.Warn(
-						"cannot accept new peer: at capacity and best peer is the only tracked peer",
-						"connection_id", connId.String(),
-						"peer_count", len(cs.peerTips),
-						"max_tracked_peers", cs.maxTrackedPeers,
-					)
-					accepted = false
-					return
-				}
+			var ok bool
+			evictedConn, ok = cs.makeRoomForNewPeerLocked(connId)
+			if !ok {
+				accepted = false
+				return
 			}
 			peerTip := &PeerChainTip{
 				ConnectionId:   connId,
@@ -670,6 +595,155 @@ func (cs *ChainSelector) updatePeerTipObservedPraosView(
 	}
 
 	return true
+}
+
+// checkPeerTipPlausibleLocked reports whether a tip observation from connId
+// may be recorded, applying the shared plausibility bound used by every path
+// that records a peer frontier (roll forward and the roll-backward
+// registration of a peer that has no entry yet). It logs and returns false
+// when the observation is rejected. Callers must hold cs.mutex.
+func (cs *ChainSelector) checkPeerTipPlausibleLocked(
+	connId ouroboros.ConnectionId,
+	tip ochainsync.Tip,
+	observedTip ochainsync.Tip,
+) bool {
+	// Reject implausible delivered frontiers that jump too far ahead of a
+	// trusted reference point. Before any local block has been applied,
+	// retain the advertised-tip bound as well: the first peer bootstraps the
+	// reference, and later peers cannot immediately inject a far claim. Once
+	// a local tip exists, the advertisement can legitimately be arbitrarily
+	// far ahead during catch-up; only its delivered frontier drives
+	// selection and must remain plausible. Three cases:
+	//  1. Known peer: compare against the peer's own previous
+	//     observed frontier — chainsync advances incrementally so the delta
+	//     is always small. Always checked (even if prev == 0).
+	//  2. New peer with existing peers: compare against the
+	//     best observed peer frontier to prevent a malicious newcomer
+	//     from injecting an extremely high delivered block number.
+	//  3. First peer ever: no reference exists, accept to
+	//     allow bootstrap.
+	//
+	// A peer registered from a chainsync rollback has delivered no header, so
+	// it is not a reference for anyone, including itself: counting its zero
+	// delivered frontier would turn case 3 into a reference of 0 and reject
+	// the next peer's first legitimate header, and counting its unverified
+	// advertisement would raise the bootstrap advertised bound. It is bounded
+	// like a brand-new peer when its own first header arrives.
+	if cs.securityParam > 0 {
+		// Callers without a distinct delivered frontier pass the
+		// advertised tip for both values, as UpdatePeerTip does. An
+		// all-zero delivered frontier therefore means the peer has
+		// delivered nothing, and is bounded as block 0 rather than
+		// being credited with its untrusted advertisement.
+		observedBlock := observedTip.BlockNumber
+		observedReject := false
+		advertisedReject := false
+		hasReference := false
+		var referenceBlock uint64
+		var advertisedReferenceBlock uint64
+		var maxPlausibleBlock uint64
+		var maxPlausibleAdvertisedBlock uint64
+		prevTip, known := cs.peerTips[connId]
+		if known && prevTip.awaitingFirstHeader {
+			known = false
+		}
+		if known {
+			// Case 1: known peer — compare against the peer's own
+			// previous delivered frontier.
+			hasReference = true
+			referenceBlock = prevTip.SelectionTip().BlockNumber
+			advertisedReferenceBlock = prevTip.Tip.BlockNumber
+		} else if len(cs.peerTips) > 0 {
+			// Case 2: new peer — check against the best observed and
+			// advertised frontiers separately.
+			for _, pt := range cs.peerTips {
+				if pt.awaitingFirstHeader {
+					continue
+				}
+				hasReference = true
+				blockNumber := pt.SelectionTip().BlockNumber
+				if blockNumber > referenceBlock {
+					referenceBlock = blockNumber
+				}
+				if pt.Tip.BlockNumber > advertisedReferenceBlock {
+					advertisedReferenceBlock = pt.Tip.BlockNumber
+				}
+			}
+		}
+		if hasReference {
+			maxPlausibleBlock = safeAddUint64(
+				referenceBlock,
+				cs.securityParam,
+			)
+			observedReject = observedBlock > maxPlausibleBlock
+			maxPlausibleAdvertisedBlock = safeAddUint64(
+				advertisedReferenceBlock,
+				cs.securityParam,
+			)
+			advertisedReject = tip.BlockNumber >
+				maxPlausibleAdvertisedBlock
+		}
+		// Catch-up relaxation: after a stall, recorded peer tips
+		// go stale while the network advances. A peer whose
+		// delta from the stale reference exceeds K looks
+		// implausible, but the network legitimately moved on.
+		// Accept the tip if it is within 2*K of the local tip
+		// AND the reference itself is stale (reference <=
+		// local tip, meaning the node hasn't updated peer
+		// records since the stall began).
+		if observedReject && cs.localTip.BlockNumber > 0 &&
+			referenceBlock <= cs.localTip.BlockNumber {
+			maxPlausibleBlock = safeAddUint64(
+				cs.localTip.BlockNumber,
+				safeAddUint64(cs.securityParam, cs.securityParam),
+			)
+			observedReject = observedBlock > maxPlausibleBlock
+		}
+		// Case 3: len(peerTips)==0 && peer not known → bootstrap
+		if observedReject ||
+			(advertisedReject && cs.localTip.BlockNumber == 0) {
+			cs.config.Logger.Warn(
+				"rejecting implausible peer tip",
+				"connection_id", connId.String(),
+				"claimed_block", tip.BlockNumber,
+				"observed_block", observedBlock,
+				"reference_block", referenceBlock,
+				"advertised_reference_block",
+				advertisedReferenceBlock,
+				"local_block", cs.localTip.BlockNumber,
+				"security_param", cs.securityParam,
+				"max_plausible_block", maxPlausibleBlock,
+				"max_plausible_advertised_block",
+				maxPlausibleAdvertisedBlock,
+			)
+			return false
+		}
+	}
+	return true
+}
+
+// makeRoomForNewPeerLocked makes room in the tracked-peer table for a new
+// entry for connId, evicting the least-recently-updated peer when the table
+// is at capacity. It returns the evicted connection (nil when no eviction was
+// needed) and whether there is room; the caller publishes PeerEvictedEvent for
+// a non-nil eviction outside the lock. Callers must hold cs.mutex.
+func (cs *ChainSelector) makeRoomForNewPeerLocked(
+	connId ouroboros.ConnectionId,
+) (*ouroboros.ConnectionId, bool) {
+	if len(cs.peerTips) < cs.maxTrackedPeers {
+		return nil, true
+	}
+	evicted := cs.evictLeastRecentPeerLocked()
+	if evicted == nil {
+		cs.config.Logger.Warn(
+			"cannot accept new peer: at capacity and best peer is the only tracked peer",
+			"connection_id", connId.String(),
+			"peer_count", len(cs.peerTips),
+			"max_tracked_peers", cs.maxTrackedPeers,
+		)
+		return nil, false
+	}
+	return evicted, true
 }
 
 func (cs *ChainSelector) TouchPeerActivity(connId ouroboros.ConnectionId) {
@@ -1110,55 +1184,71 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 		return false
 	}
 	selectionTip := peerTip.SelectionTip()
-	if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
-		safeAddUint64(selectionTip.BlockNumber, cs.securityParam) <
-			cs.localTip.BlockNumber {
-		if logSkip {
-			cs.config.Logger.Debug(
-				"skipping implausibly-behind peer",
-				"connection_id", connId.String(),
-				"peer_block_number", selectionTip.BlockNumber,
-				"local_block_number", cs.localTip.BlockNumber,
-				"security_param", cs.securityParam,
-			)
-		}
-		return false
-	}
-	// Skip peers whose tip is far behind the best known peer tip.
-	// During catch-up, switching to a behind peer causes pipeline
-	// stalls and dropped rollbacks that cost minutes of sync time.
-	// Use securityParam (K) as the threshold — peers within K blocks
-	// of the best are acceptable (normal fork variance), but peers
-	// further behind are not useful for syncing.
-	//
-	// The gap is measured on DELIVERED frontiers, which is a transport
-	// property: it says how many headers each peer has served us so far, not
-	// what chain each peer holds. Two peers that advertise the identical
-	// canonical tip are TREATED AS the same chain unless retained delivered
-	// history contradicts them (see sameCanonicalChain), so a delivered-frontier
-	// gap between them is read as delivery speed and must not make either one
-	// ineligible.
-	// Excluding the trailing peer here also excluded the incumbent, which
-	// skipped the anti-flap pin entirely (see pinIncumbentDuringCatchUpLocked)
-	// and let the active connection flap between two canonical public roots.
-	if cs.securityParam > 0 {
-		bestBlock := cs.bestKnownBlockNumber()
-		if bestBlock > 0 &&
-			safeAddUint64(
-				selectionTip.BlockNumber,
-				cs.securityParam,
-			) < bestBlock &&
-			!cs.frontierLeadIsTransportOnlyLocked(peerTip, bestBlock) {
+	// The two behind-filters below compare delivered block numbers. A peer
+	// registered from a rollback has not delivered a header yet, so its
+	// delivered block number is 0 meaning "unknown", not "at block 0"; reading
+	// it as a block number would skip the peer until its next MsgRollForward,
+	// which is exactly the post-recycle chain-selection stall this exemption
+	// exists to avoid. Such a peer still never outranks one with a real
+	// delivered frontier: block 0 loses every Praos comparison, so it can only
+	// be selected when nothing better is tracked.
+	if !peerTip.awaitingFirstHeader {
+		if cs.securityParam > 0 && cs.localTip.BlockNumber > 0 &&
+			safeAddUint64(selectionTip.BlockNumber, cs.securityParam) <
+				cs.localTip.BlockNumber {
 			if logSkip {
 				cs.config.Logger.Debug(
-					"skipping peer behind best known tip",
+					"skipping implausibly-behind peer",
 					"connection_id", connId.String(),
 					"peer_block_number", selectionTip.BlockNumber,
-					"best_known_block", bestBlock,
+					"local_block_number", cs.localTip.BlockNumber,
 					"security_param", cs.securityParam,
 				)
 			}
 			return false
+		}
+		// Skip peers whose tip is far behind the best known peer tip.
+		// During catch-up, switching to a behind peer causes pipeline
+		// stalls and dropped rollbacks that cost minutes of sync time.
+		// Use securityParam (K) as the threshold — peers within K blocks
+		// of the best are acceptable (normal fork variance), but peers
+		// further behind are not useful for syncing.
+		//
+		// The gap is measured on DELIVERED frontiers, which is a transport
+		// property: it says how many headers each peer has served us so far,
+		// not what chain each peer holds. Two peers that advertise the
+		// identical canonical tip are TREATED AS the same chain unless
+		// retained delivered history contradicts them (see
+		// sameCanonicalChain), so a delivered-frontier gap between them is
+		// read as delivery speed and must not make either one ineligible.
+		// Excluding the trailing peer here also excluded the incumbent, which
+		// skipped the anti-flap pin entirely (see
+		// pinIncumbentDuringCatchUpLocked) and let the active connection flap
+		// between two canonical public roots.
+		//
+		// A peer awaiting its first header is already exempt from this filter
+		// (outer branch) and can never be the leading frontier this escape
+		// compares against: its delivered block number is 0, and the escape
+		// only considers leaders holding a bestBlock > 0 frontier.
+		if cs.securityParam > 0 {
+			bestBlock := cs.bestKnownBlockNumber()
+			if bestBlock > 0 &&
+				safeAddUint64(
+					selectionTip.BlockNumber,
+					cs.securityParam,
+				) < bestBlock &&
+				!cs.frontierLeadIsTransportOnlyLocked(peerTip, bestBlock) {
+				if logSkip {
+					cs.config.Logger.Debug(
+						"skipping peer behind best known tip",
+						"connection_id", connId.String(),
+						"peer_block_number", selectionTip.BlockNumber,
+						"best_known_block", bestBlock,
+						"security_param", cs.securityParam,
+					)
+				}
+				return false
+			}
 		}
 	}
 	// Genesis corroboration gate: a fast source must be corroborated by the
@@ -1934,7 +2024,11 @@ func (cs *ChainSelector) HandlePeerActivityEvent(evt event.Event) {
 }
 
 // HandlePeerRollbackEvent trims Genesis observed history and refreshes the
-// tracked peer tip after a rollback.
+// tracked peer tip after a rollback. When the connection has no tracked entry
+// it registers one from the rollback (see registerPeerFromRollbackLocked),
+// because a rollback for an untracked connection is the normal post-
+// FindIntersect MsgRollBackward of a fresh or recycled connection and dropping
+// it leaves the peer unselectable until its next MsgRollForward.
 func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 	e, ok := evt.Data.(PeerRollbackEvent)
 	if !ok {
@@ -1946,18 +2040,99 @@ func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 	}
 
 	var shouldEvaluate bool
+	var evictedConn *ouroboros.ConnectionId
+	var outcome RollbackRegistrationOutcome
 	func() {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
 		if peerTip, exists := cs.peerTips[e.ConnectionId]; exists {
 			peerTip.ApplyRollback(e.Point, e.Tip)
 			shouldEvaluate = true
+			return
 		}
+		evictedConn, outcome = cs.registerPeerFromRollbackLocked(e)
+		shouldEvaluate = outcome == RollbackRegistrationRegistered
 	}()
+
+	// Publish eviction and report the registration outcome outside the lock,
+	// matching the roll-forward path: subscribers call back into the selector.
+	if evictedConn != nil && cs.config.EventBus != nil {
+		cs.config.EventBus.Publish(
+			PeerEvictedEventType,
+			event.NewEvent(
+				PeerEvictedEventType,
+				PeerEvictedEvent{ConnectionId: *evictedConn},
+			),
+		)
+	}
+	if outcome != "" && cs.config.OnRollbackRegistration != nil {
+		cs.config.OnRollbackRegistration(outcome)
+	}
 
 	if shouldEvaluate {
 		cs.EvaluateAndSwitch()
 	}
+}
+
+// registerPeerFromRollbackLocked registers a peer that reported a rollback on a
+// connection the selector is not tracking. On a fresh connection the client
+// sends MsgFindIntersect, the server answers MsgIntersectFound, and the first
+// MsgRequestNext yields MsgRollBackward to the intersection point carrying the
+// server's current tip -- and that is the only chainsync traffic until the next
+// block is minted. A connection recycle (for example the leios-fetch failover,
+// which tears down the whole multiplexed connection) deletes the peer's entry,
+// so discarding this rollback leaves the replacement connection invisible to
+// chain selection for a full block interval. On a node whose only
+// chainsync-selectable upstream was recycled that is a complete chain-selection
+// outage, with the header frontier frozen while the ledger keeps applying.
+//
+// Registration applies the same admission checks the roll-forward path applies
+// to a new peer -- connection liveness, tip plausibility, and tracked-peer
+// capacity -- and records only the confirmed intersection point as the
+// delivered frontier (see newPeerChainTipFromRollback). It returns any evicted
+// connection, for the caller to publish outside the lock, and the outcome.
+// Callers must hold cs.mutex.
+func (cs *ChainSelector) registerPeerFromRollbackLocked(
+	e PeerRollbackEvent,
+) (*ouroboros.ConnectionId, RollbackRegistrationOutcome) {
+	// A rollback can race the ConnectionClosedEvent that removed the peer, so
+	// re-registering a dead connection would resurrect an entry nothing will
+	// ever clean up except the stale-peer sweep. The roll-forward path drops
+	// tip updates from closed connections for the same reason.
+	if cs.config.ConnectionLive != nil &&
+		!cs.config.ConnectionLive(e.ConnectionId) {
+		cs.config.Logger.Debug(
+			"ignoring rollback from closed connection",
+			"connection_id", e.ConnectionId.String(),
+			"slot", e.Point.Slot,
+		)
+		return nil, RollbackRegistrationClosedConnection
+	}
+	if !cs.checkPeerTipPlausibleLocked(
+		e.ConnectionId,
+		e.Tip,
+		ochainsync.Tip{Point: e.Point},
+	) {
+		return nil, RollbackRegistrationImplausibleTip
+	}
+	evictedConn, ok := cs.makeRoomForNewPeerLocked(e.ConnectionId)
+	if !ok {
+		return nil, RollbackRegistrationAtCapacity
+	}
+	cs.peerTips[e.ConnectionId] = newPeerChainTipFromRollback(
+		e.ConnectionId,
+		e.Point,
+		e.Tip,
+	)
+	cs.advanceSelectionModeLocked()
+	cs.config.Logger.Info(
+		"registered peer from chainsync rollback",
+		"connection_id", e.ConnectionId.String(),
+		"rollback_slot", e.Point.Slot,
+		"advertised_block", e.Tip.BlockNumber,
+		"advertised_slot", e.Tip.Point.Slot,
+	)
+	return evictedConn, RollbackRegistrationRegistered
 }
 
 // onPeerRollbackPanic is the SubscribeFuncStrict onPanic hook for the

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -2049,12 +2049,44 @@ func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 		return
 	}
 
+	// Fast path: a tracked peer needs no liveness decision, so the rollback is
+	// applied in place under a single lock acquisition.
+	if cs.applyRollbackToTrackedPeer(e) {
+		cs.EvaluateAndSwitch()
+		return
+	}
+
+	// Unknown connection. Evaluate liveness BEFORE taking cs.mutex:
+	// ConnectionLive is supplied by the composition layer and reaches into the
+	// connection manager, so calling it under the selector lock lets connection
+	// teardown ordering block -- or re-enter -- the chain-selection event path.
+	// updatePeerTipObservedPraosView checks liveness outside the lock for the
+	// same reason. A rollback can race the ConnectionClosedEvent that removed
+	// the peer, and re-registering a dead connection would resurrect an entry
+	// nothing will clean up except the stale-peer sweep.
+	if cs.config.ConnectionLive != nil &&
+		!cs.config.ConnectionLive(e.ConnectionId) {
+		cs.config.Logger.Debug(
+			"ignoring rollback from closed connection",
+			"connection_id", e.ConnectionId.String(),
+			"slot", e.Point.Slot,
+		)
+		if cs.config.OnRollbackRegistration != nil {
+			cs.config.OnRollbackRegistration(
+				RollbackRegistrationClosedConnection,
+			)
+		}
+		return
+	}
+
 	var shouldEvaluate bool
 	var evictedConn *ouroboros.ConnectionId
 	var outcome RollbackRegistrationOutcome
 	func() {
 		cs.mutex.Lock()
 		defer cs.mutex.Unlock()
+		// Re-check under the lock: a concurrent roll forward (or another
+		// rollback) may have created the entry while liveness was evaluated.
 		if peerTip, exists := cs.peerTips[e.ConnectionId]; exists {
 			peerTip.ApplyRollback(e.Point, e.Tip)
 			shouldEvaluate = true
@@ -2084,6 +2116,20 @@ func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 	}
 }
 
+// applyRollbackToTrackedPeer applies a rollback to an already-tracked peer and
+// reports whether it did. It takes cs.mutex itself and calls no configured
+// callback while holding it.
+func (cs *ChainSelector) applyRollbackToTrackedPeer(e PeerRollbackEvent) bool {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	peerTip, exists := cs.peerTips[e.ConnectionId]
+	if !exists {
+		return false
+	}
+	peerTip.ApplyRollback(e.Point, e.Tip)
+	return true
+}
+
 // registerPeerFromRollbackLocked registers a peer that reported a rollback on a
 // connection the selector is not tracking. On a fresh connection the client
 // sends MsgFindIntersect, the server answers MsgIntersectFound, and the first
@@ -2097,27 +2143,18 @@ func (cs *ChainSelector) HandlePeerRollbackEvent(evt event.Event) {
 // outage, with the header frontier frozen while the ledger keeps applying.
 //
 // Registration applies the same admission checks the roll-forward path applies
-// to a new peer -- connection liveness, tip plausibility, and tracked-peer
-// capacity -- and records only the confirmed intersection point as the
-// delivered frontier (see newPeerChainTipFromRollback). It returns any evicted
+// to a new peer -- connection liveness (checked by the caller, outside the
+// lock), tip plausibility, and tracked-peer capacity -- and records only the
+// confirmed intersection point as the delivered frontier (see
+// newPeerChainTipFromRollback). It returns any evicted
 // connection, for the caller to publish outside the lock, and the outcome.
-// Callers must hold cs.mutex.
+// Callers must hold cs.mutex, and must have established that the connection is
+// live before acquiring it (HandlePeerRollbackEvent does); no configured
+// callback is invoked from here, so nothing under the lock can re-enter the
+// selector or block on the connection manager.
 func (cs *ChainSelector) registerPeerFromRollbackLocked(
 	e PeerRollbackEvent,
 ) (*ouroboros.ConnectionId, RollbackRegistrationOutcome) {
-	// A rollback can race the ConnectionClosedEvent that removed the peer, so
-	// re-registering a dead connection would resurrect an entry nothing will
-	// ever clean up except the stale-peer sweep. The roll-forward path drops
-	// tip updates from closed connections for the same reason.
-	if cs.config.ConnectionLive != nil &&
-		!cs.config.ConnectionLive(e.ConnectionId) {
-		cs.config.Logger.Debug(
-			"ignoring rollback from closed connection",
-			"connection_id", e.ConnectionId.String(),
-			"slot", e.Point.Slot,
-		)
-		return nil, RollbackRegistrationClosedConnection
-	}
 	if !cs.checkPeerTipPlausibleLocked(
 		e.ConnectionId,
 		e.Tip,

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -366,6 +366,16 @@ func (cs *ChainSelector) bestKnownGenesisSlotLocked() uint64 {
 		if !cs.isPeerSelectableLocked(connId, pt, false) {
 			continue
 		}
+		// A peer registered from a rollback has delivered no header: its
+		// ObservedTip is the intersection point the node itself proposed, so
+		// crediting it as delivered evidence would let any peer that
+		// re-intersects at the local tip and advertises a tip within the
+		// window force an immediate Genesis exit. That is precisely what the
+		// delivered-vs-advertised guard below exists to prevent, so such a
+		// peer raises no exit horizon until its first header arrives.
+		if pt.awaitingFirstHeader {
+			continue
+		}
 		advertised := pt.Tip.Point.Slot
 		delivered := pt.ObservedTip.Point.Slot
 		// Ignore an advertised tip the peer has not delivered headers up to:

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1757,6 +1757,9 @@ func (cs *ChainSelector) localTipStalledLocked() bool {
 //     near-genesis behavior and existing tests unchanged.
 //   - the incumbent is no longer selectable (gone/disconnected/ineligible/
 //     stale/implausible).
+//   - the incumbent was registered from a rollback and has not delivered a
+//     header yet (awaitingFirstHeader) — it has no head to micro-fork from, so
+//     a real delivered frontier always replaces it.
 //   - the applied local tip has stalled past catchUpPinStallTimeout
 //     (progress-aware escape — cannot pin to a dead peer forever).
 //   - the challenger is genuinely ahead of the incumbent by more than
@@ -1775,6 +1778,17 @@ func (cs *ChainSelector) pinIncumbentDuringCatchUpLocked(
 		return false
 	}
 	if incumbentTip == nil || challengerTip == nil {
+		return false
+	}
+	// Release if the incumbent was registered from a rollback and has not
+	// delivered a header yet. Such a peer has no head to micro-fork from, so
+	// there is nothing for the anti-flap pin to protect: it is selectable only
+	// because nothing better was tracked, and a peer with a real delivered
+	// frontier must always be able to take the pipeline from it. The
+	// longer-chain escape below cannot do that on its own, because the
+	// incumbent's selection block number is 0 ("nothing delivered yet"), so
+	// every challenger within catchUpPinHeadMargin of genesis still pins.
+	if incumbentTip.awaitingFirstHeader {
 		return false
 	}
 	// Release if the incumbent is no longer a viable selection target.

--- a/chainselection/selector_rollback_registration_test.go
+++ b/chainselection/selector_rollback_registration_test.go
@@ -15,7 +15,9 @@
 package chainselection
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/event"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -470,4 +472,78 @@ func TestRollbackRegisteredPeerDoesNotForceGenesisExit(t *testing.T) {
 	}
 	require.True(t, cs.UpdatePeerTip(connId, deliveredTip, nil))
 	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
+}
+
+// ConnectionLive is supplied by the composition layer and reaches into the
+// connection manager, so the registration path must evaluate it before taking
+// cs.mutex. Holding the selector lock across that callback lets connection
+// teardown ordering block -- or re-enter -- the chain-selection event path.
+//
+// The callback here re-enters the selector on the registration check and
+// blocks until that re-entry completes, so if HandlePeerRollbackEvent held
+// cs.mutex the whole handler would deadlock and the timeout below would fire.
+func TestHandlePeerRollbackEvaluatesLivenessWithoutSelectorLock(t *testing.T) {
+	connId := newTestConnectionId(1)
+	var calls atomic.Int32
+	reentered := make(chan struct{})
+	var cs *ChainSelector
+	cs = NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             2160,
+		DisableEventSubscriptions: true,
+		ConnectionLive: func(ouroboros.ConnectionId) bool {
+			// Only the first call is the registration check; later calls come
+			// from the evaluation path, which holds the lock by design.
+			if calls.Add(1) != 1 {
+				return true
+			}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_ = cs.PeerCount()
+				_ = cs.GetAllPeerTips()
+			}()
+			select {
+			case <-done:
+				close(reentered)
+			case <-time.After(5 * time.Second):
+			}
+			return true
+		},
+	})
+
+	handled := make(chan struct{})
+	go func() {
+		defer close(handled)
+		cs.HandlePeerRollbackEvent(
+			newRollbackEvent(
+				connId,
+				ocommon.Point{Slot: 2614270, Hash: []byte("intersect")},
+				ochainsync.Tip{
+					Point: ocommon.Point{
+						Slot: 2614276,
+						Hash: []byte("peer-tip"),
+					},
+					BlockNumber: 2614276,
+				},
+			),
+		)
+	}()
+
+	select {
+	case <-handled:
+	case <-time.After(20 * time.Second):
+		t.Fatal(
+			"HandlePeerRollbackEvent deadlocked: ConnectionLive must be " +
+				"evaluated before cs.mutex is taken",
+		)
+	}
+	select {
+	case <-reentered:
+	default:
+		t.Fatal(
+			"the selector lock was held while ConnectionLive ran: a callback " +
+				"that touches the selector could not make progress",
+		)
+	}
+	assert.Equal(t, 1, cs.PeerCount())
 }

--- a/chainselection/selector_rollback_registration_test.go
+++ b/chainselection/selector_rollback_registration_test.go
@@ -431,3 +431,43 @@ func TestRollbackRegisteredPeerIsNotAPlausibilityReference(t *testing.T) {
 	assert.Equal(t, uint64(5001), peerTip.SelectionTip().BlockNumber)
 	assert.False(t, peerTip.awaitingFirstHeader)
 }
+
+// A peer registered from a rollback has delivered no header, so it must not
+// raise the Genesis exit horizon: its ObservedTip is the intersection point the
+// node itself proposed, and crediting that as delivered evidence would let any
+// peer that re-intersects at the local tip and advertises a tip within the
+// Genesis window force an immediate Genesis-to-Praos transition, dropping the
+// density protection that mode exists to provide.
+func TestRollbackRegisteredPeerDoesNotForceGenesisExit(t *testing.T) {
+	connId := newTestConnectionId(1)
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             100,
+		GenesisMode:               true,
+		GenesisWindowSlots:        300,
+		DisableEventSubscriptions: true,
+	})
+	localPoint := ocommon.Point{Slot: 5000, Hash: []byte("local")}
+	cs.SetLocalTip(ochainsync.Tip{Point: localPoint, BlockNumber: 5000})
+	require.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	// Intersects at the local tip and advertises a tip inside the Genesis
+	// window of it, without delivering anything.
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(connId, localPoint, ochainsync.Tip{
+			Point:       ocommon.Point{Slot: 5100, Hash: []byte("advertised")},
+			BlockNumber: 5100,
+		}),
+	)
+	require.Equal(t, 1, cs.PeerCount())
+
+	assert.Equal(t, SelectionModeGenesis, cs.SelectionMode())
+
+	// Once the peer actually delivers headers up to its advertisement, the
+	// horizon is real and the node exits Genesis as before.
+	deliveredTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 5100, Hash: []byte("advertised")},
+		BlockNumber: 5100,
+	}
+	require.True(t, cs.UpdatePeerTip(connId, deliveredTip, nil))
+	assert.Equal(t, SelectionModePraos, cs.SelectionMode())
+}

--- a/chainselection/selector_rollback_registration_test.go
+++ b/chainselection/selector_rollback_registration_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRollbackEvent builds the PeerRollbackEvent the chainsync client publishes
+// for a MsgRollBackward: the rollback point plus the peer's advertised tip.
+func newRollbackEvent(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) event.Event {
+	return event.NewEvent(
+		PeerRollbackEventType,
+		PeerRollbackEvent{
+			ConnectionId: connId,
+			Point:        point,
+			Tip:          tip,
+		},
+	)
+}
+
+// A connection recycle deletes the peer's tracked tip (RemovePeer). The
+// replacement connection re-intersects and the server answers the first
+// MsgRequestNext with MsgRollBackward to the intersection point, carrying its
+// current tip. That rollback is the only chainsync traffic until the network
+// mints its next block, so if it does not restore the peer to chain selection
+// the node has no selectable peer for a whole block interval -- on a producer
+// whose sole upstream was recycled, that is a total chain-selection outage
+// ("chain selection stalled: no selectable peer" until the next RollForward).
+func TestHandlePeerRollbackRegistersPeerAfterConnectionRecycle(t *testing.T) {
+	connId := newTestConnectionId(1)
+	live := true
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             2160,
+		DisableEventSubscriptions: true,
+		ConnectionLive: func(ouroboros.ConnectionId) bool {
+			return live
+		},
+	})
+	localTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 2614270, Hash: []byte("local-tip")},
+		BlockNumber: 2614270,
+	}
+	cs.SetLocalTip(localTip)
+	deliveredTip := ochainsync.Tip{
+		Point:       localTip.Point,
+		BlockNumber: localTip.BlockNumber,
+	}
+	require.True(t, cs.UpdatePeerTip(connId, deliveredTip, nil))
+	cs.EvaluateAndSwitch()
+	require.NotNil(t, cs.GetBestPeer())
+
+	// The leios-fetch failover recycles the whole muxed connection.
+	cs.RemovePeer(connId)
+	require.Nil(t, cs.GetBestPeer())
+	require.Equal(t, 0, cs.PeerCount())
+
+	// The replacement connection intersects at the local tip and rolls back
+	// to it, advertising the peer's current tip.
+	advertisedTip := ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: 2614276,
+			Hash: []byte("peer-advertised"),
+		},
+		BlockNumber: 2614276,
+	}
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(connId, localTip.Point, advertisedTip),
+	)
+
+	require.Equal(t, 1, cs.PeerCount(), "peer must be tracked again")
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, advertisedTip, peerTip.Tip)
+	assert.Equal(t, localTip.Point, peerTip.SelectionTip().Point)
+
+	best := cs.GetBestPeer()
+	require.NotNil(
+		t,
+		best,
+		"peer registered from the post-intersect rollback must be selectable "+
+			"without waiting for the next RollForward",
+	)
+	assert.Equal(t, connId, *best)
+}
+
+// A rollback can race the ConnectionClosedEvent that removed the peer. The
+// roll-forward path drops tip updates from closed connections; registration
+// from a rollback must do the same rather than resurrect a dead peer.
+func TestHandlePeerRollbackDoesNotRegisterClosedConnection(t *testing.T) {
+	connId := newTestConnectionId(1)
+	var outcomes []RollbackRegistrationOutcome
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             2160,
+		DisableEventSubscriptions: true,
+		ConnectionLive: func(ouroboros.ConnectionId) bool {
+			return false
+		},
+		OnRollbackRegistration: func(o RollbackRegistrationOutcome) {
+			outcomes = append(outcomes, o)
+		},
+	})
+
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(
+			connId,
+			ocommon.Point{Slot: 100, Hash: []byte("intersect")},
+			ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 110, Hash: []byte("tip")},
+				BlockNumber: 110,
+			},
+		),
+	)
+
+	assert.Equal(t, 0, cs.PeerCount())
+	assert.Nil(t, cs.GetBestPeer())
+	assert.Equal(
+		t,
+		[]RollbackRegistrationOutcome{RollbackRegistrationClosedConnection},
+		outcomes,
+	)
+}
+
+// A peer registered from a rollback has delivered nothing, so it must never
+// displace a peer that has delivered headers, in either map iteration order.
+func TestRollbackRegisteredPeerDoesNotOutrankDeliveredFrontier(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		rollbackFirst   bool
+		deliveredConnId int
+		rollbackConnId  int
+	}{
+		{name: "delivered peer first", deliveredConnId: 1, rollbackConnId: 2},
+		{
+			name:            "rollback peer first",
+			rollbackFirst:   true,
+			deliveredConnId: 2,
+			rollbackConnId:  1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deliveredConn := newTestConnectionId(tc.deliveredConnId)
+			rollbackConn := newTestConnectionId(tc.rollbackConnId)
+			cs := NewChainSelector(ChainSelectorConfig{
+				SecurityParam:             2160,
+				DisableEventSubscriptions: true,
+			})
+			deliveredTip := ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 2614270,
+					Hash: []byte("delivered"),
+				},
+				BlockNumber: 2614270,
+			}
+			register := func() {
+				cs.HandlePeerRollbackEvent(
+					newRollbackEvent(
+						rollbackConn,
+						ocommon.Point{
+							Slot: 2614260,
+							Hash: []byte("intersect"),
+						},
+						ochainsync.Tip{
+							Point: ocommon.Point{
+								Slot: 2614999,
+								Hash: []byte("advertised"),
+							},
+							// A far-ahead advertisement must not buy
+							// selection: only delivered frontiers rank.
+							BlockNumber: 2614999,
+						},
+					),
+				)
+			}
+			if tc.rollbackFirst {
+				register()
+				require.True(
+					t,
+					cs.UpdatePeerTip(deliveredConn, deliveredTip, nil),
+				)
+			} else {
+				require.True(
+					t,
+					cs.UpdatePeerTip(deliveredConn, deliveredTip, nil),
+				)
+				register()
+			}
+
+			cs.EvaluateAndSwitch()
+			best := cs.GetBestPeer()
+			require.NotNil(t, best)
+			assert.Equal(t, deliveredConn, *best)
+			assert.Equal(t, 2, cs.PeerCount())
+		})
+	}
+}
+
+// Registration runs the same plausibility bound the roll-forward path applies
+// to a new peer, so a newcomer cannot inject a far-ahead advertised tip while
+// the node has no applied local tip to bound it against.
+func TestHandlePeerRollbackRejectsImplausibleAdvertisedTipAtBootstrap(
+	t *testing.T,
+) {
+	existingConn := newTestConnectionId(1)
+	newConn := newTestConnectionId(2)
+	var outcomes []RollbackRegistrationOutcome
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             10,
+		DisableEventSubscriptions: true,
+		OnRollbackRegistration: func(o RollbackRegistrationOutcome) {
+			outcomes = append(outcomes, o)
+		},
+	})
+	require.True(t, cs.UpdatePeerTip(existingConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("bootstrap")},
+		BlockNumber: 100,
+	}, nil))
+
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(
+			newConn,
+			ocommon.Point{Slot: 100, Hash: []byte("bootstrap")},
+			ochainsync.Tip{
+				Point: ocommon.Point{
+					Slot: 9_000_000,
+					Hash: []byte("inflated"),
+				},
+				BlockNumber: 9_000_000,
+			},
+		),
+	)
+
+	assert.Equal(t, 1, cs.PeerCount())
+	assert.Nil(t, cs.GetPeerTip(newConn))
+	assert.Equal(
+		t,
+		[]RollbackRegistrationOutcome{RollbackRegistrationImplausibleTip},
+		outcomes,
+	)
+}
+
+// Registration respects the tracked-peer capacity bound, refusing rather than
+// growing the table past MaxTrackedPeers when nothing can be evicted.
+func TestHandlePeerRollbackRefusesRegistrationAtCapacity(t *testing.T) {
+	existingConn := newTestConnectionId(1)
+	newConn := newTestConnectionId(2)
+	var outcomes []RollbackRegistrationOutcome
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             10,
+		MaxTrackedPeers:           1,
+		DisableEventSubscriptions: true,
+		OnRollbackRegistration: func(o RollbackRegistrationOutcome) {
+			outcomes = append(outcomes, o)
+		},
+	})
+	tip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("delivered")},
+		BlockNumber: 100,
+	}
+	require.True(t, cs.UpdatePeerTip(existingConn, tip, nil))
+	cs.EvaluateAndSwitch()
+	// The single tracked peer is the best peer, which evictLeastRecentPeerLocked
+	// refuses to evict.
+	require.NotNil(t, cs.GetBestPeer())
+
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(
+			newConn,
+			ocommon.Point{Slot: 100, Hash: []byte("delivered")},
+			tip,
+		),
+	)
+
+	assert.Equal(t, 1, cs.PeerCount())
+	assert.Nil(t, cs.GetPeerTip(newConn))
+	assert.Equal(
+		t,
+		[]RollbackRegistrationOutcome{RollbackRegistrationAtCapacity},
+		outcomes,
+	)
+	assert.Equal(t, existingConn, *cs.GetBestPeer())
+}
+
+// The behind-filter exemption lasts only until the peer delivers a header:
+// once it has a real delivered frontier it is filtered like any other peer.
+func TestRollbackRegisteredPeerLosesExemptionAfterFirstHeader(t *testing.T) {
+	connId := newTestConnectionId(1)
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             10,
+		DisableEventSubscriptions: true,
+	})
+	cs.SetLocalTip(ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 1000, Hash: []byte("local")},
+		BlockNumber: 1000,
+	})
+
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(
+			connId,
+			ocommon.Point{Slot: 990, Hash: []byte("intersect")},
+			ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 1010, Hash: []byte("tip")},
+				BlockNumber: 1010,
+			},
+		),
+	)
+	require.NotNil(
+		t,
+		cs.GetBestPeer(),
+		"a peer that has delivered nothing yet is not 'behind'",
+	)
+
+	// The peer then delivers a header from far behind the local tip. It is a
+	// real delivered frontier now, so the implausibly-behind filter applies.
+	behindTip := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 10, Hash: []byte("far-behind")},
+		BlockNumber: 10,
+	}
+	require.True(t, cs.UpdatePeerTip(connId, behindTip, nil))
+	cs.EvaluateAndSwitch()
+
+	assert.Nil(t, cs.GetBestPeer())
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.False(t, peerTip.awaitingFirstHeader)
+}
+
+// A rollback for a tracked peer keeps its existing ApplyRollback path: the
+// registration branch must not change how an already-tracked peer is handled.
+func TestHandlePeerRollbackTrackedPeerStillAppliesRollback(t *testing.T) {
+	connId := newTestConnectionId(1)
+	var outcomes []RollbackRegistrationOutcome
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             10,
+		DisableEventSubscriptions: true,
+		OnRollbackRegistration: func(o RollbackRegistrationOutcome) {
+			outcomes = append(outcomes, o)
+		},
+	})
+	delivered := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 100, Hash: []byte("delivered")},
+		BlockNumber: 100,
+	}
+	require.True(t, cs.UpdatePeerTip(connId, delivered, nil))
+
+	rollbackPoint := ocommon.Point{Slot: 90, Hash: []byte("rollback")}
+	advertised := ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 105, Hash: []byte("advertised")},
+		BlockNumber: 105,
+	}
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(connId, rollbackPoint, advertised),
+	)
+
+	peerTip := cs.GetPeerTip(connId)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, advertised, peerTip.Tip)
+	assert.Equal(t, rollbackPoint, peerTip.SelectionTip().Point)
+	assert.False(
+		t,
+		peerTip.awaitingFirstHeader,
+		"an already-tracked peer keeps its delivered-frontier semantics",
+	)
+	assert.Empty(t, outcomes, "no registration attempt for a tracked peer")
+	assert.Equal(t, 1, cs.PeerCount())
+}
+
+// A peer registered from a rollback has delivered nothing, so it is not a
+// plausibility reference: not for its own first header (which would otherwise
+// be bounded by a reference of 0 and rejected) and not for another peer's
+// (which would otherwise turn the bootstrap case into a reference of 0).
+func TestRollbackRegisteredPeerIsNotAPlausibilityReference(t *testing.T) {
+	rollbackConn := newTestConnectionId(1)
+	otherConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             10,
+		DisableEventSubscriptions: true,
+	})
+	// No local tip has been applied, so the catch-up relaxation cannot rescue
+	// a rejected frontier: the reference bound is the only thing under test.
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(
+			rollbackConn,
+			ocommon.Point{Slot: 5000, Hash: []byte("intersect")},
+			ochainsync.Tip{
+				Point:       ocommon.Point{Slot: 5001, Hash: []byte("tip")},
+				BlockNumber: 5001,
+			},
+		),
+	)
+	require.Equal(t, 1, cs.PeerCount())
+
+	// Another peer's first delivered header is still bootstrapped, not bounded
+	// by the registered peer's zero delivered frontier.
+	assert.True(t, cs.UpdatePeerTip(otherConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 5000, Hash: []byte("other")},
+		BlockNumber: 5000,
+	}, nil))
+
+	// And the registered peer's own first header is bounded like a new peer's,
+	// against the delivered frontier of the peers that have delivered one.
+	assert.True(t, cs.UpdatePeerTip(rollbackConn, ochainsync.Tip{
+		Point:       ocommon.Point{Slot: 5001, Hash: []byte("first-header")},
+		BlockNumber: 5001,
+	}, nil))
+	peerTip := cs.GetPeerTip(rollbackConn)
+	require.NotNil(t, peerTip)
+	assert.Equal(t, uint64(5001), peerTip.SelectionTip().BlockNumber)
+	assert.False(t, peerTip.awaitingFirstHeader)
+}

--- a/chainselection/selector_rollback_registration_test.go
+++ b/chainselection/selector_rollback_registration_test.go
@@ -547,3 +547,64 @@ func TestHandlePeerRollbackEvaluatesLivenessWithoutSelectorLock(t *testing.T) {
 	}
 	assert.Equal(t, 1, cs.PeerCount())
 }
+
+// The registration outcome is reported after cs.mutex is released, so a
+// subscriber can read selector state (for example to log the resulting peer
+// count) from the callback without deadlocking. This is the same invariant as
+// the liveness check above, for the other callback the registration path
+// invokes: no configured callback may run with the selector lock held.
+func TestHandlePeerRollbackReportsOutcomeWithoutSelectorLock(t *testing.T) {
+	connId := newTestConnectionId(1)
+	var observedPeers atomic.Int32
+	var observedOutcome atomic.Value
+	var cs *ChainSelector
+	cs = NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             2160,
+		DisableEventSubscriptions: true,
+		ConnectionLive:            func(ouroboros.ConnectionId) bool { return true },
+		OnRollbackRegistration: func(o RollbackRegistrationOutcome) {
+			observedOutcome.Store(o)
+			// Blocks forever if the outcome were reported under cs.mutex.
+			// #nosec G115 -- a tracked-peer count fits int32 in this test.
+			observedPeers.Store(int32(cs.PeerCount()))
+		},
+	})
+
+	handled := make(chan struct{})
+	go func() {
+		defer close(handled)
+		cs.HandlePeerRollbackEvent(
+			newRollbackEvent(
+				connId,
+				ocommon.Point{Slot: 2614270, Hash: []byte("intersect")},
+				ochainsync.Tip{
+					Point: ocommon.Point{
+						Slot: 2614276,
+						Hash: []byte("peer-tip"),
+					},
+					BlockNumber: 2614276,
+				},
+			),
+		)
+	}()
+
+	select {
+	case <-handled:
+	case <-time.After(20 * time.Second):
+		t.Fatal(
+			"HandlePeerRollbackEvent deadlocked: OnRollbackRegistration must " +
+				"be reported outside cs.mutex",
+		)
+	}
+	assert.Equal(
+		t,
+		RollbackRegistrationRegistered,
+		observedOutcome.Load(),
+	)
+	assert.Equal(
+		t,
+		int32(1),
+		observedPeers.Load(),
+		"the callback must observe the peer it was told about",
+	)
+}

--- a/chainselection/selector_rollback_registration_test.go
+++ b/chainselection/selector_rollback_registration_test.go
@@ -608,3 +608,56 @@ func TestHandlePeerRollbackReportsOutcomeWithoutSelectorLock(t *testing.T) {
 		"the callback must observe the peer it was told about",
 	)
 }
+
+// The anti-flap incumbent pin exists to stop the chainsync+blockfetch pipeline
+// from flapping between peers on sibling head-forks. A peer registered from a
+// rollback has no head to fork from: its selection block number is 0, meaning
+// "nothing delivered yet". Without an explicit release the pin's longer-chain
+// escape (challenger more than catchUpPinHeadMargin blocks ahead) cannot fire
+// for a challenger at block 1 or 2, so the node would keep the pipeline on a
+// connection that has delivered no header while a peer with a real delivered
+// frontier is available.
+func TestRollbackRegisteredIncumbentDoesNotPinOutDeliveredChallenger(
+	t *testing.T,
+) {
+	rollbackConn := newTestConnectionId(1)
+	deliveredConn := newTestConnectionId(2)
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam:             2160,
+		DisableEventSubscriptions: true,
+	})
+	// A local tip has been applied, so the pin is armed.
+	localPoint := ocommon.Point{Slot: 1, Hash: []byte("local")}
+	cs.SetLocalTip(ochainsync.Tip{Point: localPoint, BlockNumber: 1})
+
+	// The recycled connection re-intersects at the local tip and becomes the
+	// incumbent, because nothing better is tracked.
+	cs.HandlePeerRollbackEvent(
+		newRollbackEvent(rollbackConn, localPoint, tip(4, 4, "advertised")),
+	)
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	require.Equal(t, rollbackConn, *best)
+	incumbentTip := cs.GetPeerTip(rollbackConn)
+	require.NotNil(t, incumbentTip)
+	require.True(t, incumbentTip.awaitingFirstHeader)
+	require.Equal(t, uint64(0), incumbentTip.SelectionTip().BlockNumber)
+
+	// Another peer delivers a real header, inside the head margin of the
+	// incumbent's zero selection block number.
+	require.True(
+		t,
+		cs.UpdatePeerTip(deliveredConn, tip(2, 2, "delivered"), nil),
+	)
+	cs.EvaluateAndSwitch()
+
+	best = cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(
+		t,
+		deliveredConn,
+		*best,
+		"a delivered frontier must take the pipeline from a header-less "+
+			"rollback incumbent",
+	)
+}

--- a/metrics_chainselection.go
+++ b/metrics_chainselection.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Reasons reported by dingo_chainselection_stalled_total.
+const (
+	// chainSelectionStallNoSelectablePeer is the ordinary stall: no tracked
+	// peer passed the selectability checks.
+	chainSelectionStallNoSelectablePeer = "no_selectable_peer"
+	// chainSelectionStallGenesisCorroboration is a stall caused by the Genesis
+	// corroboration gate denying the densest fast source.
+	chainSelectionStallGenesisCorroboration = "genesis_corroboration"
+)
+
+// chainSelectionMetrics counts chain-selection transitions that are otherwise
+// only visible in the log: how often selection stalled with no selectable peer,
+// and how often a peer was (re)registered from a chainsync rollback, which is
+// the post-recycle path that keeps a stall from lasting until the next block.
+type chainSelectionMetrics struct {
+	stalls                *prometheus.CounterVec
+	rollbackRegistrations *prometheus.CounterVec
+}
+
+// registerChainSelectionMetrics registers the chain-selection counters. It runs
+// in New(), against the pre-wrap registerer, because these counters live for
+// the node's entire lifetime: the ChainSelector is not rebuilt by a live
+// database restore/truncate, so they must not be unregistered by
+// rebuildableRegisterer.unregisterAll (see metrics_registerer.go).
+//
+// Every label value is materialized here so a scrape reports an explicit 0
+// instead of a missing series before the first occurrence -- a stall counter
+// that only appears once the node has stalled is useless for alerting.
+func (n *Node) registerChainSelectionMetrics() {
+	if n.config.promRegistry == nil {
+		return
+	}
+	factory := promauto.With(n.config.promRegistry)
+	metrics := &chainSelectionMetrics{
+		stalls: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dingo_chainselection_stalled_total",
+				Help: "times chain selection transitioned to having no selectable peer",
+			},
+			[]string{"reason"},
+		),
+		rollbackRegistrations: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dingo_chainselection_rollback_registrations_total",
+				Help: "attempts to register a peer into chain selection from a chainsync rollback on an untracked connection, by outcome",
+			},
+			[]string{"outcome"},
+		),
+	}
+	for _, reason := range []string{
+		chainSelectionStallNoSelectablePeer,
+		chainSelectionStallGenesisCorroboration,
+	} {
+		metrics.stalls.WithLabelValues(reason)
+	}
+	for _, outcome := range []chainselection.RollbackRegistrationOutcome{
+		chainselection.RollbackRegistrationRegistered,
+		chainselection.RollbackRegistrationClosedConnection,
+		chainselection.RollbackRegistrationImplausibleTip,
+		chainselection.RollbackRegistrationAtCapacity,
+	} {
+		metrics.rollbackRegistrations.WithLabelValues(string(outcome))
+	}
+	n.chainSelectionMetrics = metrics
+}
+
+// recordChainSelectionStall counts one selected-to-none transition. Safe to
+// call when metrics are disabled.
+func (n *Node) recordChainSelectionStall(genesisCorroboration bool) {
+	if n.chainSelectionMetrics == nil {
+		return
+	}
+	reason := chainSelectionStallNoSelectablePeer
+	if genesisCorroboration {
+		reason = chainSelectionStallGenesisCorroboration
+	}
+	n.chainSelectionMetrics.stalls.WithLabelValues(reason).Inc()
+}
+
+// recordRollbackRegistration counts one attempt to register a peer from a
+// chainsync rollback. Safe to call when metrics are disabled.
+func (n *Node) recordRollbackRegistration(
+	outcome chainselection.RollbackRegistrationOutcome,
+) {
+	if n.chainSelectionMetrics == nil {
+		return
+	}
+	n.chainSelectionMetrics.rollbackRegistrations.
+		WithLabelValues(string(outcome)).
+		Inc()
+}

--- a/metrics_chainselection_test.go
+++ b/metrics_chainselection_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/chainsync"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMetricsTestNode(t *testing.T) (*Node, *prometheus.Registry) {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	n := &Node{
+		config: Config{
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			promRegistry: registry,
+		},
+	}
+	n.registerChainSelectionMetrics()
+	require.NotNil(t, n.chainSelectionMetrics)
+	return n, registry
+}
+
+// counterValues returns label value -> counter value for the named metric.
+func counterValues(
+	t *testing.T,
+	registry *prometheus.Registry,
+	name string,
+) map[string]float64 {
+	t.Helper()
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	values := map[string]float64{}
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			var label string
+			for _, pair := range metric.GetLabel() {
+				label = pair.GetValue()
+			}
+			values[label] = metric.GetCounter().GetValue()
+		}
+	}
+	return values
+}
+
+// Both counters materialize every label value at registration, so a scrape
+// before the first occurrence reports an explicit 0 rather than a missing
+// series. An alert on a stall counter that only appears after the first stall
+// cannot distinguish "healthy" from "not reporting".
+func TestChainSelectionMetricsPreMaterializeLabels(t *testing.T) {
+	_, registry := newMetricsTestNode(t)
+
+	stalls := counterValues(t, registry, "dingo_chainselection_stalled_total")
+	assert.Equal(t, map[string]float64{
+		chainSelectionStallNoSelectablePeer:     0,
+		chainSelectionStallGenesisCorroboration: 0,
+	}, stalls)
+
+	registrations := counterValues(
+		t,
+		registry,
+		"dingo_chainselection_rollback_registrations_total",
+	)
+	assert.Equal(t, map[string]float64{
+		string(chainselection.RollbackRegistrationRegistered):       0,
+		string(chainselection.RollbackRegistrationClosedConnection): 0,
+		string(chainselection.RollbackRegistrationImplausibleTip):   0,
+		string(chainselection.RollbackRegistrationAtCapacity):       0,
+	}, registrations)
+}
+
+// The selected-to-none handler that logs "chain selection stalled" also counts
+// the stall, labelled by whether the Genesis corroboration gate caused it.
+func TestHandleChainSelectedNoneEventCountsStall(t *testing.T) {
+	n, registry := newMetricsTestNode(t)
+	n.chainsyncState = chainsync.NewStateWithConfig(
+		nil,
+		nil,
+		chainsync.DefaultConfig(),
+	)
+	conn := newNodeTestConnId(3301)
+
+	n.handleChainSelectedNoneEvent(event.NewEvent(
+		chainselection.ChainSelectedNoneEventType,
+		chainselection.ChainSelectedNoneEvent{PreviousConnectionId: conn},
+	))
+	n.handleChainSelectedNoneEvent(event.NewEvent(
+		chainselection.ChainSelectedNoneEventType,
+		chainselection.ChainSelectedNoneEvent{
+			PreviousConnectionId: conn,
+			GenesisCorroboration: true,
+		},
+	))
+
+	assert.Equal(t, map[string]float64{
+		chainSelectionStallNoSelectablePeer:     1,
+		chainSelectionStallGenesisCorroboration: 1,
+	}, counterValues(t, registry, "dingo_chainselection_stalled_total"))
+}
+
+// buildChainSelectorConfig is the composition site the running node uses, so
+// the rollback-registration hook is verified end to end from there: build the
+// config the binary builds, hand it to a real ChainSelector, drive the rollback
+// a recycled connection produces, and require the node's counter to move. A
+// hook that is defined in chainselection but never set here is invisible at
+// runtime.
+func TestBuildChainSelectorConfigWiresRollbackRegistrationCounter(
+	t *testing.T,
+) {
+	n, registry := newMetricsTestNode(t)
+	conn := newNodeTestConnId(3302)
+	rollback := event.NewEvent(
+		chainselection.PeerRollbackEventType,
+		chainselection.PeerRollbackEvent{
+			ConnectionId: conn,
+			Point:        ocommon.NewPoint(2614270, []byte("intersect")),
+			Tip: ochainsync.Tip{
+				Point:       ocommon.NewPoint(2614276, []byte("peer-tip")),
+				BlockNumber: 2614276,
+			},
+		},
+	)
+	registrations := func() map[string]float64 {
+		return counterValues(
+			t,
+			registry,
+			"dingo_chainselection_rollback_registrations_total",
+		)
+	}
+
+	// As composed: this node has no connection manager, so the config's own
+	// ConnectionLive hook reports the connection as dead and registration is
+	// refused. The refusal is still reported through OnRollbackRegistration.
+	refusing := n.buildChainSelectorConfig(2160, false, 0)
+	require.NotNil(t, refusing.OnRollbackRegistration)
+	refusing.DisableEventSubscriptions = true
+	refusingSelector := chainselection.NewChainSelector(refusing)
+	refusingSelector.HandlePeerRollbackEvent(rollback)
+	require.Equal(t, 0, refusingSelector.PeerCount())
+	assert.Equal(
+		t,
+		float64(1),
+		registrations()[string(
+			chainselection.RollbackRegistrationClosedConnection,
+		)],
+	)
+
+	// With a live connection, the same composed config registers the peer and
+	// counts it. Only ConnectionLive is stubbed (this node has no connManager);
+	// the hook under test is the one buildChainSelectorConfig installed.
+	live := n.buildChainSelectorConfig(2160, false, 0)
+	live.DisableEventSubscriptions = true
+	live.ConnectionLive = func(ouroboros.ConnectionId) bool { return true }
+	liveSelector := chainselection.NewChainSelector(live)
+	liveSelector.HandlePeerRollbackEvent(rollback)
+
+	require.Equal(t, 1, liveSelector.PeerCount())
+	best := liveSelector.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(t, conn, *best)
+	assert.Equal(
+		t,
+		float64(1),
+		registrations()[string(chainselection.RollbackRegistrationRegistered)],
+	)
+}
+
+// New() registers the chain-selection counters, so they exist for the node's
+// whole lifetime rather than only after a component that happens to touch them
+// is built. Registration must happen against the pre-wrap registerer (see
+// registerChainSelectionMetrics), because a live database restore unregisters
+// everything registered through the rebuildable wrapper and nothing rebuilds
+// the ChainSelector.
+func TestNewRegistersChainSelectionMetrics(t *testing.T) {
+	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	registry := prometheus.NewRegistry()
+	n, err := New(NewConfig(
+		WithDatabasePath(t.TempDir()),
+		WithCardanoNodeConfig(cardanoCfg),
+		WithNetworkMagic(cardanoCfg.ShelleyGenesis().NetworkMagic),
+		WithPrometheusRegistry(registry),
+		WithStorageMode(StorageModeAPI),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithShutdownTimeout(5*time.Second),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = n.Stop() })
+
+	assert.Contains(
+		t,
+		counterValues(t, registry, "dingo_chainselection_stalled_total"),
+		chainSelectionStallNoSelectablePeer,
+	)
+	assert.Contains(
+		t,
+		counterValues(
+			t,
+			registry,
+			"dingo_chainselection_rollback_registrations_total",
+		),
+		string(chainselection.RollbackRegistrationRegistered),
+	)
+}

--- a/node.go
+++ b/node.go
@@ -76,6 +76,7 @@ type Node struct {
 	poolRelayProvider       *ledger.PoolRelayProvider
 	chainsyncState          *chainsync.State
 	chainSelector           *chainselection.ChainSelector
+	chainSelectionMetrics   *chainSelectionMetrics
 	eventBus                *event.EventBus
 	pluginHost              *plugin.Host
 	destinationRegistry     *lifecycle.DestinationRegistry
@@ -251,6 +252,7 @@ func New(cfg Config) (*Node, error) {
 	n.configWrapPromRegistry()
 	n.registerBuildInfo()
 	n.registerRTSMetrics()
+	n.registerChainSelectionMetrics()
 	// NewEventBus starts background async-worker goroutines, so create the bus
 	// only after configuration validates. If it were created earlier, a
 	// validation failure would return a nil Node while leaving those goroutines
@@ -1154,24 +1156,11 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 		!n.config.intersectTip &&
 		len(n.config.intersectPoints) == 0
 	n.chainSelector = chainselection.NewChainSelector(
-		chainselection.ChainSelectorConfig{
-			Logger:                n.config.logger,
-			EventBus:              n.eventBus,
-			SecurityParam:         chainSelectorSecurityParam,
-			GenesisMode:           genesisSelectionMode,
-			GenesisWindowSlots:    genesisWindowSlots,
-			MinCorroboratingPeers: n.config.genesisCorroborationPeers,
-			ConnectionLive: func(connId ouroboros.ConnectionId) bool {
-				return n.connManager != nil &&
-					n.connManager.GetConnectionById(connId) != nil
-			},
-			BlockfetchLatency: func(connId ouroboros.ConnectionId) (time.Duration, bool) {
-				if n.chainsyncState == nil {
-					return 0, false
-				}
-				return n.chainsyncState.BlockfetchLatency(connId)
-			},
-		},
+		n.buildChainSelectorConfig(
+			chainSelectorSecurityParam,
+			genesisSelectionMode,
+			genesisWindowSlots,
+		),
 	)
 	// Seed chain selection from the applied ledger tip before peers connect.
 	// Without this initial observation, the plausibility guard treats the
@@ -1993,6 +1982,36 @@ func (n *Node) subscribeConnectionEvents() {
 		connmanager.InboundConnectionEventType,
 		func(evt event.Event) { n.ouroboros().HandleInboundConnEvent(evt) },
 	)
+}
+
+// buildChainSelectorConfig assembles the ChainSelectorConfig this node passes
+// to chainselection.NewChainSelector. It is the single composition site for
+// the selector's callbacks, so a hook that is not set here is silently absent
+// at runtime no matter what the chainselection package offers.
+func (n *Node) buildChainSelectorConfig(
+	securityParam uint64,
+	genesisMode bool,
+	genesisWindowSlots uint64,
+) chainselection.ChainSelectorConfig {
+	return chainselection.ChainSelectorConfig{
+		Logger:                n.config.logger,
+		EventBus:              n.eventBus,
+		SecurityParam:         securityParam,
+		GenesisMode:           genesisMode,
+		GenesisWindowSlots:    genesisWindowSlots,
+		MinCorroboratingPeers: n.config.genesisCorroborationPeers,
+		ConnectionLive: func(connId ouroboros.ConnectionId) bool {
+			return n.connManager != nil &&
+				n.connManager.GetConnectionById(connId) != nil
+		},
+		BlockfetchLatency: func(connId ouroboros.ConnectionId) (time.Duration, bool) {
+			if n.chainsyncState == nil {
+				return 0, false
+			}
+			return n.chainsyncState.BlockfetchLatency(connId)
+		},
+		OnRollbackRegistration: n.recordRollbackRegistration,
+	}
 }
 
 // subscribeChainSelectorEvents wires the EventBus subscriptions that feed the

--- a/node_chainsync_recycler.go
+++ b/node_chainsync_recycler.go
@@ -256,6 +256,7 @@ func (n *Node) handleChainSelectedNoneEventLocked(
 		"previous_connection", prevConn,
 		"genesis_corroboration", e.GenesisCorroboration,
 	)
+	n.recordChainSelectionStall(e.GenesisCorroboration)
 	if n.chainSelector == nil {
 		// Direct callers without a selector cannot perform the current-selection
 		// recheck above, so retain the event's compare-and-clear behavior.


### PR DESCRIPTION
## Problem

After a chainsync connection recycle, the replacement connection cannot be
selected by chain selection until the network produces its next block. On a
node whose only chainsync-selectable upstream is the recycled connection, that
is a total chain-selection outage lasting a full inter-block interval: the
header frontier is frozen while the ledger keeps applying, so a forge
opportunity in that window is evaluated against a stale frontier.

The gap is an asymmetry between the roll-forward and roll-backward paths:

* `chainselection/selector.go` `deletePeerLocked` removes the peer's
  `peerTips` entry on disconnect.
* the roll-forward path (`updatePeerTipObservedPraosView`) **creates** an
  entry for an unknown connection.
* `HandlePeerRollbackEvent` only **updates** an entry that already exists, and
  silently drops the event otherwise.

On a fresh connection the client sends `MsgFindIntersect`, the server answers
`MsgIntersectFound`, and the first `MsgRequestNext` yields `MsgRollBackward` to
the intersection point carrying the server's current tip. That is the only
chainsync traffic until the next block is minted. `PeerRollbackEvent` carries
both the point and the tip (published from
`ouroboros/chainsync.go` `chainsyncClientRollBackward`), so the information
needed to restore the peer is present and is thrown away.

Measured on a Leios devnet node with a single trusted upstream
(`localRoots` hot = 1, everything else inbound), each recycle of that upstream
was followed by `chain selection stalled: no selectable peer`, and the stall
ended within +/-0.55 s of the moment the upstream adopted the **next** block —
not of the reconnect, which completed in ~0.2 s:

| stall duration | ended relative to the next upstream-adopted block |
|---|---|
| 17.8 s | +0.54 s |
| 13.0 s | +0.30 s |
| 25.8 s | +0.46 s |
| 47.6 s | -0.12 s |

4/4 stalls ended on the next `MsgRollForward`. The sequence in each case:

```
recycling connection with an unusable leios-fetch protocol
best peer disconnected, selecting new best
chain selection stalled: no selectable peer
connected ouroboros to <upstream>          <- ~0.2 s after the stall started
selected new best peer                     <- 13-48 s later, on the next block
```

16 recycles occurred in ~48 minutes on that node, 4 of them on the sole
chainsync-selectable upstream, so this is routine rather than exotic on a
Leios devnet, where #3779 recycles a connection whose leios-fetch protocol
instance is unusable. A node with several selectable upstreams degrades
gracefully instead, which is likely why this has not shown up on
mainnet-shaped topologies.

Verified identical at `90504583` and at `e109235a` (#3779).

## Fix

Register the peer from the rollback when no entry exists
(`registerPeerFromRollbackLocked`). The change is strictly additive: it only
creates state for connections that previously had none, so no already-tracked
peer changes behavior.

Registration applies the same admission checks the roll-forward path applies to
a new peer, rather than bypassing them:

* connection liveness (`ConnectionLive`), so a rollback that races the
  `ConnectionClosedEvent` cannot resurrect a dead peer. It is evaluated
  *before* `cs.mutex` is taken — the callback reaches into the connection
  manager, so holding the selector lock across it would let teardown ordering
  block or re-enter the chain-selection event path — and the entry's absence is
  re-checked under the lock, since a concurrent roll forward may have created
  it meanwhile;
* the tip-plausibility bound, extracted from `updatePeerTipObservedPraosView`
  into `checkPeerTipPlausibleLocked` so both paths share one implementation
  (no behavior change for roll forward);
* the tracked-peer capacity bound, extracted into `makeRoomForNewPeerLocked`,
  including publishing `PeerEvictedEvent` outside the lock.

The entry records only what the exchange proved:

* `Tip` is the peer's advertised tip, untrusted exactly as on roll forward;
* `ObservedTip` is the confirmed intersection point with block number 0,
  never the advertised tip (mirroring `ApplyRollback`, which refuses that
  promotion);
* no observed slot/point frontier is recorded, so the peer contributes no
  Genesis density and cannot corroborate another peer until it delivers
  headers.

A new `awaitingFirstHeader` flag marks that zero block number as "nothing
delivered yet" rather than "at block 0". It has exactly four effects, all
reverted by the first delivered header:

1. the two behind-filters in `isPeerSelectableLocked` are skipped for that
   peer, which is what makes it selectable ~0.2 s after reconnect instead of
   at the next block;
2. the peer is not a plausibility reference — not for its own first header,
   and not for another peer's. Without this, a registered peer's zero
   delivered frontier would turn the bootstrap case ("no reference at all",
   which accepts) into a reference of 0 and reject the next peer's first
   legitimate header;
3. the peer raises no Genesis exit horizon in `bestKnownGenesisSlotLocked`.
   Its `ObservedTip` is the intersection point the node itself proposed, so
   crediting it as delivered evidence would let any peer that re-intersects at
   the local tip and advertises a tip within the Genesis window force an
   immediate Genesis-to-Praos exit without delivering a header — exactly the
   not-yet-synced-or-lying far tip the delivered-vs-advertised guard there
   exists to reject. (Found by cubic in review; third commit.)
4. the anti-flap incumbent pin (`pinIncumbentDuringCatchUpLocked`) releases
   when such a peer is the incumbent. A selection block number of 0 would
   otherwise read as a real head, and the pin's only height-based release is a
   challenger more than `catchUpPinHeadMargin` blocks ahead — so a peer with a
   genuine delivered frontier at block 1 or 2 could be pinned out by a
   connection that had delivered no header at all. The pin exists to stop the
   pipeline flapping between sibling head-forks; a peer awaiting its first
   header has no head to fork from, so there is nothing to protect. (Found by
   cubic in review; fifth commit.)

Safety: block number 0 loses every Praos comparison, so a peer registered this
way can never displace a peer with a real delivered frontier — it can only be
selected when nothing better is tracked, which is precisely the stalled case.
`ChainsyncApplyEligible` (the ledger apply gate) is unchanged and independent
of selection, so this does not change what gets applied.

`MsgIntersectFound` was **not** wired. gouroboros exposes
`chainsync.WithIntersectFoundFunc`, but the client's `IntersectFound` is always
followed by the `MsgRollBackward` handled here, so observing it as well would
be a second, redundant registration path. Noted as a follow-up if a server is
ever seen answering `IntersectFound` without a subsequent rollback.

## Metrics

Two counters, with every label value materialized at registration so a scrape
reports an explicit `0` instead of a missing series (an alert on a counter that
only appears after the first stall cannot tell "healthy" from "not reporting"):

```
dingo_chainselection_stalled_total{reason="no_selectable_peer"|"genesis_corroboration"}
dingo_chainselection_rollback_registrations_total{outcome="registered"|"rejected_closed_connection"|"rejected_implausible_tip"|"rejected_at_capacity"}
```

The existing `chain selection stalled: no selectable peer` log line is
unchanged; registration adds one `registered peer from chainsync rollback` log
line. `chainselection` reports outcomes through a
`ChainSelectorConfig.OnRollbackRegistration` callback rather than taking a
dependency on a metrics library, matching how the package already avoids
depending on `peergov`. The counters are registered in `New()` against the
pre-wrap registerer, because the `ChainSelector` is not rebuilt by a live
database restore and `rebuildableRegisterer.unregisterAll` would otherwise drop
them permanently.

## Tests

`chainselection`:

* `TestHandlePeerRollbackRegistersPeerAfterConnectionRecycle` — the reported
  scenario end to end: peer selected, `RemovePeer` (recycle), rollback to the
  intersection point, peer tracked and selectable again. Red before the fix
  (`PeerCount() == 0`).
* `TestHandlePeerRollbackDoesNotRegisterClosedConnection`
* `TestRollbackRegisteredPeerDoesNotOutrankDeliveredFrontier` (both map
  iteration orders)
* `TestHandlePeerRollbackRejectsImplausibleAdvertisedTipAtBootstrap`
* `TestHandlePeerRollbackRefusesRegistrationAtCapacity`
* `TestRollbackRegisteredPeerLosesExemptionAfterFirstHeader`
* `TestRollbackRegisteredPeerIsNotAPlausibilityReference`
* `TestRollbackRegisteredPeerDoesNotForceGenesisExit`
* `TestHandlePeerRollbackEvaluatesLivenessWithoutSelectorLock` — a
  `ConnectionLive` that re-enters the selector and blocks until that re-entry
  completes; hangs and fails (with a timeout) if the liveness check moves back
  under the lock.
* `TestHandlePeerRollbackReportsOutcomeWithoutSelectorLock` — the same
  invariant for the other configured callback the registration path invokes:
  `OnRollbackRegistration` is reported after `cs.mutex` is released.
* `TestRollbackRegisteredIncumbentDoesNotPinOutDeliveredChallenger` — a
  header-less rollback incumbent must not pin a peer that delivers a real
  frontier inside the pin's head margin out of the pipeline.
* `TestHandlePeerRollbackTrackedPeerStillAppliesRollback` — pins that an
  already-tracked peer is unaffected.

root package:

* `TestChainSelectionMetricsPreMaterializeLabels`
* `TestHandleChainSelectedNoneEventCountsStall`
* `TestNewRegistersChainSelectionMetrics`
* `TestBuildChainSelectorConfigWiresRollbackRegistrationCounter` — builds the
  config the running node builds, hands it to a real `ChainSelector`, drives
  the rollback and requires the node's counter to move, so a hook that is
  never set at the composition site fails the test.

Each production change was mutation-checked: reverting the registration
branch, the selectability exemption, the liveness gate, the liveness
ordering, the plausibility
check, the capacity refusal, the plausibility-reference exclusion, the
Genesis-horizon exclusion, the incumbent-pin release, the flag clear, the `New()` registration, the label
pre-materialization, or the `OnRollbackRegistration` wiring each turns the
corresponding test red.

`go test ./chainselection/... ./ouroboros/... ./ledger/... . -count=1` green,
`-race` green for `chainselection` and `ouroboros`, `gofmt`/`go vet`/
`golangci-lint run ./chainselection/... .` clean.

## Follow-ups (not in this PR)

* **Recycle only the leios-fetch protocol instance.** #3779's
  `requestLeiosFetchConnRecycle` (`ouroboros/leios_backfill.go`) tears down the
  whole multiplexed connection, so chainsync is collateral damage. Resetting
  just the mini-protocol is not currently possible: gouroboros builds protocol
  instances in `Connection.setupConnection`, `leiosfetch.Client.Start`/`Stop`
  are `sync.Once`-guarded (a stopped protocol cannot be restarted), and
  `Connection` exposes no per-protocol restart. gouroboros' own
  `Client.acquireSlot` documents the current design as "not recoverable on this
  connection ... fail the connection instead". It needs a gouroboros API
  change, so it is left out rather than half-done here.
* **An already-tracked peer that rolls back beyond its retained delivered
  history** ends up with the same unresolved (zero) delivered frontier and is
  filtered as "behind" until its next header. That is the same shape of gap in
  a rarer case; it is deliberately out of scope here to keep this change
  strictly additive.

Related: #3968, #3777, #3973, #3779



## Rebase onto `680e65e5` (2026-09-09)

Rebased onto current `upstream/main` `680e65e5`, 34 commits on from the
previous head of this branch. Two of those touch a file this PR touches:
#3921 (`1dd68527`) and #4109 (`4cf4c3b1`), both in `node.go`.

**One conflict, in `New()` (`node.go`), against #4109.** #4109 moves
`configValidate()` to run *before* `configWrapPromRegistry()`,
`registerBuildInfo()` and `registerRTSMetrics()`, so that an invalid
configuration leaves no collectors in a caller-owned registry. This PR had
added `registerChainSelectionMetrics()` immediately after `registerRTSMetrics()`
and immediately before the old `configValidate()` call, which #4109 deleted from
that position.

Resolved in #4109's favour and in its spirit: its relocated early
`configValidate()` is kept as-is, this PR's duplicate `configValidate()` block is
dropped as redundant, and `registerChainSelectionMetrics()` keeps its slot after
`registerRTSMetrics()`. Both invariants hold, and the result is strictly better
than either side alone:

* registration still happens after `configWrapPromRegistry()`, so the two
  counters still carry the `network` label;
* registration still happens before `newRebuildableRegisterer(...)`, which is
  what this PR needs -- the `ChainSelector` is not rebuilt by a live database
  restore, so `rebuildableRegisterer.unregisterAll` must not be able to drop
  these counters;
* and now, per #4109, an invalid configuration returns before the
  chain-selection counters are registered too, so a rejected `New()` no longer
  leaves them behind in a caller-owned registry.

#3921 (`1dd68527`) rewrites the shutdown fields of the `Node` struct
(`shutdownOnce` to `shutdownMu`/`shutdownWait`/...); this PR's single added
field (`chainSelectionMetrics`) is elsewhere in the struct and merged clean.

**One new upstream commit is semantically relevant even though it conflicts
with nothing: #4107 (`478de234`).** It inserts a gate in
`ouroboros.chainsyncClientRollBackward` that returns early, *before* the
chain-selection observation, when `chainsync.State.UpdateClientRollback`
reports the connection is not in `trackedClients`. Traced the runtime path to
confirm it cannot suppress this PR's registration:
`ouroboros.go` calls `registerTrackedChainsyncClient(connId, ...)` and only
then `chainsyncClientStart(connId)`, so an outbound chainsync client is in
`trackedClients` before it can send `MsgFindIntersect`, and the first
`MsgRollBackward` therefore passes the new gate. The only case the gate
rejects -- a rollback on a connection that was never registered or was already
removed -- is the same case this PR's own liveness check rejects as
`rejected_closed_connection`, so the two agree rather than overlap.

No part of this PR is obsoleted by anything on `main`. (The previous rebase
onto `abddf1ad` resolved a conflict with #4048 in
`chainselection.isPeerSelectableLocked`, keeping this PR's
`awaitingFirstHeader` exemption as the outer branch and #4048's
`frontierLeadIsTransportOnlyLocked` escape unchanged on the inner condition;
that resolution is carried forward untouched, as is the ordering in
`pinIncumbentDuringCatchUpLocked` where this PR's header-less-incumbent
release runs before #4048's `sameCanonicalChain` guard.)

Re-verified at `1b122178`: `gofmt`, `go build ./...`, `go vet`, and
`golangci-lint run ./chainselection/... .` clean; `go test
./chainselection/... . ./ouroboros/... ./chainsync/... ./ledger/... -count=1`
green apart from the two inherited failures below; `-race` green for
`chainselection` and `ouroboros`; and all 16 mutation checks re-run against
the rebased tree, each still turning its test red on revert (including the two
lock-ordering mutations, which fail by timeout).

### Inherited red on `main`, not from this PR

`chainselection.TestCanonicalPeersWithCrossingFrontiersDoNotFlap` and
`ledger.TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip`, both
added by #4048, are dependent on Go map iteration order and fail
intermittently on clean `upstream/main` as well. The `go-test` workflow has
been red on `main` itself ever since #4048 landed: run `34288463269`
(`f3b7e553`), run `34295179021` (`abddf1ad`), and run `34302299172` at
**this PR's exact base `680e65e5`**.

Comparing the two runs at that same base:

| | jobs green | jobs red | distinct `--- FAIL:` tests |
|---|---|---|---|
| clean `main` `680e65e5`, run `34302299172` | Windows, Linux race, govulncheck | **Linux, macOS** | both of them |
| this PR `1b122178`, run `34304597625` | **Linux**, Windows, govulncheck | macOS, Linux race | only `TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip` |

Every `--- FAIL:` line in this PR's CI is one of the two, and the set is a
strict subset of what clean `main` fails on at the same commit. No test this
PR adds or touches fails on any platform.

Local A/B on one machine with one toolchain measured 272/300 passes on clean
`main` versus 269/300 on this branch for
`TestCanonicalPeersWithCrossingFrontiersDoNotFlap`, and 44/50 versus 47/50 for
`TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip`: the same rate,
unchanged by this PR. #4144 makes both deterministic; nothing is changed for
them here.

