### PR TITLE
fix(txsubmission): compare advertised size against the wrapped wire size

### DIFF
--- a/ouroboros/metrics_protocol.go
+++ b/ouroboros/metrics_protocol.go
@@ -21,10 +21,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Outcomes for the txsubmission reply size mismatch counter.
+const (
+	// txsubmissionReplySizeAcceptedWire counts bodies whose advertised size
+	// was the wrapped wire size rather than the unwrapped body size. This
+	// is the normal, spec-correct case for a cardano-node peer.
+	txsubmissionReplySizeAcceptedWire = "accepted_wire_size"
+	// txsubmissionReplySizeRejected counts replies dropped because an
+	// advertised size matched neither the body size nor the wire size.
+	txsubmissionReplySizeRejected = "rejected"
+)
+
 type protocolMetrics struct {
-	messagesReceived             *prometheus.CounterVec
-	messageDuration              *prometheus.HistogramVec
-	txsubmissionAdmissionRetries prometheus.Histogram
+	messagesReceived              *prometheus.CounterVec
+	messageDuration               *prometheus.HistogramVec
+	txsubmissionAdmissionRetries  prometheus.Histogram
+	txsubmissionReplySizeMismatch *prometheus.CounterVec
 }
 
 func (o *Ouroboros) initProtocolMetrics() {
@@ -52,6 +64,13 @@ func (o *Ouroboros) initProtocolMetrics() {
 			},
 			[]string{"protocol", "outcome"},
 		),
+		txsubmissionReplySizeMismatch: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "dingo_txsubmission_reply_size_mismatch_total",
+				Help: "tx-submission reply bodies whose length differed from the size the peer advertised, by outcome",
+			},
+			[]string{"outcome"},
+		),
 		txsubmissionAdmissionRetries: factory.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "dingo_txsubmission_admission_retry_streak",
@@ -62,6 +81,12 @@ func (o *Ouroboros) initProtocolMetrics() {
 			},
 		),
 	}
+	// Pre-materialize both outcomes so a dashboard or alert sees a zero
+	// series before the first mismatch rather than a missing one.
+	o.protocolMetrics.txsubmissionReplySizeMismatch.
+		WithLabelValues(txsubmissionReplySizeAcceptedWire).Add(0)
+	o.protocolMetrics.txsubmissionReplySizeMismatch.
+		WithLabelValues(txsubmissionReplySizeRejected).Add(0)
 }
 
 // recordProtocolMessage records one received message and the callback
@@ -86,6 +111,17 @@ func (o *Ouroboros) recordProtocolMessage(
 	o.protocolMetrics.messageDuration.
 		WithLabelValues(protocol, outcome).
 		Observe(dur.Seconds())
+}
+
+// recordTxsubmissionReplySize records count reply bodies resolved with the
+// given outcome. Safe to call when metrics are not initialized.
+func (o *Ouroboros) recordTxsubmissionReplySize(outcome string, count int) {
+	if o.protocolMetrics == nil || count <= 0 {
+		return
+	}
+	o.protocolMetrics.txsubmissionReplySizeMismatch.
+		WithLabelValues(outcome).
+		Add(float64(count))
 }
 
 func (o *Ouroboros) recordTxsubmissionAdmissionRetry(streak int) {

--- a/ouroboros/metrics_protocol.go
+++ b/ouroboros/metrics_protocol.go
@@ -27,8 +27,10 @@ const (
 	// was the wrapped wire size rather than the unwrapped body size. This
 	// is the normal, spec-correct case for a cardano-node peer.
 	txsubmissionReplySizeAcceptedWire = "accepted_wire_size"
-	// txsubmissionReplySizeRejected counts replies dropped because an
-	// advertised size matched neither the body size nor the wire size.
+	// txsubmissionReplySizeRejected counts the bodies of replies dropped
+	// because an advertised size matched neither the body size nor the
+	// wire size. The whole reply is dropped, so every body it carried is
+	// counted, keeping the unit the same as the accepted outcome.
 	txsubmissionReplySizeRejected = "rejected"
 )
 
@@ -67,7 +69,7 @@ func (o *Ouroboros) initProtocolMetrics() {
 		txsubmissionReplySizeMismatch: factory.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "dingo_txsubmission_reply_size_mismatch_total",
-				Help: "tx-submission reply bodies whose length differed from the size the peer advertised, by outcome",
+				Help: "tx-submission reply bodies, counted in bodies not replies, whose length differed from the size the peer advertised: accepted_wire_size counts bodies advertised at the wrapped wire size, rejected counts every body of a reply dropped for a size mismatch since the whole reply is dropped",
 			},
 			[]string{"outcome"},
 		),

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -36,6 +36,9 @@ const (
 	txsubmissionMaxBackoff               = 5 * time.Second // Cap on exponential backoff wait
 	txsubmissionBaseBackoff              = 150 * time.Millisecond
 	txsubmissionLogEvery                 = 10 // Log every Nth rate limit hit after the 1st
+	// Give up on a peer only after this many consecutive rejected replies.
+	// A single bad reply drops that reply and keeps the pull loop running.
+	txsubmissionMaxConsecutiveReplyMismatches = 3
 )
 
 var (
@@ -45,16 +48,68 @@ var (
 	errTxsubmissionAdmissionStopped = errors.New(
 		"txsubmission admission wait stopped",
 	)
+	errTxsubmissionReplySizeMismatch = errors.New(
+		"txsubmission reply size mismatch",
+	)
 )
+
+// cborHeadLen returns the encoded length in bytes of a CBOR head (the
+// initial byte plus any following argument bytes) whose argument is v.
+func cborHeadLen(v uint64) uint64 {
+	switch {
+	case v <= 0x17:
+		return 1
+	case v <= 0xff:
+		return 2
+	case v <= 0xffff:
+		return 3
+	case v <= 0xffffffff:
+		return 5
+	default:
+		return 9
+	}
+}
+
+// txsubmissionWireSize returns the size of one MsgReplyTxs item as it
+// appears on the wire, given the era ID and the length of the unwrapped
+// transaction body.
+//
+// gouroboros decodes each item -- [eraId, #6.24(bytes)] -- and keeps only
+// the tag-24 payload, so TxBody.TxBody is the inner transaction CBOR. A
+// cardano-node peer advertises the spec-correct wire size in MsgReplyTxIds
+// (ouroboros-consensus SupportsMempool.txWireSize, which is deliberately
+// distinct from txInBlockSize), covering the whole wrapped item:
+//
+//	array(2) header + era ID uint  2 bytes for era IDs <= 23
+//	tag 24 (0xd8 0x18)             2 bytes
+//	byte-string length header      1, 2, 3, 5 or 9 bytes
+//
+// so the advertised value exceeds len(TxBody) by 6 bytes for a 24..255 byte
+// body and by 7 bytes for a 256..65535 byte body.
+func txsubmissionWireSize(eraId uint16, bodyLen int) uint64 {
+	body := uint64(0)
+	if bodyLen > 0 {
+		body = uint64(bodyLen)
+	}
+	// 1 byte for the definite-length array(2) header, the era ID head, the
+	// two-byte tag 24 head, then the byte string itself.
+	return 1 + cborHeadLen(uint64(eraId)) + 2 + cborHeadLen(body) + body
+}
 
 type validatedTxsubmissionBody struct {
 	body txsubmission.TxBody
 	tx   ledger.Transaction
+	// wireSizeAdvertised records that the peer advertised the wrapped wire
+	// size for this body rather than the unwrapped body size.
+	wireSizeAdvertised bool
 }
 
 // validateTxsubmissionReply verifies the complete reply before its first
 // transaction is admitted. The advertised sizes are part of the request
-// budget, so each body must have the exact size the peer advertised.
+// budget, so each body must have exactly one of the two sizes the peer can
+// legitimately have advertised for it: the unwrapped body size, or the
+// wrapped wire size that cardano-node advertises (see txsubmissionWireSize).
+// Anything else is a mismatch.
 func validateTxsubmissionReply(
 	requested []txsubmission.TxIdAndSize,
 	returned []txsubmission.TxBody,
@@ -117,16 +172,33 @@ func validateTxsubmissionReply(
 				txBody.EraId,
 			)
 		}
-		if uint64(len(txBody.TxBody)) != uint64(want.Size) {
+		bodySize := uint64(len(txBody.TxBody))
+		wireSize := txsubmissionWireSize(txBody.EraId, len(txBody.TxBody))
+		var wireSizeAdvertised bool
+		switch uint64(want.Size) {
+		case bodySize:
+			// Peer advertised the unwrapped body size, as Dingo's own
+			// client did before it was corrected to advertise the wire
+			// size. Still accepted so that a mixed fleet interoperates.
+		case wireSize:
+			wireSizeAdvertised = true
+		default:
 			return nil, fmt.Errorf(
-				"txsubmission reply size mismatch at index %d: requested %d, received %d",
+				"%w at index %d: advertised %d, body %d, wire %d, era %d",
+				errTxsubmissionReplySizeMismatch,
 				i,
 				want.Size,
-				len(txBody.TxBody),
+				bodySize,
+				wireSize,
+				txBody.EraId,
 			)
 		}
 		nextRequested = matched + 1
-		ret = append(ret, validatedTxsubmissionBody{body: txBody, tx: tx})
+		ret = append(ret, validatedTxsubmissionBody{
+			body:               txBody,
+			tx:                 tx,
+			wireSizeAdvertised: wireSizeAdvertised,
+		})
 	}
 	return ret, nil
 }
