### PR TITLE
fix(database): drop DISTINCT from the rollback stake-ref sweep queries

### DIFF
--- a/database/plugin/metadata/sqlstore/internal/query/sqlite/operational.sql.go
+++ b/database/plugin/metadata/sqlstore/internal/query/sqlite/operational.sql.go
@@ -3540,9 +3540,12 @@ SELECT transaction_id, collateral_return_for_tx_id, tx_id, payment_key,
        deleted_slot, amount, output_idx, payment_script
 FROM utxo
 WHERE added_slot > ?
-ORDER BY id DESC
+ORDER BY added_slot DESC, id DESC
 `
 
+// Order by added_slot before id so the sort is the reverse of
+// idx_utxo_added_slot's own order; ordering by id alone costs a full table
+// scan. See the Store wrapper for the full rationale.
 func (q *Queries) GetUtxosAddedAfterSlot(ctx context.Context, addedSlot sql.NullInt64) ([]Utxo, error) {
 	rows, err := q.db.QueryContext(ctx, getUtxosAddedAfterSlot, addedSlot)
 	if err != nil {

--- a/database/plugin/metadata/sqlstore/internal/query/sqlite/querier.go
+++ b/database/plugin/metadata/sqlstore/internal/query/sqlite/querier.go
@@ -157,6 +157,9 @@ type Querier interface {
 	GetUtxoIDByRef(ctx context.Context, arg GetUtxoIDByRefParams) (int64, error)
 	GetUtxoIncludingSpent(ctx context.Context, arg GetUtxoIncludingSpentParams) (Utxo, error)
 	GetUtxoRefsBySlot(ctx context.Context, addedSlot sql.NullInt64) ([]GetUtxoRefsBySlotRow, error)
+	// Order by added_slot before id so the sort is the reverse of
+	// idx_utxo_added_slot's own order; ordering by id alone costs a full table
+	// scan. See the Store wrapper for the full rationale.
 	GetUtxosAddedAfterSlot(ctx context.Context, addedSlot sql.NullInt64) ([]Utxo, error)
 	GetUtxosDeletedBeforeSlot(ctx context.Context, arg GetUtxosDeletedBeforeSlotParams) ([]Utxo, error)
 	ImportAccount(ctx context.Context, arg ImportAccountParams) (int64, error)

--- a/database/plugin/metadata/sqlstore/queries/sqlite/operational.sql
+++ b/database/plugin/metadata/sqlstore/queries/sqlite/operational.sql
@@ -921,6 +921,9 @@ FROM asset
 WHERE utxo_id = ?
 ORDER BY id;
 
+-- Order by added_slot before id so the sort is the reverse of
+-- idx_utxo_added_slot's own order; ordering by id alone costs a full table
+-- scan. See the Store wrapper for the full rationale.
 -- name: GetUtxosAddedAfterSlot :many
 SELECT transaction_id, collateral_return_for_tx_id, tx_id, payment_key,
        staking_key, credential_tag, datum_hash, spent_at_tx_id,
@@ -928,7 +931,7 @@ SELECT transaction_id, collateral_return_for_tx_id, tx_id, payment_key,
        deleted_slot, amount, output_idx, payment_script
 FROM utxo
 WHERE added_slot > ?
-ORDER BY id DESC;
+ORDER BY added_slot DESC, id DESC;
 
 -- name: GetLiveUtxoRefsBySlot :many
 SELECT tx_id, output_idx

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -742,6 +742,11 @@ func queryStakeRefs(
 // the index that satisfies the WHERE clause, turning a bounded range search
 // into a full table pass. queryStakeRefs already materialises every row, so
 // deduping in Go costs one map insert per row.
+//
+// Neither the result nor the seen set is presized from len(rows): the callers
+// are rollback sweeps, where a window of thousands of rows routinely collapses
+// to a handful of credentials, so sizing for the input would reserve orders of
+// magnitude more than the output needs.
 func queryStakeRefsDeduped(
 	ctx context.Context,
 	db queryer,
@@ -752,13 +757,15 @@ func queryStakeRefsDeduped(
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]models.StakeCredentialRef, 0, len(rows))
-	seen := make(map[string]struct{}, len(rows))
+	ret := []models.StakeCredentialRef{}
+	seen := make(map[string]struct{})
 	for _, ref := range rows {
-		if _, ok := seen[ref.MapKey()]; ok {
+		// MapKey allocates, so compute it once per row.
+		key := ref.MapKey()
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[ref.MapKey()] = struct{}{}
+		seen[key] = struct{}{}
 		ret = append(ret, ref)
 	}
 	return ret, nil

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -144,6 +144,19 @@ func (s *Store) DeleteUtxos(
 	)
 }
 
+// utxoStakeRefsAddedAfterSlotQuery and utxoStakeRefsDeletedAfterSlotQuery
+// collect the stake credentials whose live stake a rollback sweep has to
+// recompute. They are deliberately free of SQL DISTINCT so the planner keeps
+// using the index that answers the slot predicate; see
+// queryStakeRefsDeduped. TestRollbackStakeRefQueriesUseSlotIndexes pins the
+// resulting SQLite query plans.
+const (
+	utxoStakeRefsAddedAfterSlotQuery = "SELECT credential_tag, staking_key " +
+		"FROM utxo WHERE added_slot > ?"
+	utxoStakeRefsDeletedAfterSlotQuery = "SELECT credential_tag, staking_key " +
+		"FROM utxo WHERE deleted_slot > ?"
+)
+
 func (s *Store) DeleteUtxosAfterSlot(
 	slot uint64,
 	txn types.Txn,
@@ -155,11 +168,19 @@ func (s *Store) DeleteUtxosAfterSlot(
 	return s.withWriteTransaction(
 		txn,
 		func(db queryer, ctx context.Context) error {
-			refs, err := queryStakeRefs(
+			// No SQL DISTINCT here: it makes SQLite prefer
+			// idx_utxo_staking_deleted_amount (which already yields
+			// (credential_tag, staking_key) order, so the temp B-tree can
+			// be skipped) over the purpose-built idx_utxo_added_slot. That
+			// index has no added_slot column, so the scan is not covering
+			// and every entry costs a row lookup just to test the
+			// predicate -- a full pass over the utxo table on every
+			// rollback. Dedupe in Go instead, which also keeps the plan
+			// stable across the MySQL and Postgres dialects.
+			refs, err := queryStakeRefsDeduped(
 				ctx,
 				db,
-				"SELECT DISTINCT credential_tag, staking_key FROM utxo "+
-					"WHERE added_slot > ?",
+				utxoStakeRefsAddedAfterSlotQuery,
 				slotValue,
 			)
 			if err != nil {
@@ -260,11 +281,13 @@ func (s *Store) SetUtxosNotDeletedAfterSlot(
 	return s.withWriteTransaction(
 		txn,
 		func(db queryer, ctx context.Context) error {
-			refs, err := queryStakeRefs(
+			// See DeleteUtxosAfterSlot: SQL DISTINCT costs a full index
+			// scan here too, in place of a range search on
+			// idx_utxo_deleted_staking_amount.
+			refs, err := queryStakeRefsDeduped(
 				ctx,
 				db,
-				"SELECT DISTINCT credential_tag, staking_key FROM utxo "+
-					"WHERE deleted_slot > ?",
+				utxoStakeRefsDeletedAfterSlotQuery,
 				slotValue,
 			)
 			if err != nil {
@@ -709,6 +732,36 @@ func queryStakeRefs(
 		ret = append(ret, models.NewStakeCredentialRef(uint8(tag), key))
 	}
 	return ret, rows.Err()
+}
+
+// queryStakeRefsDeduped runs query and returns its stake credential
+// references with duplicates removed, preserving the order of first
+// occurrence. It exists so range-scan queries over utxo can be written
+// without a SQL DISTINCT: DISTINCT over (credential_tag, staking_key)
+// pushes SQLite onto an index that supplies that ordering rather than onto
+// the index that satisfies the WHERE clause, turning a bounded range search
+// into a full table pass. queryStakeRefs already materialises every row, so
+// deduping in Go costs one map insert per row.
+func queryStakeRefsDeduped(
+	ctx context.Context,
+	db queryer,
+	query string,
+	args ...any,
+) ([]models.StakeCredentialRef, error) {
+	rows, err := queryStakeRefs(ctx, db, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]models.StakeCredentialRef, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, ref := range rows {
+		if _, ok := seen[ref.MapKey()]; ok {
+			continue
+		}
+		seen[ref.MapKey()] = struct{}{}
+		ret = append(ret, ref)
+	}
+	return ret, nil
 }
 
 func utxoIDPredicate(ids []models.UtxoId) (string, []any) {

--- a/database/plugin/metadata/sqlstore/utxo.go
+++ b/database/plugin/metadata/sqlstore/utxo.go
@@ -885,6 +885,22 @@ func dedupeUtxoIDs(ids []models.UtxoId) []models.UtxoId {
 	return ret
 }
 
+// GetUtxosAddedAfterSlot returns every UTxO added after slot, newest first.
+//
+// The rollback sweep calls this (through UtxosDeleteRolledback) immediately
+// before DeleteUtxosAfterSlot, to hand the blob store the objects it has to
+// drop. The statement used to end in "ORDER BY id DESC". id is the rowid, so
+// SQLite satisfied that by walking the table backwards -- a full SCAN, with
+// readahead defeated by the descending direction -- rather than
+// range-searching idx_utxo_added_slot, and the sweep read the entire utxo
+// table to return the handful of rows a rollback actually touches.
+//
+// Ordering by added_slot first fixes it without giving up a deterministic
+// order: idx_utxo_added_slot is (added_slot, rowid) and id is the rowid, so
+// "ORDER BY added_slot DESC, id DESC" is exactly that index's reverse order.
+// SQLite walks the matching range backwards and needs no sorter, at every
+// table size and whether or not ANALYZE has run.
+// TestGetUtxosAddedAfterSlotUsesSlotIndex pins the plan.
 func (s *Store) GetUtxosAddedAfterSlot(
 	slot uint64,
 	txn types.Txn,

--- a/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
@@ -1,0 +1,449 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore/migrations"
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// The DISTINCT-bearing statements this package used to run in the rollback
+// sweep. Kept here so the plan test can show, in the same run, that the two
+// forms return the same rows and that only the DISTINCT form abandons the
+// slot index.
+const (
+	legacyDistinctAddedAfterSlotQuery = "SELECT DISTINCT credential_tag, " +
+		"staking_key FROM utxo WHERE added_slot > ?"
+	legacyDistinctDeletedAfterSlotQuery = "SELECT DISTINCT credential_tag, " +
+		"staking_key FROM utxo WHERE deleted_slot > ?"
+)
+
+// newMigratedSQLiteStore opens a file-backed SQLite store carrying the real
+// migrated schema, so the utxo indexes under test (idx_utxo_added_slot,
+// idx_utxo_deleted_staking_amount, idx_utxo_staking_deleted_amount) are the
+// production ones rather than a hand-rolled CREATE TABLE.
+func newMigratedSQLiteStore(tb testing.TB) *Store {
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "metadata.sqlite")
+	db, err := OpenDB(
+		"sqlite",
+		fmt.Sprintf("file:%s?_pragma=busy_timeout(30000)", path),
+		"sqlite",
+	)
+	require.NoError(tb, err)
+	registry, err := migrations.SQLiteRegistry()
+	require.NoError(tb, err)
+	store, err := New(Config{
+		WriteDB:         db,
+		Dialect:         SQLiteDialect(),
+		Migrations:      registry,
+		MigrationLocker: migrations.NewProcessLocker(),
+	})
+	require.NoError(tb, err)
+	require.NoError(tb, store.Start(context.Background()))
+	tb.Cleanup(func() { require.NoError(tb, store.Close()) })
+	return store
+}
+
+// seedRollbackUtxos inserts n utxo rows spread over stakeCredentials distinct
+// stake credentials. Rows below rolledBackFrom are "old" (added and, for half
+// of them, deleted long before the rollback point); the last rollbackRows rows
+// sit above it and are the only ones a rollback sweep has to look at. This is
+// the shape that makes the bug visible: a large settled table, a tiny window.
+func seedRollbackUtxos(
+	tb testing.TB,
+	store *Store,
+	n int,
+	stakeCredentials int,
+	rolledBackFrom int64,
+	rollbackRows int,
+) {
+	tb.Helper()
+	tx, err := store.writeDB.Begin()
+	require.NoError(tb, err)
+	stmt, err := tx.Prepare(
+		"INSERT INTO utxo (tx_id, output_idx, staking_key, credential_tag, " +
+			"added_slot, deleted_slot, amount) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	)
+	require.NoError(tb, err)
+	for i := range n {
+		key := make([]byte, 28)
+		cred := i % stakeCredentials
+		key[0] = byte(cred >> 16)
+		key[1] = byte(cred >> 8)
+		key[2] = byte(cred)
+		txID := make([]byte, 32)
+		txID[0] = byte(i >> 24)
+		txID[1] = byte(i >> 16)
+		txID[2] = byte(i >> 8)
+		txID[3] = byte(i)
+		addedSlot := rolledBackFrom - int64(n-i)
+		deletedSlot := int64(0)
+		if i >= n-rollbackRows {
+			addedSlot = rolledBackFrom + int64(i-(n-rollbackRows)) + 1
+		} else if i%2 == 0 {
+			// A settled spend, well below the rollback point.
+			deletedSlot = addedSlot + 1
+		}
+		_, err := stmt.Exec(
+			txID,
+			i%4,
+			key,
+			int64(cred%2),
+			addedSlot,
+			deletedSlot,
+			"1000000",
+		)
+		require.NoError(tb, err)
+	}
+	require.NoError(tb, stmt.Close())
+	require.NoError(tb, tx.Commit())
+}
+
+// analyzeStore populates sqlite_stat1 for the fixture. A node only runs
+// ANALYZE at the points added by #2367 (after a Mithril import, before
+// API-mode backfill), so a producer's utxo table is normally queried without
+// current stats -- which is the state in which the DISTINCT plan goes wrong.
+func analyzeStore(tb testing.TB, store *Store) {
+	tb.Helper()
+	_, err := store.writeDB.Exec("ANALYZE")
+	require.NoError(tb, err)
+}
+
+// queryPlan returns the flattened EXPLAIN QUERY PLAN output for query.
+func queryPlan(tb testing.TB, db *sql.DB, query string, args ...any) string {
+	tb.Helper()
+	rows, err := db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(tb, err)
+	defer func() { require.NoError(tb, rows.Close()) }()
+	var lines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(tb, rows.Scan(&id, &parent, &notUsed, &detail))
+		lines = append(lines, detail)
+	}
+	require.NoError(tb, rows.Err())
+	return strings.Join(lines, "\n")
+}
+
+// TestRollbackStakeRefQueriesUseSlotIndexes pins the SQLite query plans of
+// the two statements the rollback sweep runs over utxo (from
+// DeleteUtxosAfterSlot and SetUtxosNotDeletedAfterSlot).
+//
+// With SQL DISTINCT over (credential_tag, staking_key), SQLite prefers an
+// index that already supplies that ordering -- idx_utxo_staking_deleted_amount
+// -- because it can then skip the temp B-tree, and it full-scans it. That
+// index carries no added_slot column, so for the added_slot statement the scan
+// is not even covering: every entry costs a row lookup just to evaluate the
+// slot predicate. The result is a pass over the entire utxo table on every
+// rollback, whatever the rollback depth -- minutes on a producer with a
+// multi-million-row table, during which the ledger holds its async DB
+// transaction and no block can be applied.
+//
+// Without DISTINCT the planner uses the index that answers the predicate and
+// only visits the rolled-back window, and it does so whether or not
+// sqlite_stat1 has been populated. That stats independence is the reason to
+// dedupe in Go rather than to rely on ANALYZE: a long-running node's utxo
+// stats are stale or absent (#2367 runs ANALYZE only around a Mithril import),
+// and the MySQL and Postgres stores have their own planners.
+//
+// The assertion is on the plan rather than on elapsed time so it is
+// deterministic; BenchmarkRollbackStakeRefQueries carries the timings.
+func TestRollbackStakeRefQueriesUseSlotIndexes(t *testing.T) {
+	t.Parallel()
+	const rolledBackFrom = int64(2_656_808)
+
+	for _, stats := range []struct {
+		name    string
+		analyze bool
+	}{
+		{name: "without_planner_stats"},
+		{name: "with_planner_stats", analyze: true},
+	} {
+		t.Run(stats.name, func(t *testing.T) {
+			t.Parallel()
+			store := newMigratedSQLiteStore(t)
+			seedRollbackUtxos(t, store, 20_000, 64, rolledBackFrom, 40)
+			if stats.analyze {
+				analyzeStore(t, store)
+			}
+
+			for _, tc := range []struct {
+				name        string
+				query       string
+				legacyQuery string
+				wantSearch  string
+			}{
+				{
+					name:        "added_slot",
+					query:       utxoStakeRefsAddedAfterSlotQuery,
+					legacyQuery: legacyDistinctAddedAfterSlotQuery,
+					wantSearch:  "idx_utxo_added_slot (added_slot>?)",
+				},
+				{
+					name:        "deleted_slot",
+					query:       utxoStakeRefsDeletedAfterSlotQuery,
+					legacyQuery: legacyDistinctDeletedAfterSlotQuery,
+					wantSearch:  "(deleted_slot>?)",
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					plan := queryPlan(
+						t,
+						store.writeDB,
+						tc.query,
+						rolledBackFrom,
+					)
+					legacyPlan := queryPlan(
+						t,
+						store.writeDB,
+						tc.legacyQuery,
+						rolledBackFrom,
+					)
+					t.Logf("plan without DISTINCT: %s", plan)
+					t.Logf("plan with DISTINCT:    %s", legacyPlan)
+
+					require.Contains(
+						t,
+						plan,
+						"SEARCH",
+						"rollback stake-ref query must range-search: %s",
+						plan,
+					)
+					require.Contains(
+						t,
+						plan,
+						tc.wantSearch,
+						"rollback stake-ref query must drive off the slot "+
+							"predicate: %s",
+						plan,
+					)
+					require.NotContains(
+						t,
+						plan,
+						"SCAN",
+						"rollback stake-ref query must not scan the table or "+
+							"an index: %s",
+						plan,
+					)
+					require.NotContains(
+						t,
+						plan,
+						"idx_utxo_staking_deleted_amount",
+						"rollback stake-ref query must not fall back to the "+
+							"stake-ordered index: %s",
+						plan,
+					)
+				})
+			}
+		})
+	}
+}
+
+// TestRollbackStakeRefsDedupeMatchesSQLDistinct proves the Go-side dedupe
+// returns exactly the set SQL DISTINCT returned, on a fixture holding repeated
+// credentials, two credential tags sharing a staking key, and rows with a NULL
+// or empty staking key (which queryStakeRefs drops).
+func TestRollbackStakeRefsDedupeMatchesSQLDistinct(t *testing.T) {
+	t.Parallel()
+	const rolledBackFrom = int64(100)
+	store := newMigratedSQLiteStore(t)
+
+	keyA := make([]byte, 28)
+	keyA[0] = 0xAA
+	keyB := make([]byte, 28)
+	keyB[0] = 0xBB
+
+	rows := []struct {
+		stakingKey    []byte
+		credentialTag int64
+		addedSlot     int64
+		deletedSlot   int64
+	}{
+		{keyA, 0, 101, 0},
+		{keyA, 0, 102, 0}, // repeat of (0, keyA)
+		{keyB, 0, 103, 0},
+		{keyA, 1, 104, 0},     // same key, other credential tag
+		{keyB, 0, 105, 0},     // repeat of (0, keyB)
+		{nil, 0, 106, 0},      // NULL staking key: dropped
+		{[]byte{}, 0, 107, 0}, // empty staking key: dropped
+		{keyA, 0, 50, 0},      // below the rollback point: excluded
+		{keyB, 1, 60, 101},    // deleted above the rollback point
+		{keyA, 1, 61, 102},    // deleted above the rollback point
+		{keyA, 1, 62, 50},     // deleted below: excluded
+	}
+	tx, err := store.writeDB.Begin()
+	require.NoError(t, err)
+	stmt, err := tx.Prepare(
+		"INSERT INTO utxo (tx_id, output_idx, staking_key, credential_tag, " +
+			"added_slot, deleted_slot, amount) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	)
+	require.NoError(t, err)
+	for i, row := range rows {
+		_, err := stmt.Exec(
+			[]byte{byte(i)},
+			0,
+			row.stakingKey,
+			row.credentialTag,
+			row.addedSlot,
+			row.deletedSlot,
+			"1000000",
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, stmt.Close())
+	require.NoError(t, tx.Commit())
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name        string
+		query       string
+		legacyQuery string
+		want        []models.StakeCredentialRef
+	}{
+		{
+			name:        "added_slot",
+			query:       utxoStakeRefsAddedAfterSlotQuery,
+			legacyQuery: legacyDistinctAddedAfterSlotQuery,
+			want: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(0, keyA),
+				models.NewStakeCredentialRef(0, keyB),
+				models.NewStakeCredentialRef(1, keyA),
+			},
+		},
+		{
+			name:        "deleted_slot",
+			query:       utxoStakeRefsDeletedAfterSlotQuery,
+			legacyQuery: legacyDistinctDeletedAfterSlotQuery,
+			want: []models.StakeCredentialRef{
+				models.NewStakeCredentialRef(1, keyA),
+				models.NewStakeCredentialRef(1, keyB),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := queryStakeRefsDeduped(
+				ctx,
+				store.writeDB,
+				tc.query,
+				rolledBackFrom,
+			)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.want, got)
+			require.Len(t, got, len(tc.want), "dedupe left a duplicate")
+
+			legacy, err := queryStakeRefs(
+				ctx,
+				store.writeDB,
+				tc.legacyQuery,
+				rolledBackFrom,
+			)
+			require.NoError(t, err)
+			require.ElementsMatch(
+				t,
+				legacy,
+				got,
+				"Go dedupe must return the same set as SQL DISTINCT",
+			)
+		})
+	}
+}
+
+// TestDeleteUtxosAfterSlotDedupesStakeRefs and its SetUtxosNotDeletedAfterSlot
+// twin exercise the store methods end to end: the rollback still removes (or
+// un-spends) exactly the rows above the slot, which is the behaviour the plan
+// change must not disturb.
+func TestRollbackSweepStillTruncatesUtxos(t *testing.T) {
+	t.Parallel()
+	const rolledBackFrom = uint64(200)
+	store := newMigratedSQLiteStore(t)
+	seedRollbackUtxos(t, store, 200, 8, int64(rolledBackFrom), 25)
+
+	var above int
+	require.NoError(t, store.writeDB.QueryRow(
+		"SELECT COUNT(*) FROM utxo WHERE added_slot > ?", rolledBackFrom,
+	).Scan(&above))
+	require.Equal(t, 25, above, "fixture must have rows above the slot")
+
+	require.NoError(t, store.DeleteUtxosAfterSlot(rolledBackFrom, nil))
+
+	require.NoError(t, store.writeDB.QueryRow(
+		"SELECT COUNT(*) FROM utxo WHERE added_slot > ?", rolledBackFrom,
+	).Scan(&above))
+	require.Zero(t, above, "rollback must delete every utxo added after the slot")
+
+	var total int
+	require.NoError(t, store.writeDB.QueryRow(
+		"SELECT COUNT(*) FROM utxo",
+	).Scan(&total))
+	require.Equal(t, 175, total, "rollback must not touch settled rows")
+}
+
+// BenchmarkRollbackStakeRefQueries is the secondary, timing-based evidence:
+// it runs the production statement and the DISTINCT statement it replaces
+// against the same seeded table, so the ratio between them shows the cost of
+// the abandoned index directly.
+func BenchmarkRollbackStakeRefQueries(b *testing.B) {
+	for _, n := range []int{100_000, 500_000} {
+		const rolledBackFrom = int64(4_000_000)
+		store := newMigratedSQLiteStore(b)
+		seedRollbackUtxos(b, store, n, 512, rolledBackFrom, 40)
+		ctx := context.Background()
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{
+				name:  "added_slot/no_distinct",
+				query: utxoStakeRefsAddedAfterSlotQuery,
+			},
+			{
+				name:  "added_slot/distinct",
+				query: legacyDistinctAddedAfterSlotQuery,
+			},
+			{
+				name:  "deleted_slot/no_distinct",
+				query: utxoStakeRefsDeletedAfterSlotQuery,
+			},
+			{
+				name:  "deleted_slot/distinct",
+				query: legacyDistinctDeletedAfterSlotQuery,
+			},
+		} {
+			b.Run(fmt.Sprintf("n=%d/%s", n, tc.name), func(b *testing.B) {
+				for b.Loop() {
+					if _, err := queryStakeRefs(
+						ctx,
+						store.writeDB,
+						tc.query,
+						rolledBackFrom,
+					); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -39,16 +38,21 @@ const (
 		"staking_key FROM utxo WHERE deleted_slot > ?"
 )
 
-// newMigratedSQLiteStore opens a file-backed SQLite store carrying the real
-// migrated schema, so the utxo indexes under test (idx_utxo_added_slot,
+// newMigratedSQLiteStore opens a SQLite store carrying the real migrated
+// schema, so the utxo indexes under test (idx_utxo_added_slot,
 // idx_utxo_deleted_staking_amount, idx_utxo_staking_deleted_amount) are the
-// production ones rather than a hand-rolled CREATE TABLE.
+// production ones rather than a hand-rolled CREATE TABLE. The query planner
+// reads the schema and sqlite_stat1, not the storage backend, so the
+// in-memory database this package already uses for store tests produces the
+// same plans as a file-backed one.
 func newMigratedSQLiteStore(tb testing.TB) *Store {
 	tb.Helper()
-	path := filepath.Join(tb.TempDir(), "metadata.sqlite")
 	db, err := OpenDB(
 		"sqlite",
-		fmt.Sprintf("file:%s?_pragma=busy_timeout(30000)", path),
+		fmt.Sprintf(
+			"file:rollback_scan_%d?mode=memory&cache=shared",
+			testStoreSequence.Add(1),
+		),
 		"sqlite",
 	)
 	require.NoError(tb, err)
@@ -68,9 +72,11 @@ func newMigratedSQLiteStore(tb testing.TB) *Store {
 
 // seedRollbackUtxos inserts n utxo rows spread over stakeCredentials distinct
 // stake credentials. Rows below rolledBackFrom are "old" (added and, for half
-// of them, deleted long before the rollback point); the last rollbackRows rows
-// sit above it and are the only ones a rollback sweep has to look at. This is
-// the shape that makes the bug visible: a large settled table, a tiny window.
+// of them, spent long before the rollback point); the last rollbackRows rows
+// sit above it and are the only ones a rollback sweep has to look at, half of
+// them also spent above it so both sweep statements have rows to return. This
+// is the shape that makes the bug visible: a large settled table whose rows
+// are almost all irrelevant to the rollback, and a tiny window that is not.
 func seedRollbackUtxos(
 	tb testing.TB,
 	store *Store,
@@ -102,6 +108,12 @@ func seedRollbackUtxos(
 		deletedSlot := int64(0)
 		if i >= n-rollbackRows {
 			addedSlot = rolledBackFrom + int64(i-(n-rollbackRows)) + 1
+			if i%2 == 0 {
+				// Spent after the rollback point, so the rollback has to
+				// un-spend it: this is what SetUtxosNotDeletedAfterSlot
+				// looks for.
+				deletedSlot = addedSlot
+			}
 		} else if i%2 == 0 {
 			// A settled spend, well below the rollback point.
 			deletedSlot = addedSlot + 1

--- a/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
@@ -383,10 +383,10 @@ func TestRollbackStakeRefsDedupeMatchesSQLDistinct(t *testing.T) {
 	}
 }
 
-// TestDeleteUtxosAfterSlotDedupesStakeRefs and its SetUtxosNotDeletedAfterSlot
-// twin exercise the store methods end to end: the rollback still removes (or
-// un-spends) exactly the rows above the slot, which is the behaviour the plan
-// change must not disturb.
+// TestRollbackSweepStillTruncatesUtxos exercises DeleteUtxosAfterSlot end to
+// end: the rollback still removes exactly the rows added above the slot and
+// leaves settled rows alone, which is the behaviour the plan change must not
+// disturb.
 func TestRollbackSweepStillTruncatesUtxos(t *testing.T) {
 	t.Parallel()
 	const rolledBackFrom = uint64(200)

--- a/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -453,6 +455,233 @@ func BenchmarkRollbackStakeRefQueries(b *testing.B) {
 						rolledBackFrom,
 					); err != nil {
 						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// namedQueryFromSource returns the body of a named sqlc query, read from the
+// .sql file sqlc generates the store from. Reading the shipped source rather
+// than restating the SQL in the test means the plan assertions below cannot
+// drift away from the statement the node actually runs.
+func namedQueryFromSource(tb testing.TB, name string) string {
+	tb.Helper()
+	source, err := os.ReadFile(
+		filepath.Join("queries", "sqlite", "operational.sql"),
+	)
+	require.NoError(tb, err)
+	marker := "-- name: " + name + " :"
+	start := strings.Index(string(source), marker)
+	require.GreaterOrEqual(tb, start, 0, "query %q not found in source", name)
+	// Skip the "-- name:" line itself, then take everything up to the
+	// statement terminator.
+	body := string(source)[start:]
+	body = body[strings.Index(body, "\n")+1:]
+	end := strings.Index(body, ";")
+	require.GreaterOrEqual(tb, end, 0, "query %q is unterminated", name)
+	return strings.TrimSpace(body[:end])
+}
+
+// withOrderByIDDesc rewrites a statement's trailing ORDER BY to the
+// "ORDER BY id DESC" GetUtxosAddedAfterSlot used to carry, so the tests can
+// show in the same run that ordering by the rowid alone is what costs the
+// table scan. It is deliberately not a check on the shipped text: the plan
+// assertion is the contract, so reverting the statement has to fail on the
+// plan, not on a string comparison.
+func withOrderByIDDesc(tb testing.TB, query string) string {
+	tb.Helper()
+	idx := strings.LastIndex(query, "ORDER BY")
+	require.GreaterOrEqual(tb, idx, 0, "statement has no ORDER BY: %s", query)
+	return query[:idx] + "ORDER BY id DESC"
+}
+
+// TestGetUtxosAddedAfterSlotUsesSlotIndex pins the SQLite query plan of the
+// other utxo statement the rollback sweep runs: UtxosDeleteRolledback calls
+// GetUtxosAddedAfterSlot to collect the blobs to drop, immediately before
+// DeleteUtxosAfterSlot.
+//
+// The statement used to end in "ORDER BY id DESC". id is the rowid, so SQLite
+// produced that order by walking the table backwards -- a full SCAN, and a
+// descending one, so readahead does not help -- instead of range-searching
+// idx_utxo_added_slot. Like the DISTINCT sweep queries, the cost then tracks
+// the size of the utxo table rather than the depth of the rollback.
+//
+// Ordering by added_slot first makes the requested order the reverse of
+// idx_utxo_added_slot's own order ((added_slot, rowid), and id is the rowid),
+// so the range search serves it directly with no sorter -- with or without
+// planner statistics, which is what the two sub-tests check.
+func TestGetUtxosAddedAfterSlotUsesSlotIndex(t *testing.T) {
+	t.Parallel()
+	const rolledBackFrom = int64(2_656_808)
+	query := namedQueryFromSource(t, "GetUtxosAddedAfterSlot")
+	legacyQuery := withOrderByIDDesc(t, query)
+
+	for _, stats := range []struct {
+		name    string
+		analyze bool
+	}{
+		{name: "without_planner_stats"},
+		{name: "with_planner_stats", analyze: true},
+	} {
+		t.Run(stats.name, func(t *testing.T) {
+			t.Parallel()
+			store := newMigratedSQLiteStore(t)
+			seedRollbackUtxos(t, store, 20_000, 64, rolledBackFrom, 40)
+			if stats.analyze {
+				analyzeStore(t, store)
+			}
+
+			plan := queryPlan(t, store.writeDB, query, rolledBackFrom)
+			legacyPlan := queryPlan(
+				t,
+				store.writeDB,
+				legacyQuery,
+				rolledBackFrom,
+			)
+			t.Logf("plan ordered by added_slot: %s", plan)
+			t.Logf("plan ordered by id:         %s", legacyPlan)
+
+			require.Contains(
+				t,
+				plan,
+				"SEARCH utxo USING INDEX idx_utxo_added_slot (added_slot>?)",
+				"blob-collect query must range-search the slot index: %s",
+				plan,
+			)
+			require.NotContains(
+				t,
+				plan,
+				"SCAN",
+				"blob-collect query must not scan the table: %s",
+				plan,
+			)
+			require.NotContains(
+				t,
+				plan,
+				"TEMP B-TREE",
+				"the requested order is the index order, so no sorter is "+
+					"needed: %s",
+				plan,
+			)
+		})
+	}
+}
+
+// TestGetUtxosAddedAfterSlotReturnsSameRows proves the reordering changed only
+// the order, not the set: the shipped statement returns exactly the ids the
+// old "ORDER BY id DESC" statement returned, and returns them newest first.
+func TestGetUtxosAddedAfterSlotReturnsSameRows(t *testing.T) {
+	t.Parallel()
+	const rolledBackFrom = int64(2_656_808)
+	store := newMigratedSQLiteStore(t)
+	seedRollbackUtxos(t, store, 2_000, 16, rolledBackFrom, 60)
+
+	query := namedQueryFromSource(t, "GetUtxosAddedAfterSlot")
+	legacyQuery := withOrderByIDDesc(t, query)
+
+	type row struct {
+		id        int64
+		addedSlot int64
+	}
+	read := func(q string) []row {
+		rows, err := store.writeDB.Query(q, rolledBackFrom)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, rows.Close()) }()
+		cols, err := rows.Columns()
+		require.NoError(t, err)
+		idIdx, slotIdx := -1, -1
+		for i, c := range cols {
+			switch c {
+			case "id":
+				idIdx = i
+			case "added_slot":
+				slotIdx = i
+			}
+		}
+		require.GreaterOrEqual(t, idIdx, 0)
+		require.GreaterOrEqual(t, slotIdx, 0)
+		var out []row
+		for rows.Next() {
+			cells := make([]any, len(cols))
+			for i := range cells {
+				cells[i] = new(sql.RawBytes)
+			}
+			var id, slot sql.NullInt64
+			cells[idIdx] = &id
+			cells[slotIdx] = &slot
+			require.NoError(t, rows.Scan(cells...))
+			out = append(out, row{id: id.Int64, addedSlot: slot.Int64})
+		}
+		require.NoError(t, rows.Err())
+		return out
+	}
+
+	got := read(query)
+	legacy := read(legacyQuery)
+	require.NotEmpty(t, got, "fixture must return rows above the slot")
+	require.ElementsMatch(
+		t,
+		legacy,
+		got,
+		"reordering must not change which rows are returned",
+	)
+
+	for i := 1; i < len(got); i++ {
+		prev, cur := got[i-1], got[i]
+		require.True(
+			t,
+			prev.addedSlot > cur.addedSlot ||
+				(prev.addedSlot == cur.addedSlot && prev.id > cur.id),
+			"rows must be newest first: %+v before %+v",
+			prev,
+			cur,
+		)
+		require.Greater(
+			t,
+			cur.addedSlot,
+			rolledBackFrom,
+			"only rows above the rollback point may be returned",
+		)
+	}
+}
+
+// BenchmarkGetUtxosAddedAfterSlot measures the blob-collect statement in both
+// forms against the same seeded table, the timing counterpart to the plan
+// assertion above.
+func BenchmarkGetUtxosAddedAfterSlot(b *testing.B) {
+	for _, n := range []int{100_000, 500_000} {
+		const rolledBackFrom = int64(4_000_000)
+		store := newMigratedSQLiteStore(b)
+		seedRollbackUtxos(b, store, n, 512, rolledBackFrom, 40)
+		query := namedQueryFromSource(b, "GetUtxosAddedAfterSlot")
+		legacyQuery := withOrderByIDDesc(b, query)
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{name: "order_by_added_slot", query: query},
+			{name: "order_by_id", query: legacyQuery},
+		} {
+			b.Run(fmt.Sprintf("n=%d/%s", n, tc.name), func(b *testing.B) {
+				for b.Loop() {
+					rows, err := store.writeDB.Query(tc.query, rolledBackFrom)
+					if err != nil {
+						b.Fatal(err)
+					}
+					count := 0
+					for rows.Next() {
+						count++
+					}
+					if err := rows.Err(); err != nil {
+						b.Fatal(err)
+					}
+					if err := rows.Close(); err != nil {
+						b.Fatal(err)
+					}
+					if count != 40 {
+						b.Fatalf("got %d rows, want 40", count)
 					}
 				}
 			})

--- a/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
+++ b/database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go
@@ -606,7 +606,10 @@ func TestGetUtxosAddedAfterSlotReturnsSameRows(t *testing.T) {
 		for rows.Next() {
 			cells := make([]any, len(cols))
 			for i := range cells {
-				cells[i] = new(sql.RawBytes)
+				// The fixture intentionally leaves several selected columns NULL.
+				// NullString accepts NULL and is sufficient for the columns whose
+				// values this comparison does not inspect.
+				cells[i] = new(sql.NullString)
 			}
 			var id, slot sql.NullInt64
 			cells[idIdx] = &id


### PR DESCRIPTION
Fixes #4015

The rollback sweep runs **two** full scans of `utxo`, back to back, in
`UtxosDeleteRolledback`. Both are here.

## Problem

`TruncateAfterSlot` is the rollback sweep the ledger runs inside its async DB
transaction, so nothing can be applied while it runs. Three of its statements
against `utxo` cost a pass over the whole table rather than over the rolled-back
window, so the sweep's cost tracks the size of the table and not the depth of
the rollback.

### 1. `SELECT DISTINCT credential_tag, staking_key ... WHERE added_slot > ?`

`DeleteUtxosAfterSlot` and `SetUtxosNotDeletedAfterSlot` collect the stake
credentials whose live stake has to be recomputed. SQLite satisfies a `DISTINCT`
over `(credential_tag, staking_key)` by scanning
`idx_utxo_staking_deleted_amount`, whose leading columns already supply that
ordering, instead of range-searching the index that answers the predicate: it
skips the temp B-tree at the price of visiting every entry in the table. That
index has no `added_slot` column, so for the `added_slot` statement the scan is
not even covering — each entry costs a row lookup purely to evaluate the
predicate.

### 2. `SELECT ... WHERE added_slot > ? ORDER BY id DESC`

`UtxosDeleteRolledback` calls `GetUtxosAddedAfterSlot` immediately *before*
`DeleteUtxosAfterSlot`, to collect the blobs to drop. `id` is the rowid, so
SQLite produced `ORDER BY id DESC` by walking the table backwards — a full
`SCAN`, and a descending one, so readahead does not help either — rather than
range-searching `idx_utxo_added_slot`.

Measured on a block producer with a 15.9 GB metadata database and 20.4M `utxo`
rows: with only the first fix in place the sweep still took **12–14 s warm and
329–424 s cold**. This second statement is **5.5–7.4 s warm regardless of
rollback depth**, reading **3.17 GB to return 2,375 rows** for a 43-slot
rollback, against 0.3 MB with the index. The cold case is the 300–400 s mode.
Fixing the first alone took the sweep from ~98 s to ~13 s warm; this one is the
rest.

Plans on the migrated schema (`EXPLAIN QUERY PLAN`, no `sqlite_stat1`):

```
-- before
SELECT DISTINCT credential_tag, staking_key FROM utxo WHERE added_slot > ?
  SCAN utxo USING INDEX idx_utxo_staking_deleted_amount
