### PR TITLE
fix(ledger): seed the Conway genesis committee at genesis

### DIFF
--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -4803,6 +4803,13 @@ func (ls *LedgerState) createGenesisBlock() error {
 			if err := ls.ensureGenesisConstitution(nil); err != nil {
 				return err
 			}
+			// Databases created before the committee was seeded reach
+			// only this branch, so the backfill has to run here too --
+			// a node already synced from genesis is exactly the one
+			// missing its committee rows.
+			if err := ls.ensureGenesisCommittee(nil); err != nil {
+				return err
+			}
 			return ls.ensureGenesisNetworkState()
 		}
 		// Check if genesis CBOR exists but with a different hash.

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -5051,6 +5051,13 @@ func (ls *LedgerState) createGenesisBlock() error {
 			return err
 		}
 
+		// The Conway genesis committee is seated from the Chang hard fork
+		// and any of its members not yet touched by a later UpdateCommittee
+		// action must be recognized for hot-key authorization/resignation.
+		if err := ls.ensureGenesisCommittee(txn); err != nil {
+			return err
+		}
+
 		return nil
 	})
 	return err
@@ -5092,6 +5099,112 @@ func (ls *LedgerState) ensureGenesisConstitution(txn *database.Txn) error {
 		hex.EncodeToString(genesisConstitution.PolicyHash),
 	)
 	return nil
