### PR TITLE
fix(chainselection): stop flapping on same-chain delivered frontiers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3174,6 +3174,22 @@ delivered frontier from a bounded `k+1` header history; if the point is no longe
 selector uses the rollback point with a conservative zero block number and
 never promotes the accompanying advertised tip into the observed frontier.
 
+The delivered frontier measures how many headers a peer has served US, not what
+chain it holds, so the behind-peer filter treats a gap between two peers that
+advertise the IDENTICAL tip as delivery speed rather than chain quality
+(`sameCanonicalChain` in `chainselection/selector.go`). Without that
+distinction, two canonical public roots on the same chain whose frontiers
+differed by more than `k` made each other ineligible; the incumbent's exclusion
+then skipped the anti-flap pin, and each resulting switch triggered the
+fresh-cursor close above, which reset the newly selected peer's cursor and
+handed the frontier lead back to the other peer. Because the advertised tip is
+untrusted, the same-chain allowance is checked against delivered evidence: it is
+withdrawn when either peer's retained `k+1` header history holds a different
+block at the other's frontier slot. The allowance only keeps a peer in the
+candidate pool and holds the incumbent's pin; Praos comparison, the
+implausible-frontier bound, the `k`-behind-the-applied-local-tip check, and
+Genesis corroboration are all unchanged.
+
 A queued header range that no peer will serve is bounded by a failure count,
 `blockfetchRangeFailure`, capped at `blockfetchMaxSameRangeFailures`. Failing
 to obtain the range has two shapes and both count against the same range,
@@ -3513,7 +3529,11 @@ pin to a dead/minority peer:
   implausibly behind).
 - Longer-chain escape: the challenger is genuinely taller than the incumbent by
   more than `catchUpPinHeadMargin` (= 2 blocks) — a real longer chain, not a
-  head micro-fork.
+  head micro-fork. Height here is the delivered frontier, so this escape does
+  not fire when the two peers advertise the identical tip: they hold the same
+  chain and the challenger is only further along in serving it, which is
+  transport speed rather than a longer chain. The progress-stall escape below
+  still releases an incumbent that stops driving local tip progress.
 - Progress-stall escape: the applied local tip has stopped advancing for at
   least `catchUpPinStallTimeout` (= 20s wall-clock, not 20 slots). `SetLocalTip`
   records the timestamp of the last FORWARD progress (block number advancing);

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3530,10 +3530,16 @@ pin to a dead/minority peer:
 - Longer-chain escape: the challenger is genuinely taller than the incumbent by
   more than `catchUpPinHeadMargin` (= 2 blocks) — a real longer chain, not a
   head micro-fork. Height here is the delivered frontier, so this escape does
-  not fire when the two peers advertise the identical tip: they hold the same
-  chain and the challenger is only further along in serving it, which is
-  transport speed rather than a longer chain. The progress-stall escape below
-  still releases an incumbent that stops driving local tip progress.
+  not fire when the two peers advertise the identical tip: they are TREATED AS
+  the same chain unless either one's retained `k+1` delivered history holds a
+  different block at the other's frontier slot, and the challenger is then read
+  as only further along in serving that chain, which is transport speed rather
+  than a longer chain. The classification is an allowance, not proof: a frontier
+  slot outside the retained window cannot be checked, so the allowance can rest
+  on the advertisement alone. The progress-stall escape below is evaluated
+  first and still releases an incumbent that stops driving local tip progress,
+  which is what bounds a peer that copies an advertisement it cannot be
+  contradicted on.
 - Progress-stall escape: the applied local tip has stopped advancing for at
   least `catchUpPinStallTimeout` (= 20s wall-clock, not 20 slots). `SetLocalTip`
   records the timestamp of the last FORWARD progress (block number advancing);

