### PR TITLE
fix(ledgerstate): validate imported committee state

### DIFF
--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1987,6 +1987,13 @@ type ParsedGovState struct {
 	Proposals            []ParsedGovProposal
 	PrevGovActionIds     *ParsedPrevGovActionIds
 	RatifiedGovActionIds []ParsedGovActionId
+	// EnactCommittee and EnactCommitteeQuorum are the committee values
+	// carried by RatifyState.rsEnactState.  This is the state already
+	// enacted at the snapshot boundary, independent of rsEnacted (which
+	// is applied at the next boundary).
+	EnactCommittee       []ParsedCommitteeMember
+	EnactCommitteeQuorum *cbor.Rat
+	EnactCommitteeSet    bool
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -2064,7 +2071,7 @@ func ParseGovState(
 	result.PrevGovActionIds = prevIds
 
 	if len(fields) >= 7 {
-		ratifiedIds, err := parseDRepPulsingStateRatifiedIds(
+		enactCommittee, enactQuorum, enactSet, ratifiedIds, err := parseDRepPulsingState(
 			fields[6],
 		)
 		if err != nil {
@@ -2072,6 +2079,9 @@ func ParseGovState(
 				"parsing drep pulsing state: %w", err,
 			))
 		}
+		result.EnactCommittee = enactCommittee
+		result.EnactCommitteeQuorum = enactQuorum
+		result.EnactCommitteeSet = enactSet
 		result.RatifiedGovActionIds = ratifiedIds
 	}
 
@@ -2360,23 +2370,23 @@ func parseProposals(data []byte) (
 // The enacted field is a sequence of GovActionState values in the same
 // representation used by cgsProposals, so parseGovActionState can
 // recover the exact action IDs without decoding the full enact state.
-func parseDRepPulsingStateRatifiedIds(
+func parseDRepPulsingState(
 	data []byte,
-) ([]ParsedGovActionId, error) {
+) ([]ParsedCommitteeMember, *cbor.Rat, bool, []ParsedGovActionId, error) {
 	if len(data) == 0 {
-		return nil, nil
+		return nil, nil, false, nil, nil
 	}
 	fields, err := decodeRawArray(data)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, false, nil, fmt.Errorf(
 			"decoding DRepPulsingState: %w", err,
 		)
 	}
 	if len(fields) == 0 {
-		return nil, nil
+		return nil, nil, false, nil, nil
 	}
 	if len(fields) < 2 {
-		return nil, fmt.Errorf(
+		return nil, nil, false, nil, fmt.Errorf(
 			"DRepPulsingState has %d elements, expected 2",
 			len(fields),
 		)
@@ -2384,25 +2394,38 @@ func parseDRepPulsingStateRatifiedIds(
 
 	ratifyState, err := decodeRawArray(fields[1])
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, nil, false, nil, fmt.Errorf(
 			"decoding RatifyState: %w", err,
 		)
 	}
 	if len(ratifyState) < 2 {
-		return nil, fmt.Errorf(
+		return nil, nil, false, nil, fmt.Errorf(
 			"RatifyState has %d elements, expected 4",
 			len(ratifyState),
 		)
 	}
+	var committee []ParsedCommitteeMember
+	var quorum *cbor.Rat
+	committeeSet := false
+	var errs []error
+	enactFields, enactErr := decodeRawArray(ratifyState[0])
+	if enactErr != nil {
+		errs = append(errs, fmt.Errorf("decoding RatifyState enact state: %w", enactErr))
+	} else if len(enactFields) > 0 {
+		committeeSet = true
+		committee, quorum, enactErr = parseCommittee(enactFields[0])
+		if enactErr != nil {
+			errs = append(errs, fmt.Errorf("decoding enact-state committee: %w", enactErr))
+		}
+	}
 
 	enacted, err := decodeRawArray(ratifyState[1])
 	if err != nil {
-		return nil, fmt.Errorf(
+		return committee, quorum, committeeSet, nil, errors.Join(append(errs, fmt.Errorf(
 			"decoding RatifyState enacted proposals: %w", err,
-		)
+		))...)
 	}
 	ratifiedIds := make([]ParsedGovActionId, 0, len(enacted))
-	var errs []error
 	for _, item := range enacted {
 		prop, err := parseGovActionState(item)
 		if err != nil {
@@ -2417,7 +2440,14 @@ func parseDRepPulsingStateRatifiedIds(
 		})
 	}
 
-	return ratifiedIds, errors.Join(errs...)
+	return committee, quorum, committeeSet, ratifiedIds, errors.Join(errs...)
+}
+
+// parseDRepPulsingStateRatifiedIds is retained for callers that only need
+// rsEnacted action IDs.
+func parseDRepPulsingStateRatifiedIds(data []byte) ([]ParsedGovActionId, error) {
+	_, _, _, ids, err := parseDRepPulsingState(data)
+	return ids, err
 }
 
 // parseProposalsRoots decodes the GovRelation StrictMaybe at the

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -2074,7 +2074,7 @@ func ParseGovState(
 	result.PrevGovActionIds = prevIds
 
 	if len(fields) >= 7 {
-		enactCommittee, enactQuorum, enactSet, ratifiedIds, err := parseDRepPulsingState(
+		enactCommittee, enactQuorum, enactSet, ratifiedIds, committeeErr, err := parseDRepPulsingState(
 			fields[6],
 		)
 		if err != nil {
@@ -2085,8 +2085,8 @@ func ParseGovState(
 		result.EnactCommittee = enactCommittee
 		result.EnactCommitteeQuorum = enactQuorum
 		result.EnactCommitteeSet = enactSet
-		if err != nil {
-			result.EnactCommitteeParseError = err
+		if committeeErr != nil {
+			result.EnactCommitteeParseError = committeeErr
 		}
 		result.RatifiedGovActionIds = ratifiedIds
 	}
@@ -2378,64 +2378,65 @@ func parseProposals(data []byte) (
 // recover the exact action IDs without decoding the full enact state.
 func parseDRepPulsingState(
 	data []byte,
-) ([]ParsedCommitteeMember, *cbor.Rat, bool, []ParsedGovActionId, error) {
+) ([]ParsedCommitteeMember, *cbor.Rat, bool, []ParsedGovActionId, error, error) {
 	if len(data) == 0 {
-		return nil, nil, false, nil, nil
+		return nil, nil, false, nil, nil, nil
 	}
 	fields, err := decodeRawArray(data)
 	if err != nil {
 		return nil, nil, false, nil, fmt.Errorf(
 			"decoding DRepPulsingState: %w", err,
-		)
+		), nil
 	}
 	if len(fields) == 0 {
-		return nil, nil, false, nil, nil
+		return nil, nil, false, nil, nil, nil
 	}
 	if len(fields) < 2 {
 		return nil, nil, false, nil, fmt.Errorf(
 			"DRepPulsingState has %d elements, expected 2",
 			len(fields),
-		)
+		), nil
 	}
 
 	ratifyState, err := decodeRawArray(fields[1])
 	if err != nil {
 		return nil, nil, false, nil, fmt.Errorf(
 			"decoding RatifyState: %w", err,
-		)
+		), nil
 	}
 	if len(ratifyState) < 2 {
 		return nil, nil, false, nil, fmt.Errorf(
 			"RatifyState has %d elements, expected 4",
 			len(ratifyState),
-		)
+		), nil
 	}
 	var committee []ParsedCommitteeMember
 	var quorum *cbor.Rat
 	committeeSet := false
-	var errs []error
+	var committeeErr error
+	var idErrs []error
 	enactFields, enactErr := decodeRawArray(ratifyState[0])
 	if enactErr != nil {
-		errs = append(errs, fmt.Errorf("decoding RatifyState enact state: %w", enactErr))
+		committeeErr = fmt.Errorf("decoding RatifyState enact state: %w", enactErr)
 	} else if len(enactFields) > 0 {
 		committeeSet = true
 		committee, quorum, enactErr = parseCommittee(enactFields[0])
 		if enactErr != nil {
-			errs = append(errs, fmt.Errorf("decoding enact-state committee: %w", enactErr))
+			committeeErr = fmt.Errorf("decoding enact-state committee: %w", enactErr)
 		}
 	}
 
 	enacted, err := decodeRawArray(ratifyState[1])
 	if err != nil {
-		return committee, quorum, committeeSet, nil, errors.Join(append(errs, fmt.Errorf(
+		return committee, quorum, committeeSet, nil, committeeErr, fmt.Errorf(
 			"decoding RatifyState enacted proposals: %w", err,
-		))...)
+		)
 	}
 	ratifiedIds := make([]ParsedGovActionId, 0, len(enacted))
 	for _, item := range enacted {
 		prop, err := parseGovActionState(item)
 		if err != nil {
-			errs = append(errs, fmt.Errorf(
+			idErrs = append(idErrs, fmt.Errorf(
 				"decoding enacted proposal: %w", err,
 			))
 			continue
@@ -2446,7 +2447,7 @@ func parseDRepPulsingState(
 		})
 	}
 
-	return committee, quorum, committeeSet, ratifiedIds, errors.Join(errs...)
+	return committee, quorum, committeeSet, ratifiedIds, committeeErr, errors.Join(idErrs...)
 }
 
 // parseProposalsRoots decodes the GovRelation StrictMaybe at the

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1984,6 +1984,7 @@ type ParsedGovState struct {
 	Constitution         *ParsedConstitution
 	Committee            []ParsedCommitteeMember
 	CommitteeQuorum      *cbor.Rat
+	CommitteeParseError  error
 	Proposals            []ParsedGovProposal
 	PrevGovActionIds     *ParsedPrevGovActionIds
 	RatifiedGovActionIds []ParsedGovActionId
@@ -1991,9 +1992,10 @@ type ParsedGovState struct {
 	// carried by RatifyState.rsEnactState.  This is the state already
 	// enacted at the snapshot boundary, independent of rsEnacted (which
 	// is applied at the next boundary).
-	EnactCommittee       []ParsedCommitteeMember
-	EnactCommitteeQuorum *cbor.Rat
-	EnactCommitteeSet    bool
+	EnactCommittee           []ParsedCommitteeMember
+	EnactCommitteeQuorum     *cbor.Rat
+	EnactCommitteeSet        bool
+	EnactCommitteeParseError error
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -2053,6 +2055,7 @@ func ParseGovState(
 	// Parse committee (field 1) — best-effort
 	committee, quorum, err := parseCommittee(fields[1])
 	if err != nil {
+		result.CommitteeParseError = err
 		warnings = append(warnings, fmt.Errorf(
 			"parsing committee: %w", err,
 		))
@@ -2082,6 +2085,9 @@ func ParseGovState(
 		result.EnactCommittee = enactCommittee
 		result.EnactCommitteeQuorum = enactQuorum
 		result.EnactCommitteeSet = enactSet
+		if err != nil {
+			result.EnactCommitteeParseError = err
+		}
 		result.RatifiedGovActionIds = ratifiedIds
 	}
 
@@ -2441,13 +2447,6 @@ func parseDRepPulsingState(
 	}
 
 	return committee, quorum, committeeSet, ratifiedIds, errors.Join(errs...)
-}
-
-// parseDRepPulsingStateRatifiedIds is retained for callers that only need
-// rsEnacted action IDs.
-func parseDRepPulsingStateRatifiedIds(data []byte) ([]ParsedGovActionId, error) {
-	_, _, _, ids, err := parseDRepPulsingState(data)
-	return ids, err
 }
 
 // parseProposalsRoots decodes the GovRelation StrictMaybe at the

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -1988,14 +1988,47 @@ type ParsedGovState struct {
 	Proposals            []ParsedGovProposal
 	PrevGovActionIds     *ParsedPrevGovActionIds
 	RatifiedGovActionIds []ParsedGovActionId
-	// EnactCommittee and EnactCommitteeQuorum are the committee values
-	// carried by RatifyState.rsEnactState.  This is the state already
-	// enacted at the snapshot boundary, independent of rsEnacted (which
-	// is applied at the next boundary).
-	EnactCommittee           []ParsedCommitteeMember
-	EnactCommitteeQuorum     *cbor.Rat
-	EnactCommitteeSet        bool
-	EnactCommitteeParseError error
+	// EnactCommittee and EnactCommitteeQuorum are the committee carried
+	// by RatifyState.rsEnactState. That is not a second copy of
+	// cgsCommittee: RATIFY folds every accepted action into rsEnactState
+	// and ConwayEPOCH copies the result into cgsCommittee at the next
+	// epoch boundary. See EnactedCommitteeChange.
+	EnactCommittee       []ParsedCommitteeMember
+	EnactCommitteeQuorum *cbor.Rat
+	// EnactCommitteeSet reports that cgsDRepPulsingState was present and
+	// decoded far enough to yield rsEnactState's committee field.
+	EnactCommitteeSet bool
+	// EnactedCommitteeChange reports that RatifyState.rsEnacted carries
+	// an action whose enactment rewrites EnactState.ensCommittee, namely
+	// NoConfidence (which clears it) or UpdateCommittee. Those are the
+	// only two, so cgsCommittee and EnactCommittee are required to agree
+	// only when this is false.
+	EnactedCommitteeChange bool
+	// EnactedActionTypesUnknown reports that at least one rsEnacted
+	// proposal could not be decoded, so EnactedCommitteeChange is a
+	// lower bound rather than the full answer.
+	EnactedActionTypesUnknown bool
+	// PulsingStateParseError is set when cgsDRepPulsingState could not be
+	// decoded far enough to recover rsEnactState's committee. Fatal for an
+	// import: the imported committee then has no second view to
+	// corroborate it.
+	PulsingStateParseError error
+}
+
+// parsedPulsingState holds the parts of cgsDRepPulsingState the importer
+// consumes. Its committee error is a named field rather than a second
+// bare return value because the two error channels are not
+// interchangeable: CommitteeErr is fail-closed, while a failure to decode
+// an individual rsEnacted proposal is warning-grade and is returned as
+// the bare error alongside the struct.
+type parsedPulsingState struct {
+	EnactCommittee            []ParsedCommitteeMember
+	EnactCommitteeQuorum      *cbor.Rat
+	EnactCommitteeSet         bool
+	EnactedCommitteeChange    bool
+	EnactedActionTypesUnknown bool
+	RatifiedGovActionIds      []ParsedGovActionId
+	CommitteeErr              error
 }
 
 // ParseGovState decodes governance state from raw CBOR.
@@ -2073,22 +2106,41 @@ func ParseGovState(
 	result.Proposals = proposals
 	result.PrevGovActionIds = prevIds
 
-	if len(fields) >= 7 {
-		enactCommittee, enactQuorum, enactSet, ratifiedIds, committeeErr, err := parseDRepPulsingState(
-			fields[6],
-		)
+	// ConwayGovState encodes exactly seven fields, so a shorter record is
+	// malformed. It is reported as a warning rather than rejected here
+	// because field-count enforcement for the whole record belongs with
+	// GovState shape validation, not with the committee corroboration
+	// below; a truncated record simply leaves EnactCommitteeSet false and
+	// the corroboration unavailable.
+	if len(fields) < 7 {
+		warnings = append(warnings, fmt.Errorf(
+			"GovState has %d elements, expected 7; "+
+				"cgsDRepPulsingState is absent",
+			len(fields),
+		))
+	} else {
+		pulsing, err := parseDRepPulsingState(fields[6])
 		if err != nil {
 			warnings = append(warnings, fmt.Errorf(
 				"parsing drep pulsing state: %w", err,
 			))
 		}
-		result.EnactCommittee = enactCommittee
-		result.EnactCommitteeQuorum = enactQuorum
-		result.EnactCommitteeSet = enactSet
-		if committeeErr != nil {
-			result.EnactCommitteeParseError = committeeErr
+		result.EnactCommittee = pulsing.EnactCommittee
+		result.EnactCommitteeQuorum = pulsing.EnactCommitteeQuorum
+		result.EnactCommitteeSet = pulsing.EnactCommitteeSet
+		result.EnactedCommitteeChange = pulsing.EnactedCommitteeChange
+		result.EnactedActionTypesUnknown = pulsing.EnactedActionTypesUnknown
+		result.RatifiedGovActionIds = pulsing.RatifiedGovActionIds
+		if pulsing.CommitteeErr != nil {
+			// Keep the dedicated field for the importer's fail-closed
+			// check and surface it through the returned error so every
+			// caller of this exported function still sees the failure.
+			result.PulsingStateParseError = pulsing.CommitteeErr
+			warnings = append(warnings, fmt.Errorf(
+				"parsing drep pulsing state: %w",
+				pulsing.CommitteeErr,
+			))
 		}
-		result.RatifiedGovActionIds = ratifiedIds
 	}
 
 	return result, errors.Join(warnings...)
@@ -2376,78 +2428,111 @@ func parseProposals(data []byte) (
 // The enacted field is a sequence of GovActionState values in the same
 // representation used by cgsProposals, so parseGovActionState can
 // recover the exact action IDs without decoding the full enact state.
+//
+// Every shape below the top-level array is fixed in Conway, so a
+// missing or short element is malformed input rather than an optional
+// encoding: DRepPulsingState always encodes two elements (a pulsing
+// pulser is completed before being written), RatifyState always four,
+// and EnactState always seven with the committee first. Those shapes are
+// therefore recorded in CommitteeErr, which the importer treats as
+// fatal, instead of being skipped silently.
 func parseDRepPulsingState(
 	data []byte,
-) ([]ParsedCommitteeMember, *cbor.Rat, bool, []ParsedGovActionId, error, error) {
+) (parsedPulsingState, error) {
+	var result parsedPulsingState
 	if len(data) == 0 {
-		return nil, nil, false, nil, nil, nil
+		result.CommitteeErr = errors.New(
+			"DRepPulsingState is empty",
+		)
+		return result, nil
 	}
 	fields, err := decodeRawArray(data)
 	if err != nil {
-		return nil, nil, false, nil, fmt.Errorf(
+		result.CommitteeErr = fmt.Errorf(
 			"decoding DRepPulsingState: %w", err,
-		), nil
-	}
-	if len(fields) == 0 {
-		return nil, nil, false, nil, nil, nil
+		)
+		return result, nil
 	}
 	if len(fields) < 2 {
-		return nil, nil, false, nil, fmt.Errorf(
+		result.CommitteeErr = fmt.Errorf(
 			"DRepPulsingState has %d elements, expected 2",
 			len(fields),
-		), nil
+		)
+		return result, nil
 	}
 
 	ratifyState, err := decodeRawArray(fields[1])
 	if err != nil {
-		return nil, nil, false, nil, fmt.Errorf(
+		result.CommitteeErr = fmt.Errorf(
 			"decoding RatifyState: %w", err,
-		), nil
+		)
+		return result, nil
 	}
 	if len(ratifyState) < 2 {
-		return nil, nil, false, nil, fmt.Errorf(
+		result.CommitteeErr = fmt.Errorf(
 			"RatifyState has %d elements, expected 4",
 			len(ratifyState),
-		), nil
+		)
+		return result, nil
 	}
-	var committee []ParsedCommitteeMember
-	var quorum *cbor.Rat
-	committeeSet := false
-	var committeeErr error
-	var idErrs []error
-	enactFields, enactErr := decodeRawArray(ratifyState[0])
-	if enactErr != nil {
-		committeeErr = fmt.Errorf("decoding RatifyState enact state: %w", enactErr)
-	} else if len(enactFields) > 0 {
-		committeeSet = true
-		committee, quorum, enactErr = parseCommittee(enactFields[0])
-		if enactErr != nil {
-			committeeErr = fmt.Errorf("decoding enact-state committee: %w", enactErr)
-		}
+
+	enactFields, err := decodeRawArray(ratifyState[0])
+	if err != nil {
+		result.CommitteeErr = fmt.Errorf(
+			"decoding RatifyState enact state: %w", err,
+		)
+		return result, nil
 	}
+	if len(enactFields) == 0 {
+		result.CommitteeErr = errors.New(
+			"RatifyState enact state has 0 elements, expected 7",
+		)
+		return result, nil
+	}
+	committee, quorum, err := parseCommittee(enactFields[0])
+	if err != nil {
+		result.CommitteeErr = fmt.Errorf(
+			"decoding enact-state committee: %w", err,
+		)
+		return result, nil
+	}
+	result.EnactCommittee = committee
+	result.EnactCommitteeQuorum = quorum
+	result.EnactCommitteeSet = true
 
 	enacted, err := decodeRawArray(ratifyState[1])
 	if err != nil {
-		return committee, quorum, committeeSet, nil, committeeErr, fmt.Errorf(
+		result.EnactedActionTypesUnknown = true
+		return result, fmt.Errorf(
 			"decoding RatifyState enacted proposals: %w", err,
 		)
 	}
+	var idErrs []error
 	ratifiedIds := make([]ParsedGovActionId, 0, len(enacted))
 	for _, item := range enacted {
 		prop, err := parseGovActionState(item)
 		if err != nil {
+			// The action type is unrecoverable for this entry, so
+			// whether a committee action was enacted is no longer
+			// decidable from rsEnacted.
+			result.EnactedActionTypesUnknown = true
 			idErrs = append(idErrs, fmt.Errorf(
 				"decoding enacted proposal: %w", err,
 			))
 			continue
+		}
+		if prop.ActionType == govActionTypeNoConfidence ||
+			prop.ActionType == govActionTypeUpdateCommittee {
+			result.EnactedCommitteeChange = true
 		}
 		ratifiedIds = append(ratifiedIds, ParsedGovActionId{
 			TxHash:      append([]byte(nil), prop.TxHash...),
 			ActionIndex: prop.ActionIndex,
 		})
 	}
+	result.RatifiedGovActionIds = ratifiedIds
 
-	return committee, quorum, committeeSet, ratifiedIds, committeeErr, errors.Join(idErrs...)
+	return result, errors.Join(idErrs...)
 }
 
 // parseProposalsRoots decodes the GovRelation StrictMaybe at the

--- a/ledgerstate/certstate.go
+++ b/ledgerstate/certstate.go
@@ -2113,10 +2113,14 @@ func ParseGovState(
 	// below; a truncated record simply leaves EnactCommitteeSet false and
 	// the corroboration unavailable.
 	if len(fields) < 7 {
-		warnings = append(warnings, fmt.Errorf(
+		result.PulsingStateParseError = fmt.Errorf(
 			"GovState has %d elements, expected 7; "+
 				"cgsDRepPulsingState is absent",
 			len(fields),
+		)
+		warnings = append(warnings, fmt.Errorf(
+			"parsing drep pulsing state: %w",
+			result.PulsingStateParseError,
 		))
 	} else {
 		pulsing, err := parseDRepPulsingState(fields[6])
@@ -2162,7 +2166,7 @@ func parseConstitution(data []byte) (
 			"decoding constitution: %w", err,
 		)
 	}
-	if len(fields) < 2 {
+	if len(fields) != 2 {
 		return nil, fmt.Errorf(
 			"constitution has %d elements, expected 2",
 			len(fields),
@@ -2468,7 +2472,7 @@ func parseDRepPulsingState(
 		)
 		return result, nil
 	}
-	if len(ratifyState) < 2 {
+	if len(ratifyState) != 4 {
 		result.CommitteeErr = fmt.Errorf(
 			"RatifyState has %d elements, expected 4",
 			len(ratifyState),
@@ -2483,9 +2487,10 @@ func parseDRepPulsingState(
 		)
 		return result, nil
 	}
-	if len(enactFields) == 0 {
-		result.CommitteeErr = errors.New(
-			"RatifyState enact state has 0 elements, expected 7",
+	if len(enactFields) != 7 {
+		result.CommitteeErr = fmt.Errorf(
+			"RatifyState enact state has %d elements, expected 7",
+			len(enactFields),
 		)
 		return result, nil
 	}

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -3149,6 +3149,12 @@ func importGovState(
 	if govState == nil {
 		return nil
 	}
+	if govState.CommitteeParseError != nil {
+		return fmt.Errorf("parsing imported committee: %w", govState.CommitteeParseError)
+	}
+	if govState.EnactCommitteeParseError != nil {
+		return fmt.Errorf("parsing imported enact-state committee: %w", govState.EnactCommitteeParseError)
+	}
 	if err != nil {
 		// Non-fatal warnings from committee/proposals parsing
 		cfg.Logger.Warn(

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -2845,7 +2845,6 @@ func validateImportedRewardPParams(
 			currentEpoch,
 		)
 	}
-
 	store := cfg.Database.Metadata()
 	currentAvailable, err := importedPParamsAvailable(
 		store,
@@ -3158,6 +3157,18 @@ func importGovState(
 			"error", err,
 		)
 	}
+	// Conway serializes the already-active committee in both cgsCommittee
+	// and RatifyState.rsEnactState. Refuse a partial import if those views
+	// disagree: rsEnacted is the *next* boundary's work and must not be
+	// applied here as a workaround for inconsistent snapshot state.
+	if govState.EnactCommitteeSet && !committeeStatesEqual(
+		govState.Committee, govState.CommitteeQuorum,
+		govState.EnactCommittee, govState.EnactCommitteeQuorum,
+	) {
+		return errors.New(
+			"governance committee disagrees between cgsCommittee and rsEnactState",
+		)
+	}
 
 	store := cfg.Database.Metadata()
 	currentEpochSlot := snapshotEpochAnchorSlot(
@@ -3429,6 +3440,38 @@ func importGovState(
 	})
 
 	return nil
+}
+
+func committeeStatesEqual(
+	left []ParsedCommitteeMember,
+	leftQuorum *cbor.Rat,
+	right []ParsedCommitteeMember,
+	rightQuorum *cbor.Rat,
+) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftMembers := append([]ParsedCommitteeMember(nil), left...)
+	rightMembers := append([]ParsedCommitteeMember(nil), right...)
+	sort.Slice(leftMembers, func(i, j int) bool {
+		return committeeMemberKey(leftMembers[i]) < committeeMemberKey(leftMembers[j])
+	})
+	sort.Slice(rightMembers, func(i, j int) bool {
+		return committeeMemberKey(rightMembers[i]) < committeeMemberKey(rightMembers[j])
+	})
+	for i := range leftMembers {
+		if committeeMemberKey(leftMembers[i]) != committeeMemberKey(rightMembers[i]) {
+			return false
+		}
+	}
+	if (leftQuorum == nil) != (rightQuorum == nil) {
+		return false
+	}
+	return leftQuorum == nil || leftQuorum.Rat.Cmp(rightQuorum.Rat) == 0
+}
+
+func committeeMemberKey(member ParsedCommitteeMember) string {
+	return fmt.Sprintf("%d:%x:%d", member.ColdCredential.Type, member.ColdCredential.Hash, member.ExpiresEpoch)
 }
 
 func persistImportedCommitteeCertificates(

--- a/ledgerstate/import.go
+++ b/ledgerstate/import.go
@@ -3150,10 +3150,16 @@ func importGovState(
 		return nil
 	}
 	if govState.CommitteeParseError != nil {
-		return fmt.Errorf("parsing imported committee: %w", govState.CommitteeParseError)
+		return fmt.Errorf(
+			"parsing imported committee: %w",
+			govState.CommitteeParseError,
+		)
 	}
-	if govState.EnactCommitteeParseError != nil {
-		return fmt.Errorf("parsing imported enact-state committee: %w", govState.EnactCommitteeParseError)
+	if govState.PulsingStateParseError != nil {
+		return fmt.Errorf(
+			"parsing imported governance pulsing state: %w",
+			govState.PulsingStateParseError,
+		)
 	}
 	if err != nil {
 		// Non-fatal warnings from committee/proposals parsing
@@ -3163,16 +3169,28 @@ func importGovState(
 			"error", err,
 		)
 	}
-	// Conway serializes the already-active committee in both cgsCommittee
-	// and RatifyState.rsEnactState. Refuse a partial import if those views
-	// disagree: rsEnacted is the *next* boundary's work and must not be
-	// applied here as a workaround for inconsistent snapshot state.
-	if govState.EnactCommitteeSet && !committeeStatesEqual(
-		govState.Committee, govState.CommitteeQuorum,
-		govState.EnactCommittee, govState.EnactCommitteeQuorum,
-	) {
+	// cgsCommittee is the committee in force at the snapshot.
+	// RatifyState.rsEnactState is not a second copy of it: RATIFY folds
+	// every accepted action into rsEnactState via ENACT
+	// (cardano-ledger Conway/Rules/Ratify.hs, ratifyTransition), and
+	// ConwayEPOCH copies the result into cgsCommittee at the *next*
+	// boundary (Conway/Rules/Epoch.hs, "cgsCommitteeL .~ ensCommittee").
+	// Only NoConfidence and UpdateCommittee rewrite ensCommittee
+	// (Conway/Rules/Enact.hs), so the two views corroborate each other
+	// exactly when rsEnacted carries neither. A snapshot from an epoch
+	// that ratified a committee action is expected to disagree, and the
+	// importer records those actions as ratified below so the next
+	// boundary enacts them.
+	if govState.EnactCommitteeSet &&
+		!govState.EnactedCommitteeChange &&
+		!govState.EnactedActionTypesUnknown &&
+		!committeeStatesEqual(
+			govState.Committee, govState.CommitteeQuorum,
+			govState.EnactCommittee, govState.EnactCommitteeQuorum,
+		) {
 		return errors.New(
-			"governance committee disagrees between cgsCommittee and rsEnactState",
+			"governance committee disagrees between cgsCommittee " +
+				"and rsEnactState with no committee action in rsEnacted",
 		)
 	}
 
@@ -3448,6 +3466,11 @@ func importGovState(
 	return nil
 }
 
+// committeeStatesEqual compares two decoded views of the same
+// StrictMaybe (Committee era). The quorum carries the SNothing/SJust
+// distinction: parseCommittee returns a nil quorum only for SNothing, so
+// an absent committee and a seated committee with an empty member map do
+// not compare equal.
 func committeeStatesEqual(
 	left []ParsedCommitteeMember,
 	leftQuorum *cbor.Rat,
@@ -3457,27 +3480,47 @@ func committeeStatesEqual(
 	if len(left) != len(right) {
 		return false
 	}
-	leftMembers := append([]ParsedCommitteeMember(nil), left...)
-	rightMembers := append([]ParsedCommitteeMember(nil), right...)
-	sort.Slice(leftMembers, func(i, j int) bool {
-		return committeeMemberKey(leftMembers[i]) < committeeMemberKey(leftMembers[j])
-	})
-	sort.Slice(rightMembers, func(i, j int) bool {
-		return committeeMemberKey(rightMembers[i]) < committeeMemberKey(rightMembers[j])
-	})
-	for i := range leftMembers {
-		if committeeMemberKey(leftMembers[i]) != committeeMemberKey(rightMembers[i]) {
+	leftKeys := committeeMemberKeys(left)
+	rightKeys := committeeMemberKeys(right)
+	for i := range leftKeys {
+		if leftKeys[i] != rightKeys[i] {
 			return false
 		}
 	}
 	if (leftQuorum == nil) != (rightQuorum == nil) {
 		return false
 	}
-	return leftQuorum == nil || leftQuorum.Rat.Cmp(rightQuorum.Rat) == 0
+	if leftQuorum == nil {
+		return true
+	}
+	if (leftQuorum.Rat == nil) != (rightQuorum.Rat == nil) {
+		return false
+	}
+	if leftQuorum.Rat == nil {
+		return true
+	}
+	return leftQuorum.Cmp(rightQuorum.Rat) == 0
+}
+
+// committeeMemberKeys renders each member as a sortable key and returns
+// them ordered, so the comparison does not depend on the order the CBOR
+// member map was decoded in.
+func committeeMemberKeys(members []ParsedCommitteeMember) []string {
+	keys := make([]string, 0, len(members))
+	for _, member := range members {
+		keys = append(keys, committeeMemberKey(member))
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func committeeMemberKey(member ParsedCommitteeMember) string {
-	return fmt.Sprintf("%d:%x:%d", member.ColdCredential.Type, member.ColdCredential.Hash, member.ExpiresEpoch)
+	return fmt.Sprintf(
+		"%d:%x:%d",
+		member.ColdCredential.Type,
+		member.ColdCredential.Hash,
+		member.ExpiresEpoch,
+	)
 }
 
 func persistImportedCommitteeCertificates(
@@ -3747,11 +3790,12 @@ func committeeRootActionType(noConfidence bool) uint8 {
 // need to depend on the gouroboros lcommon package — these match the
 // CIP-1694 GovActionType wire values.
 const (
-	govActionTypeParameterChange    uint8 = 0
-	govActionTypeHardForkInitiation uint8 = 1
-	govActionTypeNoConfidence       uint8 = 3
-	govActionTypeUpdateCommittee    uint8 = 4
-	govActionTypeNewConstitution    uint8 = 5
+	govActionTypeParameterChange     uint8 = 0
+	govActionTypeHardForkInitiation  uint8 = 1
+	govActionTypeTreasuryWithdrawals uint8 = 2
+	govActionTypeNoConfidence        uint8 = 3
+	govActionTypeUpdateCommittee     uint8 = 4
+	govActionTypeNewConstitution     uint8 = 5
 )
 
 func snapshotEpochAnchorSlot(

--- a/ledgerstate/import_test.go
+++ b/ledgerstate/import_test.go
@@ -1635,6 +1635,10 @@ func testGovStateData(
 			},
 			nil,
 		},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		drepPulsingStateWithEnactCommittee(t, []any{}),
 	}
 	data, err := cbor.Encode(govState)
 	require.NoError(t, err)

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -207,6 +207,37 @@ func TestParseGovStateCommitteeMatchesEnactState(t *testing.T) {
 	assert.Equal(t, parsed.CommitteeQuorum.Rat, parsed.EnactCommitteeQuorum.Rat)
 }
 
+func TestImportGovStateRejectsCommitteeMismatch(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	left := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
+	right := committeeWithMember(t, bytes.Repeat([]byte{0x43}, 28), 700)
+	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
+	govStateData, err := cbor.Encode([]any{
+		[]any{rootsAny, []any{}},
+		left,
+		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
+		drepPulsingStateWithEnactCommittee(t, right),
+	})
+	require.NoError(t, err)
+	cfg := ImportConfig{
+		Database: db,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) { return 1, 100, nil },
+	}
+	err = importGovState(context.Background(), cfg, func(ImportProgress) {})
+	require.EqualError(t, err,
+		"governance committee disagrees between cgsCommittee and rsEnactState")
+}
+
 func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
 	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
 	require.NoError(t, err)

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -160,6 +160,53 @@ func drepPulsingStateWithRatified(
 	}
 }
 
+func drepPulsingStateWithEnactCommittee(
+	t *testing.T,
+	committee any,
+) any {
+	t.Helper()
+	// RatifyState.rsEnactState is an EnactState whose first field is the
+	// committee StrictMaybe. The remaining fields are irrelevant here, but
+	// are retained to match Conway's seven-field encoding.
+	enactState := []any{committee, nil, nil, nil, nil, nil, nil}
+	return []any{
+		[]any{[]any{}, map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{}},
+		[]any{enactState, []any{}, []any{}, false},
+	}
+}
+
+func committeeWithMember(t *testing.T, hash []byte, expiry uint64) any {
+	t.Helper()
+	// Credential array keys must be kept as raw CBOR map keys; encoding a
+	// Go map with []byte keys would produce a bytestring key instead.
+	key, err := cbor.Encode([]any{uint64(0), hash})
+	require.NoError(t, err)
+	value, err := cbor.Encode(expiry)
+	require.NoError(t, err)
+	memberMap := cbor.RawMessage(append(append([]byte{0xa1}, key...), value...))
+	return []any{[]any{memberMap, cbor.Rat{Rat: big.NewRat(2, 3)}}}
+}
+
+func TestParseGovStateCommitteeMatchesEnactState(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x42}, 28)
+	committee := committeeWithMember(t, hash, 700)
+	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
+	data, err := cbor.Encode([]any{
+		[]any{rootsAny, []any{}},
+		committee,
+		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
+		drepPulsingStateWithEnactCommittee(t, committee),
+	})
+	require.NoError(t, err)
+	parsed, err := ParseGovState(data, EraConway)
+	require.NoError(t, err)
+	require.Len(t, parsed.Committee, 1)
+	require.Len(t, parsed.EnactCommittee, 1)
+	assert.Equal(t, parsed.Committee, parsed.EnactCommittee)
+	assert.Equal(t, parsed.CommitteeQuorum.Rat, parsed.EnactCommitteeQuorum.Rat)
+}
+
 func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
 	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
 	require.NoError(t, err)

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -163,6 +163,7 @@ func drepPulsingStateWithRatified(
 func drepPulsingStateWithEnactCommittee(
 	t *testing.T,
 	committee any,
+	proposals ...any,
 ) any {
 	t.Helper()
 	// RatifyState.rsEnactState is an EnactState whose first field is the
@@ -171,7 +172,7 @@ func drepPulsingStateWithEnactCommittee(
 	enactState := []any{committee, nil, nil, nil, nil, nil, nil}
 	return []any{
 		[]any{[]any{}, map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{}},
-		[]any{enactState, []any{}, []any{}, false},
+		[]any{enactState, proposals, []any{}, false},
 	}
 }
 
@@ -205,6 +206,30 @@ func TestParseGovStateCommitteeMatchesEnactState(t *testing.T) {
 	require.Len(t, parsed.EnactCommittee, 1)
 	assert.Equal(t, parsed.Committee, parsed.EnactCommittee)
 	assert.Equal(t, parsed.CommitteeQuorum.Rat, parsed.EnactCommitteeQuorum.Rat)
+}
+
+func TestParseGovStateEnactProposalWarningDoesNotInvalidateCommittee(t *testing.T) {
+	committee := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
+	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
+	data, err := cbor.Encode([]any{
+		[]any{rootsAny, []any{}}, committee,
+		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
+		drepPulsingStateWithEnactCommittee(t, committee),
+	})
+	require.NoError(t, err)
+	// Keep the active committee valid while making rsEnacted contain a
+	// malformed action. The warning must not become a committee error.
+	data, err = cbor.Encode([]any{
+		[]any{rootsAny, []any{}}, committee,
+		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
+		drepPulsingStateWithEnactCommittee(t, committee, cbor.RawMessage{0x01}),
+	})
+	require.NoError(t, err)
+	parsed, err := ParseGovState(data, EraConway)
+	require.Error(t, err)
+	assert.Nil(t, parsed.EnactCommitteeParseError)
 }
 
 func TestImportGovStateRejectsCommitteeMismatch(t *testing.T) {

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -35,8 +35,8 @@ import (
 // committeePresent: true for a 1-element StrictMaybe Committee
 // wrapper with a 2/3 quorum and empty members; false for SNothing.
 //
-// The shape mirrors testGovStateData but exposes the roots so
-// tests can assert seeding behavior end to end.
+// The shape mirrors Conway's seven-field GovState encoding but exposes the
+// roots so tests can assert seeding behavior end to end.
 func govStateWithRoots(
 	t *testing.T,
 	roots [4]*ParsedGovActionId,
@@ -89,15 +89,18 @@ func govStateWithRootsAndProposals(
 			nil,
 		},
 	}
-	if drepPulsingState != nil {
-		govState = append(
-			govState,
-			map[uint64]uint64{},
-			map[uint64]uint64{},
-			map[uint64]uint64{},
-			drepPulsingState,
+	if drepPulsingState == nil {
+		drepPulsingState = drepPulsingStateWithEnactCommittee(
+			t, committee,
 		)
 	}
+	govState = append(
+		govState,
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		drepPulsingState,
+	)
 	data, err := cbor.Encode(govState)
 	require.NoError(t, err)
 	return data

--- a/ledgerstate/seed_prev_gov_action_ids_test.go
+++ b/ledgerstate/seed_prev_gov_action_ids_test.go
@@ -141,23 +141,23 @@ func govActionStateForTest(
 	}
 }
 
+// snothingCommittee is the StrictMaybe SNothing encoding shared by
+// cgsCommittee and EnactState.ensCommittee: a zero-element array.
+func snothingCommittee() any {
+	return []any{}
+}
+
+// drepPulsingStateWithRatified builds a pulsing state whose
+// rsEnactState carries no committee, matching a cgsCommittee of
+// SNothing.
 func drepPulsingStateWithRatified(
+	t *testing.T,
 	proposals ...any,
 ) any {
-	return []any{
-		[]any{
-			[]any{},
-			map[uint64]uint64{},
-			map[uint64]uint64{},
-			map[uint64]uint64{},
-		},
-		[]any{
-			[]any{},
-			proposals,
-			[]any{},
-			false,
-		},
-	}
+	t.Helper()
+	return drepPulsingStateWithEnactCommittee(
+		t, snothingCommittee(), proposals...,
+	)
 }
 
 func drepPulsingStateWithEnactCommittee(
@@ -171,8 +171,68 @@ func drepPulsingStateWithEnactCommittee(
 	// are retained to match Conway's seven-field encoding.
 	enactState := []any{committee, nil, nil, nil, nil, nil, nil}
 	return []any{
-		[]any{[]any{}, map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{}},
+		[]any{
+			[]any{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+		},
 		[]any{enactState, proposals, []any{}, false},
+	}
+}
+
+// constitutionForTest is the constitution field shape shared by the
+// governance fixtures in this file.
+func constitutionForTest() any {
+	return []any{
+		[]any{
+			"https://example.com/constitution",
+			bytes.Repeat([]byte{0xAA}, 32),
+		},
+		nil,
+	}
+}
+
+// conwayGovStateWithPulsing assembles the seven-field Conway
+// ConwayGovState encoding around the given cgsCommittee and
+// cgsDRepPulsingState.
+func conwayGovStateWithPulsing(
+	t *testing.T,
+	committee any,
+	pulsing any,
+) []byte {
+	t.Helper()
+	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
+	data, err := cbor.Encode([]any{
+		[]any{rootsAny, []any{}},
+		committee,
+		constitutionForTest(),
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		map[uint64]uint64{},
+		pulsing,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+func govImportConfigForTest(
+	db *database.Database,
+	govStateData []byte,
+) ImportConfig {
+	return ImportConfig{
+		Database: db,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		State: &RawLedgerState{
+			GovStateData:  govStateData,
+			Epoch:         500,
+			EraIndex:      EraConway,
+			EraBoundEpoch: 100,
+			EraBoundSlot:  10_000,
+		},
+		EpochLength: func(uint) (uint, uint, error) {
+			return 1, 100, nil
+		},
 	}
 }
 
@@ -195,7 +255,7 @@ func TestParseGovStateCommitteeMatchesEnactState(t *testing.T) {
 	data, err := cbor.Encode([]any{
 		[]any{rootsAny, []any{}},
 		committee,
-		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		constitutionForTest(),
 		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
 		drepPulsingStateWithEnactCommittee(t, committee),
 	})
@@ -208,12 +268,12 @@ func TestParseGovStateCommitteeMatchesEnactState(t *testing.T) {
 	assert.Equal(t, parsed.CommitteeQuorum.Rat, parsed.EnactCommitteeQuorum.Rat)
 }
 
-func TestParseGovStateEnactProposalWarningDoesNotInvalidateCommittee(t *testing.T) {
+func TestParseGovStateEnactedWarningKeepsCommittee(t *testing.T) {
 	committee := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
 	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
 	data, err := cbor.Encode([]any{
 		[]any{rootsAny, []any{}}, committee,
-		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		constitutionForTest(),
 		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
 		drepPulsingStateWithEnactCommittee(t, committee),
 	})
@@ -222,14 +282,18 @@ func TestParseGovStateEnactProposalWarningDoesNotInvalidateCommittee(t *testing.
 	// malformed action. The warning must not become a committee error.
 	data, err = cbor.Encode([]any{
 		[]any{rootsAny, []any{}}, committee,
-		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
+		constitutionForTest(),
 		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
 		drepPulsingStateWithEnactCommittee(t, committee, cbor.RawMessage{0x01}),
 	})
 	require.NoError(t, err)
 	parsed, err := ParseGovState(data, EraConway)
 	require.Error(t, err)
-	assert.Nil(t, parsed.EnactCommitteeParseError)
+	// A malformed rsEnacted entry is warning-grade; it must not be
+	// reported as a failure to decode the enact-state committee.
+	assert.Nil(t, parsed.PulsingStateParseError)
+	require.Len(t, parsed.EnactCommittee, 1)
+	assert.True(t, parsed.EnactedActionTypesUnknown)
 }
 
 func TestImportGovStateRejectsCommitteeMismatch(t *testing.T) {
@@ -237,30 +301,177 @@ func TestImportGovStateRejectsCommitteeMismatch(t *testing.T) {
 	require.NoError(t, err)
 	left := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
 	right := committeeWithMember(t, bytes.Repeat([]byte{0x43}, 28), 700)
-	rootsAny := encodeRootsAsAny(t, [4]*ParsedGovActionId{})
-	govStateData, err := cbor.Encode([]any{
-		[]any{rootsAny, []any{}},
-		left,
-		[]any{[]any{"https://example.com/constitution", bytes.Repeat([]byte{0xAA}, 32)}, nil},
-		map[uint64]uint64{}, map[uint64]uint64{}, map[uint64]uint64{},
-		drepPulsingStateWithEnactCommittee(t, right),
-	})
-	require.NoError(t, err)
-	cfg := ImportConfig{
-		Database: db,
-		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		State: &RawLedgerState{
-			GovStateData:  govStateData,
-			Epoch:         500,
-			EraIndex:      EraConway,
-			EraBoundEpoch: 100,
-			EraBoundSlot:  10_000,
-		},
-		EpochLength: func(uint) (uint, uint, error) { return 1, 100, nil },
-	}
-	err = importGovState(context.Background(), cfg, func(ImportProgress) {})
+	// rsEnacted is empty, so nothing can have rewritten ensCommittee and
+	// the two views are required to agree.
+	govStateData := conwayGovStateWithPulsing(
+		t, left, drepPulsingStateWithEnactCommittee(t, right),
+	)
+	err = importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	)
 	require.EqualError(t, err,
-		"governance committee disagrees between cgsCommittee and rsEnactState")
+		"governance committee disagrees between cgsCommittee "+
+			"and rsEnactState with no committee action in rsEnacted")
+}
+
+// TestImportGovStateAcceptsCommitteeChangeInRsEnacted covers the mainnet
+// bootstrap shape: a snapshot from an epoch whose RATIFY pass accepted an
+// UpdateCommittee. ENACT rewrote EnactState.ensCommittee, so
+// RatifyState.rsEnactState carries the committee ConwayEPOCH will install
+// at the next boundary while cgsCommittee still carries the one in force.
+// The importer must persist cgsCommittee and must not reject the
+// snapshot.
+func TestImportGovStateAcceptsCommitteeChangeInRsEnacted(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	activeHash := bytes.Repeat([]byte{0x42}, 28)
+	nextHash := bytes.Repeat([]byte{0x43}, 28)
+	active := committeeWithMember(t, activeHash, 700)
+	next := committeeWithMember(t, nextHash, 900)
+	update := govActionStateForTest(
+		bytes.Repeat([]byte{0x77}, 32),
+		0,
+		govActionTypeUpdateCommittee,
+		nil,
+		499,
+	)
+	govStateData := conwayGovStateWithPulsing(
+		t,
+		active,
+		drepPulsingStateWithEnactCommittee(t, next, update),
+	)
+	require.NoError(t, importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	))
+
+	members, err := db.GetCommitteeMembers(nil)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, activeHash, members[0].ColdCredHash)
+	assert.Equal(t, uint64(700), members[0].ExpiresEpoch)
+}
+
+// TestImportGovStateAcceptsNoConfidenceInRsEnacted covers the other
+// committee-rewriting action: ENACT sets ensCommittee to SNothing for
+// NoConfidence, so rsEnactState carries no committee while cgsCommittee
+// still does.
+func TestImportGovStateAcceptsNoConfidenceInRsEnacted(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	activeHash := bytes.Repeat([]byte{0x42}, 28)
+	active := committeeWithMember(t, activeHash, 700)
+	noConfidence := govActionStateForTest(
+		bytes.Repeat([]byte{0x78}, 32),
+		0,
+		govActionTypeNoConfidence,
+		nil,
+		499,
+	)
+	govStateData := conwayGovStateWithPulsing(
+		t,
+		active,
+		drepPulsingStateWithEnactCommittee(
+			t, snothingCommittee(), noConfidence,
+		),
+	)
+	require.NoError(t, importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	))
+
+	members, err := db.GetCommitteeMembers(nil)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, activeHash, members[0].ColdCredHash)
+}
+
+// TestImportGovStateRejectsMismatchWithNonCommitteeRsEnacted keeps the
+// check armed for the actions that cannot touch the committee: a
+// TreasuryWithdrawals in rsEnacted leaves ensCommittee alone, so a
+// disagreement there is still corruption.
+func TestImportGovStateRejectsMismatchWithNonCommitteeRsEnacted(
+	t *testing.T,
+) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	left := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
+	right := committeeWithMember(t, bytes.Repeat([]byte{0x43}, 28), 700)
+	withdrawal := govActionStateForTest(
+		bytes.Repeat([]byte{0x79}, 32),
+		0,
+		govActionTypeTreasuryWithdrawals,
+		nil,
+		499,
+	)
+	govStateData := conwayGovStateWithPulsing(
+		t,
+		left,
+		drepPulsingStateWithEnactCommittee(t, right, withdrawal),
+	)
+	err = importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	)
+	require.EqualError(t, err,
+		"governance committee disagrees between cgsCommittee "+
+			"and rsEnactState with no committee action in rsEnacted")
+}
+
+// TestImportGovStateRejectsAbsentEnactState covers the absence case: an
+// rsEnactState encoded as an empty array. EnactState always encodes seven
+// fields in Conway, so this is malformed input and must not silently
+// disarm the corroboration.
+func TestImportGovStateRejectsAbsentEnactState(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	committee := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
+	pulsing := []any{
+		[]any{
+			[]any{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+			map[uint64]uint64{},
+		},
+		[]any{[]any{}, []any{}, []any{}, false},
+	}
+	govStateData := conwayGovStateWithPulsing(t, committee, pulsing)
+	err = importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	)
+	require.EqualError(t, err,
+		"parsing imported governance pulsing state: RatifyState enact "+
+			"state has 0 elements, expected 7")
+}
+
+// TestImportGovStateSkipsParityWhenEnactedTypesUnknown covers an
+// undecidable rsEnacted: with an entry whose action type cannot be
+// recovered, whether a committee action was accepted is unknown, so the
+// corroboration is unavailable rather than failed.
+func TestImportGovStateSkipsParityWhenEnactedTypesUnknown(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	left := committeeWithMember(t, bytes.Repeat([]byte{0x42}, 28), 700)
+	right := committeeWithMember(t, bytes.Repeat([]byte{0x43}, 28), 700)
+	govStateData := conwayGovStateWithPulsing(
+		t,
+		left,
+		drepPulsingStateWithEnactCommittee(
+			t, right, cbor.RawMessage{0x01},
+		),
+	)
+	require.NoError(t, importGovState(
+		context.Background(),
+		govImportConfigForTest(db, govStateData),
+		func(ImportProgress) {},
+	))
 }
 
 func TestImportGovStateSeedsPrevGovActionIds(t *testing.T) {
@@ -424,7 +635,7 @@ func TestImportGovStateMarksRatifiedParameterChangeFromDRepPulsingState(
 		[4]*ParsedGovActionId{ppRoot, nil, nil, nil},
 		false,
 		[]any{proposal},
-		drepPulsingStateWithRatified(proposal),
+		drepPulsingStateWithRatified(t, proposal),
 	)
 
 	cfg := ImportConfig{


### PR DESCRIPTION
## Summary

- Parse the Conway committee carried by `RatifyState.rsEnactState` separately from `rsEnacted`.
- Fail closed when the serialized active committee disagrees between `cgsCommittee` and `rsEnactState`.
- Add a focused regression fixture covering committee membership and quorum parity.

This preserves Conway boundary semantics: `rsEnactState` is already-active state, while `rsEnacted` is applied at the next epoch boundary. The importer does not apply `rsEnacted` early.

## Validation

- `go test ./ledgerstate`

Closes #3785

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates that an imported governance committee agrees with the Conway committee carried in `RatifyState.rsEnactState`, now failing only when no committee-changing action was enacted.

- Skips the comparison when `rsEnacted` carries a NoConfidence or UpdateCommittee action (which legitimately rewrites `ensCommittee` before `cgsCommittee` catches up) or when an enacted entry cannot be decoded.
- Fails closed when either committee fails to parse, `rsEnactState` lacks a committee field, or a GovState record is truncated; malformed `rsEnacted` proposals remain warnings.
- Adds regression fixtures covering matching, conflicting, changed, malformed, and indeterminate committee states.
- Closes #3785.

<sup>Written for commit 4135fc582119572b16e2c4c8c4a1988cc8cdd68f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved governance-state validation by checking committee consistency across state representations.
  * Import now rejects malformed committee or governance pulsing-state data instead of treating it as a warning.
  * Correctly handles committee changes resulting from UpdateCommittee and NoConfidence actions.
  * Reports truncated governance state data as a warning while continuing appropriate parsing.
* **Tests**
  * Added coverage for matching, conflicting, changed, malformed, and indeterminate committee states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->