### PR TITLE
fix(forging): defer the opcert KES check when history is behind the clock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4452,7 +4452,28 @@ KES periods are computed from the era-aware absolute slot (`currentSlot / slotsP
 Successful startup validation captures Shelley genesis `MaxKESEvolutions` on
 the loaded credentials together with the opcert start and overflow-checked
 exclusive expiry. `NewBlockForger` rejects credentials without that validated
-protocol lifetime. Before leader selection at each candidate slot, the runtime
+protocol lifetime.
+
+The startup KES-period judgement itself is conditional on the confirmed era
+history spanning the wall clock. `WallClockSlotFromConfirmedHistory` resolves
+the current slot from confirmed eras only, and reports unsupported when the
+wall clock falls past that history's forecast horizon — the state a node
+importing from genesis or restarting far behind is in, where `CurrentSlot`
+would extrapolate through the newest applied era's slot length (Byron's 20s
+slots on a chain that moved to 1s at epoch 208) and so cannot place a
+certificate in time. Only that past-horizon case is a deferral; any other
+failure, including an empty epoch cache or a wall clock before genesis, is
+returned as an error and keeps startup a hard failure.
+
+In the deferred state startup still loads the credential material, checks the
+opcert's cold-key signature, and arms the same protocol lifetime — it skips
+only the slot-dependent plausibility check. Enforcement is then entirely the
+per-slot runtime gate described below, which re-derives the period and rejects
+the certificate before leader selection; extrapolation through the newest
+confirmed era skews the computed period downward, so a certificate staged for
+the future or already expired lands below `opcertStart` rather than inside the
+admitted interval. When confirmed history does span the wall clock, the strict
+startup check runs unchanged and rejects such a certificate outright. Before leader selection at each candidate slot, the runtime
 gate admits exactly the
 half-open interval `[opcertStart, opcertStart + MaxKESEvolutions)`: periods
 before the start and at or after the exclusive end both log/count a

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1032,6 +1032,62 @@ func (pc *PoolCredentials) ValidateKESPeriod(
 	return nil
 }
 
+// ArmKesProtocolLifetime seeds the protocol-level KES lifetime from the
+// Shelley genesis without judging the operational certificate against the
+// current wall-clock slot. It exists for block producer startup when the
+// ledger's confirmed era history does not yet span the wall clock (genesis
+// re-import, long downtime): in that state the extrapolated current slot uses
+// the newest known era's slot length and cannot reliably place an opcert in
+// time (a fresh mainnet ledger extrapolates Byron's 20s slots over the whole
+// chain, so the current KES period reads far below the real one). The per-slot
+// forge gate still enforces the armed window against the reliable slot, so no
+// block leaves the node outside the operational certificate's lifetime.
+func (pc *PoolCredentials) ArmKesProtocolLifetime(
+	genesis *shelley.ShelleyGenesis,
+) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	pc.generation++
+	// Any failed arming leaves the credentials unusable for production
+	// forging rather than retaining stale policy data.
+	pc.maxKESEvolutions = 0
+	pc.opCertExpiryKES = 0
+	pc.opCertValidated = false
+
+	if pc.opCert == nil {
+		pc.opCertStartKES = 0
+		return errors.New("operational certificate not loaded")
+	}
+	pc.opCertStartKES = pc.opCert.KESPeriod
+	if pc.isLoadedUnsafe() {
+		if err := pc.validateOpCertUnsafe(); err != nil {
+			return fmt.Errorf("validate operational certificate: %w", err)
+		}
+		pc.opCertValidated = true
+	}
+	if genesis == nil {
+		return errors.New("shelley genesis is required")
+	}
+	if genesis.MaxKESEvolutions <= 0 {
+		return fmt.Errorf(
+			"genesis maxKESEvolutions must be positive, got %d",
+			genesis.MaxKESEvolutions,
+		)
+	}
+	// #nosec G115 -- guarded positive above; int fits within uint64.
+	maxEvolutions := uint64(genesis.MaxKESEvolutions)
+	expiryPeriod, err := opCertExpiryPeriod(
+		pc.opCert.KESPeriod,
+		maxEvolutions,
+	)
+	if err != nil {
+		return err
+	}
+	pc.maxKESEvolutions = maxEvolutions
+	pc.opCertExpiryKES = expiryPeriod
+	return nil
+}
+
 // LedgerView is the subset of ledger state the post-startup credential
 // cross-check needs. The forging package depends on it as a small
 // interface so the package itself stays free of a ledger dependency, and

--- a/ledger/forging/keys.go
+++ b/ledger/forging/keys.go
@@ -1059,12 +1059,21 @@ func (pc *PoolCredentials) ArmKesProtocolLifetime(
 		return errors.New("operational certificate not loaded")
 	}
 	pc.opCertStartKES = pc.opCert.KESPeriod
-	if pc.isLoadedUnsafe() {
-		if err := pc.validateOpCertUnsafe(); err != nil {
-			return fmt.Errorf("validate operational certificate: %w", err)
-		}
-		pc.opCertValidated = true
+	// Without signing material the certificate cannot be validated, so
+	// opCertValidated would stay false and OpCertExpiryPeriod would report 0
+	// however far the rest of this function got. Fail rather than return
+	// nil: a method named Arm that reports success and arms nothing leaves
+	// the caller believing the per-slot forge gate has data to enforce when
+	// it does not. Unreachable from the block producer startup path, where
+	// LoadFromFiles precedes this, but this is exported API on an exported
+	// type.
+	if !pc.isLoadedUnsafe() {
+		return errors.New("signing material not loaded")
 	}
+	if err := pc.validateOpCertUnsafe(); err != nil {
+		return fmt.Errorf("validate operational certificate: %w", err)
+	}
+	pc.opCertValidated = true
 	if genesis == nil {
 		return errors.New("shelley genesis is required")
 	}

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -158,6 +158,77 @@ func writeTestOpCert(t *testing.T, contents string) string {
 	return path
 }
 
+func TestArmKesProtocolLifetime(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	genesis := synthGenesis(
+		129600, 62, time.Second,
+		time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC),
+	)
+
+	pc := NewPoolCredentials()
+	err := pc.LoadFromFiles(vrfPath, kesPath, opCertPath)
+	require.NoError(t, err)
+
+	// Before arming there is no usable protocol lifetime.
+	assert.Zero(t, pc.OpCertExpiryPeriod())
+	assert.Zero(t, pc.PeriodsRemaining(1))
+
+	require.NoError(t, pc.ArmKesProtocolLifetime(genesis))
+	assert.Equal(t, uint64(0), pc.opCertStartKES)
+	assert.Equal(t, uint64(62), pc.maxKESEvolutions)
+	assert.Equal(t, uint64(62), pc.opCertExpiryKES)
+	assert.Equal(t, uint64(62), pc.OpCertExpiryPeriod())
+	// Periods inside the armed window count down; at/after expiry they are 0.
+	assert.Equal(t, uint64(57), pc.PeriodsRemaining(5))
+	assert.Equal(t, uint64(61), pc.PeriodsRemaining(1))
+	assert.Zero(t, pc.PeriodsRemaining(62))
+	assert.Zero(t, pc.PeriodsRemaining(100))
+	assert.True(t, pc.opCertValidated)
+}
+
+func TestArmKesProtocolLifetime_RequiresGenesis(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	err := pc.ArmKesProtocolLifetime(nil)
+	require.Error(t, err)
+	// The opcert structure may validate before the genesis is consulted, but
+	// without genesis data there is no protocol lifetime to enforce.
+	assert.Zero(t, pc.maxKESEvolutions)
+	assert.Zero(t, pc.opCertExpiryKES)
+	assert.Zero(t, pc.OpCertExpiryPeriod())
+	assert.Zero(t, pc.PeriodsRemaining(1))
+}
+
+func TestArmKesProtocolLifetime_RequiresCredentials(t *testing.T) {
+	genesis := synthGenesis(
+		129600, 62, time.Second,
+		time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC),
+	)
+	pc := NewPoolCredentials()
+	err := pc.ArmKesProtocolLifetime(genesis)
+	require.Error(t, err)
+	assert.Zero(t, pc.OpCertExpiryPeriod())
+}
+
+func TestArmKesProtocolLifetime_RequiresPositiveMaxEvolutions(t *testing.T) {
+	vrfPath, kesPath, opCertPath := createTestKeys(t)
+	genesis := synthGenesis(
+		129600, 0, time.Second,
+		time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC),
+	)
+	pc := NewPoolCredentials()
+	require.NoError(t, pc.LoadFromFiles(vrfPath, kesPath, opCertPath))
+
+	err := pc.ArmKesProtocolLifetime(genesis)
+	require.Error(t, err)
+	assert.Zero(t, pc.maxKESEvolutions)
+	assert.Zero(t, pc.opCertExpiryKES)
+	assert.Zero(t, pc.OpCertExpiryPeriod())
+	assert.Zero(t, pc.PeriodsRemaining(1))
+}
+
 func TestPoolCredentialsLoadFromFiles(t *testing.T) {
 	vrfPath, kesPath, opCertPath := createTestKeys(t)
 	loadedVRF, err := loadSecretKeyFromFile(vrfPath)

--- a/ledger/forging/keys_test.go
+++ b/ledger/forging/keys_test.go
@@ -1538,3 +1538,23 @@ func TestValidateOpCertSequence(t *testing.T) {
 		})
 	}
 }
+
+// TestArmKesProtocolLifetime_RequiresSigningMaterial pins that Arm reports
+// failure when it cannot arm anything. With an opcert present but no signing
+// material the certificate cannot be validated, so the protocol lifetime
+// would be unreadable; returning nil there would tell the block producer the
+// per-slot forge gate has data to enforce when it has none.
+func TestArmKesProtocolLifetime_RequiresSigningMaterial(t *testing.T) {
+	genesis := synthGenesis(
+		129600, 62, time.Second,
+		time.Date(2017, 9, 23, 21, 44, 51, 0, time.UTC),
+	)
+	pc := &PoolCredentials{opCert: &OpCert{KESPeriod: 1}}
+	require.False(t, pc.IsLoaded())
+
+	err := pc.ArmKesProtocolLifetime(genesis)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signing material not loaded")
+	assert.Zero(t, pc.OpCertExpiryPeriod())
+	assert.Zero(t, pc.PeriodsRemaining(1))
+}

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -233,3 +233,28 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 	}
 	return &summary, nil
 }
+
+// WallClockSlotFromConfirmedHistory returns the absolute slot corresponding to
+// the current wall-clock time derived only from the confirmed era history, and
+// false when the wall clock falls past that history's forecast horizon.
+//
+// In the false case CurrentSlot can only extrapolate the wall clock through
+// the newest confirmed era's slot length, which does not reflect chains whose
+// later eras have not been applied yet: a mainnet node importing from genesis
+// judges the wall clock with Byron's 20s slots even though the real chain
+// moved to one-second slots at epoch 208. Operational callers that must make a
+// time-sensitive judgement against the wall-clock slot — such as the block
+// producer's operational-certificate KES-period preflight — should use this
+// instead of the extrapolated CurrentSlot, and defer the judgement until the
+// confirmed era history spans the wall clock again.
+func (ls *LedgerState) WallClockSlotFromConfirmedHistory() (uint64, bool) {
+	sum, err := ls.HardForkSummary()
+	if err != nil {
+		return 0, false
+	}
+	slot, err := sum.TimeToSlot(time.Now())
+	if err != nil {
+		return 0, false
+	}
+	return slot, true
+}

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -16,6 +16,7 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
@@ -238,6 +239,16 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 // the current wall-clock time derived only from the confirmed era history, and
 // false when the wall clock falls past that history's forecast horizon.
 //
+// Only the past-horizon case reports false. Any other failure -- an empty
+// epoch cache, a summary that will not build, a wall clock before genesis --
+// is returned as an error instead. The distinction matters to the block
+// producer: false means "cannot judge yet, defer and let the per-slot gate
+// enforce", so conflating a genuine internal failure with it would silently
+// downgrade a hard startup failure into a warning. Note that before-genesis
+// reaches here as hardfork.ErrBeforeGenesis, a different sentinel from
+// ledger.ErrBeforeGenesis, and returning it as an error keeps that case a
+// hard failure regardless of which sentinel a caller happens to check.
+//
 // In the false case CurrentSlot can only extrapolate the wall clock through
 // the newest confirmed era's slot length, which does not reflect chains whose
 // later eras have not been applied yet: a mainnet node importing from genesis
@@ -247,14 +258,24 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 // producer's operational-certificate KES-period preflight — should use this
 // instead of the extrapolated CurrentSlot, and defer the judgement until the
 // confirmed era history spans the wall clock again.
-func (ls *LedgerState) WallClockSlotFromConfirmedHistory() (uint64, bool) {
+func (ls *LedgerState) WallClockSlotFromConfirmedHistory() (
+	uint64,
+	bool,
+	error,
+) {
 	sum, err := ls.HardForkSummary()
 	if err != nil {
-		return 0, false
+		return 0, false, fmt.Errorf("build confirmed era summary: %w", err)
 	}
 	slot, err := sum.TimeToSlot(time.Now())
-	if err != nil {
-		return 0, false
+	switch {
+	case errors.Is(err, hardfork.ErrPastHorizon):
+		return 0, false, nil
+	case err != nil:
+		return 0, false, fmt.Errorf(
+			"resolve wall-clock slot from confirmed history: %w",
+			err,
+		)
 	}
-	return slot, true
+	return slot, true, nil
 }

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -944,3 +944,106 @@ func TestHardForkSummary_HorizonAnchoredAtAppliedParent(t *testing.T) {
 		"an anchor behind the published tip must not shrink the horizon",
 	)
 }
+
+func TestWallClockSlotFromConfirmedHistory_SupportedWhenEraSpansNow(t *testing.T) {
+	// A single unbounded era whose slot length is 1s spans the real wall
+	// clock, so the method returns the true current slot. The exact slot
+	// changes every second, but it must be far larger than the warm-up
+	// overhead of a fresh epoch cache (a value that can only grow, never
+	// shrink).
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       5,
+				StartSlot:     500,
+				SlotLength:    1000,
+				LengthInSlots: 100,
+				EraId:         1,
+			},
+		},
+		currentEra:     eras.EraDesc{Id: 1, Name: "Shelley"},
+		transitionInfo: hardfork.NewTransitionKnown(7),
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(550, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	// UnsafeIndefiniteSafeZone → End nil → now always in-era.
+	ls.cachedShape.Store(&hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 1,
+			Params: hardfork.EraParams{
+				EpochSize:     100,
+				SlotLength:    time.Second,
+				SafeZoneSlots: 0,
+			},
+		}},
+	})
+	ls.publishSnapshotsLocked()
+
+	slot, ok := ls.WallClockSlotFromConfirmedHistory()
+	require.True(t, ok, "a 1s-era covering now must resolve the wall-clock slot")
+	assert.Greater(t, slot, uint64(100_000_000),
+		"2026 wall-clock slot via 1s slots since 2022-10-25 must exceed 100M")
+}
+
+func TestWallClockSlotFromConfirmedHistory_UnsupportedWhenPastHorizon(t *testing.T) {
+	// A bounded era whose forecast horizon ends far in the past (fresh
+	// mainnet has only a single bounded Byron era) cannot resolve the
+	// current wall-clock time, so the method must return false.
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				SlotLength:    20000,
+				LengthInSlots: 21600,
+				EraId:         0,
+			},
+		},
+		currentEra: eras.EraDesc{Id: 0, Name: "Byron"},
+		transitionInfo: hardfork.TransitionInfo{
+			State: hardfork.TransitionUnknown,
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(0, []byte("genesis")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	// NormalSafeZone snaps the end well within the same epoch — far past the
+	// real wall clock in 2026.
+	ls.cachedShape.Store(&hardfork.Shape{
+		Eras: []hardfork.ShapeEntry{{
+			EraID: 0,
+			Params: hardfork.EraParams{
+				EpochSize:     21600,
+				SlotLength:    20 * time.Second,
+				SafeZoneSlots: 21600,
+			},
+			NextEraTrigger: hardfork.NewTriggerAtEpoch(1),
+		}},
+	})
+	ls.publishSnapshotsLocked()
+
+	slot, ok := ls.WallClockSlotFromConfirmedHistory()
+	assert.False(t, ok,
+		"bounded era horizon must not resolve the current wall-clock slot")
+	assert.Zero(t, slot)
+}
+
+func TestWallClockSlotFromConfirmedHistory_EmptyCache(t *testing.T) {
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			CardanoNodeConfig: newTestEraHistoryCfg(t),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	slot, ok := ls.WallClockSlotFromConfirmedHistory()
+	assert.False(t, ok, "empty epoch cache must yield unsupported")
+	assert.Zero(t, slot)
+}

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -983,7 +983,8 @@ func TestWallClockSlotFromConfirmedHistory_SupportedWhenEraSpansNow(t *testing.T
 	})
 	ls.publishSnapshotsLocked()
 
-	slot, ok := ls.WallClockSlotFromConfirmedHistory()
+	slot, ok, err := ls.WallClockSlotFromConfirmedHistory()
+	require.NoError(t, err)
 	require.True(t, ok, "a 1s-era covering now must resolve the wall-clock slot")
 	assert.Greater(t, slot, uint64(100_000_000),
 		"2026 wall-clock slot via 1s slots since 2022-10-25 must exceed 100M")
@@ -1029,7 +1030,9 @@ func TestWallClockSlotFromConfirmedHistory_UnsupportedWhenPastHorizon(t *testing
 	})
 	ls.publishSnapshotsLocked()
 
-	slot, ok := ls.WallClockSlotFromConfirmedHistory()
+	slot, ok, err := ls.WallClockSlotFromConfirmedHistory()
+	require.NoError(t, err,
+		"past-horizon is the deferral signal, not an internal failure")
 	assert.False(t, ok,
 		"bounded era horizon must not resolve the current wall-clock slot")
 	assert.Zero(t, slot)
@@ -1043,7 +1046,12 @@ func TestWallClockSlotFromConfirmedHistory_EmptyCache(t *testing.T) {
 	}
 	ls.publishSnapshotsLocked()
 
-	slot, ok := ls.WallClockSlotFromConfirmedHistory()
-	assert.False(t, ok, "empty epoch cache must yield unsupported")
+	// An empty epoch cache is an internal failure, not the past-horizon
+	// deferral signal. It must surface as an error: reporting it as
+	// unsupported would let the block producer downgrade a hard startup
+	// failure into a warning and carry on with an unjudged certificate.
+	slot, ok, err := ls.WallClockSlotFromConfirmedHistory()
+	require.Error(t, err, "empty epoch cache must not masquerade as deferral")
+	assert.False(t, ok)
 	assert.Zero(t, slot)
 }

--- a/node_forging.go
+++ b/node_forging.go
@@ -52,19 +52,60 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 			"block producer mode requires ledger state for current slot",
 		)
 	}
-	currentSlot, err := n.ledgerState.CurrentSlot()
-	if err != nil {
+	if _, err := n.ledgerState.CurrentSlot(); err != nil {
 		if !errors.Is(err, ledger.ErrBeforeGenesis) {
 			return nil, fmt.Errorf("compute current slot: %w", err)
 		}
-		currentSlot = 0
+		// Clock before genesis: preserve the historical hard fail through the
+		// strict preflight (an opcert can never be "current" before genesis).
+		return n.validateBlockProducerStartupAtSlot(0)
 	}
-	return n.validateBlockProducerStartupAtSlot(currentSlot)
+	// The current wall-clock slot only reliably places an operational
+	// certificate in time when the confirmed era history spans the wall clock.
+	// A node importing from genesis or restarting far behind has confirmed
+	// history that stops at its newest applied era: CurrentSlot then
+	// extrapolates through that era's slot length — a fresh mainnet node
+	// judges the wall clock with Byron's 20s slots even though the real chain
+	// moved to one-second slots at epoch 208 — which cannot judge an opcert for
+	// the actual chain. In that state defer the plausibility check: forging
+	// stays gated on sync progress and re-enforces the opcert KES lifetime per
+	// slot, and the protocol lifetime is still armed below so that runtime gate
+	// has data to enforce.
+	supportedSlot, supported := n.ledgerState.WallClockSlotFromConfirmedHistory()
+	if !supported {
+		creds, err := n.validateBlockProducerCredentialMaterial()
+		if err != nil {
+			return nil, err
+		}
+		genesis, err := n.blockProducerShelleyGenesis()
+		if err != nil {
+			return nil, err
+		}
+		if err := creds.ArmKesProtocolLifetime(genesis); err != nil {
+			return nil, fmt.Errorf("arm KES protocol lifetime: %w", err)
+		}
+		opCert := creds.GetOpCert()
+		n.config.logger.Warn(
+			"block producer startup: confirmed era history does not span the current wall-clock slot yet; "+
+				"deferring the operational-certificate KES-period plausibility check until the ledger catches up. "+
+				"Credential material is validated; forging stays gated on sync progress and re-checks the opcert KES lifetime per slot.",
+			"component", "node",
+			"tip_slot", n.ledgerState.ChainTipSlot(),
+			"opcert_kes_period", opCert.KESPeriod,
+			"opcert_expiry_period", creds.OpCertExpiryPeriod(),
+		)
+		return creds, nil
+	}
+	return n.validateBlockProducerStartupAtSlot(supportedSlot)
 }
 
-func (n *Node) validateBlockProducerStartupAtSlot(
-	currentSlot uint64,
-) (*forging.PoolCredentials, error) {
+// validateBlockProducerCredentialMaterial loads the pool credentials and
+// validates the operational certificate's structure and cold-key signature,
+// without judging it against any slot. The slot-dependent KES-period
+// plausibility check lives in validateBlockProducerStartupAtSlot; callers
+// needing the certificate armed but not yet placed in time combine this with
+// PoolCredentials.ArmKesProtocolLifetime.
+func (n *Node) validateBlockProducerCredentialMaterial() (*forging.PoolCredentials, error) {
 	creds := forging.NewPoolCredentials()
 	if err := creds.LoadFromFiles(
 		n.config.shelleyVRFKey,
@@ -75,6 +116,16 @@ func (n *Node) validateBlockProducerStartupAtSlot(
 	}
 	if err := creds.ValidateOpCert(); err != nil {
 		return nil, fmt.Errorf("validate operational certificate: %w", err)
+	}
+	return creds, nil
+}
+
+func (n *Node) validateBlockProducerStartupAtSlot(
+	currentSlot uint64,
+) (*forging.PoolCredentials, error) {
+	creds, err := n.validateBlockProducerCredentialMaterial()
+	if err != nil {
+		return nil, err
 	}
 	genesis, err := n.blockProducerShelleyGenesis()
 	if err != nil {

--- a/node_forging.go
+++ b/node_forging.go
@@ -58,7 +58,7 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 		}
 		// Clock before genesis: preserve the historical hard fail through the
 		// strict preflight (an opcert can never be "current" before genesis).
-		return n.validateBlockProducerStartupAtSlot(0)
+		return n.validateBlockProducerStartupForClock(0, true)
 	}
 	// The current wall-clock slot only reliably places an operational
 	// certificate in time when the confirmed era history spans the wall clock.
@@ -67,36 +67,67 @@ func (n *Node) validateBlockProducerStartup() (*forging.PoolCredentials, error) 
 	// extrapolates through that era's slot length — a fresh mainnet node
 	// judges the wall clock with Byron's 20s slots even though the real chain
 	// moved to one-second slots at epoch 208 — which cannot judge an opcert for
-	// the actual chain. In that state defer the plausibility check: forging
-	// stays gated on sync progress and re-enforces the opcert KES lifetime per
-	// slot, and the protocol lifetime is still armed below so that runtime gate
-	// has data to enforce.
-	supportedSlot, supported := n.ledgerState.WallClockSlotFromConfirmedHistory()
-	if !supported {
-		creds, err := n.validateBlockProducerCredentialMaterial()
-		if err != nil {
-			return nil, err
-		}
-		genesis, err := n.blockProducerShelleyGenesis()
-		if err != nil {
-			return nil, err
-		}
-		if err := creds.ArmKesProtocolLifetime(genesis); err != nil {
-			return nil, fmt.Errorf("arm KES protocol lifetime: %w", err)
-		}
-		opCert := creds.GetOpCert()
-		n.config.logger.Warn(
-			"block producer startup: confirmed era history does not span the current wall-clock slot yet; "+
-				"deferring the operational-certificate KES-period plausibility check until the ledger catches up. "+
-				"Credential material is validated; forging stays gated on sync progress and re-checks the opcert KES lifetime per slot.",
-			"component", "node",
-			"tip_slot", n.ledgerState.ChainTipSlot(),
-			"opcert_kes_period", opCert.KESPeriod,
-			"opcert_expiry_period", creds.OpCertExpiryPeriod(),
-		)
-		return creds, nil
+	// the actual chain.
+	supportedSlot, supported, err := n.ledgerState.
+		WallClockSlotFromConfirmedHistory()
+	if err != nil {
+		return nil, fmt.Errorf("wall-clock slot from confirmed history: %w", err)
 	}
-	return n.validateBlockProducerStartupAtSlot(supportedSlot)
+	return n.validateBlockProducerStartupForClock(supportedSlot, supported)
+}
+
+// validateBlockProducerStartupForClock decides how to judge the operational
+// certificate given a wall-clock slot and whether the confirmed era history
+// actually supports it.
+//
+// When supported, this is the strict historical preflight: a certificate
+// staged for the future or already expired fails startup here. When not
+// supported, the KES-period plausibility check is deferred rather than
+// skipped — credential material is still validated and the protocol lifetime
+// is still armed, so the forger's per-slot gate has the data it needs to
+// reject the certificate before Praos leader selection.
+//
+// Split out from validateBlockProducerStartup so both branches are reachable
+// without a live LedgerState, the same reason
+// validateBlockProducerStartupAtSlot and validateBlockProducerLedgerWithView
+// exist separately.
+func (n *Node) validateBlockProducerStartupForClock(
+	slot uint64,
+	supported bool,
+) (*forging.PoolCredentials, error) {
+	if supported {
+		return n.validateBlockProducerStartupAtSlot(slot)
+	}
+	creds, err := n.validateBlockProducerCredentialMaterial()
+	if err != nil {
+		return nil, err
+	}
+	genesis, err := n.blockProducerShelleyGenesis()
+	if err != nil {
+		return nil, err
+	}
+	if err := creds.ArmKesProtocolLifetime(genesis); err != nil {
+		return nil, fmt.Errorf("arm KES protocol lifetime: %w", err)
+	}
+	opCert := creds.GetOpCert()
+	if opCert == nil {
+		return nil, errors.New("block producer operational certificate is nil")
+	}
+	var tipSlot uint64
+	if n.ledgerState != nil {
+		tipSlot = n.ledgerState.ChainTipSlot()
+	}
+	n.config.logger.Warn(
+		"block producer startup: confirmed era history does not span the current wall-clock slot yet; "+
+			"deferring the operational-certificate KES-period plausibility check until the ledger catches up. "+
+			"The opcert KES lifetime is re-checked per slot and forging cannot proceed while it fails; "+
+			"sync progress additionally gates forging whenever an upstream peer is active.",
+		"component", "node",
+		"tip_slot", tipSlot,
+		"opcert_kes_period", opCert.KESPeriod,
+		"opcert_expiry_period", creds.OpCertExpiryPeriod(),
+	)
+	return creds, nil
 }
 
 // validateBlockProducerCredentialMaterial loads the pool credentials and

--- a/node_forging_test.go
+++ b/node_forging_test.go
@@ -468,3 +468,107 @@ func legacyLeiosParentBlock(
 		Type:   dijkstra.BlockTypeDijkstra,
 	}
 }
+
+// expiredKESGenesisForBP builds a Shelley genesis under which the devnet
+// opcert (KESPeriod 0) is well outside its validity window: many KES periods
+// have elapsed since systemStart and maxKESEvolutions=1 makes anything past
+// period 1 expired. The strict preflight must reject it, which is what makes
+// it useful for showing the deferred path is a deferral and not a bypass.
+func expiredKESGenesisForBP(t *testing.T) *cardano.CardanoNodeConfig {
+	t.Helper()
+	cfg := &cardano.CardanoNodeConfig{}
+	systemStart := time.Now().Add(-365 * 24 * time.Hour)
+	if err := cfg.LoadShelleyGenesisFromReader(strings.NewReader(`{
+		"systemStart": "` + systemStart.UTC().Format(time.RFC3339Nano) + `",
+		"securityParam": 10,
+		"activeSlotsCoeff": 0.5,
+		"slotsPerKESPeriod": 10,
+		"maxKESEvolutions": 1,
+		"slotLength": 1
+	}`)); err != nil {
+		t.Fatalf("LoadShelleyGenesisFromReader: %v", err)
+	}
+	return cfg
+}
+
+// TestValidateBlockProducerStartupForClock_SupportedStillRejectsExpiredOpCert
+// is the property that keeps the deferral from being a relaxation of the
+// gate. When the confirmed era history does span the wall clock there is
+// nothing to defer, so an expired or future-staged certificate must still
+// fail startup exactly as it did before the deferral existed.
+func TestValidateBlockProducerStartupForClock_SupportedStillRejectsExpiredOpCert(
+	t *testing.T,
+) {
+	vrf, kes, opcert := devnetCredPaths(t)
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, expiredKESGenesisForBP(t))
+	_, err := n.validateBlockProducerStartupForClock(20, true)
+	if err == nil {
+		t.Fatal(
+			"supported wall clock must still reject an expired opcert;" +
+				" the deferral would otherwise be a relaxation of the gate",
+		)
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error, got: %v", err)
+	}
+}
+
+// TestValidateBlockProducerStartupForClock_DeferredArmsInsteadOfFailing pins
+// the other half, against the identical genesis and credentials that the
+// supported case above rejects. The only difference between the two calls is
+// whether the confirmed era history supports the wall-clock slot, so this
+// pair isolates the behavior change to exactly that condition.
+//
+// The armed protocol lifetime is asserted, not just the absence of an error:
+// the per-slot gate in the forger is what enforces the certificate in the
+// deferred state, and it fails closed on a zero expiry period. Returning
+// unarmed credentials here would leave the node unable to forge at all
+// rather than deferring the judgement.
+func TestValidateBlockProducerStartupForClock_DeferredArmsInsteadOfFailing(
+	t *testing.T,
+) {
+	vrf, kes, opcert := devnetCredPaths(t)
+	n := newTestNodeForBP(t, true, vrf, kes, opcert, expiredKESGenesisForBP(t))
+	creds, err := n.validateBlockProducerStartupForClock(20, false)
+	if err != nil {
+		t.Fatalf(
+			"deferred path must not fail startup on the slot-dependent"+
+				" check it is deferring: %v",
+			err,
+		)
+	}
+	if !creds.IsLoaded() {
+		t.Error("expected credentials to be loaded")
+	}
+	if creds.OpCertExpiryPeriod() == 0 {
+		t.Error(
+			"expected the KES protocol lifetime to be armed;" +
+				" the forger's per-slot gate fails closed on a zero expiry",
+		)
+	}
+}
+
+// TestValidateBlockProducerStartupForClock_DeferredStillValidatesMaterial
+// pins what the deferral does *not* cover. Only the slot-dependent
+// KES-period judgement is deferred; the credential material itself is still
+// loaded and its cold-key signature still checked, so missing or unreadable
+// key files fail startup on this path too.
+func TestValidateBlockProducerStartupForClock_DeferredStillValidatesMaterial(
+	t *testing.T,
+) {
+	tmp := t.TempDir()
+	n := newTestNodeForBP(
+		t, true,
+		filepath.Join(tmp, "missing-vrf.skey"),
+		filepath.Join(tmp, "missing-kes.skey"),
+		filepath.Join(tmp, "missing-opcert.cert"),
+		shelleyGenesisCfgForBP(t, time.Now().Add(-time.Hour)),
+	)
+	_, err := n.validateBlockProducerStartupForClock(20, false)
+	if err == nil {
+		t.Fatal("deferred path must still validate credential material")
+	}
+	if !strings.Contains(err.Error(), "load pool credentials") {
+		t.Errorf("expected 'load pool credentials' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`CurrentSlot` extrapolates the wall clock through the **newest confirmed era's** slot length. A node starting from an empty or far-behind ledger has confirmed history that stops at Byron, so it interprets ~197M seconds of wall clock as Byron 20s slots and computes a current slot near 14,125,000 — KES period 108.

A perfectly valid mainnet operational certificate then looks like it is from the future, and the block producer crash-loops at startup:

```
opcert KES period 1486 is in the future (current 108)
```

The certificate is correct; the clock the check used is not. Nothing the operator can do fixes it — rotating the certificate makes it worse — and it resolves itself the moment confirmed era history spans the wall clock. Observed on a mainnet block producer recovering from an empty ledger.

## Change

Run the strict plausibility check only when the confirmed era history actually spans the wall clock, determined by the new `LedgerState.WallClockSlotFromConfirmedHistory`.

When it does not, still validate the credential material (structure and cold-key signature) and arm the protocol KES lifetime via `PoolCredentials.ArmKesProtocolLifetime`, but defer judging the certificate against a slot that cannot place it, logging a warning that says so.

A clock genuinely **before genesis** keeps the original hard failure, since no certificate can be current then.

## Why deferring is safe

The startup check is not the only enforcement. `forging.forger` re-derives the KES period on **every forge attempt**, before Praos leader selection, and refuses to forge when the period is below the certificate's start or at/past its expiry (`forger.go` — "forge skip: operational certificate is not yet valid" / "...expired"). An unvalidated lifetime fails closed there too.

Arming the lifetime at startup is precisely what gives that per-slot gate its data — so the deferral narrows *when* the certificate is judged, not *whether* it is.

## Relationship to existing work

- **#4001** widens the opcert counter and KES period to full uint64. Different root cause (overflow), does not address era-length extrapolation.
- **#3926** added, then reverted, a startup era-scoped no-gap opcert counter check. The revert rationale — that a node whose applied tip is behind wall-clock time, several rotations in, would fail startup — is the same class of problem. That change removed the check; this one defers it while keeping the runtime gate.

## Tests

- `TestWallClockSlotFromConfirmedHistory_SupportedWhenEraSpansNow` / `_UnsupportedWhenPastHorizon` / `_EmptyCache`
- `TestArmKesProtocolLifetime` plus its `_RequiresGenesis` / `_RequiresCredentials` / `_RequiresPositiveMaxEvolutions` failure paths

All pass under `-race`, along with the pre-existing `TestHardForkSummary_HorizonAnchoredAtAppliedParent` from #3844, which shares the file. `go build ./...`, `go vet`, `gofmt` clean.

Note: `ledger/leader`'s `TestThresholdPreservesProtocolBoundary` fails on `main` independently of this PR (confirmed on a clean `origin/main` checkout) — pre-existing, out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the block producer crash-loop that treated a valid mainnet operational certificate as "in the future" on startup from an empty or far-behind ledger: `CurrentSlot` extrapolates the wall clock through the newest confirmed era's slot length, so a node whose confirmed history stops at Byron computes a KES period far below the certificate's real one.

The strict KES-period check now runs only when the confirmed era history spans the wall clock, via the new `WallClockSlotFromConfirmedHistory`. When it doesn't, the node validates credential material and arms the protocol KES lifetime via `ArmKesProtocolLifetime`, but defers judging the period, logs a warning, and the clock-before-genesis case keeps its original hard failure. Only the past-horizon case defers; internal failures like an empty epoch cache still error out at startup.

**Deferral is safe**
- The forger re-checks the KES period on every forge attempt and refuses to forge outside the certificate's lifetime, so an unvalidated startup check fails closed per slot.
- Arming the lifetime at startup is what feeds that per-slot gate; the deferral narrows *when* the certificate is judged, not *whether* it is.

**Tests**
- New tests cover `WallClockSlotFromConfirmedHistory`, `ArmKesProtocolLifetime`, and the deferred branch: it arms credentials instead of failing, the strict path still rejects an expired certificate, and missing key material still fails startup.
- `ledger/leader`'s `TestThresholdPreservesProtocolBoundary` fails on `main` independently of this PR.

<sup>Written for commit 42d096f7a0f77a905c7132f36fd6a54ee54d1fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block producer startup validation when confirmed era history does not cover the current wall-clock time.
  - Startup now defers only slot-dependent KES expiry checks when the forecast horizon is insufficient, while continuing to validate credentials and operational certificates.
  - KES protocol lifetime is initialized for deferred validation, allowing runtime checks to remain available.
  - Runtime validation enforces the KES interval before leader selection.
  - Other startup failures, including invalid credentials, missing configuration, and pre-genesis conditions, continue to fail startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->