SELECT DISTINCT credential_tag, staking_key FROM utxo WHERE deleted_slot > ?
  SCAN utxo USING COVERING INDEX idx_utxo_staking_deleted_amount
SELECT ... FROM utxo WHERE added_slot > ? ORDER BY id DESC
  SCAN utxo

-- after
SELECT credential_tag, staking_key FROM utxo WHERE added_slot > ?
  SEARCH utxo USING INDEX idx_utxo_added_slot (added_slot>?)
SELECT credential_tag, staking_key FROM utxo WHERE deleted_slot > ?
  SEARCH utxo USING COVERING INDEX idx_utxo_deleted_staking_amount (deleted_slot>?)
SELECT ... FROM utxo WHERE added_slot > ? ORDER BY added_slot DESC, id DESC
  SEARCH utxo USING INDEX idx_utxo_added_slot (added_slot>?)
```

## Fix

**The `DISTINCT` queries:** drop the SQL `DISTINCT` and dedupe in Go, matching
the sibling helper `queryUtxoStakeRefs`, which already keeps a `seen` map.
`queryStakeRefs` materialises every row regardless, so deduping costs one map
insert per row.

**The blob-collect query:** order by `added_slot` before `id`. Dropping the
clause also fixes the plan — the sole caller, `deleteUtxoBlobs`, batches by 500
and deletes by `(tx_id, output_idx)`, so it never uses the order — but the order
is free here, so there is no reason to give it up: `idx_utxo_added_slot` is
`(added_slot, rowid)` and `id` is the rowid, so `ORDER BY added_slot DESC, id
DESC` is exactly that index's reverse order. SQLite walks the range backwards
with **no sorter**, with or without `ANALYZE`. Same rows, still newest first.

No index and no `INDEXED BY` hint is added, deliberately:

* `INDEXED BY` would pin SQLite only, and this store is shared by the MySQL and
  Postgres backends, which have their own planners and can regress the same way.
  The statements are defined once and rebound per dialect by
  `operationalQueries`, so both fixes reach all three engines; there is no
  separate MySQL/Postgres copy to change.
* A new covering index would add write cost to the hottest table in the node.
* Relying on `ANALYZE` does not hold either. With `sqlite_stat1` populated
  SQLite does pick the range search for the `DISTINCT` form, and downgrades the
  `ORDER BY id DESC` form to a `SEARCH` plus `USE TEMP B-TREE FOR ORDER BY`
  rather than a scan — but a node only runs `ANALYZE` around a Mithril import /
  API-mode backfill (#2367), so a long-running producer's `utxo` statistics are
  absent or many millions of rows stale. In the no-stats state the wrong plans
  reproduced at every table size (20k, 200k) and stake-credential cardinality
  (64, 5k, 50k) tested.

### The rest of the sweep

Every other statement `TruncateAfterSlot` runs against `utxo` was checked the
same way, in both statistics states, and already range-searches:

| statement | plan |
| --- | --- |
| stake-refs `added_slot > ?` | `SEARCH ... idx_utxo_added_slot (added_slot>?)` |
| stake-refs `deleted_slot > ?` | `SEARCH ... idx_utxo_deleted_staking_amount (deleted_slot>?)` |
| `DELETE FROM utxo WHERE added_slot > ?` | `SEARCH ... idx_utxo_added_slot (added_slot>?)` |
| unspend `UPDATE ... WHERE deleted_slot > ?` | `SEARCH ... idx_utxo_deleted_payment_script (deleted_slot>?)` |
| `utxo_reference_input` delete | `SEARCH ... (utxo_id=?)` |
| `GetLiveUtxoRefsBySlot` / `GetUtxoRefsBySlot` | `SEARCH ... idx_utxo_added_slot (added_slot=?)` — equality, and `ORDER BY id` is that index's own order |

## Tests

All in `database/plugin/metadata/sqlstore/utxo_rollback_scan_test.go`, against
the real migrated schema (`migrations.SQLiteRegistry()`), so the indexes under
test are the production ones. The plan tests read the statements from the `.sql`
file sqlc generates from, so they cannot drift from what the node runs.

* `TestRollbackStakeRefQueriesUseSlotIndexes` — pins the plans of both
  `DISTINCT`-derived statements, `without_planner_stats` and
  `with_planner_stats`. Restoring `DISTINCT` fails it:
  `"SCAN utxo USING INDEX idx_utxo_staking_deleted_amount" does not contain "SEARCH"`.
* `TestGetUtxosAddedAfterSlotUsesSlotIndex` — pins the blob-collect plan.
  Restoring `ORDER BY id DESC` fails it in **both** states: `SCAN utxo` without
  stats, and `USE TEMP B-TREE FOR ORDER BY` with them.
* `TestRollbackStakeRefsDedupeMatchesSQLDistinct` — the Go dedupe returns
  exactly the set SQL `DISTINCT` returned, on a fixture with repeated
  credentials, one staking key shared by two credential tags, NULL and empty
  staking keys, and rows on both sides of the rollback point. Removing the
  `seen` check fails it.
* `TestGetUtxosAddedAfterSlotReturnsSameRows` — the reorder changed only the
  order: same ids as `ORDER BY id DESC`, and newest first. Flipping the
  statement to ascending fails it.
* `TestRollbackSweepStillTruncatesUtxos` — `DeleteUtxosAfterSlot` end to end.

Benchmarks, `-benchtime 20x`, in-memory so there is no page-cache noise:

```
BenchmarkRollbackStakeRefQueries
  n=100000/added_slot/no_distinct        81127 ns/op
  n=100000/added_slot/distinct        85820448 ns/op    1058x
  n=100000/deleted_slot/no_distinct      55068 ns/op
  n=100000/deleted_slot/distinct       8118708 ns/op     147x
  n=500000/added_slot/no_distinct        92101 ns/op
  n=500000/added_slot/distinct       577202962 ns/op    6267x
  n=500000/deleted_slot/no_distinct      91699 ns/op
  n=500000/deleted_slot/distinct      45035908 ns/op     491x

