### PR TITLE
docs(metadata): name the NULL path a DRep refund never takes

### DIFF
--- a/database/plugin/metadata/sqlstore/transaction_certificates.go
+++ b/database/plugin/metadata/sqlstore/transaction_certificates.go
@@ -338,7 +338,9 @@ RETURNING id`,
 		return id, nil, err
 	case *lcommon.DeregistrationDrepCertificate:
 		// A DRep deregistration carries its refund in the certificate
-		// itself, so this amount is always known and never NULL.
+		// itself, so this amount is always known. The pointer below is
+		// never nil, so this deposit never takes nullableDecimalUint64's
+		// NULL path, which exists for a deposit the ingest never knew.
 		amount := uint64(cert.Amount)
 		id, err := applyDrepDeregistrationCertificate(
 			ctx,


### PR DESCRIPTION
Comment-only. No behaviour change.

`applySpecializedCertificate`'s `DeregistrationDrepCertificate` case builds `amount` and passes `&amount`, so the pointer is never nil and the deposit cannot reach `nullableDecimalUint64`'s NULL branch. The existing comment states the conclusion — "always known and never NULL" — without naming the branch it is talking about or why that branch exists.

`nullableDecimalUint64` returns a nil interface only for a nil pointer, which the driver writes as SQL NULL, and its own doc records the rule: a deposit the ingest never knew must not be filled in from today's protocol parameters. That distinction is what #3836 introduced and what #3829 was about.

Naming the branch keeps a later change from routing a known deposit through the unknown-deposit path.

Verification:

- `go build ./...`: exit 0
- `go test ./database/plugin/metadata/sqlstore/`: exit 0, `ok ... 9.296s`
- `golangci-lint run ./database/plugin/metadata/...`: 0 issues

Related: #3918 carried an equivalent comment at this same case and was closed as superseded by #3836; the wording there named the fallback, which `main`'s did not. This keeps that detail without the rest of that branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the comment in `DeregistrationDrepCertificate` handling to name the NULL path the refund never takes and explain why that path exists. Comment-only, no behavior change.

<sup>Written for commit 8db757505c44ff7b86a8c3d8fbddc012f4cb1fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation regarding deposit handling during DRep deregistration certificate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->