--- a/chainselection/frontier_flap_test.go
+++ b/chainselection/frontier_flap_test.go
@@ -1,0 +1,520 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainselection
+
+import (
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blinklabs-io/dingo/event"
+)
+
+// These tests pin the transport-frontier flapping reproduction from Preview
+// from-genesis validation: two canonical public roots advertise the SAME chain
+// tip while their locally delivered frontiers differ by more than k, purely
+// because one has served us more headers than the other. A delivered-frontier
+// difference between peers that agree on where the chain ends is a
+// transport-delivery artifact, not a chain-quality difference, and must not
+// drive the active-connection handoff.
+
+const (
+	// previewSecurityParam is Preview's k, the value in the reproduction.
+	previewSecurityParam = 432
+
+	// canonicalAdvertisedBlock and canonicalAdvertisedSlot are the tip both
+	// public roots advertised in the reproduction.
+	canonicalAdvertisedBlock = 4625199
+	canonicalAdvertisedSlot  = 121697834
+)
+
+// canonicalAdvertisedTip is the identical tip advertised by both canonical
+// peers.
+func canonicalAdvertisedTip() ochainsync.Tip {
+	return tip(
+		canonicalAdvertisedBlock,
+		canonicalAdvertisedSlot,
+		"canonical-preview-tip",
+	)
+}
+
+// deliveredFrontier builds a delivered-header frontier. Both peers are on the
+// same chain, so the same block number always carries the same slot and hash.
+func deliveredFrontier(block uint64) ochainsync.Tip {
+	return tip(block, 600000+block, "hdr-"+itoa(block))
+}
+
+func itoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+// drainChainSwitchEvents collects every ChainSwitchEvent already delivered to
+// the subscriber channel. The selector publishes synchronously from
+// EvaluateAndSwitch, so anything it decided has already been buffered by the
+// time the driving update call returns.
+func drainChainSwitchEvents(
+	t *testing.T,
+	ch <-chan event.Event,
+) []ChainSwitchEvent {
+	t.Helper()
+	var out []ChainSwitchEvent
+	for {
+		select {
+		case evt := <-ch:
+			switchEvent, ok := evt.Data.(ChainSwitchEvent)
+			require.True(t, ok, "unexpected event payload on switch channel")
+			out = append(out, switchEvent)
+		default:
+			return out
+		}
+	}
+}
+
+// peerSelectable exposes the selectability gate for assertions.
+func peerSelectable(
+	t *testing.T,
+	cs *ChainSelector,
+	connId ouroboros.ConnectionId,
+) bool {
+	t.Helper()
+	cs.mutex.RLock()
+	defer cs.mutex.RUnlock()
+	peerTip, ok := cs.peerTips[connId]
+	require.True(t, ok, "peer must be tracked")
+	return cs.isPeerSelectableLocked(connId, peerTip, false)
+}
+
+// TestSameChainFrontierLeadKeepsLaggingIncumbentSelectable pins the
+// eligibility half of the interaction. The observed-frontier k-behind filter
+// in isPeerSelectableLocked measures the DELIVERED frontier against the best
+// delivered frontier. Two canonical peers advertising the identical tip
+// differed by 742 delivered blocks (> Preview k=432), which marked the
+// incumbent ineligible and skipped the anti-flap pin entirely.
+func TestSameChainFrontierLeadKeepsLaggingIncumbentSelectable(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	advertised := canonicalAdvertisedTip()
+	require.True(t, cs.updatePeerTipObserved(
+		incumbent,
+		advertised,
+		deliveredFrontier(28029),
+		nil,
+	))
+	require.True(t, cs.updatePeerTipObserved(
+		challenger,
+		advertised,
+		deliveredFrontier(28029),
+		nil,
+	))
+
+	// Walk the challenger's delivered frontier forward in steps within k so
+	// the implausible-frontier bound accepts each one, until it leads by the
+	// 742 blocks observed in the reproduction.
+	for _, block := range []uint64{28461, 28771} {
+		require.True(t, cs.updatePeerTipObserved(
+			challenger,
+			advertised,
+			deliveredFrontier(block),
+			nil,
+		))
+	}
+
+	require.Equal(
+		t,
+		uint64(742),
+		cs.GetPeerTip(challenger).SelectionTip().BlockNumber-
+			cs.GetPeerTip(incumbent).SelectionTip().BlockNumber,
+		"scenario must reproduce the observed 742-block frontier gap",
+	)
+
+	assert.True(
+		t,
+		peerSelectable(t, cs, incumbent),
+		"a peer advertising the same canonical tip must stay selectable when it trails only in delivered headers",
+	)
+}
+
+// TestCanonicalPeersWithCrossingFrontiersDoNotFlap is the regression test for
+// the reported failure: equal canonical advertised tips with delivered
+// frontiers that repeatedly cross, including a gap larger than k. The active
+// connection must not change, and no peer-to-peer ChainSwitchEvent may be
+// published — that event is what drives the ledger's fresh-cursor close of a
+// selected peer that is ahead of the local tip
+// (ledger.chainSwitchNeedsFreshCursorLocked returns false for an empty
+// PreviousConnectionId, so only a peer-to-peer switch can trigger it).
+func TestCanonicalPeersWithCrossingFrontiersDoNotFlap(t *testing.T) {
+	eventBus := event.NewEventBus(nil, nil)
+	t.Cleanup(eventBus.Stop)
+	cs := NewChainSelector(ChainSelectorConfig{
+		EventBus:      eventBus,
+		SecurityParam: previewSecurityParam,
+	})
+	_, switchCh := eventBus.Subscribe(ChainSwitchEventType)
+
+	rootA := newTestConnectionId(1)
+	rootB := newTestConnectionId(2)
+	advertised := canonicalAdvertisedTip()
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	// Both roots have delivered the same header; A is established first and
+	// becomes the incumbent.
+	require.True(t, cs.updatePeerTipObserved(
+		rootA,
+		advertised,
+		deliveredFrontier(27900),
+		nil,
+	))
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, rootA, *cs.GetBestPeer())
+	require.True(t, cs.updatePeerTipObserved(
+		rootB,
+		advertised,
+		deliveredFrontier(27900),
+		nil,
+	))
+	require.Equal(t, rootA, *cs.GetBestPeer())
+
+	// Delivered frontiers now cross repeatedly. Every step keeps the two
+	// advertised tips identical, so no step is a chain-quality change; the
+	// last two crossings exceed k in both directions.
+	steps := []struct {
+		conn  ouroboros.ConnectionId
+		block uint64
+		note  string
+	}{
+		{rootB, 28029, "challenger leads by 129 (beyond the head margin)"},
+		{rootA, 28100, "incumbent retakes the lead"},
+		{rootB, 28461, "challenger leads by 361, still within k"},
+		{rootB, 28842, "challenger leads by 742, beyond k"},
+		{rootA, 28532, "incumbent catches up"},
+		{rootA, 28964, "incumbent retakes the lead"},
+		{rootB, 29274, "challenger leads by 310"},
+		{rootB, 29706, "challenger leads by 742, beyond k again"},
+	}
+	for _, step := range steps {
+		require.True(
+			t,
+			cs.updatePeerTipObserved(
+				step.conn,
+				advertised,
+				deliveredFrontier(step.block),
+				nil,
+			),
+			"delivered frontier %d must be accepted: %s",
+			step.block,
+			step.note,
+		)
+		best := cs.GetBestPeer()
+		require.NotNil(t, best, "selection must not stall: %s", step.note)
+		assert.Equal(
+			t,
+			rootA,
+			*best,
+			"active peer must not flap on delivered-frontier lead: %s",
+			step.note,
+		)
+	}
+
+	switchEvents := drainChainSwitchEvents(t, switchCh)
+	require.Len(
+		t,
+		switchEvents,
+		1,
+		"only the initial selection may publish a chain switch",
+	)
+	assert.Equal(
+		t,
+		ouroboros.ConnectionId{},
+		switchEvents[0].PreviousConnectionId,
+		"the only switch must be the initial selection, which cannot trigger a fresh-cursor close",
+	)
+}
+
+// TestDivergentPeersStillSwitchOnLongerDeliveredChain is the AC #2 negative
+// case for genuine chain divergence: the two peers advertise the same height
+// and slot but DIFFERENT blocks, so they are not on the same chain. The
+// delivered-frontier lead is then real chain quality and the selector must
+// converge to the longer chain.
+func TestDivergentPeersStillSwitchOnLongerDeliveredChain(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	incumbentAdvertised := tip(
+		canonicalAdvertisedBlock,
+		canonicalAdvertisedSlot,
+		"fork-a-tip",
+	)
+	challengerAdvertised := tip(
+		canonicalAdvertisedBlock,
+		canonicalAdvertisedSlot,
+		"fork-b-tip",
+	)
+
+	require.True(t, cs.updatePeerTipObserved(
+		incumbent,
+		incumbentAdvertised,
+		deliveredFrontier(28029),
+		nil,
+	))
+	require.NotNil(t, cs.GetBestPeer())
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	require.True(t, cs.updatePeerTipObserved(
+		challenger,
+		challengerAdvertised,
+		tip(28029, 628029, "fork-b-28029"),
+		nil,
+	))
+	for _, block := range []uint64{28461, 28842} {
+		require.True(t, cs.updatePeerTipObserved(
+			challenger,
+			challengerAdvertised,
+			tip(block, 600000+block, "fork-b-"+itoa(block)),
+			nil,
+		))
+	}
+
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(
+		t,
+		challenger,
+		*best,
+		"a genuinely divergent longer delivered chain must still win selection",
+	)
+}
+
+// TestContradictedAdvertisedTipDoesNotExemptFrontierLag is the AC #2 negative
+// case for a spoofed advertisement: a peer copies the honest peer's advertised
+// tip but its delivered headers contradict the honest chain at a shared slot.
+// The delivered history is the trusted signal, so the copied advertisement
+// must not buy it the same-chain treatment.
+func TestContradictedAdvertisedTipDoesNotExemptFrontierLag(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	honest := newTestConnectionId(1)
+	spoofer := newTestConnectionId(2)
+	advertised := canonicalAdvertisedTip()
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	// The spoofer delivers a conflicting block at slot 628029.
+	require.True(t, cs.updatePeerTipObserved(
+		spoofer,
+		advertised,
+		tip(28029, 628029, "spoofed-28029"),
+		nil,
+	))
+	// The honest peer delivers the canonical block at the same slot and then
+	// runs its frontier more than k ahead.
+	require.True(t, cs.updatePeerTipObserved(
+		honest,
+		advertised,
+		deliveredFrontier(28029),
+		nil,
+	))
+	for _, block := range []uint64{28461, 28842} {
+		require.True(t, cs.updatePeerTipObserved(
+			honest,
+			advertised,
+			deliveredFrontier(block),
+			nil,
+		))
+	}
+
+	assert.False(
+		t,
+		peerSelectable(t, cs, spoofer),
+		"a peer whose delivered headers contradict the leader must not be exempted by a copied advertised tip",
+	)
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(t, honest, *best)
+}
+
+// TestSameChainExemptionDoesNotRescueImplausiblyBehindPeer is the AC #2
+// negative case for the implausible-tip bound: the same-chain exemption
+// applies only to the behind-best-frontier filter. A peer whose delivered
+// frontier is more than k behind the APPLIED LOCAL tip is useless and must
+// stay unselectable even when it advertises the canonical tip.
+func TestSameChainExemptionDoesNotRescueImplausiblyBehindPeer(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	stuck := newTestConnectionId(1)
+	advertised := canonicalAdvertisedTip()
+
+	require.True(t, cs.updatePeerTipObserved(
+		stuck,
+		advertised,
+		deliveredFrontier(27000),
+		nil,
+	))
+	// Local tip advances well past the peer's delivered frontier.
+	cs.SetLocalTip(deliveredFrontier(27000 + previewSecurityParam + 1))
+
+	assert.False(
+		t,
+		peerSelectable(t, cs, stuck),
+		"a peer more than k behind the applied local tip must stay unselectable",
+	)
+	cs.EvaluateAndSwitch()
+	assert.Nil(
+		t,
+		cs.GetBestPeer(),
+		"no peer may be selected when the only peer is implausibly behind",
+	)
+}
+
+// TestSameChainPinStillReleasesOnLocalTipStall asserts the progress-aware
+// escape survives the same-chain pin: an incumbent that stops driving local
+// tip progress is released even though it advertises the same canonical tip as
+// the challenger.
+func TestSameChainPinStillReleasesOnLocalTipStall(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+	clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	installFakeClock(cs, clock)
+
+	incumbent := newTestConnectionId(1)
+	challenger := newTestConnectionId(2)
+	advertised := canonicalAdvertisedTip()
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+	require.True(t, cs.updatePeerTipObserved(
+		incumbent,
+		advertised,
+		deliveredFrontier(27900),
+		nil,
+	))
+	require.True(t, cs.updatePeerTipObserved(
+		challenger,
+		advertised,
+		deliveredFrontier(27900),
+		nil,
+	))
+	require.Equal(t, incumbent, *cs.GetBestPeer())
+
+	require.True(t, cs.updatePeerTipObserved(
+		challenger,
+		advertised,
+		deliveredFrontier(28332),
+		nil,
+	))
+	require.Equal(
+		t,
+		incumbent,
+		*cs.GetBestPeer(),
+		"same-chain frontier lead alone must not release the pin",
+	)
+
+	// The applied local tip has not moved; past the stall timeout the pin
+	// must release so the node can leave a non-progressing incumbent.
+	clock.Advance(catchUpPinStallTimeout)
+	require.True(t, cs.EvaluateAndSwitch())
+	best := cs.GetBestPeer()
+	require.NotNil(t, best)
+	assert.Equal(
+		t,
+		challenger,
+		*best,
+		"the progress-aware stall escape must still release the same-chain pin",
+	)
+}
+
+// TestDivergentLeaderDoesNotSuppressPeersAgreeingWithAnotherLeader asserts the
+// same-chain check scans every peer holding the leading delivered frontier, not
+// one arbitrary representative. With two equally tall leaders on different
+// chains, a trailing peer that agrees with one of them must stay selectable
+// regardless of map iteration order.
+func TestDivergentLeaderDoesNotSuppressPeersAgreeingWithAnotherLeader(
+	t *testing.T,
+) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	trailing := newTestConnectionId(1)
+	honestLeader := newTestConnectionId(2)
+	divergentLeader := newTestConnectionId(3)
+
+	canonical := canonicalAdvertisedTip()
+	divergent := tip(
+		canonicalAdvertisedBlock,
+		canonicalAdvertisedSlot,
+		"divergent-tip",
+	)
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	require.True(t, cs.updatePeerTipObserved(
+		trailing,
+		canonical,
+		deliveredFrontier(28029),
+		nil,
+	))
+	for _, block := range []uint64{28029, 28461, 28842} {
+		require.True(t, cs.updatePeerTipObserved(
+			honestLeader,
+			canonical,
+			deliveredFrontier(block),
+			nil,
+		))
+		require.True(t, cs.updatePeerTipObserved(
+			divergentLeader,
+			divergent,
+			tip(block, 600000+block, "divergent-"+itoa(block)),
+			nil,
+		))
+	}
+
+	assert.True(
+		t,
+		peerSelectable(t, cs, trailing),
+		"a peer agreeing with one of the leading frontiers must stay selectable",
+	)
+}

