### PR TITLE
fix(leaderthreshold): stop rounding the leader threshold up twice

### DIFF
--- a/consensus/leaderthreshold/threshold.go
+++ b/consensus/leaderthreshold/threshold.go
@@ -23,124 +23,21 @@ import (
 // Threshold returns the integer comparison threshold for the Praos leader
 // rule. The ledger rule compares the real-valued certified-natural ratio
 // strictly against 1-(1-f)^sigma. For an integer leader value v, that is
-// equivalent to v < ceil(certNatMax*(1-(1-f)^sigma)), not v < floor(...).
+// equivalent to v < ceil(certNatMax*(1-(1-f)^sigma)).
 //
-// The gouroboros version used by Dingo currently returns floor(...). Keep its
-// rigorously calculated value as the base, and raise it by one only when exact
-// rational arithmetic proves the real cutoff is not an integer. When the
-// cutoff is integral, the returned floor is retained so the exact boundary is
-// still rejected.
+// consensus.CertifiedNatThresholdWithMode returns that ceiling, so its value
+// is used unchanged. Adding to it would admit the ceiling itself, which the
+// real-valued rule rejects.
 func Threshold(
 	poolStake uint64,
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 	mode consensus.ConsensusMode,
 ) (*big.Int, error) {
-	threshold, err := consensus.CertifiedNatThresholdWithMode(
+	return consensus.CertifiedNatThresholdWithMode(
 		poolStake,
 		totalStake,
 		activeSlotCoeff,
 		mode,
 	)
-	if err != nil {
-		return nil, err
-	}
-	if cutoffIsInteger(poolStake, totalStake, activeSlotCoeff, mode) {
-		return threshold, nil
-	}
-	return new(big.Int).Add(threshold, big.NewInt(1)), nil
-}
-
-// cutoffIsInteger proves whether the real cutoff is an integer for the
-// rational protocol inputs Dingo has available. If sigma's reduced exponent
-// does not make (1-f)^sigma rational, the cutoff is irrational and therefore
-// cannot be an integer. The rational case is evaluated exactly.
-func cutoffIsInteger(
-	poolStake uint64,
-	totalStake uint64,
-	activeSlotCoeff *big.Rat,
-	mode consensus.ConsensusMode,
-) bool {
-	if activeSlotCoeff == nil || activeSlotCoeff.Sign() <= 0 ||
-		totalStake == 0 || poolStake == 0 {
-		return true
-	}
-	if activeSlotCoeff.Cmp(big.NewRat(1, 1)) >= 0 {
-		// f == 1 has cutoff certNatMax. f > 1 is rejected by the
-		// underlying threshold helper before this result is used.
-		return true
-	}
-	if poolStake > totalStake {
-		poolStake = totalStake
-	}
-
-	sigma := new(big.Rat).SetFrac(
-		new(big.Int).SetUint64(poolStake),
-		new(big.Int).SetUint64(totalStake),
-	)
-	rootDegree := sigma.Denom()
-	if !rootDegree.IsUint64() {
-		return false
-	}
-	rootDegreeUint := rootDegree.Uint64()
-	oneMinusF := new(big.Rat).Sub(big.NewRat(1, 1), activeSlotCoeff)
-	rootNumerator, ok := exactNthRoot(oneMinusF.Num(), rootDegreeUint)
-	if !ok {
-		return false
-	}
-	rootDenominator, ok := exactNthRoot(oneMinusF.Denom(), rootDegreeUint)
-	if !ok {
-		return false
-	}
-
-	power := new(big.Rat).SetFrac(
-		new(big.Int).Exp(rootNumerator, sigma.Num(), nil),
-		new(big.Int).Exp(rootDenominator, sigma.Num(), nil),
-	)
-	probability := new(big.Rat).Sub(big.NewRat(1, 1), power)
-	upperBound := new(big.Int).Lsh(big.NewInt(1), 256)
-	if mode == consensus.ConsensusModeTPraos {
-		upperBound.Lsh(big.NewInt(1), 512)
-	}
-	cutoffNumerator := new(big.Int).Mul(upperBound, probability.Num())
-	remainder := new(big.Int)
-	new(big.Int).QuoRem(cutoffNumerator, probability.Denom(), remainder)
-	return remainder.Sign() == 0
-}
-
-// exactNthRoot reports an integer nth root only when the input is a perfect
-// power. Protocol stake denominators are at most 64 bits; avoiding a search
-// for degrees larger than the input's bit length keeps adversarial inputs
-// bounded while preserving the exact proof.
-func exactNthRoot(value *big.Int, degree uint64) (*big.Int, bool) {
-	if value.Sign() < 0 || degree == 0 {
-		return nil, false
-	}
-	if value.Sign() == 0 || value.Cmp(big.NewInt(1)) == 0 || degree == 1 {
-		return new(big.Int).Set(value), true
-	}
-	if degree > uint64(value.BitLen()) { //nolint:gosec // BitLen is non-negative.
-		return nil, false
-	}
-
-	low := big.NewInt(1)
-	high := new(big.Int).Lsh(
-		big.NewInt(1),
-		uint((uint64(value.BitLen())+degree-1)/degree), //nolint:gosec // bounded by BitLen.
-	)
-	for low.Cmp(high) < 0 {
-		mid := new(big.Int).Add(low, high)
-		mid.Rsh(mid, 1)
-		power := new(big.Int).Exp(mid, new(big.Int).SetUint64(degree), nil)
-		if power.Cmp(value) < 0 {
-			low.Add(mid, big.NewInt(1))
-		} else {
-			high.Set(mid)
-		}
-	}
-	if new(big.Int).Exp(low, new(big.Int).SetUint64(degree), nil).
-		Cmp(value) != 0 {
-		return nil, false
-	}
-	return low, true
 }


### PR DESCRIPTION
Fixes #4021.

`leaderthreshold.Threshold` added one to `consensus.CertifiedNatThresholdWithMode`
whenever exact rational arithmetic showed the real cutoff was not an integer. That
compensated for gouroboros v0.202.8, which returned `floor(T)`.

gouroboros v0.202.9 (`e5261b1`, #2192) changed the function to return `ceil(T)`:

```
-// integer threshold floor(upperBound * (1-(1-f)^sigma)) computed via
+// integer comparison threshold ceil(upperBound * (1-(1-f)^sigma)) computed
```

Since `main` adopted v0.202.10 the increment is applied on top of a ceiling, so
the comparison threshold is one too large and `certNat < threshold` admits the
ceiling itself, which the real-valued rule rejects.

Measured for f=1/3, poolStake=1, totalStake=1, relative to `floor(2^bits/3)`:

| | CPraos (256) | TPraos (512) |
|---|---|---|
| `CertifiedNatThresholdWithMode` | floor + 1 | floor + 1 |
| `Threshold` before | floor + 2 | floor + 2 |
| `Threshold` after | floor + 1 | floor + 1 |

For an integer leader value `v` and non-integer `T`, `v < T` iff `v <= floor(T)`
iff `v < ceil(T)`; for integer `T`, `ceil(T) == T`. The upstream value is therefore
correct on both paths and is now returned unchanged.

`cutoffIsInteger` and `exactNthRoot` existed only to decide that increment and have
no other callers or tests, so they are removed.

Verification:

- `go test ./ledger/leader/`: exit 0, `ok ... 2.319s`
- reverting the fix in place: exit 1, `TestThresholdPreservesProtocolBoundary/cpraos_fractional_cutoff_admits_its_floor` and `/tpraos_fractional_cutoff_admits_its_floor` fail
- `go test ./ledger/ ./ledger/leader/ ./consensus/...`: exit 0
- `golangci-lint run ./consensus/... ./ledger/...`: 0 issues

`TestThresholdPreservesProtocolBoundary` was added by #3897 alongside the code it
tests and has never passed on `main`; #3897 was green because it was pinned to
v0.202.8, and #4006 adopted v0.202.10 four minutes before it merged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4021. Stops rounding the leader threshold up twice so the protocol boundary is no longer admitted. `leaderthreshold.Threshold` added 1 to `consensus.CertifiedNatThresholdWithMode` to compensate for gouroboros v0.202.8 returning `floor(T)`, but since v0.202.9 that function returns `ceil(T)`, so the increment made the threshold one too large and admitted the ceiling itself. The upstream value is now returned unchanged, and the `cutoffIsInteger` and `exactNthRoot` helpers that existed only to decide that increment are removed.

<sup>Written for commit 96f39d8d2b5dd5b5a49a5dc3f875fb8557432410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

