### PR TITLE
fix(ledger): guard bufferedHeaderEvents with the blockfetch mutex

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -2080,12 +2080,17 @@ func (ls *LedgerState) replayBufferedHeaderEvents(
 // chainsyncBlockfetchMutex. Taking it here too, self-contained, closes that
 // gap without widening handleEventBlockfetch's own critical section to
 // cover chainsyncMutex as well.
+//
+// The bufferedHeaderEvents delete belongs inside that lock for the same
+// reason: handleEventBlockfetch holds chainsyncBlockfetchMutex while
+// nextBufferedHeaderConnId ranges over the map, so deleting from this
+// goroutine under a different mutex is a concurrent iteration and write.
 func (ls *LedgerState) discardBufferedPeerHeaders(
 	connId ouroboros.ConnectionId,
 ) {
-	delete(ls.bufferedHeaderEvents, connIdKey(connId))
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
+	delete(ls.bufferedHeaderEvents, connIdKey(connId))
 	if sameConnectionId(ls.headerPipelineConnId, connId) {
 		ls.clearQueuedHeaders()
 	}
@@ -2554,13 +2559,15 @@ func (ls *LedgerState) clearRollbackHistoryForPoint(point ocommon.Point) {
 func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.rollbackHistory = nil
 	ls.headerMismatchCount = 0
-	ls.bufferedHeaderEvents = nil
 	ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 	ls.chainsyncBlockfetchMutex.Lock()
-	// clearQueuedHeaders mutates headerPipelineConnId, which every other
-	// mutator guards with chainsyncBlockfetchMutex -- moved inside this
-	// lock (rather than called before it, as this used to) to close that
-	// gap.
+	// bufferedHeaderEvents is read under chainsyncBlockfetchMutex (see
+	// nextBufferedHeaderConnId, which ranges over it), so clearing it must
+	// happen inside this lock rather than before it. clearQueuedHeaders
+	// mutates headerPipelineConnId, which every other mutator guards with
+	// chainsyncBlockfetchMutex -- moved inside this lock (rather than
+	// called before it, as this used to) to close that gap.
+	ls.bufferedHeaderEvents = nil
 	ls.clearQueuedHeaders()
 	ls.blockfetchRequestRangeCleanup()
 	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -1020,7 +1020,9 @@ func (ls *LedgerState) handleConnectionClosedEvent(evt event.Event) {
 	if sameConnectionId(ls.shadowBlockfetchConnId, e.ConnectionId) {
 		ls.shadowBlockfetchConnId = ouroboros.ConnectionId{}
 	}
+	ls.bufferedHeaderMutex.Lock()
 	delete(ls.bufferedHeaderEvents, connIdKey(e.ConnectionId))
+	ls.bufferedHeaderMutex.Unlock()
 	delete(ls.peerHeaderHistory, connIdKey(e.ConnectionId))
 	// Cancel in-flight blockfetch if the dead connection owns it.
 	// Without this, chainsyncBlockfetchReadyChan stays non-nil and
@@ -1220,9 +1222,11 @@ func (ls *LedgerState) handoffPipelineOnSwitchLocked(
 		return ouroboros.ConnectionId{}, nil
 	}
 
+	ls.bufferedHeaderMutex.Lock()
 	hasBufferedHeadersForNewConn := len(
 		ls.bufferedHeaderEvents[connIdKey(newConnId)],
 	) > 0
+	ls.bufferedHeaderMutex.Unlock()
 
 	// When a blockfetch batch is already in progress on a different connection,
 	// let it complete rather than canceling it. The fetched blocks are canonical
@@ -1307,7 +1311,10 @@ func (ls *LedgerState) chainSwitchNeedsFreshCursorLocked(
 	if ls.chain != nil && ls.chain.HeaderCount() > 0 {
 		return false
 	}
-	if len(ls.bufferedHeaderEvents[connIdKey(connId)]) > 0 {
+	ls.bufferedHeaderMutex.Lock()
+	hasBuffered := len(ls.bufferedHeaderEvents[connIdKey(connId)]) > 0
+	ls.bufferedHeaderMutex.Unlock()
+	if hasBuffered {
 		return false
 	}
 	newObservedTip, ok := ls.chainSwitchObservedTipForConnection(e, connId)
@@ -1355,6 +1362,12 @@ func chainSwitchNewObservedTip(
 }
 
 func (ls *LedgerState) bufferHeaderEvent(e ChainsyncEvent) {
+	// Reached from the chainsync dispatch goroutine, which holds only
+	// chainsyncMutex: claimHeaderPipelineOwnership released
+	// chainsyncBlockfetchMutex on return, so this write is otherwise
+	// unprotected against nextBufferedHeaderConnId's iteration.
+	ls.bufferedHeaderMutex.Lock()
+	defer ls.bufferedHeaderMutex.Unlock()
 	if ls.bufferedHeaderEvents == nil {
 		ls.bufferedHeaderEvents = make(
 			map[string][]ChainsyncEvent,
@@ -1842,7 +1855,9 @@ func (ls *LedgerState) requestChainsyncResync(
 ) {
 	ls.headerMismatchCount = 0
 	ls.rollbackHistory = nil
+	ls.bufferedHeaderMutex.Lock()
 	delete(ls.bufferedHeaderEvents, connIdKey(connId))
+	ls.bufferedHeaderMutex.Unlock()
 	pending.add(
 		ls.config.EventBus,
 		event.ChainsyncResyncEventType,
@@ -1986,6 +2001,8 @@ func (ls *LedgerState) nextBufferedHeaderConnId() (
 	ouroboros.ConnectionId,
 	bool,
 ) {
+	ls.bufferedHeaderMutex.Lock()
+	defer ls.bufferedHeaderMutex.Unlock()
 	if key := connIdKey(ls.selectedBlockfetchConnId); key != "" {
 		if events := ls.bufferedHeaderEvents[key]; len(events) > 0 {
 			return events[len(events)-1].ConnectionId, true
@@ -2057,7 +2074,13 @@ func (ls *LedgerState) replayBufferedHeaderEvents(
 	pending *pendingPublishes,
 ) error {
 	key := connIdKey(connId)
+	// Take the events and clear the entry under the lock, then replay
+	// outside it: the replay calls back into
+	// handleEventChainsyncBlockHeaderWithPending, which can buffer more
+	// headers and would deadlock on a lock still held here.
+	ls.bufferedHeaderMutex.Lock()
 	if len(ls.bufferedHeaderEvents[key]) == 0 {
+		ls.bufferedHeaderMutex.Unlock()
 		return nil
 	}
 	events := append(
@@ -2065,6 +2088,7 @@ func (ls *LedgerState) replayBufferedHeaderEvents(
 		ls.bufferedHeaderEvents[key]...,
 	)
 	delete(ls.bufferedHeaderEvents, key)
+	ls.bufferedHeaderMutex.Unlock()
 	for _, evt := range events {
 		if err := ls.handleEventChainsyncBlockHeaderWithPending(evt, pending); err != nil {
 			return err
@@ -2090,7 +2114,9 @@ func (ls *LedgerState) discardBufferedPeerHeaders(
 ) {
 	ls.chainsyncBlockfetchMutex.Lock()
 	defer ls.chainsyncBlockfetchMutex.Unlock()
+	ls.bufferedHeaderMutex.Lock()
 	delete(ls.bufferedHeaderEvents, connIdKey(connId))
+	ls.bufferedHeaderMutex.Unlock()
 	if sameConnectionId(ls.headerPipelineConnId, connId) {
 		ls.clearQueuedHeaders()
 	}
@@ -2561,13 +2587,13 @@ func (ls *LedgerState) resetChainsyncResyncState() {
 	ls.headerMismatchCount = 0
 	ls.selectedBlockfetchConnId = ouroboros.ConnectionId{}
 	ls.chainsyncBlockfetchMutex.Lock()
-	// bufferedHeaderEvents is read under chainsyncBlockfetchMutex (see
-	// nextBufferedHeaderConnId, which ranges over it), so clearing it must
-	// happen inside this lock rather than before it. clearQueuedHeaders
-	// mutates headerPipelineConnId, which every other mutator guards with
-	// chainsyncBlockfetchMutex -- moved inside this lock (rather than
-	// called before it, as this used to) to close that gap.
+	// clearQueuedHeaders mutates headerPipelineConnId, which every other
+	// mutator guards with chainsyncBlockfetchMutex -- moved inside this
+	// lock (rather than called before it, as this used to) to close that
+	// gap. bufferedHeaderEvents has its own lock; see bufferedHeaderMutex.
+	ls.bufferedHeaderMutex.Lock()
 	ls.bufferedHeaderEvents = nil
+	ls.bufferedHeaderMutex.Unlock()
 	ls.clearQueuedHeaders()
 	ls.blockfetchRequestRangeCleanup()
 	ls.activeBlockfetchConnId = ouroboros.ConnectionId{}

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1221,9 +1221,11 @@ func TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration(
 			ls.discardBufferedPeerHeaders(connIds[i%conns])
 		}
 	}()
-	// The buffering write path. claimHeaderPipelineOwnership releases
-	// chainsyncBlockfetchMutex before this runs, so it is a genuinely
-	// unsynchronized writer without bufferedHeaderMutex.
+	// The buffering write path, which bufferedHeaderMutex alone protects.
+	// claimHeaderPipelineOwnership releases chainsyncBlockfetchMutex on
+	// return, so this write never holds that lock -- it is the case the
+	// previous, narrower fix missed, and it fails here without the
+	// dedicated mutex.
 	go func() {
 		defer wg.Done()
 		for i := range 200 {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1160,6 +1160,70 @@ func TestShouldBufferHeaderEventDoesNotRaceDiscardBufferedPeerHeaders(
 	wg.Wait()
 }
 
+// TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration guards the
+// bufferedHeaderEvents map itself, which is a different field from the
+// headerPipelineConnId race above.
+//
+// handleEventBlockfetch holds chainsyncBlockfetchMutex for its whole batch-done
+// path, and nextBufferedHeaderConnId ranges over bufferedHeaderEvents inside
+// it. discardBufferedPeerHeaders runs on handleEventChainsync's dispatch
+// goroutine, which holds only chainsyncMutex, and used to delete from that same
+// map before taking chainsyncBlockfetchMutex -- a concurrent map iteration and
+// map write, which is fatal at runtime rather than merely racy. It was observed
+// killing a mainnet block producer inside nextBufferedHeaderConnId.
+//
+// This runs both paths concurrently under go test -race; a clean run is the
+// pass condition, so there is nothing else to assert.
+func TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration(
+	t *testing.T,
+) {
+	ls := &LedgerState{
+		chain: &chain.Chain{},
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	// Several connections so the range in nextBufferedHeaderConnId has real
+	// work to do and overlaps the concurrent deletes.
+	const conns = 50
+	connIds := make([]ouroboros.ConnectionId, conns)
+	for i := range connIds {
+		connIds[i] = ouroboros.ConnectionId{
+			LocalAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 6000},
+			RemoteAddr: &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 3001 + i,
+			},
+		}
+		ls.bufferHeaderEvent(ChainsyncEvent{
+			ConnectionId: connIds[i],
+			Point:        ocommon.NewPoint(uint64(i), []byte("hdr")),
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Mirrors handleEventBlockfetch: the read side holds
+	// chainsyncBlockfetchMutex across the iteration.
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			ls.chainsyncBlockfetchMutex.Lock()
+			ls.nextBufferedHeaderConnId()
+			ls.chainsyncBlockfetchMutex.Unlock()
+		}
+	}()
+	// Mirrors handleEventChainsync's dispatch goroutine.
+	go func() {
+		defer wg.Done()
+		for i := range 200 {
+			ls.discardBufferedPeerHeaders(connIds[i%conns])
+		}
+	}()
+	wg.Wait()
+}
+
 func TestHandleChainSwitchEventReplaysBufferedHeadersForSelectedConnection(
 	t *testing.T,
 ) {

--- a/ledger/chainsync_switch_test.go
+++ b/ledger/chainsync_switch_test.go
@@ -1203,7 +1203,7 @@ func TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration(
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(4)
 	// Mirrors handleEventBlockfetch: the read side holds
 	// chainsyncBlockfetchMutex across the iteration.
 	go func() {
@@ -1219,6 +1219,31 @@ func TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration(
 		defer wg.Done()
 		for i := range 200 {
 			ls.discardBufferedPeerHeaders(connIds[i%conns])
+		}
+	}()
+	// The buffering write path. claimHeaderPipelineOwnership releases
+	// chainsyncBlockfetchMutex before this runs, so it is a genuinely
+	// unsynchronized writer without bufferedHeaderMutex.
+	go func() {
+		defer wg.Done()
+		for i := range 200 {
+			ls.bufferHeaderEvent(ChainsyncEvent{
+				ConnectionId: connIds[i%conns],
+				Point:        ocommon.NewPoint(uint64(i), []byte("hdr")),
+			})
+		}
+	}()
+	// The resync delete path, which reaches the map from callers that do
+	// not all hold chainsyncBlockfetchMutex.
+	go func() {
+		defer wg.Done()
+		var pending pendingPublishes
+		for i := range 200 {
+			ls.requestChainsyncResync(
+				connIds[i%conns],
+				"race probe",
+				&pending,
+			)
 		}
 	}()
 	wg.Wait()

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -941,9 +941,17 @@ type LedgerState struct {
 	chainsyncMutex                sync.Mutex
 	chainsyncBlockfetchMutex      sync.Mutex
 	chainsyncBlockfetchReadyMutex sync.Mutex
-	chainsyncBlockfetchReadyChan  chan struct{}
-	activeBlockfetchConnId        ouroboros.ConnectionId // connection used for current blockfetch pipeline
-	shadowBlockfetchConnId        ouroboros.ConnectionId // shadow peer dispatched for parallel blockfetch
+	// bufferedHeaderMutex guards bufferedHeaderEvents alone. That map is
+	// reached from both the chainsync dispatch goroutine (which holds
+	// chainsyncMutex) and the blockfetch path (which holds
+	// chainsyncBlockfetchMutex), so neither of those locks covers every
+	// access and a concurrent iteration and write is fatal at runtime.
+	// Where both are held, acquire this one last; nothing calls out to
+	// other ledger code while holding it, so the order stays fixed.
+	bufferedHeaderMutex          sync.Mutex
+	chainsyncBlockfetchReadyChan chan struct{}
+	activeBlockfetchConnId       ouroboros.ConnectionId // connection used for current blockfetch pipeline
+	shadowBlockfetchConnId       ouroboros.ConnectionId // shadow peer dispatched for parallel blockfetch
 	// blockfetchPrimaryRequestGeneration identifies the currently running
 	// primary request. A timeout may fire while the request is blocked in the
 	// protocol client; keeping its generation lets the timeout wait instead of


### PR DESCRIPTION
## Problem

`bufferedHeaderEvents` is read and written from two goroutines under two different mutexes.

- **Blockfetch goroutine** — `handleEventBlockfetch` takes `chainsyncBlockfetchMutex` (`ledger/chainsync.go:787`) and holds it across the whole batch-done path, during which `nextBufferedHeaderConnId` **ranges over** `bufferedHeaderEvents`.
- **Chainsync dispatch goroutine** — `handleEventChainsync` takes `chainsyncMutex` (`ledger/chainsync.go:249`), a *different* lock, then calls `discardBufferedPeerHeaders`, which **deleted** from that same map *before* acquiring `chainsyncBlockfetchMutex`.

`resetChainsyncResyncState` had the same shape: `ls.bufferedHeaderEvents = nil` executed before the lock it takes two lines later.

That is a concurrent map iteration and map write, which the Go runtime treats as **fatal**, not merely racy. It was observed killing a mainnet block producer inside `nextBufferedHeaderConnId`:

```
fatal error: concurrent map iteration and map write
```

The existing comment above `discardBufferedPeerHeaders` already documented that this function "holds only chainsyncMutex" and reasoned about `headerPipelineConnId` needing the blockfetch mutex — but `bufferedHeaderEvents`, mutated on the line just above, has identical exposure and was missed.

## Change

Move both mutations inside the critical sections that already exist in those functions. Each function takes `chainsyncBlockfetchMutex` a line or two later anyway, so this **widens no critical section** — it only orders the map write correctly against the reader. Comments updated to record why the map belongs inside the lock.

## Tests

`TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration` runs the two real paths concurrently: the read side takes `chainsyncBlockfetchMutex` and calls `nextBufferedHeaderConnId` (mirroring `handleEventBlockfetch`), while the write side calls `discardBufferedPeerHeaders` (mirroring the chainsync dispatch goroutine), across 50 buffered connections so the iteration and the deletes genuinely overlap.

Verified it fails without the fix: reverting only the `discardBufferedPeerHeaders` ordering produces `WARNING: DATA RACE` and a test failure under `-race`; restoring it passes.

This is deliberately distinct from the existing `TestShouldBufferHeaderEventDoesNotRaceDiscardBufferedPeerHeaders`, which guards `headerPipelineConnId` — a different field, and one that fix did not cover.

`go build ./...`, `gofmt`, and `go test -race ./ledger/...` are clean with this change.

Note: `ledger/leader`'s `TestThresholdPreservesProtocolBoundary` fails on `main` independently of this PR — I confirmed the identical failure on a clean `origin/main` checkout, so it is pre-existing and out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fatal data race on `bufferedHeaderEvents` that could kill a mainnet block producer. The map was iterated under `chainsyncBlockfetchMutex` while mutated under `chainsyncMutex` or with no lock at all; a dedicated `bufferedHeaderMutex` now guards every access and is acquired last when both locks are held.

Adds `TestDiscardBufferedPeerHeadersDoesNotRaceBufferedHeaderIteration`, which runs the iteration, discard, buffering, and resync paths concurrently under `-race`.

<sup>Written for commit a342b1dfa8179a84551993888df982081e79e068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization for chain synchronization and blockfetch state updates.
  * Prevented potential concurrency issues when buffered headers are read, cleared, or discarded.

* **Tests**
  * Added coverage to verify safe concurrent handling of buffered header data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->