### PR TITLE
fix(chainsync): keep a peer that is merely behind on our own chain instead of evicting it as an over-K fork

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1490,11 +1490,49 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	if c.tipBlockIndex <= initialBlockIndex {
 		return points
 	}
+	// Beyond the dense band the ladder doubles, so a peer L blocks behind
+	// resolves its FindIntersect to the next rung at or past L. Once that
+	// rung passes the security parameter K, the rollback the peer asks for
+	// is refused as an over-K fork even though the peer's chain is a strict
+	// prefix of ours: at K=108 the first rung past K is 128, so a peer only
+	// 65 blocks behind is already refused. Offering the rung at exactly K
+	// closes that band — with a point at offset K, every peer within K of
+	// our tip holds it, so the shallowest rung it can match is at most K
+	// deep and stays crossable. It costs exactly one extra point, so the
+	// FindIntersect message stays the same size in practice (the list is
+	// capped by count).
+	//
+	// securityParam is written once by ChainManager.SetLedger during
+	// startup and read without the manager lock elsewhere on this path
+	// (see MaxQueuedHeaders); a zero value simply skips the extra rung.
+	securityRung := uint64(0)
+	if c.manager != nil && c.manager.securityParam > 0 {
+		securityRung = uint64(c.manager.securityParam) //nolint:gosec // guarded positive
+	}
 	for offset := uint64(denseCount); len(points) < count; offset *= 2 { //nolint:gosec // denseCount is bounded to non-negative values
 		if offset == 0 || offset >= c.tipBlockIndex {
 			break
 		}
+		// Keep the list descending: emit the K rung before the first
+		// doubling rung that would overshoot it.
+		if securityRung > 0 && securityRung < offset {
+			if securityRung < c.tipBlockIndex {
+				appendBlockPoint(c.tipBlockIndex - securityRung)
+			}
+			securityRung = 0
+			if len(points) >= count {
+				break
+			}
+		}
 		appendBlockPoint(c.tipBlockIndex - offset)
+	}
+	// The doubling loop can stop before reaching the K rung when the chain
+	// is shorter than the next rung. Every offset it emitted is then at or
+	// below K (a smaller K would have been emitted inside the loop), so
+	// appending it here keeps the list descending.
+	if securityRung > 0 && securityRung < c.tipBlockIndex &&
+		len(points) < count {
+		appendBlockPoint(c.tipBlockIndex - securityRung)
 	}
 	if len(points) < count {
 		appendBlockPoint(initialBlockIndex)

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -1437,6 +1437,13 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	if c == nil || count <= 0 {
 		return nil
 	}
+	// Read K before taking any chain lock: SetLedger can run while the node
+	// is serving chainsync, and the accessor takes the manager lock, which
+	// must not be acquired underneath the block-index read locks below.
+	securityRung := uint64(0)
+	if k := c.manager.SecurityParam(); k > 0 {
+		securityRung = uint64(k) //nolint:gosec // guarded positive
+	}
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	unlockBlockIndexReadLocks := c.lockBlockIndexReadLocks()
@@ -1502,13 +1509,6 @@ func (c *Chain) IntersectPoints(count int) []ocommon.Point {
 	// FindIntersect message stays the same size in practice (the list is
 	// capped by count).
 	//
-	// securityParam is written once by ChainManager.SetLedger during
-	// startup and read without the manager lock elsewhere on this path
-	// (see MaxQueuedHeaders); a zero value simply skips the extra rung.
-	securityRung := uint64(0)
-	if c.manager != nil && c.manager.securityParam > 0 {
-		securityRung = uint64(c.manager.securityParam) //nolint:gosec // guarded positive
-	}
 	for offset := uint64(denseCount); len(points) < count; offset *= 2 { //nolint:gosec // denseCount is bounded to non-negative values
 		if offset == 0 || offset >= c.tipBlockIndex {
 			break

--- a/chain/intersect_behind_peer_test.go
+++ b/chain/intersect_behind_peer_test.go
@@ -15,7 +15,6 @@
 package chain_test
 
 import (
-	"errors"
 	"testing"
 
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -137,12 +136,10 @@ func TestIntersectPointsStillExceedKForPeerBehindBeyondK(t *testing.T) {
 		behindPeerDepth(headers, answer),
 		uint64(behindPeerSecurityParam),
 	)
-	require.True(
+	require.ErrorIs(
 		t,
-		errors.Is(
-			c.ValidateRollback(answer),
-			chain.ErrRollbackExceedsSecurityParam,
-		),
+		c.ValidateRollback(answer),
+		chain.ErrRollbackExceedsSecurityParam,
 		"expected the chain layer to refuse a rollback deeper than K",
 	)
 }

--- a/chain/intersect_behind_peer_test.go
+++ b/chain/intersect_behind_peer_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chain_test
+
+import (
+	"errors"
+	"testing"
+
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/chain"
+)
+
+// behindPeerChainLength is long enough that the intersect ladder reaches
+// several sparse rungs past the dense band.
+const behindPeerChainLength = 200
+
+// behindPeerSecurityParam is the security parameter K used by these tests. It
+// sits above the dense band (32 points) so the ladder's sparse rungs, not the
+// dense band, decide where a lagging peer intersects — the same relationship
+// every real network has (K = 108/432/2160 against a fixed 32-point band).
+const behindPeerSecurityParam = 40
+
+// newBehindPeerChain builds a persistent chain of behindPeerChainLength linked
+// blocks with K = behindPeerSecurityParam and returns it with its headers.
+func newBehindPeerChain(t *testing.T) (*chain.Chain, []*MockBlock) {
+	t.Helper()
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	mustSetLedger(t, cm, behindPeerSecurityParam)
+	c := cm.PrimaryChain()
+	headers := makeLinkedHeaders(behindPeerChainLength, 0, 1, "")
+	for _, header := range headers {
+		require.NoError(t, c.AddBlock(header, nil))
+	}
+	return c, headers
+}
+
+// peerIntersectAnswer models what a chainsync server holding every block up to
+// peerTipSlot answers to our FindIntersect. Our points are descending, and the
+// server replies with the first point it holds, so the answer is the shallowest
+// ladder rung at or below the peer's tip.
+func peerIntersectAnswer(
+	t *testing.T,
+	points []ocommon.Point,
+	peerTipSlot uint64,
+) ocommon.Point {
+	t.Helper()
+	for _, point := range points {
+		if point.Slot <= peerTipSlot {
+			return point
+		}
+	}
+	t.Fatalf("peer holding slot %d matched none of our intersect points", peerTipSlot)
+	return ocommon.Point{}
+}
+
+// makeLinkedHeaders spaces blocks 20 slots apart, so a point's depth below the
+// tip in blocks is recoverable from its slot.
+func behindPeerDepth(headers []*MockBlock, point ocommon.Point) uint64 {
+	tipSlot := headers[len(headers)-1].MockSlot
+	return (tipSlot - point.Slot) / 20
+}
+
+// A peer that is behind us by fewer than K blocks is inside the security
+// parameter by every measure that matters, yet the intersect ladder resolves
+// its best common point to the next power-of-two rung, which can sit past K.
+// The rollback the peer then asks for is refused as a deeper-than-K fork even
+// though the peer's chain is a strict prefix of ours and nothing diverged.
+//
+// The ladder must offer a rung at K itself so that any peer within K of our
+// tip resolves to a point at most K back.
+func TestIntersectPointsKeepPeerWithinSecurityParamCrossable(t *testing.T) {
+	c, headers := newBehindPeerChain(t)
+
+	// The peer is 35 blocks behind: comfortably inside K=40.
+	const peerLag = 35
+	peerTip := headers[len(headers)-1-peerLag]
+
+	points := c.IntersectPoints(100)
+	answer := peerIntersectAnswer(t, points, peerTip.MockSlot)
+	depth := behindPeerDepth(headers, answer)
+
+	require.LessOrEqualf(
+		t,
+		depth,
+		uint64(behindPeerSecurityParam),
+		"a peer only %d blocks behind must resolve to an intersect within "+
+			"K=%d, got depth %d",
+		peerLag,
+		behindPeerSecurityParam,
+		depth,
+	)
+	require.NoErrorf(
+		t,
+		c.ValidateRollback(answer),
+		"rollback to the intersect a peer %d blocks behind resolves to "+
+			"must be crossable with K=%d",
+		peerLag,
+		behindPeerSecurityParam,
+	)
+}
+
+// A peer further behind than K still resolves to a rung past K, and the chain
+// layer still refuses that rollback: from the chain's point of view the depth
+// is real. Nothing about the peer is divergent, though — its chain is a strict
+// prefix of ours — so this rejection must not be turned into an eviction. That
+// classification belongs to the ledger's chainsync handler; this test pins the
+// chain-layer half of the contract so the ladder change above is not mistaken
+// for a full fix.
+func TestIntersectPointsStillExceedKForPeerBehindBeyondK(t *testing.T) {
+	c, headers := newBehindPeerChain(t)
+
+	// The peer is 45 blocks behind, past K=40.
+	const peerLag = 45
+	peerTip := headers[len(headers)-1-peerLag]
+
+	points := c.IntersectPoints(100)
+	answer := peerIntersectAnswer(t, points, peerTip.MockSlot)
+
+	require.Greater(
+		t,
+		behindPeerDepth(headers, answer),
+		uint64(behindPeerSecurityParam),
+	)
+	require.True(
+		t,
+		errors.Is(
+			c.ValidateRollback(answer),
+			chain.ErrRollbackExceedsSecurityParam,
+		),
+		"expected the chain layer to refuse a rollback deeper than K",
+	)
+}
+
+// The K rung is merged into a list the chainsync protocol requires to be
+// ordered newest-first, and it must land in its sorted position for every
+// relationship between K, the dense band and the chain length — including
+// chains shorter than the next doubling rung, where the loop that emits the
+// sparse rungs stops early.
+func TestIntersectPointsStayDescendingWithSecurityRung(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		chainLength int
+		securityK   int
+	}{
+		{name: "k inside dense band", chainLength: 200, securityK: 8},
+		{name: "k at dense band edge", chainLength: 200, securityK: 32},
+		{name: "k between rungs", chainLength: 200, securityK: 40},
+		{name: "k on a rung", chainLength: 200, securityK: 64},
+		{name: "k past chain", chainLength: 40, securityK: 100},
+		{name: "chain shorter than next rung", chainLength: 45, securityK: 40},
+		{name: "chain equal to k", chainLength: 41, securityK: 40},
+		{name: "tiny chain", chainLength: 3, securityK: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			cm, err := chain.NewManager(db, nil)
+			require.NoError(t, err)
+			mustSetLedger(t, cm, tc.securityK)
+			c := cm.PrimaryChain()
+			headers := makeLinkedHeaders(tc.chainLength, 0, 1, "")
+			for _, header := range headers {
+				require.NoError(t, c.AddBlock(header, nil))
+			}
+
+			points := c.IntersectPoints(100)
+			require.NotEmpty(t, points)
+			for i := 0; i+1 < len(points); i++ {
+				require.Greaterf(
+					t,
+					points[i].Slot,
+					points[i+1].Slot,
+					"intersect points must be strictly descending at %d",
+					i,
+				)
+			}
+
+			// Whenever the chain is longer than K, a peer exactly K
+			// behind must find a point at most K deep, so the rollback
+			// it asks for stays inside the security parameter.
+			if tc.chainLength > tc.securityK+1 {
+				peerTip := headers[len(headers)-1-tc.securityK]
+				answer := peerIntersectAnswer(t, points, peerTip.MockSlot)
+				require.LessOrEqual(
+					t,
+					behindPeerDepth(headers, answer),
+					uint64(tc.securityK),
+				)
+				require.NoError(t, c.ValidateRollback(answer))
+			}
+		})
+	}
+}

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -118,8 +118,23 @@ func (cm *ChainManager) SetLedger(
 			k,
 		)
 	}
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
 	cm.securityParam = k
 	return nil
+}
+
+// SecurityParam returns the configured Ouroboros security parameter K, or zero
+// before SetLedger has run. SetLedger is not confined to startup — the state
+// database can be reloaded while the node is serving chainsync — so readers
+// outside the manager lock must go through here.
+func (cm *ChainManager) SecurityParam() int {
+	if cm == nil {
+		return 0
+	}
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+	return cm.securityParam
 }
 
 func (cm *ChainManager) PrimaryChain() *Chain {

--- a/chainselection/behind_peer_valency_test.go
+++ b/chainselection/behind_peer_valency_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tipAt builds a chainsync tip with a distinct hash per block number.
+func behindPeerTipAt(blockNumber uint64) ochainsync.Tip {
+	return ochainsync.Tip{
+		Point: ocommon.Point{
+			Slot: blockNumber * 2,
+			Hash: []byte("behind-peer-" + string(rune('a'+blockNumber%26))),
+		},
+		BlockNumber: blockNumber,
+	}
+}
+
+// A block producer with a single configured upstream must keep that upstream
+// usable while it is behind on our own chain. The intersect ladder resolves a
+// peer this far back to a rung past K, which the chainsync layer used to treat
+// as an over-K fork and evict; chain selection itself has no such notion, and
+// this pins the invariant the eviction was breaking: one behind-but-inside-K
+// peer stays registered and selectable, so the producer never reaches the
+// "chain selection stalled: no selectable peer" state, and it is selected
+// immediately once it overtakes us.
+func TestValencyOneUpstreamBehindStaysSelectable(t *testing.T) {
+	const securityParam = 108
+	const localBlock = 115195
+	// 65 blocks behind: the point at which the intersect ladder's first rung
+	// past K (128 at K=108) starts manufacturing an over-K rollback, while
+	// the peer is still well inside K.
+	const behindBlock = localBlock - 65
+
+	cs := NewChainSelector(ChainSelectorConfig{})
+	cs.SetSecurityParam(securityParam)
+	cs.SetLocalTip(behindPeerTipAt(localBlock))
+
+	connId := newTestConnectionId(1)
+	require.True(t, cs.UpdatePeerTip(connId, behindPeerTipAt(behindBlock), nil))
+
+	require.Equal(t, 1, cs.PeerCount(), "the only upstream must be retained")
+	best := cs.SelectBestChain()
+	require.NotNil(
+		t,
+		best,
+		"a sole upstream inside K must remain selectable, otherwise the "+
+			"producer stalls with no selectable peer",
+	)
+	assert.Equal(t, connId, *best)
+
+	// The peer catches up and overtakes us; it must be selected.
+	require.True(t, cs.UpdatePeerTip(connId, behindPeerTipAt(localBlock+5), nil))
+	cs.SetLocalTip(behindPeerTipAt(localBlock))
+	best = cs.SelectBestChain()
+	require.NotNil(t, best)
+	assert.Equal(t, connId, *best)
+}
+
+// A sole upstream further behind than K is not worth syncing from, so chain
+// selection declines to select it — but it must still be retained, because it
+// is the only peer we have and it becomes selectable again the moment it
+// catches back up to within K. Evicting it instead (the over-K chainsync
+// denial) leaves the node with no upstream at all.
+func TestValencyOneUpstreamBeyondKIsRetainedNotEvicted(t *testing.T) {
+	const securityParam = 108
+	const localBlock = 115195
+	// The lag observed in the field: 119 blocks, past K.
+	const behindBlock = localBlock - 119
+
+	cs := NewChainSelector(ChainSelectorConfig{})
+	cs.SetSecurityParam(securityParam)
+	cs.SetLocalTip(behindPeerTipAt(localBlock))
+
+	connId := newTestConnectionId(1)
+	require.True(t, cs.UpdatePeerTip(connId, behindPeerTipAt(behindBlock), nil))
+
+	assert.Equal(t, 1, cs.PeerCount(), "the only upstream must be retained")
+	assert.Nil(
+		t,
+		cs.SelectBestChain(),
+		"a peer more than K behind is not a useful sync source",
+	)
+
+	// It catches up to within K and becomes usable again without any
+	// reconnect, denial cooldown, or operator intervention.
+	require.True(
+		t,
+		cs.UpdatePeerTip(connId, behindPeerTipAt(localBlock-10), nil),
+	)
+	best := cs.SelectBestChain()
+	require.NotNil(t, best)
+	assert.Equal(t, connId, *best)
+}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2201,6 +2201,23 @@ func (ls *LedgerState) handleEventChainsyncRollback(
 			skipRollback = false
 		}
 		if skipRollback {
+			// A peer that is merely behind on our own chain repeats
+			// the same intersect on every reconnect by construction,
+			// so it reaches this threshold without anything having
+			// diverged. Skipping its rollback is right; reporting it
+			// as unrecoverable divergence (which advises the operator
+			// to re-bootstrap from a Mithril snapshot) and forcing a
+			// fresh connection are not.
+			if depth, behind := ls.chainsyncPeerBehindOnOurChain(
+				e,
+			); behind {
+				ls.noteChainsyncPeerBehind(
+					e,
+					depth,
+					"rollback loop detected",
+				)
+				return nil
+			}
 			// Surface the stuck condition through the point-keyed tracker
 			// that survives the resync reset+reconnect cycle. Without this
 			// the skip silently breaks the loop and the #2728 escalation
@@ -2335,6 +2352,26 @@ func (ls *LedgerState) handleEventChainsyncRollback(
 			}
 			if reconciled {
 				ls.resetChainsyncResyncState()
+				ls.setChainsyncState(SyncingChainsyncState)
+				return nil
+			}
+			// A peer whose advertised tip is a strict ancestor of
+			// ours holds a prefix of our chain: it is behind, not
+			// forked, and the over-K depth is only our intersect
+			// ladder's granularity (see
+			// chainsyncPeerBehindOnOurChain). Keep it attached and
+			// unselected until it catches up instead of rejecting,
+			// denying and escalating it — with a single configured
+			// upstream, evicting it is a self-inflicted outage.
+			if depth, behind := ls.chainsyncPeerBehindOnOurChain(
+				e,
+			); behind {
+				ls.noteChainsyncPeerBehind(
+					e,
+					depth,
+					"rollback exceeds security parameter K",
+				)
+				// No rollback occurred, so we are still syncing.
 				ls.setChainsyncState(SyncingChainsyncState)
 				return nil
 			}

--- a/ledger/chainsync_behind_peer.go
+++ b/ledger/chainsync_behind_peer.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+)
+
+// chainsyncPeerBehindOnOurChain reports whether a chainsync peer that asked us
+// to roll back is merely behind on our own chain rather than offering a
+// competing one, and by how many blocks.
+//
+// Chain.IntersectPoints samples our history at doubling offsets past a dense
+// band of 32 points, so a peer L blocks behind resolves its FindIntersect to
+// the next rung at or past L, not to L itself. The rollback it then asks for is
+// as deep as that rung, which can exceed the security parameter K while the
+// peer is still inside K — with a 32-point dense band the rejection starts at a
+// lag of only K/2-ish blocks. Fork depth there is the ladder's granularity, not
+// evidence of divergence.
+//
+// The peer's own advertised tip settles it: if that tip is a strict ancestor of
+// our tip on our primary chain, the peer holds a prefix of our chain. There is
+// nothing to roll back to and nothing to follow — we are ahead — so the peer
+// must be kept and simply left unselected until it catches up. The Mithril
+// branch of the same handler already discriminates this way.
+//
+// Every condition must hold, and anything unknown fails safe to "not behind"
+// so the security-parameter rejection keeps its full force:
+//
+//   - the peer advertised a tip at all (a zero tip is unknown, not behind);
+//   - that tip is strictly behind our tip (a peer at or past our tip is
+//     offering a competing chain, not a prefix of ours);
+//   - the rollback point is at or below the peer's own tip (a peer cannot
+//     intersect above its own tip);
+//   - both the peer's tip and the rollback point are on our primary chain.
+//
+// Callers must hold chainsyncMutex.
+func (ls *LedgerState) chainsyncPeerBehindOnOurChain(
+	e ChainsyncEvent,
+) (uint64, bool) {
+	if ls.chain == nil {
+		return 0, false
+	}
+	peerTip := e.Tip.Point
+	if peerTip.Slot == 0 && len(peerTip.Hash) == 0 {
+		return 0, false
+	}
+	if e.Point.Slot == 0 && len(e.Point.Hash) == 0 {
+		return 0, false
+	}
+	localTip := ls.chain.HeaderTip()
+	if peerTip.Slot >= localTip.Point.Slot {
+		return 0, false
+	}
+	if e.Point.Slot > peerTip.Slot {
+		return 0, false
+	}
+	onChain, err := ls.primaryChainContainsPoint(peerTip)
+	if err != nil {
+		ls.logChainsyncBehindLookupError(e, "peer tip", err)
+		return 0, false
+	}
+	if !onChain {
+		return 0, false
+	}
+	onChain, err = ls.primaryChainContainsPoint(e.Point)
+	if err != nil {
+		ls.logChainsyncBehindLookupError(e, "rollback point", err)
+		return 0, false
+	}
+	if !onChain {
+		return 0, false
+	}
+	var depth uint64
+	if localTip.BlockNumber > 0 && e.Tip.BlockNumber > 0 &&
+		localTip.BlockNumber >= e.Tip.BlockNumber {
+		depth = localTip.BlockNumber - e.Tip.BlockNumber
+	}
+	return depth, true
+}
+
+// logChainsyncBehindLookupError records a failed primary-chain membership
+// lookup. The caller falls back to treating the peer as divergent, so this is
+// only diagnostic.
+func (ls *LedgerState) logChainsyncBehindLookupError(
+	e ChainsyncEvent,
+	subject string,
+	err error,
+) {
+	if ls.config.Logger == nil {
+		return
+	}
+	ls.config.Logger.Debug(
+		"failed to check whether a chainsync peer is behind on our chain",
+		"component", "ledger",
+		"subject", subject,
+		"rollback_slot", e.Point.Slot,
+		"peer_tip_slot", e.Tip.Point.Slot,
+		"connection_id", e.ConnectionId.String(),
+		"error", err,
+	)
+}
+
+// noteChainsyncPeerBehind records a peer left attached because it is behind on
+// our own chain. It is deliberately Info, not Warn: nothing is wrong locally,
+// and the condition clears itself when the peer catches up.
+func (ls *LedgerState) noteChainsyncPeerBehind(
+	e ChainsyncEvent,
+	depth uint64,
+	path string,
+) {
+	if ls.metrics.chainsyncBehindPeers != nil {
+		ls.metrics.chainsyncBehindPeers.Inc()
+	}
+	if ls.config.Logger == nil {
+		return
+	}
+	localTip := ls.chain.HeaderTip()
+	ls.config.Logger.Info(
+		"chainsync peer is behind on our chain, waiting for it to catch up",
+		"component", "ledger",
+		"behind_blocks", depth,
+		"rollback_slot", e.Point.Slot,
+		"rollback_hash", hex.EncodeToString(e.Point.Hash),
+		"peer_tip_slot", e.Tip.Point.Slot,
+		"peer_tip_block", e.Tip.BlockNumber,
+		"local_tip_slot", localTip.Point.Slot,
+		"local_tip_block", localTip.BlockNumber,
+		"path", path,
+		"connection_id", e.ConnectionId.String(),
+	)
+}

--- a/ledger/chainsync_behind_peer.go
+++ b/ledger/chainsync_behind_peer.go
@@ -16,6 +16,11 @@ package ledger
 
 import (
 	"encoding/hex"
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // chainsyncPeerBehindOnOurChain reports whether a chainsync peer that asked us
@@ -67,7 +72,7 @@ func (ls *LedgerState) chainsyncPeerBehindOnOurChain(
 	if e.Point.Slot > peerTip.Slot {
 		return 0, false
 	}
-	onChain, err := ls.primaryChainContainsPoint(peerTip)
+	peerBlock, onChain, err := ls.primaryChainBlockAtPoint(peerTip)
 	if err != nil {
 		ls.logChainsyncBehindLookupError(e, "peer tip", err)
 		return 0, false
@@ -83,12 +88,39 @@ func (ls *LedgerState) chainsyncPeerBehindOnOurChain(
 	if !onChain {
 		return 0, false
 	}
+	// Measure the lag against the block number our own chain records for the
+	// peer's tip, not the one the peer advertised: the point is verified to be
+	// on our chain, but the block number riding along with it is not, and this
+	// value is what the operator reads.
 	var depth uint64
-	if localTip.BlockNumber > 0 && e.Tip.BlockNumber > 0 &&
-		localTip.BlockNumber >= e.Tip.BlockNumber {
-		depth = localTip.BlockNumber - e.Tip.BlockNumber
+	if localTip.BlockNumber > peerBlock.Number {
+		depth = localTip.BlockNumber - peerBlock.Number
 	}
 	return depth, true
+}
+
+// primaryChainBlockAtPoint returns the block our primary chain currently holds
+// at point. Blob presence alone is not authoritative — abandoned-fork blocks
+// stay in the append-only store — so membership is confirmed the same way
+// primaryChainContainsPoint confirms it.
+func (ls *LedgerState) primaryChainBlockAtPoint(
+	point ocommon.Point,
+) (models.Block, bool, error) {
+	if ls.db == nil {
+		return models.Block{}, false, nil
+	}
+	block, err := database.BlockByPoint(ls.db, point)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return models.Block{}, false, nil
+		}
+		return models.Block{}, false, err
+	}
+	onChain, err := ls.primaryChainContainsBlock(block, point)
+	if err != nil {
+		return models.Block{}, false, err
+	}
+	return block, onChain, nil
 }
 
 // logChainsyncBehindLookupError records a failed primary-chain membership

--- a/ledger/chainsync_behind_peer_test.go
+++ b/ledger/chainsync_behind_peer_test.go
@@ -1,0 +1,381 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// behindPeerFixture is a ledger state on a linked chain long enough that a
+// rollback well inside the chain still exceeds the (small) security parameter,
+// which is the shape a lagging peer's FindIntersect produces on a real network.
+type behindPeerFixture struct {
+	ls        *LedgerState
+	connId    ouroboros.ConnectionId
+	blocks    []chain.RawBlock
+	resyncCh  chan event.ChainsyncResyncEvent
+	securityP int
+}
+
+const (
+	behindPeerChainLength   = 20
+	behindPeerSecurityParam = 4
+)
+
+// tipOf returns the chainsync tip for the block at depth blocks below the
+// chain tip.
+func (f *behindPeerFixture) tipAtDepth(depth int) ochainsync.Tip {
+	blk := f.blocks[len(f.blocks)-1-depth]
+	return ochainsync.Tip{
+		Point:       ocommon.NewPoint(blk.Slot, blk.Hash),
+		BlockNumber: blk.BlockNumber,
+	}
+}
+
+func (f *behindPeerFixture) pointAtDepth(depth int) ocommon.Point {
+	return f.tipAtDepth(depth).Point
+}
+
+func newBehindPeerFixture(t *testing.T) *behindPeerFixture {
+	t.Helper()
+
+	db := newTestDB(t)
+	cm, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		cm.SetLedger(
+			testSecurityParamLedger{securityParam: behindPeerSecurityParam},
+		),
+	)
+
+	blocks := make([]chain.RawBlock, 0, behindPeerChainLength)
+	var prevHash []byte
+	for idx := range behindPeerChainLength {
+		hash := testHashBytes(fmt.Sprintf("behind-peer-block-%d", idx))
+		blocks = append(blocks, chain.RawBlock{
+			Slot:        uint64(idx+1) * 10,
+			Hash:        hash,
+			BlockNumber: uint64(idx + 1),
+			Type:        1,
+			PrevHash:    prevHash,
+			Cbor:        []byte{0x80},
+		})
+		prevHash = hash
+	}
+	require.NoError(t, cm.PrimaryChain().AddRawBlocks(blocks))
+
+	ls, err := NewLedgerState(
+		LedgerStateConfig{
+			Database:          db,
+			ChainManager:      cm,
+			CardanoNodeConfig: newTestShelleyGenesisCfg(t),
+			Logger:            slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	)
+	require.NoError(t, err)
+	ls.metrics.init(prometheus.NewRegistry())
+
+	tipBlock := blocks[len(blocks)-1]
+	tip := ochainsync.Tip{
+		Point:       ocommon.NewPoint(tipBlock.Slot, tipBlock.Hash),
+		BlockNumber: tipBlock.BlockNumber,
+	}
+	nonce := []byte("nonce-behind-peer-tip")
+	require.NoError(
+		t,
+		db.SetBlockNonce(tip.Point.Hash, tip.Point.Slot, nonce, false, nil),
+	)
+	require.NoError(t, db.SetTip(tip, nil))
+	ls.currentTip = tip
+	ls.currentTipBlockNonce = append([]byte(nil), nonce...)
+	ls.chainsyncState = SyncingChainsyncState
+	ls.publishSnapshotsLocked()
+
+	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(func() { bus.Stop() })
+	ls.config.EventBus = bus
+	resyncCh := make(chan event.ChainsyncResyncEvent, 8)
+	subId := bus.SubscribeFunc(
+		event.ChainsyncResyncEventType,
+		func(evt event.Event) {
+			e, ok := evt.Data.(event.ChainsyncResyncEvent)
+			if !ok {
+				return
+			}
+			select {
+			case resyncCh <- e:
+			default:
+			}
+		},
+	)
+	t.Cleanup(func() {
+		bus.Unsubscribe(event.ChainsyncResyncEventType, subId)
+	})
+
+	return &behindPeerFixture{
+		ls: ls,
+		connId: ouroboros.ConnectionId{
+			LocalAddr: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 6000,
+			},
+			RemoteAddr: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 3001,
+			},
+		},
+		blocks:    blocks,
+		resyncCh:  resyncCh,
+		securityP: behindPeerSecurityParam,
+	}
+}
+
+// requireNoResyncEvent fails if any chainsync re-sync was published. Every
+// re-sync reason reachable from the over-K branch closes the connection, and
+// the over-K reason additionally denies the peer for two minutes, which is the
+// eviction this fix exists to prevent.
+func (f *behindPeerFixture) requireNoResyncEvent(t *testing.T) {
+	t.Helper()
+	select {
+	case e := <-f.resyncCh:
+		t.Fatalf(
+			"peer merely behind on our own chain must not trigger a "+
+				"chainsync re-sync, got reason %q",
+			e.Reason,
+		)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A peer whose advertised tip is an ancestor of our tip holds a strict prefix
+// of our chain: it is behind, not forked. Its FindIntersect answer is only as
+// deep as our intersect ladder's granularity, so the resulting "fork depth" can
+// exceed K with nothing having diverged. We must keep such a peer: no rollback,
+// no re-sync, no denial, and no unrecoverable-divergence escalation telling the
+// operator to re-bootstrap a perfectly canonical database.
+func TestHandleEventChainsyncRollbackKeepsPeerBehindOnOurChain(t *testing.T) {
+	f := newBehindPeerFixture(t)
+	localTip := f.ls.chain.Tip()
+
+	// The rollback point is 12 blocks back — past K=4 — and the peer's own
+	// advertised tip is 6 blocks back, both on our primary chain.
+	err := f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			Tip:          f.tipAtDepth(6),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		localTip,
+		f.ls.chain.Tip(),
+		"a peer behind us must not move our chain tip",
+	)
+	assert.Equal(t, SyncingChainsyncState, f.ls.chainsyncState)
+	f.requireNoResyncEvent(t)
+	assert.Zero(
+		t,
+		promtestutil.ToFloat64(f.ls.metrics.unrecoverableRollbacks),
+		"a peer that is merely behind must not count as unrecoverable divergence",
+	)
+	assert.Empty(
+		t,
+		f.ls.unrecoverableRollbacks,
+		"a peer that is merely behind must not be tracked as un-crossable",
+	)
+}
+
+// The same behind peer reconnecting and offering the same intersect must not
+// escalate either: the per-connection rollback-loop detector fires on the
+// second identical rollback, and its un-crossable branch reports the
+// operator-facing "local chain has diverged ... re-bootstrap from a Mithril
+// snapshot" error, which would destroy a healthy database.
+func TestHandleEventChainsyncRollbackBehindPeerRepeatDoesNotEscalate(
+	t *testing.T,
+) {
+	f := newBehindPeerFixture(t)
+	localTip := f.ls.chain.Tip()
+
+	evt := ChainsyncEvent{
+		ConnectionId: f.connId,
+		Point:        f.pointAtDepth(12),
+		Tip:          f.tipAtDepth(6),
+	}
+	for attempt := range rollbackLoopThreshold + 2 {
+		require.NoErrorf(
+			t,
+			f.ls.handleEventChainsyncRollback(evt, nil),
+			"attempt %d",
+			attempt,
+		)
+	}
+
+	assert.Equal(t, localTip, f.ls.chain.Tip())
+	f.requireNoResyncEvent(t)
+	assert.Zero(
+		t,
+		promtestutil.ToFloat64(f.ls.metrics.unrecoverableRollbacks),
+	)
+}
+
+// Control: a peer whose advertised tip is not on our chain and which asks us to
+// roll back further than K is a genuine deep fork. It must still be rejected
+// and evicted — the fix must not weaken the security-parameter gate.
+func TestHandleEventChainsyncRollbackStillRejectsDeepForkPeer(t *testing.T) {
+	f := newBehindPeerFixture(t)
+	localTip := f.ls.chain.Tip()
+
+	err := f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			// A tip on a competing chain: our chain has no such block.
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					f.pointAtDepth(6).Slot,
+					testHashBytes("competing-fork-tip"),
+				),
+				BlockNumber: f.tipAtDepth(6).BlockNumber,
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, localTip, f.ls.chain.Tip())
+	select {
+	case e := <-f.resyncCh:
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackExceedsK,
+			e.Reason,
+		)
+		assert.Equal(t, f.connId, e.ConnectionId)
+	case <-time.After(time.Second):
+		t.Fatal("expected over-K rejection for a genuinely divergent peer")
+	}
+}
+
+// Control: an unknown (zero) peer tip carries no evidence that the peer is
+// behind rather than forked, so it must fail safe to the existing rejection.
+func TestHandleEventChainsyncRollbackRejectsUnknownPeerTipOverK(t *testing.T) {
+	f := newBehindPeerFixture(t)
+
+	err := f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	select {
+	case e := <-f.resyncCh:
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackExceedsK,
+			e.Reason,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected over-K rejection for an unknown peer tip")
+	}
+}
+
+// Control: a peer whose advertised tip is ahead of ours is offering a
+// competing longer chain, not a prefix of ours, even when the rollback point
+// itself is on our chain. It must keep the over-K rejection.
+func TestHandleEventChainsyncRollbackRejectsPeerTipAheadOfUs(t *testing.T) {
+	f := newBehindPeerFixture(t)
+	localTip := f.ls.chain.Tip()
+
+	err := f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					localTip.Point.Slot+10,
+					testHashBytes("longer-competing-chain-tip"),
+				),
+				BlockNumber: localTip.BlockNumber + 1,
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	select {
+	case e := <-f.resyncCh:
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackExceedsK,
+			e.Reason,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected over-K rejection for a peer ahead of us")
+	}
+}
+
+// Control: a peer advertising exactly our own tip is not behind us. Asking for
+// a rollback past K from there is intersect drift, not a lagging peer, and must
+// keep the existing rejection.
+func TestHandleEventChainsyncRollbackRejectsPeerTipEqualToOurs(t *testing.T) {
+	f := newBehindPeerFixture(t)
+	localTip := f.ls.chain.Tip()
+
+	err := f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			Tip:          f.tipAtDepth(0),
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, localTip, f.ls.chain.Tip())
+	select {
+	case e := <-f.resyncCh:
+		assert.Equal(
+			t,
+			event.ChainsyncResyncReasonRollbackExceedsK,
+			e.Reason,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("expected over-K rejection for a peer at our own tip")
+	}
+}