--- a/chainselection/frontier_flap_test.go
+++ b/chainselection/frontier_flap_test.go
@@ -518,3 +518,53 @@ func TestDivergentLeaderDoesNotSuppressPeersAgreeingWithAnotherLeader(
 		"a peer agreeing with one of the leading frontiers must stay selectable",
 	)
 }
+
+// TestUnadvertisedTipIsNotSameChainEvidence pins the empty-hash guard in
+// sameAdvertisedTip. Two peers that have not told us where their chains end
+// both carry a zero advertised tip, which is identical but says nothing: it is
+// the absence of an advertisement, not agreement on one. Without the guard the
+// zero tips compare equal and every such pair is granted the same-chain
+// exemption, so a peer that has advertised nothing and trails the leading
+// frontier by more than k would stay selectable on no evidence at all.
+func TestUnadvertisedTipIsNotSameChainEvidence(t *testing.T) {
+	cs := NewChainSelector(ChainSelectorConfig{
+		SecurityParam: previewSecurityParam,
+	})
+
+	trailing := newTestConnectionId(1)
+	leader := newTestConnectionId(2)
+	var unadvertised ochainsync.Tip
+
+	cs.SetLocalTip(deliveredFrontier(27900))
+
+	require.True(t, cs.updatePeerTipObserved(
+		trailing,
+		unadvertised,
+		deliveredFrontier(28029),
+		nil,
+	))
+	for _, block := range []uint64{28029, 28461, 28771} {
+		require.True(t, cs.updatePeerTipObserved(
+			leader,
+			unadvertised,
+			deliveredFrontier(block),
+			nil,
+		))
+	}
+
+	// The gap is the reproduction's, and neither peer is filtered out by the
+	// k-behind-the-applied-local-tip check, so the behind-best-frontier filter
+	// is the only thing under test here.
+	require.Equal(
+		t,
+		uint64(742),
+		cs.GetPeerTip(leader).SelectionTip().BlockNumber-
+			cs.GetPeerTip(trailing).SelectionTip().BlockNumber,
+	)
+
+	assert.False(
+		t,
+		peerSelectable(t, cs, trailing),
+		"a zero advertised tip is an absent advertisement, not agreement, and must not exempt a peer from the behind-best-frontier filter",
+	)
+}

