### PR TITLE
fix(consensus): avoid double-ceiling leader threshold

### DIFF
--- a/consensus/leaderthreshold/threshold.go
+++ b/consensus/leaderthreshold/threshold.go
@@ -23,124 +23,21 @@ import (
 // Threshold returns the integer comparison threshold for the Praos leader
 // rule. The ledger rule compares the real-valued certified-natural ratio
 // strictly against 1-(1-f)^sigma. For an integer leader value v, that is
-// equivalent to v < ceil(certNatMax*(1-(1-f)^sigma)), not v < floor(...).
+// equivalent to v < ceil(certNatMax*(1-(1-f)^sigma)).
 //
-// The gouroboros version used by Dingo currently returns floor(...). Keep its
-// rigorously calculated value as the base, and raise it by one only when exact
-// rational arithmetic proves the real cutoff is not an integer. When the
-// cutoff is integral, the returned floor is retained so the exact boundary is
-// still rejected.
+// consensus.CertifiedNatThresholdWithMode returns that ceiling, so its value
+// is used unchanged. Adding to it would admit the ceiling itself, which the
+// real-valued rule rejects.
 func Threshold(
 	poolStake uint64,
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 	mode consensus.ConsensusMode,
 ) (*big.Int, error) {
-	threshold, err := consensus.CertifiedNatThresholdWithMode(
+	return consensus.CertifiedNatThresholdWithMode(
 		poolStake,
 		totalStake,
 		activeSlotCoeff,
 		mode,
 	)
-	if err != nil {
-		return nil, err
-	}
-	if cutoffIsInteger(poolStake, totalStake, activeSlotCoeff, mode) {
-		return threshold, nil
-	}
-	return new(big.Int).Add(threshold, big.NewInt(1)), nil
-}
-
-// cutoffIsInteger proves whether the real cutoff is an integer for the
-// rational protocol inputs Dingo has available. If sigma's reduced exponent
-// does not make (1-f)^sigma rational, the cutoff is irrational and therefore
-// cannot be an integer. The rational case is evaluated exactly.
-func cutoffIsInteger(
-	poolStake uint64,
-	totalStake uint64,
-	activeSlotCoeff *big.Rat,
-	mode consensus.ConsensusMode,
-) bool {
-	if activeSlotCoeff == nil || activeSlotCoeff.Sign() <= 0 ||
-		totalStake == 0 || poolStake == 0 {
-		return true
-	}
-	if activeSlotCoeff.Cmp(big.NewRat(1, 1)) >= 0 {
-		// f == 1 has cutoff certNatMax. f > 1 is rejected by the
-		// underlying threshold helper before this result is used.
-		return true
-	}
-	if poolStake > totalStake {
-		poolStake = totalStake
-	}
-
-	sigma := new(big.Rat).SetFrac(
-		new(big.Int).SetUint64(poolStake),
-		new(big.Int).SetUint64(totalStake),
-	)
-	rootDegree := sigma.Denom()
-	if !rootDegree.IsUint64() {
-		return false
-	}
-	rootDegreeUint := rootDegree.Uint64()
-	oneMinusF := new(big.Rat).Sub(big.NewRat(1, 1), activeSlotCoeff)
-	rootNumerator, ok := exactNthRoot(oneMinusF.Num(), rootDegreeUint)
-	if !ok {
-		return false
-	}
-	rootDenominator, ok := exactNthRoot(oneMinusF.Denom(), rootDegreeUint)
-	if !ok {
-		return false
-	}
-
-	power := new(big.Rat).SetFrac(
-		new(big.Int).Exp(rootNumerator, sigma.Num(), nil),
-		new(big.Int).Exp(rootDenominator, sigma.Num(), nil),
-	)
-	probability := new(big.Rat).Sub(big.NewRat(1, 1), power)
-	upperBound := new(big.Int).Lsh(big.NewInt(1), 256)
-	if mode == consensus.ConsensusModeTPraos {
-		upperBound.Lsh(big.NewInt(1), 512)
-	}
-	cutoffNumerator := new(big.Int).Mul(upperBound, probability.Num())
-	remainder := new(big.Int)
-	new(big.Int).QuoRem(cutoffNumerator, probability.Denom(), remainder)
-	return remainder.Sign() == 0
-}
-
-// exactNthRoot reports an integer nth root only when the input is a perfect
-// power. Protocol stake denominators are at most 64 bits; avoiding a search
-// for degrees larger than the input's bit length keeps adversarial inputs
-// bounded while preserving the exact proof.
-func exactNthRoot(value *big.Int, degree uint64) (*big.Int, bool) {
-	if value.Sign() < 0 || degree == 0 {
-		return nil, false
-	}
-	if value.Sign() == 0 || value.Cmp(big.NewInt(1)) == 0 || degree == 1 {
-		return new(big.Int).Set(value), true
-	}
-	if degree > uint64(value.BitLen()) { //nolint:gosec // BitLen is non-negative.
-		return nil, false
-	}
-
-	low := big.NewInt(1)
-	high := new(big.Int).Lsh(
-		big.NewInt(1),
-		uint((uint64(value.BitLen())+degree-1)/degree), //nolint:gosec // bounded by BitLen.
-	)
-	for low.Cmp(high) < 0 {
-		mid := new(big.Int).Add(low, high)
-		mid.Rsh(mid, 1)
-		power := new(big.Int).Exp(mid, new(big.Int).SetUint64(degree), nil)
-		if power.Cmp(value) < 0 {
-			low.Add(mid, big.NewInt(1))
-		} else {
-			high.Set(mid)
-		}
-	}
-	if new(big.Int).Exp(low, new(big.Int).SetUint64(degree), nil).
-		Cmp(value) != 0 {
-		return nil, false
-	}
-	return low, true
 }


### PR DESCRIPTION
## Summary

- remove the Dingo-side ceiling adjustment from the Praos leader threshold
  wrapper
- preserve strict rejection of an exact integer cutoff through the existing
  boundary tests

The gouroboros threshold helper now returns the ceiling required by the strict
VRF comparison. Dingo was adding one more for fractional cutoffs, causing the
fractional boundary tests to fail on `main` across Linux, Windows, macOS, and
race jobs.

## Validation

- `go test -race -run 'TestThreshold(PreservesProtocolBoundary|RejectsInvalidExactBoundaryForPartialStake|ExactBoundaryRemainsRejected|BoundaryFeedsTheVRFComparator)' ./ledger/leader`
- `go test -race -timeout 20m ./ledger/leader ./consensus/leaderthreshold`
- Conformance was attempted but the runner was terminated by the execution
  environment before producing an exit status.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Praos leader threshold calculation to use the ceiling from `consensus.CertifiedNatThresholdWithMode` directly, removing an extra ceiling adjustment that caused fractional boundary tests to fail on all platforms. The exact integer cutoff remains rejected.

<sup>Written for commit 44ae9aadb6222eb8049ac0bc81c10a02194dcbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