--- a/ledger/chainsync_behind_peer_test.go
+++ b/ledger/chainsync_behind_peer_test.go
@@ -422,3 +422,29 @@ func TestHandleEventChainsyncRollbackRejectsPeerTipEqualToOurs(t *testing.T) {
 		t.Fatal("expected over-K rejection for a peer at our own tip")
 	}
 }
+
+// The reported lag must come from our own chain, not from the block number the
+// peer attached to its tip: the tip point is verified to be on our chain, but
+// the number riding along with it is untrusted peer input, and it is what an
+// operator reads out of the log and the metric.
+func TestChainsyncPeerBehindDepthIgnoresAdvertisedBlockNumber(t *testing.T) {
+	f := newBehindPeerFixture(t)
+
+	peerTip := f.tipAtDepth(6)
+	for _, advertised := range []uint64{peerTip.BlockNumber, 0, 1} {
+		peerTip.BlockNumber = advertised
+		depth, behind := f.ls.chainsyncPeerBehindOnOurChain(ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			Tip:          peerTip,
+		})
+		require.Truef(t, behind, "advertised block number %d", advertised)
+		assert.Equalf(
+			t,
+			uint64(6),
+			depth,
+			"advertised block number %d must not change the measured lag",
+			advertised,
+		)
+	}
+}