--- a/chainselection/peer_tip.go
+++ b/chainselection/peer_tip.go
@@ -332,6 +332,28 @@ func cloneObservedPoints(points []ocommon.Point) []ocommon.Point {
 	return out
 }
 
+// observedHistoryConflictsAt reports whether this peer's recorded delivered
+// header history contains a DIFFERENT block at point's slot.
+//
+// It is deliberately one-sided. A false result means "no contradiction found",
+// which includes the common case where the slot is outside the retained
+// history window (k+1 delivered tips) and therefore cannot be checked at all.
+// Only a true result is evidence, and it is evidence of divergence: the two
+// peers delivered conflicting blocks at the same slot, so they are not serving
+// the same chain regardless of what they advertise.
+func (p *PeerChainTip) observedHistoryConflictsAt(point ocommon.Point) bool {
+	if p == nil || len(point.Hash) == 0 {
+		return false
+	}
+	for _, historyTip := range p.observedTipHistory {
+		if historyTip.Point.Slot != point.Slot {
+			continue
+		}
+		return !bytes.Equal(historyTip.Point.Hash, point.Hash)
+	}
+	return false
+}
+
 // confirmsRecentChain reports whether witness confirms this peer's (candidate's)
 // chain across the window range they overlap. It is true when, for every block
 // the witness observed within the candidate's frontier slot range, the candidate

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1067,8 +1067,10 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 	// The gap is measured on DELIVERED frontiers, which is a transport
 	// property: it says how many headers each peer has served us so far, not
 	// what chain each peer holds. Two peers that advertise the identical