+}
+
+// ensureGenesisCommittee seeds the Conway genesis Constitutional Committee
+// members from conway-genesis.json's committee section for any cold
+// credential that has no committee_member row yet.
+//
+// Only two paths ever write committee_member: UpdateCommittee enactment
+// (ledger/governance/enact.go) and Mithril snapshot import
+// (ledgerstate/import.go). Neither seeds the committee actually seated at the
+// Chang hard fork (blinklabs-io/dingo#3785), so an original genesis member
+// that no later UpdateCommittee has ever touched has no row at all, and any
+// operation on its cold credential -- hot-key authorization, resignation --
+// is rejected as "not a CC member" even though the real chain has recognized
+// it since genesis.
+//
+// Checking each credential against the existing (including soft-deleted) set
+// before inserting makes this safe to call on every startup: a credential a
+// later UpdateCommittee has since re-elected or removed already has a row, so
+// its real history is left alone instead of being reverted to genesis state.
+func (ls *LedgerState) ensureGenesisCommittee(txn *database.Txn) error {
+	conwayGenesis := ls.config.CardanoNodeConfig.ConwayGenesis()
+	if conwayGenesis == nil || len(conwayGenesis.Committee.Members) == 0 {
+		return nil
+	}
+	existing, err := ls.db.GetCommitteeMembersIncludeDeleted(txn)
+	if err != nil {
+		return fmt.Errorf("get existing committee members: %w", err)
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, member := range existing {
+		seen[(models.CommitteeCredential{
+			CredentialTag: member.ColdCredentialTag,
+			Credential:    member.ColdCredHash,
+		}).Key()] = struct{}{}
+	}
+	newMembers := make([]*models.CommitteeMember, 0, len(conwayGenesis.Committee.Members))
+	for raw, expiry := range conwayGenesis.Committee.Members {
+		tag, hash, err := parseGenesisCommitteeCredential(raw)
+		if err != nil {
+			return fmt.Errorf("genesis committee credential %q: %w", raw, err)
+		}
+		key := (models.CommitteeCredential{
+			CredentialTag: tag,
+			Credential:    hash,
+		}).Key()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		newMembers = append(newMembers, &models.CommitteeMember{
+			ColdCredentialTag: tag,
+			ColdCredHash:      hash,
+			ExpiresEpoch:      uint64(expiry),
+			TermStartSlot:     0,
+			TermStartSlotSet:  true,
+			AddedSlot:         0,
+		})
+	}
+	if len(newMembers) == 0 {
+		return nil
+	}
+	// Sort by full cold credential identity so the auto-increment ID assigned
+	// by the DB is stable across nodes (Go map iteration is random).
+	slices.SortFunc(newMembers, func(a, b *models.CommitteeMember) int {
+		if cmp := bytes.Compare(a.ColdCredHash, b.ColdCredHash); cmp != 0 {
+			return cmp
+		}
+		return int(a.ColdCredentialTag) - int(b.ColdCredentialTag)
+	})
+	if err := ls.db.SetCommitteeMembers(newMembers, txn); err != nil {
+		return fmt.Errorf("set genesis committee members: %w", err)
+	}
+	ls.config.Logger.Info(
+		fmt.Sprintf(
+			"recorded %d Conway genesis committee member(s)",
+			len(newMembers),
+		),
+		"component", "ledger",
+	)
+	return nil
+}
+
+// parseGenesisCommitteeCredential decodes a conway-genesis.json committee
+// member map key, formatted as "keyHash-<hex>" or "scriptHash-<hex>" (see
+// gouroboros's common.Credential.UnmarshalJSON, which this mirrors for the
+// bare map-key string rather than a quoted JSON value).
+func parseGenesisCommitteeCredential(raw string) (uint8, []byte, error) {
+	var tag uint8
+	var hexPart string
+	switch {
+	case strings.HasPrefix(raw, "keyHash-"):
+		tag = lcommon.CredentialTypeAddrKeyHash
+		hexPart = raw[len("keyHash-"):]
+	case strings.HasPrefix(raw, "scriptHash-"):
+		tag = lcommon.CredentialTypeScriptHash
+		hexPart = raw[len("scriptHash-"):]
+	default:
+		return 0, nil, errors.New("unknown credential prefix")
+	}
+	hash, err := hex.DecodeString(hexPart)
+	if err != nil {
+		return 0, nil, fmt.Errorf("decode credential hash: %w", err)
+	}
+	if len(hash) != 28 {
+		return 0, nil, errors.New("credential hash is wrong length")
+	}
+	return tag, hash, nil
 }
 
 // ensureGenesisNetworkState initializes the slot-0 treasury/reserves baseline

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -5147,16 +5147,21 @@ func (ls *LedgerState) ensureGenesisCommittee(txn *database.Txn) error {
 		if err != nil {
 			return fmt.Errorf("genesis committee credential %q: %w", raw, err)
 		}
+		// Validate the whole genesis entry before the already-seeded check, so
+		// a malformed expiry fails closed the same way on a fresh database and
+		// on one that already holds a row for this credential. Validating
+		// after the check would accept a genesis this function itself declares
+		// malformed, purely because some earlier startup got there first.
+		expiresEpoch, err := genesisCommitteeExpiryEpoch(expiry)
+		if err != nil {
+			return fmt.Errorf("genesis committee credential %q: %w", raw, err)
+		}
 		key := (models.CommitteeCredential{
 			CredentialTag: tag,
 			Credential:    hash,
 		}).Key()
 		if _, ok := seen[key]; ok {
 			continue
-		}
-		expiresEpoch, err := genesisCommitteeExpiryEpoch(expiry)
-		if err != nil {
-			return fmt.Errorf("genesis committee credential %q: %w", raw, err)
 		}
 		newMembers = append(newMembers, &models.CommitteeMember{
 			ColdCredentialTag: tag,

--- a/ledger/chainsync.go
+++ b/ledger/chainsync.go
@@ -5154,10 +5154,14 @@ func (ls *LedgerState) ensureGenesisCommittee(txn *database.Txn) error {
 		if _, ok := seen[key]; ok {
 			continue
 		}
+		expiresEpoch, err := genesisCommitteeExpiryEpoch(expiry)
+		if err != nil {
+			return fmt.Errorf("genesis committee credential %q: %w", raw, err)
+		}
 		newMembers = append(newMembers, &models.CommitteeMember{
 			ColdCredentialTag: tag,
 			ColdCredHash:      hash,
-			ExpiresEpoch:      uint64(expiry),
+			ExpiresEpoch:      expiresEpoch,
 			TermStartSlot:     0,
 			TermStartSlotSet:  true,
 			AddedSlot:         0,
@@ -5185,6 +5189,23 @@ func (ls *LedgerState) ensureGenesisCommittee(txn *database.Txn) error {
 		"component", "ledger",
 	)
 	return nil
+}
+
+// genesisCommitteeExpiryEpoch converts a conway-genesis.json committee member
+// expiry epoch to the unsigned epoch the store records.
+//
+// The genesis committee section models the expiry as a bare JSON number, so
+// gouroboros decodes it into a signed int (conway.ConwayGenesisCommittee's
+// Members map is map[string]int). A negative value is malformed genesis: a
+// straight conversion would wrap it to a near-maximum uint64 and silently seat
+// the member with an effectively unbounded term, which no later epoch boundary
+// would ever expire. Refuse it the same way an unparseable credential is
+// refused rather than committing a term the real chain never granted.
+func genesisCommitteeExpiryEpoch(expiry int) (uint64, error) {
+	if expiry < 0 {
+		return 0, fmt.Errorf("negative expiry epoch %d", expiry)
+	}
+	return uint64(expiry), nil
 }
 
 // parseGenesisCommitteeCredential decodes a conway-genesis.json committee

--- a/ledger/genesis_committee_test.go
+++ b/ledger/genesis_committee_test.go
@@ -63,6 +63,47 @@ func TestCreateGenesisBlockSeedsCommittee(t *testing.T) {
 	}
 }
 
+// TestCreateGenesisBlockSeedsCommitteeOnExistingDatabase covers the upgrade
+// path, which is the population that actually has the bug: a node already
+// synced from genesis on a build that never seeded the committee.
+//
+// Such a database has matching genesis CBOR and a nonzero tip, so
+// createGenesisBlock takes its early-return branch and never reaches the
+// genesis-creation transaction. Seeding only from that transaction would
+// therefore fix new nodes and leave every existing one broken.
+func TestCreateGenesisBlockSeedsCommitteeOnExistingDatabase(t *testing.T) {
+	ls, db := genesisConstitutionTestState(t)
+
+	// Stand in for a database written by a build with no committee seed:
+	// genesis CBOR present and matching, a tip well past zero, and no
+	// committee_member rows at all.
+	genesisHash, err := GenesisBlockHash(ls.config.CardanoNodeConfig)
+	require.NoError(t, err)
+	require.NoError(t, db.SetGenesisCbor(0, genesisHash[:], []byte{0x80}, nil))
+	ls.currentTip.Point = ocommon.Point{Slot: 1_000_000}
+	require.Equal(t, 0, committeeMemberRowCount(t, db))
+
+	require.NoError(t, ls.createGenesisBlock())
+
+	lv := &LedgerView{ls: ls}
+	for _, coldKeyHex := range musashiGenesisCommitteeColdKeys {
+		coldKey, err := hex.DecodeString(coldKeyHex)
+		require.NoError(t, err)
+		member, err := lv.CommitteeCredentialMember(lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(coldKey),
+		})
+		require.NoError(t, err)
+		require.NotNil(
+			t,
+			member,
+			"genesis committee member %s must be backfilled on an existing database",
+			coldKeyHex,
+		)
+		require.Equal(t, uint64(musashiGenesisCommitteeExpiry), member.ExpiryEpoch)
+	}
+}
+
 // TestCreateGenesisBlockCommitteeReplayIdempotent proves re-running genesis
 // initialization over a store that already holds the genesis committee
 // leaves a single row per member rather than a duplicate soft-delete/insert

--- a/ledger/genesis_committee_test.go
+++ b/ledger/genesis_committee_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// The Musashi Conway genesis declares three genesis committee members, all
+// key-hash cold credentials, each expiring at epoch 293.
+var musashiGenesisCommitteeColdKeys = []string{
+	"4a45ab0e4dc24e2567d282adc3928a69e6b6a8e155a9b14ae7147c21",
+	"6bb088d6ada8d97d130a8e3406360fbdf39be38b699a77778d26ae72",
+	"c3c5d6f905a91c12ea51b328953ccee359efb2cff6130d9fee8dea05",
+}
+
+const musashiGenesisCommitteeExpiry = 293
+
+// TestCreateGenesisBlockSeedsCommittee proves a node initialized from Conway
+// genesis recognizes every genesis Constitutional Committee member for
+// hot-key authorization. Without the seed (blinklabs-io/dingo#3785) a
+// genesis member never touched by an UpdateCommittee action has no row at
+// all, and AuthCommitteeHot/ResignCommitteeCold validation rejects it as
+// "not a CC member" even though the real chain has recognized it since the
+// hard fork.
+func TestCreateGenesisBlockSeedsCommittee(t *testing.T) {
+	ls, _ := genesisConstitutionTestState(t)
+	require.NoError(t, ls.createGenesisBlock())
+
+	lv := &LedgerView{ls: ls}
+	for _, coldKeyHex := range musashiGenesisCommitteeColdKeys {
+		coldKey, err := hex.DecodeString(coldKeyHex)
+		require.NoError(t, err)
+		member, err := lv.CommitteeCredentialMember(lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(coldKey),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, member, "genesis committee member %s must resolve", coldKeyHex)
+		require.False(t, member.Resigned)
+		require.Equal(t, uint64(musashiGenesisCommitteeExpiry), member.ExpiryEpoch)
+	}
+}
+
+// TestCreateGenesisBlockCommitteeReplayIdempotent proves re-running genesis
+// initialization over a store that already holds the genesis committee
+// leaves a single row per member rather than a duplicate soft-delete/insert
+// pair.
+func TestCreateGenesisBlockCommitteeReplayIdempotent(t *testing.T) {
+	ls, db := genesisConstitutionTestState(t)
+	require.NoError(t, ls.createGenesisBlock())
+	require.NoError(t, ls.createGenesisBlock())
+
+	require.Equal(t, len(musashiGenesisCommitteeColdKeys), committeeMemberRowCount(t, db))
+}
+
+// TestCreateGenesisBlockCommitteeEnactmentWins proves a real UpdateCommittee
+// enactment for a genesis cold credential outranks the genesis seed, and
+// that a later genesis initialization pass does not revert it back to the
+// genesis term -- the hazard a naive unconditional reseed on every startup
+// would create.
+func TestCreateGenesisBlockCommitteeEnactmentWins(t *testing.T) {
+	ls, db := genesisConstitutionTestState(t)
+	require.NoError(t, ls.createGenesisBlock())
+
+	coldKey, err := hex.DecodeString(musashiGenesisCommitteeColdKeys[0])
+	require.NoError(t, err)
+	require.NoError(t, db.SetCommitteeMembers([]*models.CommitteeMember{
+		{
+			ColdCredentialTag: 0,
+			ColdCredHash:      coldKey,
+			ExpiresEpoch:      999,
+			TermStartSlot:     100,
+			TermStartSlotSet:  true,
+			AddedSlot:         100,
+		},
+	}, nil))
+
+	ls.currentTip.Point = ocommon.Point{Slot: 200}
+	require.NoError(t, ls.createGenesisBlock())
+
+	lv := &LedgerView{ls: ls}
+	member, err := lv.CommitteeCredentialMember(lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.NewBlake2b224(coldKey),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, member)
+	require.Equal(t, uint64(999), member.ExpiryEpoch)
+
+	// The other two genesis members are untouched and still resolve.
+	for _, coldKeyHex := range musashiGenesisCommitteeColdKeys[1:] {
+		otherKey, err := hex.DecodeString(coldKeyHex)
+		require.NoError(t, err)
+		other, err := lv.CommitteeCredentialMember(lcommon.Credential{
+			CredType:   lcommon.CredentialTypeAddrKeyHash,
+			Credential: lcommon.NewBlake2b224(otherKey),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, other)
+		require.Equal(t, uint64(musashiGenesisCommitteeExpiry), other.ExpiryEpoch)
+	}
+}
+
+// TestParseGenesisCommitteeCredential exercises both credential prefixes and
+// the rejection paths for malformed genesis committee member keys.
+func TestParseGenesisCommitteeCredential(t *testing.T) {
+	keyHash := bytes.Repeat([]byte{0xab}, 28)
+	tag, hash, err := parseGenesisCommitteeCredential(
+		"keyHash-" + hex.EncodeToString(keyHash),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint8(lcommon.CredentialTypeAddrKeyHash), tag)
+	require.Equal(t, keyHash, hash)
+
+	scriptHash := bytes.Repeat([]byte{0xcd}, 28)
+	tag, hash, err = parseGenesisCommitteeCredential(
+		"scriptHash-" + hex.EncodeToString(scriptHash),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint8(lcommon.CredentialTypeScriptHash), tag)
+	require.Equal(t, scriptHash, hash)
+
+	_, _, err = parseGenesisCommitteeCredential("bogus-deadbeef")
+	require.Error(t, err)
+
+	_, _, err = parseGenesisCommitteeCredential("keyHash-nothex")
+	require.Error(t, err)
+
+	_, _, err = parseGenesisCommitteeCredential("keyHash-abcd")
+	require.Error(t, err)
+}
+
+// committeeMemberRowCount returns the number of stored committee_member rows.
+func committeeMemberRowCount(t *testing.T, db *database.Database) int {
+	t.Helper()
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, raw.Close()) }()
+	var count int
+	require.NoError(
+		t,
+		raw.QueryRow("SELECT COUNT(*) FROM committee_member").Scan(&count),
+	)
+	return count
+}

--- a/ledger/genesis_committee_test.go
+++ b/ledger/genesis_committee_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"bytes"
 	"encoding/hex"
+	"math"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -191,6 +192,77 @@ func TestParseGenesisCommitteeCredential(t *testing.T) {
 
 	_, _, err = parseGenesisCommitteeCredential("keyHash-abcd")
 	require.Error(t, err)
+}
+
+// TestEnsureGenesisCommitteeRejectsNegativeExpiry proves a malformed Conway
+// genesis fails initialization instead of seating a member with a wrapped
+// term.
+//
+// conway-genesis.json models the committee expiry as a bare JSON number, so it
+// decodes into a signed int. Converting a negative value straight to the
+// store's unsigned epoch would wrap it to a near-maximum uint64 -- a term no
+// epoch boundary would ever expire -- so the seed must refuse it outright.
+func TestEnsureGenesisCommitteeRejectsNegativeExpiry(t *testing.T) {
+	ls, db := genesisConstitutionTestState(t)
+
+	// The embedded config is parsed fresh on every load, so mutating this
+	// state's genesis below cannot leak into the other tests in this file.
+	other, _ := genesisConstitutionTestState(t)
+	require.NotSame(
+		t,
+		ls.config.CardanoNodeConfig.ConwayGenesis(),
+		other.config.CardanoNodeConfig.ConwayGenesis(),
+		"each test state must own its genesis for the mutation below to be safe",
+	)
+
+	members := ls.config.CardanoNodeConfig.ConwayGenesis().Committee.Members
+	rawKey := "keyHash-" + musashiGenesisCommitteeColdKeys[0]
+	require.Contains(t, members, rawKey)
+	members[rawKey] = -1
+
+	err := ls.ensureGenesisCommittee(nil)
+	require.ErrorContains(t, err, "negative expiry epoch -1")
+	require.ErrorContains(t, err, musashiGenesisCommitteeColdKeys[0])
+	require.Equal(
+		t,
+		0,
+		committeeMemberRowCount(t, db),
+		"a malformed genesis committee must seat no members at all",
+	)
+}
+
+// TestGenesisCommitteeExpiryEpoch covers the signed-to-unsigned conversion
+// directly, including the most negative int, which is the value a straight
+// conversion wraps furthest.
+func TestGenesisCommitteeExpiryEpoch(t *testing.T) {
+	tests := []struct {
+		name    string
+		expiry  int
+		want    uint64
+		wantErr bool
+	}{
+		{"zero", 0, 0, false},
+		{
+			"musashi genesis expiry",
+			musashiGenesisCommitteeExpiry,
+			musashiGenesisCommitteeExpiry,
+			false,
+		},
+		{"negative one", -1, 0, true},
+		{"most negative int", math.MinInt, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := genesisCommitteeExpiryEpoch(tc.expiry)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Zero(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // committeeMemberRowCount returns the number of stored committee_member rows.

--- a/ledger/genesis_committee_test.go
+++ b/ledger/genesis_committee_test.go
@@ -231,6 +231,37 @@ func TestEnsureGenesisCommitteeRejectsNegativeExpiry(t *testing.T) {
 	)
 }
 
+// TestEnsureGenesisCommitteeRejectsNegativeExpiryWhenAlreadySeeded proves the
+// malformed-genesis check fails closed on the upgrade path too.
+//
+// Validating the expiry only after the already-seeded check would let the same
+// malformed genesis start a node whose database happens to hold rows already
+// while refusing a fresh one, even though the genesis file is equally
+// malformed in both cases.
+func TestEnsureGenesisCommitteeRejectsNegativeExpiryWhenAlreadySeeded(
+	t *testing.T,
+) {
+	ls, db := genesisConstitutionTestState(t)
+	require.NoError(t, ls.createGenesisBlock())
+	seeded := committeeMemberRowCount(t, db)
+	require.Equal(t, len(musashiGenesisCommitteeColdKeys), seeded)
+
+	members := ls.config.CardanoNodeConfig.ConwayGenesis().Committee.Members
+	rawKey := "keyHash-" + musashiGenesisCommitteeColdKeys[0]
+	require.Contains(t, members, rawKey)
+	members[rawKey] = -7
+
+	err := ls.ensureGenesisCommittee(nil)
+	require.ErrorContains(t, err, "negative expiry epoch -7")
+	require.ErrorContains(t, err, musashiGenesisCommitteeColdKeys[0])
+	require.Equal(
+		t,
+		seeded,
+		committeeMemberRowCount(t, db),
+		"the failed check must not add or remove rows",
+	)
+}
+
 // TestGenesisCommitteeExpiryEpoch covers the signed-to-unsigned conversion
 // directly, including the most negative int, which is the value a straight
 // conversion wraps furthest.


### PR DESCRIPTION
Fixes #3785

## Problem

Only two paths ever write `committee_member`: `UpdateCommittee` enactment (`ledger/governance/enact.go`) and Mithril snapshot import (`ledgerstate/import.go`). Neither seeds the committee actually seated at the Chang hard fork.

So on a node synced from genesis, an original Conway genesis committee member that no later `UpdateCommittee` action has touched has **no row at all**. Any operation on that cold credential — `AuthCommitteeHot`, `ResignCommitteeCold` — is rejected as "not a CC member", even though the real chain has recognized it since the hard fork.

A Mithril-bootstrapped node happens to be fine because import carries the rows; a genesis-synced node is not. That difference is the bug.

## Change

`ensureGenesisCommittee` seeds the members declared in `conway-genesis.json`'s committee section for any cold credential that has no `committee_member` row yet, called from `createGenesisBlock` alongside the existing `ensureGenesisConstitution` / `ensureGenesisNetworkState` seeds.

Each candidate is checked against the existing set **including soft-deleted rows** (`GetCommitteeMembersIncludeDeleted`) before inserting. That is what makes it safe to run on every startup: a credential that a later `UpdateCommittee` has since re-elected *or removed* already has a row, so its real governance history is left alone rather than being reverted to genesis state.

If the config declares no Conway genesis or an empty committee, it is a no-op.

## Tests

`ledger/genesis_committee_test.go`, against the Musashi Conway genesis (three key-hash cold credentials, expiry epoch 293):

- `TestCreateGenesisBlockSeedsCommittee` — every genesis member resolves via `CommitteeCredentialMember` after genesis creation, which is the lookup `AuthCommitteeHot` depends on
- `TestCreateGenesisBlockCommitteeReplayIdempotent` — running genesis creation again does not duplicate rows
- `TestCreateGenesisBlockCommitteeEnactmentWins` — a member whose row was later changed by enactment keeps that state instead of being reset to genesis
- `TestParseGenesisCommitteeCredential` — credential parsing, including the key-hash/script-hash distinction

Verified the behaviour test genuinely fails without the fix: removing just the `ensureGenesisCommittee` call from `createGenesisBlock` fails `TestCreateGenesisBlockSeedsCommittee`; restoring it passes.

`go build ./...`, `gofmt`, and `go test -race` on these tests are clean.

Note: `ledger/leader`'s `TestThresholdPreservesProtocolBoundary` fails on `main` independently of this PR — confirmed identical on a clean `origin/main` checkout, so it is pre-existing and out of scope.

## Follow-up, not in this PR

The committee state exposed to `CommitteeStateAvailable` may want the same genesis-awareness; worth a separate look rather than widening this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nodes synced from genesis not recognizing original Conway genesis committee members. Previously, a genesis committee member never touched by a later `UpdateCommittee` action or Mithril snapshot import had no stored row, so hot-key authorization and resignation were rejected as "not a CC member". `createGenesisBlock` now seeds missing members from `conway-genesis.json`, both when creating a fresh database and on the upgrade path for already-synced nodes, checking existing rows (including soft-deleted) so later governance history is preserved. Negative expiry epochs now fail startup instead of wrapping to an unbounded term, with the validation run before the already-seeded check so malformed genesis fails closed on fresh and existing databases alike. No-op when the config declares no Conway genesis or an empty committee.

**Tests**

- `ledger/genesis_committee_test.go` covers member resolution, existing-database backfill, replay idempotency, credential parsing, enactment precedence, and negative expiry rejection on both fresh and already-seeded paths.
- The seed and negative-expiry tests fail without their respective fixes; `go build`, `gofmt`, and `go test -race` are clean.
- `ledger/leader`'s `TestThresholdPreservesProtocolBoundary` already fails on `main` independently of this PR.

<sup>Written for commit 47e9e20c47ab863023d1bedb93f3fc916b84ef00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Conway genesis initialization now automatically seeds the Constitutional Committee members defined in the genesis configuration.
  - Committee members are also populated when initializing an existing database that already contains genesis data.

- **Bug Fixes**
  - Repeated genesis initialization no longer creates duplicate committee entries.
  - Later committee governance updates are preserved over the initial genesis values.
  - Invalid negative committee expiry epochs are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->