--- a/ledger/chainsync_behind_peer_test.go
+++ b/ledger/chainsync_behind_peer_test.go
@@ -350,6 +350,49 @@ func TestHandleEventChainsyncRollbackRejectsPeerTipAheadOfUs(t *testing.T) {
 	}
 }
 
+// The behind-peer classification is observable: an operator seeing repeated
+// over-K rejections needs to tell "our upstreams are lagging us" from "someone
+// is offering a competing chain", and the counter is the signal that
+// distinguishes them.
+func TestHandleEventChainsyncRollbackBehindPeerCounter(t *testing.T) {
+	f := newBehindPeerFixture(t)
+
+	require.NoError(t, f.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: f.connId,
+			Point:        f.pointAtDepth(12),
+			Tip:          f.tipAtDepth(6),
+		},
+		nil,
+	))
+	assert.Equal(
+		t,
+		float64(1),
+		promtestutil.ToFloat64(f.ls.metrics.chainsyncBehindPeers),
+	)
+
+	// A genuinely divergent peer must not be counted as behind.
+	divergent := newBehindPeerFixture(t)
+	require.NoError(t, divergent.ls.handleEventChainsyncRollback(
+		ChainsyncEvent{
+			ConnectionId: divergent.connId,
+			Point:        divergent.pointAtDepth(12),
+			Tip: ochainsync.Tip{
+				Point: ocommon.NewPoint(
+					divergent.pointAtDepth(6).Slot,
+					testHashBytes("counter-competing-fork-tip"),
+				),
+				BlockNumber: divergent.tipAtDepth(6).BlockNumber,
+			},
+		},
+		nil,
+	))
+	assert.Zero(
+		t,
+		promtestutil.ToFloat64(divergent.ls.metrics.chainsyncBehindPeers),
+	)
+}
+
 // Control: a peer advertising exactly our own tip is not behind us. Asking for
 // a rollback past K from there is intersect drift, not a lagging peer, and must
 // keep the existing rejection.

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -44,6 +44,12 @@ type stateMetrics struct {
 	// we cannot cross to (local chain diverged), so a stuck node surfaces
 	// as a metric instead of only a WARN loop. See issue #2728.
 	unrecoverableRollbacks prometheus.Counter
+	// Incremented when a chainsync peer asks for a rollback we refuse, but
+	// its own advertised tip is a strict ancestor of ours on our primary
+	// chain: the peer is behind, not forked, and is kept attached instead
+	// of being rejected and denied. A rising value with a flat local tip
+	// means our upstreams are lagging us, not that anything diverged.
+	chainsyncBehindPeers prometheus.Counter
 	// Incremented when at-tip validation recovery detects a non-converging,
 	// descending series of distinct failures and holds at the ledger tip
 	// instead of rewinding the primary chain ever deeper. A rising value
@@ -346,6 +352,12 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.CounterOpts{
 			Name: "dingo_chainsync_unrecoverable_rollback_total",
 			Help: "times a peer repeatedly requested a rollback we cannot cross to (local chain diverged, operator intervention required)",
+		},
+	)
+	m.chainsyncBehindPeers = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_chainsync_behind_peers_total",
+			Help: "times a chainsync peer asked for a rollback past the security parameter while its own tip was a strict ancestor of ours (peer behind on our chain, kept attached rather than denied)",
 		},
 	)
 	m.atTipRecoveryNonConverging = promautoFactory.NewCounter(

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -349,6 +349,20 @@ func chainsyncResyncRequiresFreshConnection(reason string) bool {
 	}
 }
 