-	// canonical tip hold the same chain, so a delivered-frontier gap between
-	// them is delivery speed alone and must not make either one ineligible.
+	// canonical tip are TREATED AS the same chain unless retained delivered
+	// history contradicts them (see sameCanonicalChain), so a delivered-frontier
+	// gap between them is read as delivery speed and must not make either one
+	// ineligible.
 	// Excluding the trailing peer here also excluded the incumbent, which
 	// skipped the anti-flap pin entirely (see pinIncumbentDuringCatchUpLocked)
 	// and let the active connection flap between two canonical public roots.
@@ -1169,9 +1171,10 @@ func (cs *ChainSelector) bestKnownBlockNumber() uint64 {
 }
 
 // frontierLeadIsTransportOnlyLocked reports whether peerTip's shortfall against
-// the leading delivered frontier is a delivery-speed artifact rather than a
-// chain-quality difference: some eligible, non-stale peer that holds the
-// leading frontier is on the same chain as peerTip.
+// the leading delivered frontier can be attributed to delivery speed rather
+// than chain quality: some eligible, non-stale peer holding the leading
+// frontier classifies as same-chain with peerTip under sameCanonicalChain.
+// That classification is an allowance, not proof — see its doc comment.
 //
 // Every leader is scanned rather than one representative, so the answer does
 // not depend on map iteration order when several peers share the leading
@@ -1203,25 +1206,37 @@ func sameAdvertisedTip(a, b ochainsync.Tip) bool {
 	return len(a.Point.Hash) > 0 && sameSelectionTip(a, b)
 }
 
-// sameCanonicalChain reports whether two peers are following the same chain, so
-// that a difference in their DELIVERED frontiers is a transport-delivery
-// artifact rather than a chain-quality difference.
+// sameCanonicalChain classifies two peers as the same canonical chain, so that
+// a difference in their DELIVERED frontiers may be attributed to transport
+// delivery rather than chain quality.
+//
+// This is an ALLOWANCE, not proof of chain identity. It is granted when the
+// peers name the identical advertised tip and neither one's retained delivered
+// history contradicts the other, and withdrawn as soon as a contradiction is
+// visible. It is never positive confirmation that the two peers hold the same
+// chain: observedHistoryConflictsAt is one-sided by construction, so when the
+// other peer's frontier slot falls outside the retained k+1 history window
+// there is nothing to check and the allowance stands on the advertisement
+// alone.
 //
 // Agreement on the advertised tip is the primary signal, and it is exactly the
 // canonical-public-root case that flapped: both roots named block 4625199 at
 // slot 121697834 while their delivered frontiers differed by 742 blocks.
 //
 // The advertised tip is untrusted on its own, so it is checked against the
-// delivered evidence: if either peer's retained delivered history holds a
-// different block at the other's frontier slot, they demonstrably served
-// conflicting chains and the copied advertisement buys nothing. That check is
-// one-sided by construction (see observedHistoryConflictsAt), so this predicate
-// never grants same-chain treatment over a contradiction it can see, and never
-// invents one it cannot.
+// delivered evidence that is available: if either peer's retained delivered
+// history holds a different block at the other's frontier slot, they
+// demonstrably served conflicting chains and the copied advertisement buys
+// nothing. The predicate never grants the allowance over a contradiction it can
+// see, and never invents one it cannot.
 //
-// This is a narrow allowance. It only keeps a peer in the candidate pool and
-// only holds the incumbent's pin; it never makes a peer win selection. The
-// Praos comparison still ranks candidates by their delivered frontiers, the
+// The allowance is deliberately narrow, which is what bounds a peer that copies
+// an advertisement it cannot be contradicted on. It only keeps a peer in the
+// candidate pool and only holds the incumbent's pin; it never makes a peer win
+// selection, and it cannot hold a pin across a catchUpPinStallTimeout window in
+// which the incumbent drove no local tip progress, because the progress-stall
+// escape is evaluated before the longer-chain escape. The Praos comparison
+// still ranks candidates by their delivered frontiers, the
 // implausible-frontier bound in updatePeerTipObservedPraosView still rejects
 // delivered jumps beyond k, the k-behind-the-applied-local-tip check above
 // still drops peers that cannot serve the block the node needs, and Genesis