BenchmarkGetUtxosAddedAfterSlot
  n=100000/order_by_added_slot          181852 ns/op
  n=100000/order_by_id                13959667 ns/op      77x
  n=500000/order_by_added_slot          198988 ns/op
  n=500000/order_by_id                61927288 ns/op     311x
```

The broken forms track table size (5x the rows costs 4.4x–6.7x the time) while
the fixed ones stay flat — that is the whole point: today a rollback pays for
the size of the `utxo` table rather than for its own depth. These are in-memory
numbers and so a lower bound; on a file-backed multi-million-row table the
non-covering scans also stop hitting page cache, which is how they reach the
minutes seen in the field.

`go test ./database/...` passes, `make sql-check` is clean (sqlc output
re-run under the pinned v1.31.1), `go build ./...` and `go vet` clean. No
schema change — the metadata `target_version` stays at 10.

## Related

* Fixes #4015
* #3968 — the chainsync symptom whose premise is "until the rollback finishes";
  this is why rollbacks take that long.
* #2953 / #2954 — prior art, the live-stake refresh scanning `utxo` in the same
  helper family, there because an index was dropped during backfill.
* #2367 — added the `ANALYZE` runs referred to above; it is why a freshly
  imported database does not show this and an aged one does.
* #3967, #3910, #3952, #3938 — other open work on the rollback path; this change
  touches only the metadata-store queries and no rollback control flow.