+// chainsyncResyncDeniesPeer lists the re-sync reasons that also put the peer
+// in peer governance's deny list for chainsyncDivergentPeerCooldown.
+//
+// A peer that is merely behind on our own chain is deliberately absent: the
+// ledger now classifies it before any of these reasons is published (see
+// LedgerState.chainsyncPeerBehindOnOurChain) and publishes no re-sync at all,
+// so the connection is kept and the peer resumes on its own once it catches
+// up. Denying such a peer is what turns a lagging upstream into an outage on a
+// node whose valency is one. Do not add a behind-peer reason here.
+//
+// ChainsyncResyncReasonPeerTipBehindMithril stays, even though that peer is
+// also just behind: unlike the case above we still close its connection,
+// because we cannot follow it below the trust anchor, and without the cooldown
+// it is redialed and rejected again within a second, forever.
 func chainsyncResyncDeniesPeer(reason string) bool {
 	switch reason {
 	case event.ChainsyncResyncReasonRollbackExceedsK,


### PR DESCRIPTION
## Problem

A peer whose chain is a strict **prefix** of ours — same chain, no divergence,
just behind — is rejected with `rollback exceeds security parameter K`, denied
for two minutes, and eventually reported as unrecoverable local divergence with
the advice to re-bootstrap from a Mithril snapshot. Nothing has forked.

The trigger is not the size of the lag. `Chain.IntersectPoints`
(`chain/chain.go`) emits a dense band of `intersectDensePointCount = 32` points
at offsets 0…31 from our tip and then samples at doubling offsets — 32, 64, 128,
256 … The FindIntersect list is descending, so a lagging peer answers with the
first point it holds, which is the **next rung at or past its lag**, not its lag.

For a lag `L > 32` the resolved intersect offset is
`O(L) = 32 · 2^ceil(log2(L/32))`, `Chain.rollbackForkDepth` reports
`tip − O(L)`, and the K gate in `ValidateRollback` / `rollbackLocked` rejects
whenever `O(L) > K`. Rejection therefore begins at `L = O/2 + 1`, where `O` is
the first rung above K:

| K | first ladder rung > K | peer evicted from a lag of |
|---|---|---|
| 108 | 128 | **65 blocks** |
| 432 (preview / preprod) | 512 | **257 blocks** |
| 2160 (mainnet) | 4096 | **2049 blocks** |

So on every network the effective eviction threshold is roughly 0.5–0.6 × K, not
K, and throughout the band between it and K the peer is inside the security
parameter and is thrown away anyway.

Three things then compound it:

1. `ledger/chainsync.go` publishes `ChainsyncResyncReasonRollbackExceedsK`, which
   `chainsyncResyncDeniesPeer` (`ouroboros/chainsync.go`) turns into
   `DenyPeer(address, 2m)`. On a node with a single configured upstream that is
   every upstream it has.
2. The cycle is self-sustaining: the same lag produces the same intersect
   produces the same rejection on every reconnect. The peer can only escape by
   catching up, which it cannot do from us.
3. `reportUnrecoverableRollbackIfStuck`
   (`ledger/chainsync_unrecoverable_rollback.go`) fires after three failures on
   the same point — guaranteed here — and tells the operator the local chain has
   diverged and to re-bootstrap from a Mithril snapshot. Following that advice
   destroys a database that is fully canonical.

Observed on a private devnet with K=108 and one-second slots: a block producer
whose only upstream had frozen 119 blocks behind evicted it 65 times in 90
minutes, logging `chain selection stalled: no selectable peer` after each one.
Its tip did not move for just over two hours and it missed a scheduled leader
slot. All three points involved — the rejected rollback target, the peer's tip
and our tip — were confirmed canonical against an independent chain index; the
peer's chain was a strict prefix of ours. Nothing on the producer was touched:
restarting the *other* node cleared it.

The discriminator is already present and unused. `ChainsyncEvent.Tip`
(`ledger/event.go`) carries the peer's advertised tip on the rollback event, and
`LedgerState.primaryChainContainsPoint` (`ledger/state.go`) answers whether a
point is on our chain. The Mithril branch of the same handler, ~50 lines below
the K branch, already uses exactly that pair to separate "the peer is simply
behind … stale, not a competing fork" from a genuine divergence.

## Fix

**`ledger/chainsync.go` — classify before rejecting.** Before treating an over-K
rollback as a fork, check the peer's advertised tip. If the tip and the rollback
point are both on our primary chain and the tip is strictly behind ours, the peer
holds a prefix of our chain: do not roll back, do not re-sync, do not deny, do
not escalate. The connection stays up and chain selection simply does not pick a
peer that is behind us — which it already declines to do — until it catches up.
No re-sync event is published at all, so no code path can deny the peer, and the
peer resumes on its own: its replayed headers are ignored as historical until it
passes our tip.

Everything unknown fails safe to the existing rejection: no advertised tip, a tip
we do not hold, a tip at or past our own, or a rollback point above the peer's
own tip. The security-parameter gate is unchanged for genuine forks.

The rollback-loop detector in the same handler gets the same guard. A behind peer
repeats its intersect by construction, so its un-crossable branch was reporting
the Mithril re-bootstrap advice for the same non-problem.

**`chain/chain.go` — offer the rung at K.** The ladder now emits a point at
offset K, merged into its sorted position so the list stays strictly descending.
Any peer within K of our tip holds the block K back, so the shallowest rung it
can match is at most K deep and the rollback stays crossable. That closes the
manufactured 0.5 K … K band at its source. It is exactly one extra point, so the
FindIntersect message does not grow in practice (the list is capped by `count`,
100 by default). A zero K (before `SetLedger`) simply skips the rung.

`SetLedger` is not confined to startup — the node reloads its state database
while it is serving chainsync — so this is the first `securityParam` read on the
FindIntersect path that could overlap the write. `SetLedger` now writes under the
manager lock and the read goes through a `SecurityParam()` accessor, taken before
any chain lock so the manager lock is never acquired underneath the block-index
read locks.

This is a narrowing, not a fix on its own: a peer further behind than K still
resolves past K and must still be classified rather than evicted.

**`ouroboros/chainsync.go` — documentation only.** No behavioural change. The
deny list is what converts a lagging upstream into an outage, so the reason a
behind peer never reaches it is now recorded at the definition.
`ChainsyncResyncReasonPeerTipBehindMithril` deliberately stays: that peer is also
only behind, but we still close its connection, and without the cooldown it is
redialed and rejected again within a second — the redial storm the deny was added
to stop. Retaining it the way this change retains a behind peer means not closing
that connection either, which is a larger change to a different path; see
follow-ups.

## Tests

Red→green. The first commit adds the reproductions and fails; the fix commits
turn them green. Each assertion was mutation-checked — the guard it covers was
removed or weakened in turn and the test observed to fail.

`ledger` (`ledger/chainsync_behind_peer_test.go`, over-K by construction):

- a peer whose tip is a strict ancestor of ours on our own chain is kept: tip
  unmoved, no re-sync published, no unrecoverable-divergence tracking (**red**
  before: re-syncs with `rollback exceeds security parameter K`);
- the same peer repeating that intersect past the loop-detector threshold does
  not escalate either (**red** before: `ErrRollbackLoopDetected`, which forces a
  fresh connection, plus the operator-facing divergence error);
- `dingo_chainsync_behind_peers_total` counts the behind peer and not a divergent
  one;
- the reported lag is measured against the block number our own chain records for
  the peer's tip, so a peer advertising a bogus block number cannot skew the log
  line or the metric;
- controls, all green before and after, each mutation-checked: a peer whose tip
  is not on our chain, a peer with an unknown tip, a peer ahead of us, and a peer
  at exactly our tip all keep the over-K rejection.

`chain` (`chain/intersect_behind_peer_test.go`, K=40 against the fixed 32-point
dense band — the same relationship every real network has):

- a peer 35 blocks behind (inside K) resolves to an intersect at most K deep and
  the rollback is crossable (**red** before: depth 64, refused);
- a peer 45 blocks behind (past K) still resolves past K and is still refused by
  the chain layer, pinning that the ladder change is not a full fix;
- the merged rung keeps the list strictly descending across eight
  K/chain-length combinations, including K inside the dense band, K on a rung,
  and chains shorter than the next rung.

`chainselection` (`chainselection/behind_peer_valency_test.go`) — the invariant
the eviction was breaking, at the scale seen in the field: a node with one
upstream keeps it, is not stalled with "no selectable peer" while that upstream
is within K, and selects it the moment it catches up. A sole upstream further
than K behind is retained too — not selected, because it is not a useful sync
source, but available again without a reconnect or cooldown as soon as it is back
within K.

Full suite on the touched packages: `go test ./chain/... ./ledger/
./ouroboros/... ./chainselection/... . -count=1 -timeout 40m` all `ok`, and
`-race` on `chain`, `ledger` and `chainselection` all `ok`. `gofmt`, `go vet
./...` and `golangci-lint` on the touched packages are clean (0 issues). No
metadata migration is added; the schema target version is unchanged.

## Metrics

`dingo_chainsync_behind_peers_total` — times a peer asked for a rollback past K
while its own tip was a strict ancestor of ours, and was kept attached instead of
denied. A rising value with a flat local tip means the upstreams are lagging us,
not that anything diverged, which is precisely the distinction the log line alone
could not make.

## Follow-ups (not in this PR)

- **The structural one.** The post-FindIntersect RollBackward is a cursor anchor,
  not a chain switch. Truncating the local chain on it — before any competing
  header has been offered, let alone shown to be better — is what makes a peer's
  position on our *own* chain look like a deep reorg. Applying the peer's
  rollback to a per-peer candidate fragment, and truncating the local chain only
  when a better chain is actually selected, would make this class of
  misclassification structurally impossible. A behind peer within K is still
  handled by rolling our own canonical blocks back and re-fetching them today.
- **`PeerTipBehindMithril`.** Retaining that peer instead of closing and denying
  it, as this change does for a behind-on-our-chain peer, would remove the last
  eviction path for a peer that has merely not caught up. It needs the redial
  dynamics the current deny is pacing to be handled first.

Related: #3035, #3889, #3968, #3987, #3989

Fixes #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of peers that are temporarily behind the local chain, keeping them connected instead of incorrectly treating them as divergent.
  - Peers within the security limit can remain selectable and recover automatically as they catch up.
  - Peers beyond the security limit are retained but remain unselected until they return within the allowed range.
  - Improved chain intersection and rollback decisions around the security boundary.

- **Monitoring**
  - Added a metric to track retained peers identified as behind the local chain.

- **Documentation**
  - Clarified peer resynchronization and deny-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->