### PR TITLE
test(midnight): tolerate the io.EOF gRPC reports from Send on a terminated stream

### DIFF
--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -16,6 +16,7 @@ package server_test
 
 import (
 	"context"
+	"io"
 	"net"
 	"strconv"
 	"testing"
@@ -269,6 +270,34 @@ func TestReflectionListsService(t *testing.T) {
 }
 
 func TestReflectionDisabledByDefault(t *testing.T) {
+	stream := reflectionStreamToServerWithoutReflection(t)
+
+	sendListServices(t, stream)
+	_, err := stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+// TestReflectionDisabledByDefaultWhenRejectionArrivesFirst resolves the
+// race that made the test above flaky, deterministically, the losing way:
+// the server's rejection is observed first, so the Send that follows runs
+// against a stream the server has already terminated. That is the ordering
+// CI hit, and it must be a pass -- the status is carried by Recv, and Send
+// can only report the termination as io.EOF.
+func TestReflectionDisabledByDefaultWhenRejectionArrivesFirst(t *testing.T) {
+	stream := reflectionStreamToServerWithoutReflection(t)
+
+	_, err := stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	sendListServices(t, stream)
+}
+
+func reflectionStreamToServerWithoutReflection(
+	t *testing.T,
+) grpc.BidiStreamingClient[reflectionpb.ServerReflectionRequest, reflectionpb.ServerReflectionResponse] {
+	t.Helper()
 	addr := startTestServer(t)
 	conn := dial(t, addr)
 	readyCtx, readyCancel := context.WithTimeout(
@@ -281,20 +310,35 @@ func TestReflectionDisabledByDefault(t *testing.T) {
 		&healthpb.HealthCheckRequest{},
 	)
 	require.NoError(t, err)
-	client := reflectionpb.NewServerReflectionClient(conn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	stream, err := client.ServerReflectionInfo(ctx)
+	t.Cleanup(cancel)
+	stream, err := reflectionpb.NewServerReflectionClient(conn).
+		ServerReflectionInfo(ctx)
 	require.NoError(t, err)
-	require.NoError(t, stream.Send(&reflectionpb.ServerReflectionRequest{
+	return stream
+}
+
+// sendListServices tolerates the io.EOF that gRPC returns from Send once
+// the server has terminated the stream, which is what an unregistered
+// reflection service does. Per the ClientStream contract, SendMsg returns
+// io.EOF on a stream the server has already completed and the real status
+// is only available from Recv -- so an io.EOF here carries no information
+// and asserting its absence just made the test lose a race with the
+// server's own rejection.
+func sendListServices(
+	t *testing.T,
+	stream grpc.BidiStreamingClient[reflectionpb.ServerReflectionRequest, reflectionpb.ServerReflectionResponse],
+) {
+	t.Helper()
+	err := stream.Send(&reflectionpb.ServerReflectionRequest{
 		MessageRequest: &reflectionpb.ServerReflectionRequest_ListServices{
 			ListServices: "*",
 		},
-	}))
-	_, err = stream.Recv()
-	require.Error(t, err)
-	require.Equal(t, codes.Unimplemented, status.Code(err))
+	})
+	if err != nil {
+		require.ErrorIs(t, err, io.EOF)
+	}
 }
 
 // New rejects a half-configured TLS pair (cert without key, or key without


### PR DESCRIPTION
## Problem

`midnight/server/server_test.go`'s `TestReflectionDisabledByDefault` asserts

```go
require.NoError(t, stream.Send(&reflectionpb.ServerReflectionRequest{...}))
```

With reflection unregistered — the default — the server rejects
`ServerReflectionInfo` with `Unimplemented` and terminates the stream. It
does not wait for a request first, so its rejection can reach the client
transport before the client's `Send` runs.

gRPC's `ClientStream` contract makes that ordering an assertion failure
rather than a real defect: `SendMsg` returns `io.EOF` once the stream has
been terminated by the server, and the RPC status "can be discovered by
calling RecvMsg". The test already reads the status from `Recv` on the
next three lines and asserts `codes.Unimplemented` there — so the `Send`
assertion carries no information, and only ever loses a race.

CI hit the losing ordering on run 33625153589 (`go-test (macOS)` and
`go-test (Linux, race)`), failing with `Received unexpected error: EOF`.
No `DATA RACE` was reported: it is an assertion failure, not a detector
finding.

## Fix

`Send` tolerates `io.EOF` (and only `io.EOF`); every other error still
fails the test. The `Unimplemented` assertion on `Recv` is unchanged, so
what the test actually covers — reflection is off unless opted in — is
untouched.

`TestReflectionDisabledByDefaultWhenRejectionArrivesFirst` pins the
losing ordering deterministically: it reads the rejection first, so the
`Send` that follows always runs against an already-terminated stream. The
two tests together cover both orderings instead of only the one a fast
runner happens to produce.

## Verification

- Red before the fix: with the previous `require.NoError` assertion, the
  new test fails with exactly the reported error —
  `Received unexpected error: EOF` at the `Send`. Green after.
- `go test ./midnight/server/ -count=30 -race` green (573 s).
- `gofmt`, `go vet ./midnight/server/` and `golangci-lint run ./midnight/...`
  clean.

The flake was not reproducible by repetition locally (the issue reports
300 plain + 150 race runs without a failure), which is why the regression
test forces the ordering rather than repeating the test and hoping.

Related: #3774 (this flake), #3848 (lifecycle tests failing under
parallel suite load), #3823, #3759, #3768, #3541 — the same "CI-only,
load-sensitive test assertion" family. No open PR addresses #3774.

Fixes #3774

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in `midnight/server` where `TestReflectionDisabledByDefault` sometimes failed because the server's `Unimplemented` rejection could reach the client before `Send` completed. Now `Send` tolerates `io.EOF` from a terminated stream, and a new test deterministically covers that ordering.

- `TestReflectionDisabledByDefault` keeps asserting `codes.Unimplemented` from `Recv`, so verification is unchanged.
- Adds `TestReflectionDisabledByDefaultWhenRejectionArrivesFirst` to force the rejection-first ordering.
- Only `io.EOF` is tolerated; any other `Send` error still fails the test.

<sup>Written for commit 50c320467197d44b79358a6fe16b2beeb9e8e9fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