@@ -1567,8 +1582,10 @@ func (cs *ChainSelector) pinIncumbentDuringCatchUpLocked(
 	//
 	// "Taller" is measured on delivered frontiers, so it only means a longer
 	// chain when the two peers disagree about where the chain ends. When they
-	// advertise the identical canonical tip they hold the same chain and the
-	// challenger is merely further along in serving it to us; handing the
+	// advertise the identical canonical tip they are treated as the same chain
+	// unless retained delivered history contradicts them (sameCanonicalChain is
+	// an allowance, not proof), and the challenger is then read as merely
+	// further along in serving that chain to us; handing the
 	// pipeline over buys no chain and costs a chainsync/blockfetch reset plus,
 	// via the ledger's fresh-cursor path, a close of the connection we just
 	// selected. The stall escape above still releases an incumbent that stops

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -1063,13 +1063,23 @@ func (cs *ChainSelector) isPeerSelectableLocked(
 	// Use securityParam (K) as the threshold — peers within K blocks
 	// of the best are acceptable (normal fork variance), but peers
 	// further behind are not useful for syncing.
+	//
+	// The gap is measured on DELIVERED frontiers, which is a transport
+	// property: it says how many headers each peer has served us so far, not
+	// what chain each peer holds. Two peers that advertise the identical
+	// canonical tip hold the same chain, so a delivered-frontier gap between
+	// them is delivery speed alone and must not make either one ineligible.
+	// Excluding the trailing peer here also excluded the incumbent, which
+	// skipped the anti-flap pin entirely (see pinIncumbentDuringCatchUpLocked)
+	// and let the active connection flap between two canonical public roots.
 	if cs.securityParam > 0 {
 		bestBlock := cs.bestKnownBlockNumber()
 		if bestBlock > 0 &&
 			safeAddUint64(
 				selectionTip.BlockNumber,
 				cs.securityParam,
-			) < bestBlock {
+			) < bestBlock &&
+			!cs.frontierLeadIsTransportOnlyLocked(peerTip, bestBlock) {
 			if logSkip {
 				cs.config.Logger.Debug(
 					"skipping peer behind best known tip",
@@ -1156,6 +1166,78 @@ func (cs *ChainSelector) bestKnownBlockNumber() uint64 {
 		}
 	}
 	return best
+}
+
+// frontierLeadIsTransportOnlyLocked reports whether peerTip's shortfall against
+// the leading delivered frontier is a delivery-speed artifact rather than a
+// chain-quality difference: some eligible, non-stale peer that holds the
+// leading frontier is on the same chain as peerTip.
+//
+// Every leader is scanned rather than one representative, so the answer does
+// not depend on map iteration order when several peers share the leading
+// frontier, and one leader on a chain of its own cannot suppress the peers that
+// agree with a different leader.
+func (cs *ChainSelector) frontierLeadIsTransportOnlyLocked(
+	peerTip *PeerChainTip,
+	bestBlock uint64,
+) bool {
+	for connId, pt := range cs.peerTips {
+		if pt == peerTip ||
+			pt.SelectionTip().BlockNumber != bestBlock {
+			continue
+		}
+		if !cs.isConnectionEligible(connId) || cs.isPeerTipStale(pt) {
+			continue
+		}
+		if sameCanonicalChain(peerTip, pt) {
+			return true
+		}
+	}
+	return false
+}
+
+// sameAdvertisedTip reports whether two peers name the identical block as their
+// chain tip. The hash must be present: an all-zero advertised tip means the
+// peer has not told us where its chain ends, which is not agreement.
+func sameAdvertisedTip(a, b ochainsync.Tip) bool {
+	return len(a.Point.Hash) > 0 && sameSelectionTip(a, b)
+}
+
+// sameCanonicalChain reports whether two peers are following the same chain, so
+// that a difference in their DELIVERED frontiers is a transport-delivery
+// artifact rather than a chain-quality difference.
+//
+// Agreement on the advertised tip is the primary signal, and it is exactly the
+// canonical-public-root case that flapped: both roots named block 4625199 at
+// slot 121697834 while their delivered frontiers differed by 742 blocks.
+//
+// The advertised tip is untrusted on its own, so it is checked against the
+// delivered evidence: if either peer's retained delivered history holds a
+// different block at the other's frontier slot, they demonstrably served
+// conflicting chains and the copied advertisement buys nothing. That check is
+// one-sided by construction (see observedHistoryConflictsAt), so this predicate
+// never grants same-chain treatment over a contradiction it can see, and never
+// invents one it cannot.
+//
+// This is a narrow allowance. It only keeps a peer in the candidate pool and
+// only holds the incumbent's pin; it never makes a peer win selection. The
+// Praos comparison still ranks candidates by their delivered frontiers, the
+// implausible-frontier bound in updatePeerTipObservedPraosView still rejects
+// delivered jumps beyond k, the k-behind-the-applied-local-tip check above
+// still drops peers that cannot serve the block the node needs, and Genesis
+// corroboration still gates a fast source on independent witnesses.
+func sameCanonicalChain(a, b *PeerChainTip) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if !sameAdvertisedTip(a.Tip, b.Tip) {
+		return false
+	}
+	if a.observedHistoryConflictsAt(b.SelectionTip().Point) ||
+		b.observedHistoryConflictsAt(a.SelectionTip().Point) {
+		return false
+	}
+	return true
 }
 
 func (cs *ChainSelector) isConnectionEligible(
@@ -1482,9 +1564,20 @@ func (cs *ChainSelector) pinIncumbentDuringCatchUpLocked(
 	// Longer-chain escape: a challenger genuinely taller than the incumbent
 	// by more than the head margin is a real longer chain, not a sibling
 	// head-fork — release so the node converges to it promptly.
+	//
+	// "Taller" is measured on delivered frontiers, so it only means a longer
+	// chain when the two peers disagree about where the chain ends. When they
+	// advertise the identical canonical tip they hold the same chain and the
+	// challenger is merely further along in serving it to us; handing the
+	// pipeline over buys no chain and costs a chainsync/blockfetch reset plus,
+	// via the ledger's fresh-cursor path, a close of the connection we just
+	// selected. The stall escape above still releases an incumbent that stops
+	// driving local tip progress, so this cannot pin to a peer that is not
+	// actually feeding us.
 	incumbentBlock := incumbentTip.SelectionTip().BlockNumber
 	challengerBlock := challengerTip.SelectionTip().BlockNumber
-	if challengerBlock > safeAddUint64(incumbentBlock, catchUpPinHeadMargin) {
+	if challengerBlock > safeAddUint64(incumbentBlock, catchUpPinHeadMargin) &&
+		!sameCanonicalChain(incumbentTip, challengerTip) {
 		return false
 	}
 	// Otherwise this is a head micro-fork / same-height sibling: pin the

--- a/ledger/chainsync_frontier_flap_test.go
+++ b/ledger/chainsync_frontier_flap_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"io"
+	"log/slog"
+	"strconv"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/chain"
+	"github.com/blinklabs-io/dingo/chainselection"
+	"github.com/blinklabs-io/dingo/event"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip closes the loop
+// between chain selection and the ledger's fresh-cursor handling.
+//
+// Two canonical public roots advertise the SAME tip while their delivered
+// frontiers cross by more than k. Every peer-to-peer ChainSwitchEvent the
+// selector publishes for a peer whose delivered frontier is ahead of the local
+// tip makes chainSwitchNeedsFreshCursorLocked request a resync, and
+// ChainsyncResyncReasonChainSwitchCursorAhead requires a fresh connection — so
+// each such switch closes the selected connection, resets its cursor back to
+// the local tip and hands the frontier lead to the other peer. That is the
+// self-sustaining switch loop observed during Preview from-genesis validation.
+//
+// The assertion is on the pair, not on either component alone: no chain-switch
+// event this scenario produces may ask the ledger for a fresh cursor.
+func TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip(
+	t *testing.T,
+) {
+	chainManager, err := chain.NewManager(nil, nil)
+	require.NoError(t, err)
+	testChain := chainManager.PrimaryChain()
+	require.NoError(t, testChain.AddLocalBlock(&mockBabbageBlock{slot: 100}))
+	require.Zero(t, testChain.HeaderCount())
+	localTip := testChain.Tip()
+
+	ls := &LedgerState{
+		chain: testChain,
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		},
+	}
+
+	selectorBus := event.NewEventBus(nil, nil)
+	t.Cleanup(selectorBus.Stop)
+	_, switchCh := selectorBus.Subscribe(chainselection.ChainSwitchEventType)
+
+	const securityParam = 432 // Preview k
+	selector := chainselection.NewChainSelector(
+		chainselection.ChainSelectorConfig{
+			EventBus:      selectorBus,
+			SecurityParam: securityParam,
+			Logger:        slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			// The rollback subscription is not needed here and would race with
+			// the synchronous tip updates below.
+			DisableEventSubscriptions: true,
+		},
+	)
+	selector.SetLocalTip(localTip)
+
+	rootA := testChainsyncConnId(6000, 3001)
+	rootB := testChainsyncConnId(6000, 3002)
+	// The tip both canonical public roots advertised in the reproduction.
+	advertised := ochainsync.Tip{
+		Point: ocommon.NewPoint(
+			121697834,
+			[]byte("canonical-preview-tip"),
+		),
+		BlockNumber: 4625199,
+	}
+	frontier := func(block uint64) ochainsync.Tip {
+		return ochainsync.Tip{
+			Point: ocommon.NewPoint(
+				600000+block,
+				[]byte("hdr-"+strconv.FormatUint(block, 10)),
+			),
+			BlockNumber: block,
+		}
+	}
+	deliver := func(connId ouroboros.ConnectionId, block uint64) {
+		t.Helper()
+		observed := frontier(block)
+		selector.HandlePeerTipUpdateEvent(event.NewEvent(
+			chainselection.PeerTipUpdateEventType,
+			chainselection.PeerTipUpdateEvent{
+				ConnectionId: connId,
+				Tip:          advertised,
+				ObservedTip:  observed,
+				PraosView: chainselection.PraosTiebreakerViewFromTip(
+					observed,
+					nil,
+					chainselection.PraosTiebreakerConfigUnknown(),
+				),
+			},
+		))
+	}
+
+	// Both roots start on the same delivered header, well ahead of the local
+	// tip, then their delivered frontiers cross repeatedly. Each step stays
+	// within k of the peer's own previous frontier so the plausibility bound
+	// accepts it; the crossings at 28842 and 29706 put the lead at 742 blocks,
+	// the gap seen in the reproduction.
+	deliver(rootA, 27900)
+	deliver(rootB, 27900)
+	for _, step := range []struct {
+		conn  ouroboros.ConnectionId
+		block uint64
+	}{
+		{rootB, 28029},
+		{rootA, 28100},
+		{rootB, 28461},
+		{rootB, 28842},
+		{rootA, 28532},
+		{rootA, 28964},
+		{rootB, 29274},
+		{rootB, 29706},
+	} {
+		deliver(step.conn, step.block)
+	}
+
+	// The selector publishes synchronously from the update call, so everything
+	// it decided is already buffered on the subscriber channel.
+	var checked int
+	for drained := false; !drained; {
+		select {
+		case evt := <-switchCh:
+			switchEvent, ok := evt.Data.(chainselection.ChainSwitchEvent)
+			require.True(t, ok)
+			checked++
+			assert.False(
+				t,
+				ls.chainSwitchNeedsFreshCursorLocked(
+					switchEvent,
+					switchEvent.NewConnectionId,
+				),
+				"a delivered-frontier crossing between peers on the same advertised chain must not close the selected connection (switch to %s at delivered block %d)",
+				switchEvent.NewConnectionId.String(),
+				switchEvent.NewObservedTip.BlockNumber,
+			)
+		default:
+			drained = true
+		}
+	}
+	require.Positive(
+		t,
+		checked,
+		"the scenario must publish at least the initial selection event",
+	)
+}


### PR DESCRIPTION
Fixes #3777.

## Defect

Two canonical public roots that advertise the identical tip can differ by more
than `k` in the headers they have delivered locally, because the delivered
frontier measures transport progress rather than chain quality. In the Preview
from-genesis reproduction both roots advertised block `4625199` at slot
`121697834` while their delivered frontiers were `28029` and `28771` — a gap of
742 against Preview `k=432`.

The observed-frontier `k`-behind filter in `isPeerSelectableLocked` marked the
trailing peer ineligible. That also excluded the incumbent, which skipped
`pinIncumbentDuringCatchUpLocked` entirely, and the pin's longer-chain escape
then read the challenger's delivery lead as a longer chain. Each resulting
switch reached the ledger's fresh-cursor path, which closes a selected
connection that is ahead of the local tip, resetting that peer's cursor and
handing the frontier lead back to the other peer — 207 active-peer switches in
one observation window.

## Change

Peers that advertise the identical tip are treated as the same chain for both
decisions, so a delivered-frontier gap between them is read as delivery speed
rather than chain quality.

Because the advertised tip is untrusted, the allowance is checked against
delivered evidence: it is withdrawn when either peer's retained `k+1`
delivered-header history holds a different block at the other's frontier slot.
That check is deliberately one-sided — only a contradiction is evidence, and a
slot outside the retained window is not one. A zero advertised tip is the
absence of an advertisement, not agreement, and never grants the allowance.

`frontierLeadIsTransportOnlyLocked` scans every peer holding the leading
frontier rather than one representative, so the answer does not depend on map
iteration order and one leader on a chain of its own cannot suppress peers that
agree with a different leader.

## Guards preserved

The allowance only keeps a peer in the candidate pool and holds the incumbent's
pin; it never makes a peer win selection. Unchanged: the Praos comparison, the
implausible-frontier bound in `updatePeerTipObservedPraosView`, the
`k`-behind-the-**applied-local-tip** filter, Genesis corroboration, and the
progress-stall escape. The stall escape is the bound that matters for the pin:
an incumbent held by an identical advertised tip is still released after
`catchUpPinStallTimeout` if it stops driving local tip progress.

## Tests

`chainselection/frontier_flap_test.go` and `ledger/chainsync_frontier_flap_test.go`.
Fail-before was proven by reverting only the two production files in place and
re-running; they compile against the base, so these are behavioral failures, not
compile errors.

Fail without the fix:

- `TestSameChainFrontierLeadKeepsLaggingIncumbentSelectable`
- `TestCanonicalPeersWithCrossingFrontiersDoNotFlap`
- `TestSameChainPinStillReleasesOnLocalTipStall`
- `TestDivergentLeaderDoesNotSuppressPeersAgreeingWithAnotherLeader`
- `ledger.TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip`

`TestUnadvertisedTipIsNotSameChainEvidence` fails with the empty-hash guard in
`sameAdvertisedTip` removed.

Guards that hold either way, pinning the preserved behavior:

- `TestDivergentPeersStillSwitchOnLongerDeliveredChain` — same height and slot,
  different block, still switches to the longer delivered chain.
- `TestContradictedAdvertisedTipDoesNotExemptFrontierLag` — a copied
  advertisement contradicted by delivered headers buys nothing.
- `TestSameChainExemptionDoesNotRescueImplausiblyBehindPeer` — the
  `k`-behind-the-applied-local-tip filter is untouched.

## Merge note for #3989

#3989 modifies the same two functions: it wraps both behind-filters in
`if !peerTip.awaitingFirstHeader { ... }` and adds an early
`awaitingFirstHeader` release in `pinIncumbentDuringCatchUpLocked`. There is no
design conflict — the two escapes are independent and compose — but
`git merge-tree` does report one textual conflict in
`chainselection/selector.go`, in the reindented behind-filter block. Whoever
merges second keeps the `awaitingFirstHeader` wrapper and keeps
`&& !cs.frontierLeadIsTransportOnlyLocked(peerTip, bestBlock)` on the inner
condition. The pin hunks auto-merge. #3939 merges clean.

## Skipped checks

The issue's remaining acceptance criterion — re-run Preview from genesis through
tip and its 30-minute live serve window — was **not** run. It requires live
Cardano network infrastructure that is unavailable in this environment. This
change is not validated against a real Preview replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vJhjXgwH1NU7c2tqBTcpY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3777. Two canonical peers that advertise the identical tip used to flap the active connection whenever their delivered frontiers crossed by more than `k`: the selector read the transport gap as a chain-quality difference, switched, and each switch reset the selected connection's cursor. Peers that advertise the identical tip are now treated as the same chain, so that gap no longer drives the handoff.

- The same-chain allowance is withdrawn when either peer's retained `k+1` delivered-header history holds a different block at the other's frontier slot, so a copied advertisement buys nothing.
- The allowance is not proof of chain identity; a frontier slot outside the retained window simply can't be checked.
- A zero advertised tip never grants the allowance, since it is an absent advertisement rather than agreement.
- The leader check scans every peer holding the leading frontier, so the answer does not depend on map iteration order.
- Praos comparison, the implausible-frontier bound, the `k`-behind-the-applied-local-tip filter, Genesis corroboration, and the progress-stall escape are unchanged; the pin still releases after `catchUpPinStallTimeout` if the local tip stalls.
- New tests reproduce the 742-block Preview gap and fail without the fix; `ARCHITECTURE.md` documents the same-chain classification as an allowance.

<sup>Written for commit 9e6ee8b611f7efc1a3c3044b3cbae244b5d0061d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability when peers advertise the same canonical tip but deliver blocks at different speeds.
  * Prevented unnecessary chain switching and connection changes caused by temporary delivery-frontier fluctuations.
  * Preserved switching to genuinely longer, divergent chains and existing safety protections.
  * Maintained correct behavior when peer history conflicts, local progress stalls, or advertised tips are absent.

* **Documentation**
  * Clarified how delivery-speed differences are distinguished from chain-quality differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->