### PR TITLE
build(deps): adopt gOuroboros v0.202.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.9
-	github.com/blinklabs-io/ouroboros-mock v0.18.0
+	github.com/blinklabs-io/gouroboros v0.202.10
+	github.com/blinklabs-io/ouroboros-mock v0.19.0
 	github.com/blinklabs-io/plutigo v0.5.1
 	github.com/blockfrost/blockfrost-go v0.5.0
 	github.com/btcsuite/btcd/btcutil v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,12 @@ github.com/blinklabs-io/gouroboros v0.202.8 h1:dRw7Dpqd2C9d2WvPl8ePgTuhI3mzhu6Zp
 github.com/blinklabs-io/gouroboros v0.202.8/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/gouroboros v0.202.9 h1:eAR655rEVT2zdL7ogdBi+LKzIVpk/Qi6L98Zh3FBZr0=
 github.com/blinklabs-io/gouroboros v0.202.9/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
+github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuvdoc0pqvC35s=
+github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
+github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
+github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
 github.com/blinklabs-io/plutigo v0.5.1 h1:cHmv2LII0fZggrOfp6wzW9t644HzTB6s7/vzHVpHJs8=
 github.com/blinklabs-io/plutigo v0.5.1/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
 github.com/blockfrost/blockfrost-go v0.5.0 h1:I+qEQw5Re9UHolKZGJE0FtuQL3a7L0WqEYkEO4GisIw=

--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.7
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
-	github.com/blinklabs-io/gouroboros v0.202.6
+	github.com/blinklabs-io/gouroboros v0.202.10
 	github.com/blinklabs-io/plutigo v0.5.0
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -15,7 +15,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.6 // indirect
-	github.com/blinklabs-io/ouroboros-mock v0.18.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0 // indirect
 	github.com/btcsuite/btcd/btcutil v1.2.0 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0 // indirect

--- a/internal/test/antithesis/go.sum
+++ b/internal/test/antithesis/go.sum
@@ -4,10 +4,10 @@ github.com/antithesishq/antithesis-sdk-go v0.7.0 h1:uWDG8BqLD1lI2ps38WDz2vXflrTX
 github.com/antithesishq/antithesis-sdk-go v0.7.0/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/bits-and-blooms/bitset v1.24.6 h1:qcrftZUVBIwfs+m+nhoCBAPT+ZPZZjti8SbHbDQQkZ4=
 github.com/bits-and-blooms/bitset v1.24.6/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/gouroboros v0.202.6 h1:xIJluYjLjmtZp0tVRXviMzuLm7hNkiT7T7yNuXMwpG8=
-github.com/blinklabs-io/gouroboros v0.202.6/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
-github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
-github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
+github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuvdoc0pqvC35s=
+github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
+github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
+github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
 github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=
 github.com/blinklabs-io/plutigo v0.5.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -1049,6 +1049,8 @@ func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 		}
 	}
 
+	m.pruneCommitteeResignations()
+
 	// Phase 2: ratify proposals that meet threshold requirements.
 	if err := m.ratifyProposals(txn, newEpoch, boundarySlot); err != nil {
 		return fmt.Errorf("ratify proposals: %w", err)
@@ -1069,6 +1071,37 @@ func (m *DingoStateManager) ProcessEpochBoundary(newEpoch uint64) error {
 	}
 
 	return txn.Commit()
+}
+
+// pruneCommitteeResignations drops the resignation recorded for a cold
+// credential that holds no committee seat in the pre-validation govState
+// mirror.
+//
+// cardano-ledger keeps resignations and hot-key authorizations in one
+// committee credential map and intersects that map with the current
+// committee at every epoch boundary
+// (eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+// updateCommitteeState), so a resignation lives exactly as long as the seat
+// it was filed against: a member an UpdateCommittee action removed carries
+// none forward, and a later re-election seats a member that may authorize a
+// hot key again. Without this, a cold credential that resigns once is
+// treated as resigned for the rest of the vector, which rejects that second
+// authorization.
+//
+// Only the resignation is pruned. Hot-key authorizations are left alone
+// because this mirror's simplified ratification (see the ProcessEpochBoundary
+// doc comment) does not seat every member the vectors elect, so intersecting
+// those as well would withdraw voting rights a vector still exercises.
+func (m *DingoStateManager) pruneCommitteeResignations() {
+	for coldKey := range m.govState.CommitteeResignations {
+		if _, ok := m.govState.CommitteeMembersByCredential[coldKey]; ok {
+			continue
+		}
+		if _, ok := m.govState.CommitteeMembers[coldKey.Credential]; ok {
+			continue
+		}
+		delete(m.govState.CommitteeResignations, coldKey)
+	}
 }
 
 // ratifyProposals performs the harness's simplified proposal ratification


### PR DESCRIPTION
## Summary

- Update Gouroboros to released v0.202.10.
- Adopt the required ouroboros-mock v0.19.0 module version.

## Validation

- `GOWORK=off go test -timeout 20m ./...` (one conformance vector fails: `CC_re-election`; all other packages pass).
- The same conformance package passes on origin/main with the previous dependency set.

Related to #3847.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `gouroboros` to v0.202.10 and `ouroboros-mock` to v0.19.0, and fixes the `CC_re-election` conformance failure the bump introduced. The harness now expires stale committee resignations at each epoch boundary when the credential no longer holds a seat, so a later re-election can authorize its hot key again. Related to #3847.

**Validation**
- `GOWORK=off go test -timeout 20m ./...` passes with the new dependency set; the pruning fix resolves the previously failing `CC_re-election` vector.

<sup>Written for commit d89960098fbf4ef6b51b8e5d4b40ff3bf1d5288a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal networking and testing dependencies to newer patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->