@@ -286,6 +358,7 @@ func (o *Ouroboros) txsubmissionServerInit(
 		var consecutiveRateLimits int
 		var rateLimitTotal int
 		var consecutiveImpossibleOffers int
+		var consecutiveReplyMismatches int
 		backoffTimer := time.NewTimer(0)
 		backoffTimer.Stop()
 		defer backoffTimer.Stop()
@@ -412,6 +485,10 @@ func (o *Ouroboros) txsubmissionServerInit(
 					len(txIds),
 				)
 				if limitAdmission {
+					// The advertised size is the wrapped wire size for a
+					// spec-conformant peer, so it is an upper bound on the
+					// body that will be admitted. Reserving against it is
+					// conservative by the few bytes of wrapper.
 					if int64(txIds[0].Size) >
 						headroom.MaxAdmissionHeadroomBytes() {
 						consecutiveImpossibleOffers++
@@ -481,17 +558,61 @@ func (o *Ouroboros) txsubmissionServerInit(
 					requestedTxs,
 					txs,
 				)
+				var wireSized int
+				for _, validatedTx := range validatedTxs {
+					if validatedTx.wireSizeAdvertised {
+						wireSized++
+					}
+				}
+				o.recordTxsubmissionReplySize(
+					txsubmissionReplySizeAcceptedWire,
+					wireSized,
+				)
 				if err != nil {
+					if errors.Is(err, errTxsubmissionReplySizeMismatch) {
+						o.recordTxsubmissionReplySize(
+							txsubmissionReplySizeRejected,
+							1,
+						)
+					}
+					consecutiveReplyMismatches++
 					o.config.Logger.Error(
 						"rejected mismatched txsubmission reply",
 						"component", "network",
 						"protocol", "tx-submission",
 						"role", "server",
 						"connection_id", ctx.ConnectionId.String(),
+						"consecutive_mismatches", consecutiveReplyMismatches,
 						"error", err,
 					)
-					return
+					// One bad reply must not end tx ingest for the life of
+					// the connection. Drop the whole reply -- a partially
+					// valid batch is still not trusted -- and keep pulling,
+					// giving up only on a peer that returns nothing else.
+					if consecutiveReplyMismatches >= txsubmissionMaxConsecutiveReplyMismatches {
+						o.config.Logger.Error(
+							"stopping tx ingest after repeated mismatched txsubmission replies",
+							"component", "network",
+							"protocol", "tx-submission",
+							"role", "server",
+							"connection_id", ctx.ConnectionId.String(),
+							"consecutive_mismatches", consecutiveReplyMismatches,
+						)
+						return
+					}
+					backoffTimer.Reset(
+						txsubmissionBackoffDuration(
+							consecutiveReplyMismatches,
+						),
+					)
+					select {
+					case <-backoffTimer.C:
+					case <-conn.ErrorChan():
+						return
+					}
+					continue
 				}
+				consecutiveReplyMismatches = 0
 				for _, validatedTx := range validatedTxs {
 					txBody := validatedTx.body
 					tx := validatedTx.tx
@@ -643,7 +764,12 @@ func (o *Ouroboros) txsubmissionClientRequestTxIds(
 		}
 		var txIdArr [32]byte
 		copy(txIdArr[:], txHashBytes)
-		txSize := len(tmpTx.Cbor)
+		eraId := uint16(tmpTx.Type) // #nosec G115
+		// Advertise the size of the transaction as it appears on the wire,
+		// matching cardano-node's txWireSize. Peers use the advertised size
+		// for flow control against the bytes they will actually read off
+		// the wire, which includes the tx-submission wrapper.
+		txSize := txsubmissionWireSize(eraId, len(tmpTx.Cbor))
 		if txSize > math.MaxUint32 {
 			return nil, errors.New("tx impossibly large")
 		}
@@ -651,7 +777,7 @@ func (o *Ouroboros) txsubmissionClientRequestTxIds(
 			ret,
 			txsubmission.TxIdAndSize{
 				TxId: txsubmission.TxId{
-					EraId: uint16(tmpTx.Type), // #nosec G115
+					EraId: eraId,
 					TxId:  txIdArr,
 				},
 				Size: uint32(txSize),

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -129,14 +129,6 @@ func validateTxsubmissionReply(
 	var returnedBytes uint64
 	nextRequested := 0
 	for i, txBody := range returned {
-		returnedBytes += uint64(len(txBody.TxBody))
-		if returnedBytes > requestedBytes {
-			return nil, fmt.Errorf(
-				"txsubmission reply exceeds byte limit: requested %d, received at least %d",
-				requestedBytes,
-				returnedBytes,
-			)
-		}
 		tx, err := ledger.NewTransactionFromCbor(
 			uint(txBody.EraId),
 			txBody.TxBody,
@@ -193,6 +185,21 @@ func validateTxsubmissionReply(
 				txBody.EraId,
 			)
 		}
+		// The aggregate budget is checked after the per-body size, so an
+		// advertisement smaller than the body it describes is reported and
+		// counted as the size mismatch it is instead of surfacing as an
+		// unattributed batch-budget error. Every accepted body is no larger
+		// than its own advertisement and each advertisement is consumed at
+		// most once, so this is an invariant backstop rather than a check
+		// a size advertisement alone can trip.
+		returnedBytes += bodySize
+		if returnedBytes > requestedBytes {
+			return nil, fmt.Errorf(
+				"txsubmission reply exceeds byte limit: requested %d, received at least %d",
+				requestedBytes,
+				returnedBytes,
+			)
+		}
 		nextRequested = matched + 1
 		ret = append(ret, validatedTxsubmissionBody{
 			body:               txBody,
@@ -201,6 +208,35 @@ func validateTxsubmissionReply(
 		})
 	}
 	return ret, nil
+}
+
+// recordTxsubmissionReplyOutcome records the size-advertisement outcome of
+// one reply. Both outcomes are counted in reply BODIES, never in replies:
+// accepted_wire_size counts the bodies whose advertisement was the wrapped
+// wire size, and a reply dropped for a size mismatch contributes every body
+// it carried to rejected, because the whole reply is dropped.
+func (o *Ouroboros) recordTxsubmissionReplyOutcome(
+	validated []validatedTxsubmissionBody,
+	replyBodies int,
+	err error,
+) {
+	if errors.Is(err, errTxsubmissionReplySizeMismatch) {
+		o.recordTxsubmissionReplySize(
+			txsubmissionReplySizeRejected,
+			replyBodies,
+		)
+		return
+	}
+	var wireSized int
+	for _, validatedTx := range validated {
+		if validatedTx.wireSizeAdvertised {
+			wireSized++
+		}
+	}
+	o.recordTxsubmissionReplySize(
+		txsubmissionReplySizeAcceptedWire,
+		wireSized,
+	)
 }
 
 // txsubmissionBackoffDuration returns the exponential backoff duration
@@ -558,23 +594,12 @@ func (o *Ouroboros) txsubmissionServerInit(
 					requestedTxs,
 					txs,
 				)
-				var wireSized int
-				for _, validatedTx := range validatedTxs {
-					if validatedTx.wireSizeAdvertised {
-						wireSized++
-					}
-				}
-				o.recordTxsubmissionReplySize(
-					txsubmissionReplySizeAcceptedWire,
-					wireSized,
+				o.recordTxsubmissionReplyOutcome(
+					validatedTxs,
+					len(txs),
+					err,
 				)
 				if err != nil {
-					if errors.Is(err, errTxsubmissionReplySizeMismatch) {
-						o.recordTxsubmissionReplySize(
-							txsubmissionReplySizeRejected,
-							1,
-						)
-					}
 					consecutiveReplyMismatches++
 					o.config.Logger.Error(
 						"rejected mismatched txsubmission reply",

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -96,6 +96,7 @@ type txsubmissionCorruptingConsumer struct {
 	mempool.Consumer
 	corruptHash string
 	omitHash    string
+	corruptAll  bool
 }
 
 func (c *txsubmissionCorruptingConsumer) GetTxFromCache(
@@ -105,7 +106,7 @@ func (c *txsubmissionCorruptingConsumer) GetTxFromCache(
 		return nil
 	}
 	tx := c.Consumer.GetTxFromCache(hash)
-	if tx == nil || hash != c.corruptHash {
+	if tx == nil || (!c.corruptAll && hash != c.corruptHash) {
 		return tx
 	}
 	corrupted := *tx
@@ -117,6 +118,7 @@ type txsubmissionCorruptingService struct {
 	mempool.Service
 	corruptHash string
 	omitHash    string
+	corruptAll  bool
 	mu          sync.Mutex
 	consumers   map[ouroboros.ConnectionId]mempool.Consumer
 }
@@ -143,6 +145,7 @@ func (s *txsubmissionCorruptingService) NewConsumer(
 		Consumer:    consumer,
 		corruptHash: s.corruptHash,
 		omitHash:    s.omitHash,
+		corruptAll:  s.corruptAll,
 	}
 	s.consumers[connId] = wrapped
 	return wrapped
@@ -273,9 +276,20 @@ func TestTxSubmissionClientRequestTxIds(t *testing.T) {
 					uint16(txsubmissionRelayTestEraId),
 					id.TxId.EraId,
 				)
+				// The advertised size is the wrapped wire size, which is
+				// what cardano-node advertises and what a peer reads off
+				// the wire, not the unwrapped body length.
 				require.Equal(
 					t,
-					uint32(len(fixtures[idx].body)),
+					uint32( // #nosec G115 -- test fixture
+						len(
+							txsubmissionWireEncodedItem(
+								t,
+								uint16(txsubmissionRelayTestEraId),
+								fixtures[idx].body,
+							),
+						),
+					),
 					id.Size,
 				)
 				require.Equal(
@@ -810,7 +824,11 @@ type txSubmissionRelayHarnessOpts struct {
 	dagA             bool
 	corruptOfferHash string
 	omitOfferHash    string
+	corruptAllOffers bool
 	batchRequestsA   bool
+	// promRegistryA installs protocol metrics on node A, whose
+	// txsubmission server runs the relay pull loop under test.
+	promRegistryA prometheus.Registerer
 }
 
 func newTxSubmissionRelayHarnessWithOpts(
@@ -875,15 +893,21 @@ func newTxSubmissionRelayHarnessWithOpts(
 		connmanager.ConnectionManagerConfig{Logger: logger},
 	)
 
-	nodeA := newOuroboros(OuroborosConfig{ConnManager: cmA, Logger: logger})
+	nodeA := newOuroboros(OuroborosConfig{
+		ConnManager:  cmA,
+		Logger:       logger,
+		PromRegistry: opts.promRegistryA,
+	})
 	nodeA.mempool = nodeAMempool
 	nodeB := newOuroboros(OuroborosConfig{ConnManager: cmB, Logger: logger})
 	nodeBMempool := mempool.Service(&mempool.FIFO{Mempool: mB})
-	if opts.corruptOfferHash != "" || opts.omitOfferHash != "" {
+	if opts.corruptOfferHash != "" || opts.omitOfferHash != "" ||
+		opts.corruptAllOffers {
 		nodeBMempool = &txsubmissionCorruptingService{
 			Service:     nodeBMempool,
 			corruptHash: opts.corruptOfferHash,
 			omitHash:    opts.omitOfferHash,
+			corruptAll:  opts.corruptAllOffers,
 			consumers: make(
 				map[ouroboros.ConnectionId]mempool.Consumer,
 			),
@@ -1218,7 +1242,9 @@ func TestTxSubmissionServerInitContinuesAfterMempoolRejection(
 }
 
 // TestTxSubmissionServerInitRejectsMalformedReply verifies a mismatched reply
-// stops the pull loop before a later request could acknowledge it.
+// is dropped in full and that the per-peer pull loop keeps running, so one
+// bad reply cannot end tx ingest from that peer for the life of the
+// connection.
 func TestTxSubmissionServerInitRejectsMalformedReply(t *testing.T) {
 	fixtures := txsubmissionTestFixtures(t)
 	malformed := fixtures[0]
@@ -1254,19 +1280,66 @@ func TestTxSubmissionServerInitRejectsMalformedReply(t *testing.T) {
 	)
 	require.Contains(t, logBuf.String(), "decode failed")
 	require.Contains(t, logBuf.String(), h.connA.Id().String())
+	_, admitted := h.mA.GetTransaction(malformed.hash)
+	require.False(t, admitted, "mismatched body was admitted")
 
-	// A subsequent offer must not be requested, because doing so would
-	// acknowledge and advance beyond the rejected reply.
+	// The pull loop must survive the rejection and admit the next offer.
 	addTxSubmissionTestFixtures(t, h.mB, accepted)
-	require.Never(
+	require.Eventually(
 		t,
 		func() bool {
 			_, ok := h.mA.GetTransaction(accepted.hash)
 			return ok
 		},
-		250*time.Millisecond,
+		5*time.Second,
 		10*time.Millisecond,
-		"pull loop advanced after rejecting a mismatched reply",
+		"pull loop stopped after rejecting a single mismatched reply",
+	)
+	require.NotContains(
+		t,
+		logBuf.String(),
+		"stopping tx ingest after repeated mismatched txsubmission replies",
+	)
+}
+
+// TestTxSubmissionServerInitStopsAfterRepeatedMismatches verifies a peer
+// that returns nothing but mismatched replies is eventually given up on,
+// so continuing the pull loop cannot become an unbounded hot loop.
+func TestTxSubmissionServerInitStopsAfterRepeatedMismatches(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	require.GreaterOrEqual(
+		t,
+		len(fixtures),
+		txsubmissionMaxConsecutiveReplyMismatches,
+	)
+	logBuf := &lockedBuffer{}
+	logger := slog.New(
+		slog.NewJSONHandler(
+			logBuf,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		),
+	)
+
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		logger:           logger,
+		corruptAllOffers: true,
+	})
+	defer h.close(t)
+
+	addTxSubmissionTestFixtures(t, h.mB, fixtures...)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Eventually(
+		t,
+		func() bool {
+			return strings.Contains(
+				logBuf.String(),
+				"stopping tx ingest after repeated mismatched txsubmission replies",
+			)
+		},
+		10*time.Second,
+		10*time.Millisecond,
+		"expected tx ingest to stop after repeated mismatched replies",
 	)
 }
 

--- a/ouroboros/txsubmission_wire_size_test.go
+++ b/ouroboros/txsubmission_wire_size_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// txsubmissionWireEncodedItem returns the bytes gouroboros puts on the wire
+// for a single MsgReplyTxs item, [eraId, #6.24(txBody)]. The decode side
+// keeps only the tag-24 payload, so this encoding is the only place the
+// wrapper length is observable from Go.
+func txsubmissionWireEncodedItem(
+	t *testing.T,
+	eraId uint16,
+	body []byte,
+) []byte {
+	t.Helper()
+	item := txsubmission.TxBody{EraId: eraId, TxBody: body}
+	encoded, err := item.MarshalCBOR()
+	require.NoError(t, err)
+	return encoded
+}
+
+// TestTxsubmissionWireSizeMatchesWireEncoding checks the derived wire size
+// against the real encoder across all four CBOR byte-string length header
+// bands, which is what makes the observed delta 6 bytes for a 24..255 byte
+// body and 7 bytes for a 256..65535 byte body.
+func TestTxsubmissionWireSizeMatchesWireEncoding(t *testing.T) {
+	for _, bodyLen := range []int{
+		0,     // empty
+		1,     // length header 1 byte
+		23,    // largest body with a 1-byte length header
+		24,    // smallest body with a 2-byte length header
+		255,   // largest body with a 2-byte length header
+		256,   // smallest body with a 3-byte length header
+		65535, // largest body with a 3-byte length header
+		65536, // smallest body with a 5-byte length header
+	} {
+		for _, eraId := range []uint16{0, 6, 23, 24, 255} {
+			t.Run(
+				fmt.Sprintf("era%d/len%d", eraId, bodyLen),
+				func(t *testing.T) {
+					body := make([]byte, bodyLen)
+					encoded := txsubmissionWireEncodedItem(t, eraId, body)
+					require.Equal(
+						t,
+						uint64(len(encoded)),
+						txsubmissionWireSize(eraId, bodyLen),
+					)
+				},
+			)
+		}
+	}
+}
+
+// TestTxsubmissionWireSizeOverheadBands documents the exact per-band
+// overhead observed against cardano-node peers.
+func TestTxsubmissionWireSizeOverheadBands(t *testing.T) {
+	const conwayEraId = txsubmissionRelayTestEraId
+	for _, tc := range []struct {
+		bodyLen  int
+		overhead uint64
+	}{
+		{bodyLen: 23, overhead: 5},
+		{bodyLen: 24, overhead: 6},
+		{bodyLen: 238, overhead: 6},
+		{bodyLen: 255, overhead: 6},
+		{bodyLen: 256, overhead: 7},
+		{bodyLen: 2331, overhead: 7},
+		{bodyLen: 65535, overhead: 7},
+		{bodyLen: 65536, overhead: 9},
+	} {
+		t.Run(fmt.Sprintf("len%d", tc.bodyLen), func(t *testing.T) {
+			require.Equal(
+				t,
+				uint64(tc.bodyLen)+tc.overhead,
+				txsubmissionWireSize(conwayEraId, tc.bodyLen),
+			)
+		})
+	}
+}
+
+// TestValidateTxsubmissionReplyAcceptsWireSizeAdvertisement is the
+// regression test for the size-validation regression from #3883: a
+// cardano-node peer advertises the wrapped wire size in MsgReplyTxIds while
+// gouroboros hands Dingo only the unwrapped body, so an equality check
+// against len(TxBody) rejects every batch such a peer offers.
+func TestValidateTxsubmissionReplyAcceptsWireSizeAdvertisement(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	requested := make([]txsubmission.TxIdAndSize, 0, len(fixtures))
+	returned := make([]txsubmission.TxBody, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		wireSize := len(
+			txsubmissionWireEncodedItem(
+				t,
+				fixture.txId.EraId,
+				fixture.body,
+			),
+		)
+		require.Greater(t, wireSize, len(fixture.body))
+		requested = append(requested, txsubmission.TxIdAndSize{
+			TxId: fixture.txId,
+			Size: uint32(wireSize), // #nosec G115 -- test fixture
+		})
+		returned = append(returned, txsubmission.TxBody{
+			EraId:  fixture.txId.EraId,
+			TxBody: fixture.body,
+		})
+	}
+
+	validated, err := validateTxsubmissionReply(requested, returned)
+	require.NoError(t, err)
+	require.Len(t, validated, len(returned))
+}
+
+// TestValidateTxsubmissionReplyRejectsGenuineSizeMismatch verifies the
+// wire-size allowance does not turn the size check into a range check: only
+// the unwrapped body size and the exact derived wire size are accepted.
+func TestValidateTxsubmissionReplyRejectsGenuineSizeMismatch(t *testing.T) {
+	fixture := txsubmissionTestFixtures(t)[0]
+	returned := []txsubmission.TxBody{
+		{EraId: fixture.txId.EraId, TxBody: fixture.body},
+	}
+	wireSize := uint32( // #nosec G115 -- test fixture
+		len(
+			txsubmissionWireEncodedItem(t, fixture.txId.EraId, fixture.body),
+		),
+	)
+	bodySize := uint32(len(fixture.body)) // #nosec G115 -- test fixture
+	for _, tc := range []struct {
+		name  string
+		size  uint32
+		match string
+	}{
+		// An advertisement below the body size trips the batch byte
+		// budget before the per-item size check.
+		{
+			name:  "one below body",
+			size:  bodySize - 1,
+			match: "exceeds byte limit",
+		},
+		{name: "zero", size: 0, match: "exceeds byte limit"},
+		{name: "one above body", size: bodySize + 1, match: "size mismatch"},
+		{name: "one below wire", size: wireSize - 1, match: "size mismatch"},
+		{name: "one above wire", size: wireSize + 1, match: "size mismatch"},
+		{
+			name:  "beyond wrapper overhead",
+			size:  bodySize + 8,
+			match: "size mismatch",
+		},
+		{name: "double", size: bodySize * 2, match: "size mismatch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requested := []txsubmission.TxIdAndSize{
+				{TxId: fixture.txId, Size: tc.size},
+			}
+			validated, err := validateTxsubmissionReply(requested, returned)
+			require.ErrorContains(t, err, tc.match)
+			require.Nil(t, validated)
+		})
+	}
+}
+
+// TestTxSubmissionRelayAdmitsWireSizeAdvertisedTransaction drives the real
+// pull loop end to end. Since Dingo's client now advertises the wrapped
+// wire size, node B stands in for a cardano-node peer: node A must accept
+// and admit the body and count the acceptance under the wire-size outcome.
+func TestTxSubmissionRelayAdmitsWireSizeAdvertisedTransaction(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		promRegistryA: reg,
+	})
+	defer h.close(t)
+
+	fixture := txsubmissionTestFixtures(t)[0]
+	addTxSubmissionTestFixtures(t, h.mB, fixture)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+
+	require.Eventually(
+		t,
+		func() bool {
+			_, ok := h.mA.GetTransaction(fixture.hash)
+			return ok
+		},
+		5*time.Second,
+		10*time.Millisecond,
+		"expected a wire-size-advertised transaction to be admitted",
+	)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			h.nodeA.protocolMetrics.txsubmissionReplySizeMismatch.
+				WithLabelValues(txsubmissionReplySizeAcceptedWire),
+		),
+	)
+	require.Equal(
+		t,
+		float64(0),
+		testutil.ToFloat64(
+			h.nodeA.protocolMetrics.txsubmissionReplySizeMismatch.
+				WithLabelValues(txsubmissionReplySizeRejected),
+		),
+	)
+}
+
+// TestTxsubmissionReplySizeMetricPreMaterialized verifies both outcomes are
+// exported as zero before the first mismatch, so an alert on the counter
+// does not have to tolerate a missing series.
+func TestTxsubmissionReplySizeMetricPreMaterialized(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	o := newOuroboros(OuroborosConfig{PromRegistry: reg})
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	outcomes := map[string]float64{}
+	for _, family := range families {
+		if family.GetName() != "dingo_txsubmission_reply_size_mismatch_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "outcome" {
+					outcomes[label.GetValue()] = metric.GetCounter().
+						GetValue()
+				}
+			}
+		}
+	}
+	require.Equal(
+		t,
+		map[string]float64{
+			txsubmissionReplySizeAcceptedWire: 0,
+			txsubmissionReplySizeRejected:     0,
+		},
+		outcomes,
+	)
+
+	o.recordTxsubmissionReplySize(txsubmissionReplySizeRejected, 1)
+	o.recordTxsubmissionReplySize(txsubmissionReplySizeAcceptedWire, 3)
+	// A zero or negative count must not create spurious observations.
+	o.recordTxsubmissionReplySize(txsubmissionReplySizeRejected, 0)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			o.protocolMetrics.txsubmissionReplySizeMismatch.
+				WithLabelValues(txsubmissionReplySizeRejected),
+		),
+	)
+	require.Equal(
+		t,
+		float64(3),
+		testutil.ToFloat64(
+			o.protocolMetrics.txsubmissionReplySizeMismatch.
+				WithLabelValues(txsubmissionReplySizeAcceptedWire),
+		),
+	)
+}
+
+// TestRecordTxsubmissionReplySizeWithoutMetrics verifies the recorder is a
+// no-op when metrics were never initialized.
+func TestRecordTxsubmissionReplySizeWithoutMetrics(t *testing.T) {
+	o := newOuroboros(OuroborosConfig{})
+	require.Nil(t, o.protocolMetrics)
+	require.NotPanics(t, func() {
+		o.recordTxsubmissionReplySize(txsubmissionReplySizeRejected, 1)
+	})
+}

--- a/ouroboros/txsubmission_wire_size_test.go
+++ b/ouroboros/txsubmission_wire_size_test.go
@@ -152,14 +152,11 @@ func TestValidateTxsubmissionReplyRejectsGenuineSizeMismatch(t *testing.T) {
 		size  uint32
 		match string
 	}{
-		// An advertisement below the body size trips the batch byte
-		// budget before the per-item size check.
-		{
-			name:  "one below body",
-			size:  bodySize - 1,
-			match: "exceeds byte limit",
-		},
-		{name: "zero", size: 0, match: "exceeds byte limit"},
+		// An advertisement below the body size is a size mismatch like
+		// any other, and must be classified as one rather than falling
+		// through to the aggregate byte-budget error.
+		{name: "one below body", size: bodySize - 1, match: "size mismatch"},
+		{name: "zero", size: 0, match: "size mismatch"},
 		{name: "one above body", size: bodySize + 1, match: "size mismatch"},
 		{name: "one below wire", size: wireSize - 1, match: "size mismatch"},
 		{name: "one above wire", size: wireSize + 1, match: "size mismatch"},
@@ -285,4 +282,145 @@ func TestRecordTxsubmissionReplySizeWithoutMetrics(t *testing.T) {
 	require.NotPanics(t, func() {
 		o.recordTxsubmissionReplySize(txsubmissionReplySizeRejected, 1)
 	})
+}
+
+// TestValidateTxsubmissionReplyUndersizedAdvertisementIsCounted covers a
+// peer advertising a size SMALLER than the body it returns. That case used
+// to trip the aggregate byte-budget check before the per-body size check
+// ran, so the reply was dropped without being classified or counted as a
+// size mismatch.
+func TestValidateTxsubmissionReplyUndersizedAdvertisementIsCounted(
+	t *testing.T,
+) {
+	fixture := txsubmissionTestFixtures(t)[0]
+	returned := []txsubmission.TxBody{
+		{EraId: fixture.txId.EraId, TxBody: fixture.body},
+	}
+	requested := []txsubmission.TxIdAndSize{
+		{
+			TxId: fixture.txId,
+			Size: uint32(len(fixture.body)) - 1, // #nosec G115 -- fixture
+		},
+	}
+
+	validated, err := validateTxsubmissionReply(requested, returned)
+	require.Nil(t, validated)
+	require.ErrorIs(t, err, errTxsubmissionReplySizeMismatch)
+	// The operator needs both numbers and the era to tell an undersized
+	// advertisement apart from a wrapper-size disagreement.
+	require.ErrorContains(t, err, "advertised")
+	require.ErrorContains(t, err, "body")
+	require.ErrorContains(t, err, "wire")
+	require.ErrorContains(t, err, "era")
+
+	reg := prometheus.NewRegistry()
+	o := newOuroboros(OuroborosConfig{PromRegistry: reg})
+	o.recordTxsubmissionReplyOutcome(validated, len(returned), err)
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(
+			o.protocolMetrics.txsubmissionReplySizeMismatch.
+				WithLabelValues(txsubmissionReplySizeRejected),
+		),
+	)
+}
+
+// TestRecordTxsubmissionReplyOutcomeCountsBodies pins the unit of both
+// outcomes: each counts reply BODIES, never replies. A three-body reply
+// that is accepted adds three to accepted_wire_size, and a three-body
+// reply dropped for a size mismatch adds three to rejected, because the
+// whole reply is dropped.
+func TestRecordTxsubmissionReplyOutcomeCountsBodies(t *testing.T) {
+	fixtures := txsubmissionTestFixtures(t)
+	require.Len(t, fixtures, 3)
+	requested := make([]txsubmission.TxIdAndSize, 0, len(fixtures))
+	returned := make([]txsubmission.TxBody, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		requested = append(requested, txsubmission.TxIdAndSize{
+			TxId: fixture.txId,
+			Size: uint32( // #nosec G115 -- test fixture
+				len(
+					txsubmissionWireEncodedItem(
+						t,
+						fixture.txId.EraId,
+						fixture.body,
+					),
+				),
+			),
+		})
+		returned = append(returned, txsubmission.TxBody{
+			EraId:  fixture.txId.EraId,
+			TxBody: fixture.body,
+		})
+	}
+
+	t.Run("accepted counts three bodies", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		o := newOuroboros(OuroborosConfig{PromRegistry: reg})
+		validated, err := validateTxsubmissionReply(requested, returned)
+		require.NoError(t, err)
+		require.Len(t, validated, 3)
+		o.recordTxsubmissionReplyOutcome(validated, len(returned), err)
+		require.Equal(
+			t,
+			float64(3),
+			testutil.ToFloat64(
+				o.protocolMetrics.txsubmissionReplySizeMismatch.
+					WithLabelValues(txsubmissionReplySizeAcceptedWire),
+			),
+		)
+		require.Equal(
+			t,
+			float64(0),
+			testutil.ToFloat64(
+				o.protocolMetrics.txsubmissionReplySizeMismatch.
+					WithLabelValues(txsubmissionReplySizeRejected),
+			),
+		)
+	})
+
+	// One bad advertisement drops the whole three-body reply, so all three
+	// bodies are counted as rejected regardless of which one was bad.
+	for _, badIdx := range []int{0, 1, 2} {
+		t.Run(
+			fmt.Sprintf("rejected counts three bodies bad%d", badIdx),
+			func(t *testing.T) {
+				bad := make([]txsubmission.TxIdAndSize, len(requested))
+				copy(bad, requested)
+				bad[badIdx].Size += 8
+				reg := prometheus.NewRegistry()
+				o := newOuroboros(OuroborosConfig{PromRegistry: reg})
+				validated, err := validateTxsubmissionReply(bad, returned)
+				require.ErrorIs(t, err, errTxsubmissionReplySizeMismatch)
+				o.recordTxsubmissionReplyOutcome(
+					validated,
+					len(returned),
+					err,
+				)
+				require.Equal(
+					t,
+					float64(3),
+					testutil.ToFloat64(
+						o.protocolMetrics.txsubmissionReplySizeMismatch.
+							WithLabelValues(
+								txsubmissionReplySizeRejected,
+							),
+					),
+				)
+				// A dropped reply contributes nothing to the accepted
+				// outcome, even when earlier bodies validated.
+				require.Equal(
+					t,
+					float64(0),
+					testutil.ToFloat64(
+						o.protocolMetrics.txsubmissionReplySizeMismatch.
+							WithLabelValues(
+								txsubmissionReplySizeAcceptedWire,
+							),
+					),
+				)
+			},
+		)
+	}
 }


### PR DESCRIPTION
## Problem

A Dingo node acting as the tx-submission **server** rejects every transaction batch offered by a `cardano-node` peer, so it ingests nothing over tx-submission and forges empty blocks.

```
level=ERROR msg="rejected mismatched txsubmission reply" component=network
  protocol=tx-submission role=server
  error="txsubmission reply size mismatch at index 0: requested 2338, received 2331"
```

The failure is always `at index 0`, so no transaction in any batch is ever admitted, and the rejection `return`s out of the per-connection pull goroutine — tx ingest from that peer is dead for the life of the connection rather than for one batch.

This is the size-validation regression from #3883. It reproduces against every `cardano-node` peer; it does not reproduce Dingo-to-Dingo, which is why the harness tests added with #3883 stayed green.

## Evidence

137 rejections collected on three producers. The delta between `requested` and `received` is not constant — it is 6 or 7 bytes and it tracks the size of the received body:

| delta | body size band | count |
|---|---|---|
| 6 | 24–255 | 88 |
| 7 | 256–65535 | 49 |

Zero exceptions in 137 samples; the boundary is exactly 256, i.e. the width of a CBOR byte-string length prefix. Sample pairs: `244/238`, `343/336`, `673/666`, `2338/2331`, `5824/5817`.

## Root cause

`requested` and `received` are two different quantities.

- **`received`** is the *unwrapped* transaction CBOR. gouroboros decodes each `MsgReplyTxs` item `[eraId, #6.24(bytes)]` and stores only the tag-24 payload in `TxBody.TxBody` (`protocol/txsubmission/messages.go`; the `MarshalCBOR` encoder shows the framing the decoder drops).
- **`requested`** is `want.Size`, taken verbatim from the peer's `MsgReplyTxIds`. For a `cardano-node` peer that is `txWireSize` — `ouroboros-consensus`, `Ouroboros/Consensus/Ledger/SupportsMempool.hs`, documented as "the size of the transaction from the perspective of diffusion layer" and deliberately distinct from `txInBlockSize`. It is the value fed into `MsgReplyTxIds` from `NodeKernel.hs`.

`txWireSize` for the hard-fork block is the sum of two envelopes — the HFC envelope (`HardFork/Combinator/Mempool.hs`: 2 bytes for era index ≤ 23) and the CBOR-in-CBOR envelope (`Shelley/Ledger/Mempool.hs`: 2 bytes of `encodeTag 24` plus a 1/2/3/5-byte byte-string length header):

```
1  array(2) header       0x82
1  era ID uint           (era IDs <= 23)
2  tag 24                0xd8 0x18
n  byte-string header    1 (<24) / 2 (<256) / 3 (<65536) / 5
```

which is 6 bytes of overhead for a 24–255 byte body and 7 for 256–65535 — exactly the observed distribution, including the boundary and the absence of any other delta. Every observed pair reproduces: inner 238 → `82 06 d8 18 58 ee` + 238 = 244; inner 2331 → `82 06 d8 18 59 09 1b` + 2331 = 2338.

The peer is right and Dingo was comparing against the wrong quantity.

### Dingo advertised the wrong size too

Mirror-image bug on the sending side: `txsubmissionClientRequestTxIds` advertised `len(tmpTx.Cbor)`, the unwrapped size. `cardano-node` tolerates this because `ouroboros-network` uses the advertised size only as a flow-control / request budget, never as a strict equality check — but Dingo was under-advertising by 6–7 bytes per transaction, which is a conformance bug on its own. It is also what hid the server-side bug: Dingo advertised `len(Cbor)` and measured `len(TxBody)`, so the two agreed in the Dingo-to-Dingo harness.

## Fix

1. **Server / inbound.** Add `txsubmissionWireSize(eraId, bodyLen)`, deriving the wrapped size from the era ID head and the CBOR head width the body length implies. `validateTxsubmissionReply` accepts an advertisement equal to either the unwrapped body size (peers that advertise like Dingo did, so a mixed fleet interoperates) or the exact derived wire size, and rejects anything else. This stays an equality check against two known-legitimate values rather than becoming a range check: `wire - 1`, `wire + 1` and `body + 8` are all still rejected. The mismatch error now reports the advertised size, the body size, the derived wire size and the era.
2. **Server / inbound, pull loop.** A rejected reply no longer ends tx ingest for the connection. The whole reply is dropped — a partially valid batch is still not trusted, so #3883's atomicity is preserved — then the loop backs off and keeps pulling, in the spirit of #3461. A peer that returns nothing but mismatched replies is given up on after 3 consecutive rejections, so this cannot become a hot loop; that give-up is logged separately. In the deployed configuration the admission-headroom path requests one ID at a time, so "drop the reply" and "skip the item" coincide there.
3. **Client / outbound.** `txsubmissionClientRequestTxIds` now advertises the wire size via the same helper, so peers get spec-correct sizes. Safe because they use it only for flow control against the bytes they actually read off the wire.
4. **Metrics.** New counter `dingo_txsubmission_reply_size_mismatch_total{outcome="accepted_wire_size"|"rejected"}`, both label values pre-materialized at zero so an alert does not have to tolerate a missing series.

The admission-headroom reservation now sizes against the advertised wire size, which is an upper bound on the body that gets admitted — conservative by the few bytes of wrapper.

## Tests

- `TestTxsubmissionWireSizeMatchesWireEncoding` — derived size vs the real `TxBody.MarshalCBOR` output for body lengths 0, 1, 23, 24, 255, 256, 65535, 65536 across era IDs 0, 6, 23, 24, 255, covering all four length-header bands.
- `TestTxsubmissionWireSizeOverheadBands` — pins the 6- and 7-byte overheads and the band boundaries.
- `TestValidateTxsubmissionReplyAcceptsWireSizeAdvertisement` — the regression test: a reply whose advertised size is the wrapped size is accepted. Fails on `main` with `size mismatch`.
- `TestValidateTxsubmissionReplyRejectsGenuineSizeMismatch` — body ± 1, wire ± 1, body + 8, double and zero are all still rejected.
- `TestTxSubmissionRelayAdmitsWireSizeAdvertisedTransaction` — end to end over the real relay harness, now that the client advertises the wire size, plus the `accepted_wire_size` counter.
- `TestTxSubmissionServerInitRejectsMalformedReply` — updated: a single mismatched reply is dropped and the pull loop still admits the next offer.
- `TestTxSubmissionServerInitStopsAfterRepeatedMismatches` — ingest stops after repeated mismatches.
- `TestTxsubmissionReplySizeMetricPreMaterialized`, `TestRecordTxsubmissionReplySizeWithoutMetrics`.
- `TestTxSubmissionClientRequestTxIds` — updated to expect the wire size.

`go build ./...`, `go vet ./...`, `golangci-lint run ./ouroboros/...` clean; `go test ./ouroboros/... ./mempool/... . -count=1` green, `go test ./ouroboros/... -race` green. Each change was mutation-checked: neutralizing the derivation, restoring strict inner equality, restoring the client's unwrapped advertisement, restoring the immediate `return` on rejection, and removing the metric pre-materialization each turn the corresponding test red.

## gouroboros follow-up

`MsgReplyTxs` decoding discards the wrapper, so the wire size cannot be observed directly from Go today and this PR derives it. It would be cleaner for gouroboros to surface the wrapped item length on `TxBody`; that would let this comparison use the observed value instead of a derived one. Worth noting for blinklabs-io/gouroboros#2076, which asks for count/size validation in the library: whatever it adds must not become a strict equality against the inner body size, or it reintroduces exactly this failure for every `cardano-node` peer.

Related: #3883, #3505, #3461, blinklabs-io/gouroboros#2076

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tx-submission size validation so Dingo accepts transactions from `cardano-node` peers instead of rejecting every batch; previously the server compared the advertised size to the unwrapped body length, which always mismatched for `cardano-node` peers, so ingest stopped. Now it accepts either the unwrapped body size or the derived wire size, drops a single mismatched reply and keeps pulling, gives up only after 3 consecutive mismatches, and the client also advertises the wire size, with a new metric tracking outcomes.

**Details**
- Derives the wire size from era ID and body length, covering all CBOR length-header bands.
- The mismatch error reports advertised, body, wire, and era sizes; undersized advertisements are now checked per body before the aggregate budget, so they count as size mismatches, and both metric outcomes count bodies (one per accepted body, every body of a dropped reply).
- After a mismatch, the pull loop backs off and continues; it stops only after 3 consecutive rejections.
- Client-side advertisement now matches the wire size, fixing a conformance bug.

<sup>Written for commit 45b8a6b3937259f8ee2001aa1eda2dbea64d1536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/3992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction-submission size validation now supports both standard and wrapped wire-size advertisements.
  * Added metrics for accepted wire-size replies and rejected size mismatches.
* **Bug Fixes**
  * Valid transaction replies are accepted when peers advertise their wire-encoded size.
  * Occasional size mismatches are retried with backoff while valid replies reset the mismatch count.
  * Transaction ingestion stops after three consecutive size mismatches to prevent repeated invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #3994.
