### PR TITLE
fix(leios): keep the best-effort endorser-block wait off the ledger apply path

### DIFF
--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -403,8 +403,13 @@ func buildEndorserBlockBlob(
 //
 //   - Near the head (within the wait window): the relay co-produces and
 //     diffuses the endorser block with its ranking block, so it is already
-//     being pushed; wait for the in-flight leios-notify/leios-fetch to cache
-//     it, with an active by-point fetch as a fallback if the window elapses.
+//     being pushed. Only the references that applying THIS batch actually
+//     reads are waited for (see leiosApplyReadsOwnAnnouncement and
+//     splitTipWaitByApplyDependency); the rest are dispatched as background
+//     prefetch and never block the pipeline. The waits that remain run
+//     concurrently under one shared window and dispatch an active by-point
+//     fetch up front, so a batch costs at most one diffusion window rather
+//     than one per missing endorser block.
 //   - Historical backlog (well below the head, e.g. during a from-scratch
 //     catch-up): the relay does not diffuse these, but it does serve any
 //     endorser block by point on demand, so actively fetch them -- in parallel
@@ -603,41 +608,49 @@ func (ls *LedgerState) ensureReferencedEndorserBlocks(
 				) {
 					continue
 				}
-				ls.leiosBackfill.awaitFetch(ctx, r, poll)
-			}
-		}
-	}
-	for _, r := range tipWait {
-		if endorserBlockAvailableAt(
-			ls.config.EndorserBlockProvider,
-			r.hash.Bytes(),
-			r.slot,
-		) {
-			continue
-		}
-		ls.waitForEndorserBlock(ctx, r.slot, r.hash, timeout, poll)
-		if ls.config.EndorserBlockFetcher == nil {
-			continue
-		}
-		if !endorserBlockAvailableAt(
-			ls.config.EndorserBlockProvider,
-			r.hash.Bytes(),
-			r.slot,
-		) {
-			if err := ls.config.EndorserBlockFetcher(
-				ctx,
-				r.slot,
-				r.hash.Bytes(),
-			); err != nil {
-				ls.config.Logger.Debug(
-					"endorser block tip fetch fallback failed",
-					"component", "ledger",
-					"slot", r.slot,
-					"eb_hash", r.hash.String(),
-					"error", err,
+				ls.leiosBackfill.awaitFetch(
+					ctx,
+					r,
+					poll,
+					leiosBackfillMaxWait,
 				)
 			}
 		}
+	}
+	// Near the head: split the references by whether applying THIS batch
+	// actually reads them, and block only on the ones it does. See
+	// leiosApplyReadsOwnAnnouncement for the contract.
+	blockingWait, prefetch := splitTipWaitByApplyDependency(
+		tipWait,
+		required,
+		certDrivenHistorical,
+	)
+	// Best-effort references: never block the ledger pipeline on them. The
+	// fetch is dispatched in the background (deduped and concurrency-bounded by
+	// the backfiller) so the endorser block is in cache by the time something
+	// does depend on it, and this batch is delivered to ledgerProcessBlock
+	// immediately.
+	if ls.leiosBackfill != nil {
+		for _, r := range prefetch {
+			ls.leiosBackfill.spawn(ctx, r)
+		}
+	}
+	// Blocking references: one shared diffusion window for the whole batch,
+	// with an active by-point fetch dispatched up front for each one.
+	ls.awaitEndorserBlocks(ctx, blockingWait, timeout, poll)
+	// CIP path only: application reads these references and nothing re-applies
+	// an endorser block that lands after the batch, so a fetch still in flight
+	// when the window elapsed is waited out rather than abandoned. See
+	// awaitInFlightEndorserFetches; timeout is the reporting threshold, not the
+	// bound.
+	if !certDrivenHistorical {
+		ls.awaitInFlightEndorserFetches(
+			ctx,
+			blockingWait,
+			timeout,
+			poll,
+			leiosTipFetchHardBound,
+		)
 	}
 	// Musashi path: a certified closure is mandatory, so each required endorser
 	// block still missing after the diffusion waits gets a bounded retry across
@@ -649,6 +662,257 @@ func (ls *LedgerState) ensureReferencedEndorserBlocks(
 	// restart, or none at all when every connection was unusable (dingo #3552).
 	fetchMissingRequired(poll)
 	return ensureRequiredAvailable()
+}
+
+// leiosApplyReadsOwnAnnouncement reports whether ledger application of a
+// ranking block reads that block's OWN endorser-block announcement, as opposed
+// to only the certified closure announced by a certifying block's parent. It
+// is the apply-path contract that decides whether the pre-apply gate may block
+// on a reference, and it mirrors leiosEndorserBlockForApply exactly -- the two
+// must stay in step, since blocking on a reference application never reads buys
+// nothing, and not blocking on one it does read silently drops the endorser
+// block's transactions.
+//
+//   - CIP-conformant path (LeiosApplyEndorserBlockTxs true): true. Application
+//     resolves the block's own announcement and applies the endorser-resident
+//     transactions ahead of the ranking block whose transactions spend their
+//     outputs. Nothing re-applies them later -- the endorser-block arrival
+//     handler drives Leios voting only, not ledger application -- so an
+//     announcement skipped here is omitted from the UTxO set permanently and
+//     the ranking block's spends fall through to the interim trust path.
+//     The wait is therefore load-bearing and is kept.
+//   - Haskell-conformant (Musashi prototype) path: false. Application resolves
+//     only the certified closure: the endorser block announced by a certifying
+//     ranking block's PARENT. A block's own announcement is never read when
+//     that block is applied; it becomes relevant only later, if and when a
+//     descendant certifies it, at which point it is a mandatory reference in
+//     its own right (requiredCertifiedEndorserBlocks) and is fetched and waited
+//     for then. Blocking this batch on it buys nothing: on expiry the gate
+//     applied the block unchanged, having stalled every block queued behind it
+//     on the single ledger pipeline for the whole diffusion window.
+func leiosApplyReadsOwnAnnouncement(applyEndorserBlockTxs bool) bool {
+	return applyEndorserBlockTxs
+}
+
+// splitTipWaitByApplyDependency partitions the near-head references into the
+// ones ledger application of this batch depends on (blocking) and the ones it
+// does not (prefetch, dispatched in the background and never waited on).
+//
+// required is the set of mandatory certified closures for this batch. Those are
+// always blocking: committing a certifying ranking block without its closure
+// would permanently omit the endorser block's transaction and certificate
+// effects, and ensureRequiredAvailable fails the chunk rather than allow it.
+//
+// On the CIP path required is empty and every reference is read at apply time
+// (see leiosApplyReadsOwnAnnouncement), so everything stays blocking and the
+// only change is that the waits now share one window instead of running back to
+// back. On the Musashi path the non-required references are announcements this
+// batch never reads, so they are demoted to background prefetch.
+func splitTipWaitByApplyDependency(
+	tipWait, required []leiosEbRef,
+	certDrivenHistorical bool,
+) (blocking, prefetch []leiosEbRef) {
+	if leiosApplyReadsOwnAnnouncement(!certDrivenHistorical) {
+		return tipWait, nil
+	}
+	requiredKeys := make(map[string]struct{}, len(required))
+	for _, r := range required {
+		requiredKeys[leiosEbRefKey(r)] = struct{}{}
+	}
+	for _, r := range tipWait {
+		if _, ok := requiredKeys[leiosEbRefKey(r)]; ok {
+			blocking = append(blocking, r)
+			continue
+		}
+		prefetch = append(prefetch, r)
+	}
+	return blocking, prefetch
+}
+
+// awaitEndorserBlocks waits for every still-missing reference in refs to become
+// available, CONCURRENTLY under one shared diffusion window.
+//
+// The waits are independent -- none of them observes another's result -- so
+// running them back to back charged the ledger pipeline one full window per
+// missing endorser block (k missing references cost k windows), which is where
+// the multi-window apply stalls came from. Running them together bounds the
+// whole batch by a single window.
+//
+// Each wait also dispatches an active by-point fetch up front rather than
+// polling passively and only falling back to a fetch after the window has
+// already been spent: the reference is wanted now, so ask for it now. The
+// backfiller dedups by (slot, hash) and bounds concurrency, so a reference
+// already in flight is not fetched twice.
+func (ls *LedgerState) awaitEndorserBlocks(
+	ctx context.Context,
+	refs []leiosEbRef,
+	timeout, poll time.Duration,
+) {
+	var wg sync.WaitGroup
+	for _, r := range refs {
+		if endorserBlockAvailableAt(
+			ls.config.EndorserBlockProvider,
+			r.hash.Bytes(),
+			r.slot,
+		) {
+			continue
+		}
+		// The fetch is bound to ctx, not to the wait window, so a fetch that
+		// outlives the window is not abandoned. On its own that is not enough
+		// for the CIP path -- see awaitInFlightEndorserFetches, which is what
+		// makes a late fetch actually reach this batch's application.
+		if ls.leiosBackfill != nil {
+			ls.leiosBackfill.spawn(ctx, r)
+		}
+		wg.Add(1)
+		go func(r leiosEbRef) {
+			defer wg.Done()
+			ls.waitForEndorserBlock(ctx, r.slot, r.hash, timeout, poll)
+		}(r)
+	}
+	wg.Wait()
+}
+
+// leiosTipFetchHardBound bounds how long the CIP apply path will hold a batch
+// waiting for its own in-flight by-point fetch. It is the same backstop the
+// backfiller uses, and deliberately so: the code this replaces issued a
+// SYNCHRONOUS FetchEndorserBlockByPoint after the diffusion window, which swept
+// every peer and was bounded only by the leios-fetch timeout, so waiting for
+// the fetch to actually finish is parity rather than a new cost. In practice
+// awaitFetch returns as soon as the in-flight marker clears, so this is reached
+// only if a fetch neither caches nor completes.
+const leiosTipFetchHardBound = leiosBackfillMaxWait
+
+// awaitInFlightEndorserFetches waits for this batch's own by-point fetches to
+// FINISH, for references whose absence would otherwise be permanent.
+//
+// It exists because the diffusion window and the fetch are different clocks.
+// The window bounds how long to wait for the network to PUSH an endorser block
+// to us; it says nothing about how long our own PULL of it takes. The wait
+// dispatches that pull up front, so when the window expires the fetch is often
+// still in flight and moments from completing.
+//
+// That distinction only matters where nothing re-reads the endorser block
+// later. On the certificate-driven path a missing closure is mandatory and is
+// retried by fetchMissingRequired, and an announcement this batch does not read
+// is picked up by whichever later batch certifies it. On the CIP path neither
+// is true: application reads each ranking block's own announcement, nothing
+// re-applies an endorser block that lands afterwards, and the ranking block's
+// spends fall through to the interim trust path permanently.
+//
+// The bound is the FETCH's completion, not a second diffusion window. An
+// earlier version of this waited one further window and returned even if the
+// fetch was still running, which lost exactly the transactions it was added to
+// protect, just one window later. awaitFetch returns as soon as the endorser
+// block is cached or the in-flight marker clears, so a fetch that fails fast
+// costs nothing; hardBound (leiosTipFetchHardBound in production) is only a
+// backstop against a fetch that neither caches nor clears. softWarn is a
+// reporting threshold, not a deadline: crossing it means this batch is holding
+// the ledger pipeline on a slow fetch, which is worth a log line, and it is the
+// signal an operator needs to distinguish this from the pre-fetch stall.
+//
+// When the fetch finishes without caching -- no peer holds the endorser block
+// -- application proceeds without it. That is the long-standing behaviour of
+// this path and is NOT changed here: failing the chunk instead would turn an
+// unfetchable endorser block into an unbounded pipeline retry, which is a wedge
+// this codebase has hit before. The loss is real but it is pre-existing and
+// orthogonal to the regression this function fixes.
+//
+// The waits run concurrently, so k references cost one wait, not k.
+func (ls *LedgerState) awaitInFlightEndorserFetches(
+	ctx context.Context,
+	refs []leiosEbRef,
+	softWarn, poll, hardBound time.Duration,
+) {
+	if ls.leiosBackfill == nil {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, r := range refs {
+		if endorserBlockAvailableAt(
+			ls.config.EndorserBlockProvider,
+			r.hash.Bytes(),
+			r.slot,
+		) {
+			continue
+		}
+		wg.Add(1)
+		go func(r leiosEbRef) {
+			defer wg.Done()
+			start := time.Now()
+			ls.leiosBackfill.awaitFetch(
+				ctx,
+				r,
+				poll,
+				hardBound,
+			)
+			elapsed := time.Since(start)
+			cached := endorserBlockAvailableAt(
+				ls.config.EndorserBlockProvider,
+				r.hash.Bytes(),
+				r.slot,
+			)
+			if cached && elapsed < softWarn {
+				return
+			}
+			if cached {
+				ls.config.Logger.Warn(
+					"endorser block fetch outlived the diffusion window; held block application until it landed",
+					"component", "ledger",
+					"slot", r.slot,
+					"eb_hash", r.hash.String(),
+					"waited_seconds", elapsed.Seconds(),
+				)
+				return
+			}
+			if ctx.Err() != nil {
+				// The pass was cancelled, not the fetch exhausted. Nothing
+				// was learned about whether any peer holds the endorser
+				// block, so saying it "could not be fetched" would be a
+				// false diagnosis emitted on every shutdown.
+				ls.config.Logger.Debug(
+					"endorser block fetch cancelled before it completed",
+					"component", "ledger",
+					"slot", r.slot,
+					"eb_hash", r.hash.String(),
+					"waited_seconds", elapsed.Seconds(),
+					"error", ctx.Err(),
+				)
+				return
+			}
+			// Two very different outcomes reach here, and only one is
+			// anomalous. awaitFetch returns either because the all-peers
+			// fetch CLEARED its in-flight marker without caching -- no peer
+			// holds this endorser block -- or because it neither cached nor
+			// cleared before hardBound. The first is the expected,
+			// long-standing behaviour of this path (see the function comment
+			// above); the code this replaced logged its equivalent at Debug,
+			// and on a CIP node where endorser blocks are routinely
+			// unfetchable a WARN per reference is normal operation escalated
+			// to alertable volume. The second means a fetch is wedged and the
+			// pipeline was held for the full backstop, which is worth waking
+			// someone for. The in-flight marker is what distinguishes them,
+			// so read it rather than inferring from elapsed time.
+			if ls.leiosBackfill.fetchInFlight(r) {
+				ls.config.Logger.Warn(
+					"endorser block fetch neither completed nor cached within the hard bound; applying its ranking block without the endorser-resident transactions",
+					"component", "ledger",
+					"slot", r.slot,
+					"eb_hash", r.hash.String(),
+					"waited_seconds", elapsed.Seconds(),
+				)
+				return
+			}
+			ls.config.Logger.Debug(
+				"endorser block could not be fetched; applying its ranking block without the endorser-resident transactions",
+				"component", "ledger",
+				"slot", r.slot,
+				"eb_hash", r.hash.String(),
+				"waited_seconds", elapsed.Seconds(),
+			)
+		}(r)
+	}
+	wg.Wait()
 }
 
 // leiosEbRef pairs a ranking block's slot with the hash of the endorser block
@@ -1098,6 +1362,26 @@ func (b *leiosBackfiller) fetchRequired(
 			if lastErr == nil {
 				lastErr = budgetCtx.Err()
 			}
+			// budgetCtx is a timeout child of ctx, so its Done also closes
+			// when the PARENT is cancelled -- node shutdown, or the
+			// block-processing pass being aborted. Reporting that as "the
+			// retry budget elapsed" tells an operator the peers failed to
+			// serve the endorser block when in fact nothing was asked of
+			// them, and it is loudest exactly when a node is shutting down.
+			// Same discrimination as waitForEndorserBlock: the child's error
+			// is stable once resolved, so a deadline that fires first stays
+			// DeadlineExceeded even if the parent is cancelled straight after.
+			if !errors.Is(budgetCtx.Err(), context.DeadlineExceeded) {
+				b.logger.Debug(
+					"certified leios endorser block fetch cancelled",
+					"component", "ledger",
+					"slot", r.slot,
+					"eb_hash", r.hash.String(),
+					"attempts", attempt,
+					"error", lastErr,
+				)
+				return lastErr
+			}
 			b.logger.Warn(
 				"certified leios endorser block fetch budget elapsed",
 				"component", "ledger",
@@ -1141,7 +1425,7 @@ func (b *leiosBackfiller) fetchOnce(
 	if _, loaded := b.inflight.LoadOrStore(key, struct{}{}); loaded {
 		// Another fetch for this endorser block is in flight; wait for it
 		// rather than starting a second one on the same connections.
-		b.awaitFetch(ctx, r, poll)
+		b.awaitFetch(ctx, r, poll, leiosBackfillMaxWait)
 		return nil
 	}
 	defer b.inflight.Delete(key)
@@ -1162,12 +1446,22 @@ func (b *leiosBackfiller) fetchOnce(
 // diffusion-window timeout elapses. The concurrent leios-notify/leios-fetch
 // handlers keep making progress while this blocks, so the in-flight fetch
 // completes during the wait.
+//
+// Every wait is recorded to dingo_metrics_leios_eb_wait_seconds with its
+// outcome -- arrived, timeout, or cancelled, the last being a cancellation of
+// the block-processing context rather than a diffusion-window expiry -- and
+// expiries additionally to dingo_metrics_leios_eb_wait_timeouts_total. This wait is taken on the single
+// ledger pipeline ahead of the batch's DB transaction, so it is apply latency
+// for every block queued behind the batch as well; it previously had no metric
+// at all, only an Info log, which is why a producer could sit in it for tens of
+// seconds per block with nothing in monitoring to show for it.
 func (ls *LedgerState) waitForEndorserBlock(
 	ctx context.Context,
 	rbSlot uint64,
 	ebHash lcommon.Blake2b256,
 	timeout, poll time.Duration,
 ) {
+	start := time.Now()
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	ticker := time.NewTicker(poll)
@@ -1178,10 +1472,55 @@ func (ls *LedgerState) waitForEndorserBlock(
 			ebHash.Bytes(),
 			rbSlot,
 		) {
+			ls.metrics.observeLeiosEbWait(
+				time.Since(start),
+				leiosEbWaitOutcomeArrived,
+			)
 			return
 		}
 		select {
 		case <-waitCtx.Done():
+			// waitCtx is a timeout child of ctx, so its Done also closes when
+			// the PARENT is cancelled -- node shutdown, or the block-processing
+			// pass being aborted and restarted. That is not a diffusion-window
+			// expiry: nothing was learned about whether the endorser block is
+			// obtainable, and reporting it as one would inflate the timeout
+			// rate exactly when a node is shutting down or restarting its
+			// pipeline. waitCtx.Err() distinguishes the two and is stable once
+			// resolved -- a deadline that fires first leaves DeadlineExceeded
+			// even if the parent is cancelled immediately afterwards.
+			//
+			// The caller's behaviour is unchanged either way, and deliberately
+			// so: this function returns, and ensureReferencedEndorserBlocks
+			// then runs its mandatory-closure fetch and availability check as
+			// usual, so a cancelled pass still fails the chunk when a certified
+			// closure is missing and still proceeds when every reference was
+			// best-effort. That is what the code did before the wait was
+			// instrumented; only the classification is new.
+			if !errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				ls.metrics.observeLeiosEbWait(
+					time.Since(start),
+					leiosEbWaitOutcomeCancelled,
+				)
+				ls.config.Logger.Debug(
+					"endorser block wait cancelled before the diffusion window elapsed",
+					"component",
+					"ledger",
+					"slot",
+					rbSlot,
+					"eb_hash",
+					ebHash.String(),
+					"waited_seconds",
+					time.Since(start).Seconds(),
+					"error",
+					waitCtx.Err(),
+				)
+				return
+			}
+			ls.metrics.observeLeiosEbWait(
+				time.Since(start),
+				leiosEbWaitOutcomeTimeout,
+			)
 			ls.config.Logger.Info(
 				"endorser block not fetched within diffusion window; proceeding without it",
 				"component",
@@ -1190,6 +1529,8 @@ func (ls *LedgerState) waitForEndorserBlock(
 				rbSlot,
 				"eb_hash",
 				ebHash.String(),
+				"waited_seconds",
+				time.Since(start).Seconds(),
 			)
 			return
 		case <-ticker.C:
@@ -1218,12 +1559,21 @@ const leiosBackfillMaxWait = 2 * time.Minute
 // leiosBackfillMaxWait is a backstop against a fetch that neither caches nor
 // clears (the fetch itself is bounded by the leios-fetch timeout, so this is
 // rarely reached).
+// fetchInFlight reports whether the by-point fetch for r is still marked
+// in flight. awaitFetch returning while this is true means it hit its bound
+// rather than observing the fetch finish, which is the difference between a
+// wedged fetch and the routine "no peer holds this endorser block".
+func (b *leiosBackfiller) fetchInFlight(r leiosEbRef) bool {
+	_, inFlight := b.inflight.Load(leiosEbRefKey(r))
+	return inFlight
+}
+
 func (b *leiosBackfiller) awaitFetch(
 	ctx context.Context,
 	r leiosEbRef,
-	poll time.Duration,
+	poll, maxWait time.Duration,
 ) {
-	waitCtx, cancel := context.WithTimeout(ctx, leiosBackfillMaxWait)
+	waitCtx, cancel := context.WithTimeout(ctx, maxWait)
 	defer cancel()
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -840,34 +840,41 @@ func (ls *LedgerState) awaitInFlightEndorserFetches(
 		go func(r leiosEbRef) {
 			defer wg.Done()
 			start := time.Now()
-			ls.leiosBackfill.awaitFetch(
+			outcome := ls.leiosBackfill.awaitFetch(
 				ctx,
 				r,
 				poll,
 				hardBound,
 			)
 			elapsed := time.Since(start)
-			cached := endorserBlockAvailableAt(
-				ls.config.EndorserBlockProvider,
-				r.hash.Bytes(),
-				r.slot,
-			)
+			cached := outcome == leiosFetchWaitCached
 			// This grace phase is apply-path wait time too, and it is the
 			// LONGEST one the pipeline can incur (up to hardBound), so it
 			// belongs in the same histogram as the diffusion window rather
 			// than being invisible to monitoring.
-			switch {
-			case cached:
+			//
+			// Classified from the wait's OWN termination cause, not from
+			// re-reading the cache and the context afterwards: by then a
+			// bound that expired just before a shutdown looks like a
+			// cancellation, and a fetch that completed without caching looks
+			// like a timeout.
+			switch outcome {
+			case leiosFetchWaitCached:
 				ls.metrics.observeLeiosEbWait(
 					elapsed,
 					leiosEbWaitOutcomeArrived,
 				)
-			case ctx.Err() != nil:
+			case leiosFetchWaitUnavailable:
+				ls.metrics.observeLeiosEbWait(
+					elapsed,
+					leiosEbWaitOutcomeUnavailable,
+				)
+			case leiosFetchWaitCancelled:
 				ls.metrics.observeLeiosEbWait(
 					elapsed,
 					leiosEbWaitOutcomeCancelled,
 				)
-			default:
+			case leiosFetchWaitDeadline:
 				ls.metrics.observeLeiosEbWait(
 					elapsed,
 					leiosEbWaitOutcomeTimeout,
@@ -886,7 +893,7 @@ func (ls *LedgerState) awaitInFlightEndorserFetches(
 				)
 				return
 			}
-			if ctx.Err() != nil {
+			if outcome == leiosFetchWaitCancelled {
 				// The pass was cancelled, not the fetch exhausted. Nothing
 				// was learned about whether any peer holds the endorser
 				// block, so saying it "could not be fetched" would be a
@@ -914,7 +921,7 @@ func (ls *LedgerState) awaitInFlightEndorserFetches(
 			// pipeline was held for the full backstop, which is worth waking
 			// someone for. The in-flight marker is what distinguishes them,
 			// so read it rather than inferring from elapsed time.
-			if ls.leiosBackfill.fetchInFlight(r) {
+			if outcome == leiosFetchWaitDeadline {
 				ls.config.Logger.Warn(
 					"endorser block fetch neither completed nor cached within the hard bound; applying its ranking block without the endorser-resident transactions",
 					"component", "ledger",
@@ -1600,6 +1607,26 @@ func (ls *LedgerState) waitForEndorserBlock(
 // because a from-scratch backfill is throughput-bound, not diffusion-bound.
 const leiosBackfillMaxWait = 2 * time.Minute
 
+// leiosFetchWaitOutcome is why awaitFetch returned. The caller cannot infer it
+// afterwards: the in-flight marker and the parent context are both racy by the
+// time it looks, so a hard bound that expired just before a shutdown would be
+// reported as a cancellation and a fetch that completed without caching would
+// be reported as a timeout. Returning the cause removes the guess.
+type leiosFetchWaitOutcome int
+
+const (
+	// leiosFetchWaitCached: the endorser block is available.
+	leiosFetchWaitCached leiosFetchWaitOutcome = iota
+	// leiosFetchWaitUnavailable: the all-peers fetch COMPLETED without
+	// caching. Nothing timed out; no peer holds the block.
+	leiosFetchWaitUnavailable
+	// leiosFetchWaitDeadline: maxWait elapsed with the fetch neither caching
+	// nor clearing its marker.
+	leiosFetchWaitDeadline
+	// leiosFetchWaitCancelled: the parent context was cancelled.
+	leiosFetchWaitCancelled
+)
+
 // awaitFetch waits for the in-flight by-point fetch of the endorser block
 // referenced by r to finish (it has already been spawned). The spawned fetch
 // (FetchEndorserBlockByPoint) tries every connected peer in turn before
@@ -1613,20 +1640,12 @@ const leiosBackfillMaxWait = 2 * time.Minute
 // leiosBackfillMaxWait is a backstop against a fetch that neither caches nor
 // clears (the fetch itself is bounded by the leios-fetch timeout, so this is
 // rarely reached).
-// fetchInFlight reports whether the by-point fetch for r is still marked
-// in flight. awaitFetch returning while this is true means it hit its bound
-// rather than observing the fetch finish, which is the difference between a
-// wedged fetch and the routine "no peer holds this endorser block".
-func (b *leiosBackfiller) fetchInFlight(r leiosEbRef) bool {
-	_, inFlight := b.inflight.Load(leiosEbRefKey(r))
-	return inFlight
-}
 
 func (b *leiosBackfiller) awaitFetch(
 	ctx context.Context,
 	r leiosEbRef,
 	poll, maxWait time.Duration,
-) {
+) leiosFetchWaitOutcome {
 	waitCtx, cancel := context.WithTimeout(ctx, maxWait)
 	defer cancel()
 	ticker := time.NewTicker(poll)
@@ -1634,14 +1653,33 @@ func (b *leiosBackfiller) awaitFetch(
 	key := leiosEbRefKey(r)
 	for {
 		if endorserBlockAvailableAt(b.provider, r.hash.Bytes(), r.slot) {
-			return // cached: the referencing block can apply it
+			return leiosFetchWaitCached
+		}
+		// Checked BEFORE the in-flight marker, because cancelling the pass
+		// also makes spawn clear that marker. Looking at the marker first
+		// would race, and would report a shutdown as "no peer holds it" --
+		// the false diagnosis this classification exists to avoid.
+		if waitCtx.Err() != nil {
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return leiosFetchWaitDeadline
+			}
+			return leiosFetchWaitCancelled
 		}
 		if _, inFlight := b.inflight.Load(key); !inFlight {
-			return // the all-peers fetch finished without caching: skip fast
+			// The all-peers fetch finished without caching: skip fast.
+			return leiosFetchWaitUnavailable
 		}
 		select {
 		case <-waitCtx.Done():
-			return
+			// waitCtx is a timeout child of ctx, so its Done also closes on a
+			// PARENT cancellation. Discriminate on the child's own error,
+			// which is stable once resolved: a deadline that fires first
+			// stays DeadlineExceeded even if the parent is cancelled straight
+			// after, so a real bound is never reported as a shutdown.
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return leiosFetchWaitDeadline
+			}
+			return leiosFetchWaitCancelled
 		case <-ticker.C:
 		}
 	}

--- a/ledger/leios_apply.go
+++ b/ledger/leios_apply.go
@@ -852,6 +852,27 @@ func (ls *LedgerState) awaitInFlightEndorserFetches(
 				r.hash.Bytes(),
 				r.slot,
 			)
+			// This grace phase is apply-path wait time too, and it is the
+			// LONGEST one the pipeline can incur (up to hardBound), so it
+			// belongs in the same histogram as the diffusion window rather
+			// than being invisible to monitoring.
+			switch {
+			case cached:
+				ls.metrics.observeLeiosEbWait(
+					elapsed,
+					leiosEbWaitOutcomeArrived,
+				)
+			case ctx.Err() != nil:
+				ls.metrics.observeLeiosEbWait(
+					elapsed,
+					leiosEbWaitOutcomeCancelled,
+				)
+			default:
+				ls.metrics.observeLeiosEbWait(
+					elapsed,
+					leiosEbWaitOutcomeTimeout,
+				)
+			}
 			if cached && elapsed < softWarn {
 				return
 			}
@@ -1204,6 +1225,20 @@ func (ls *LedgerState) leiosEndorserBlockForApply(
 // empty manifests when hammered, so the backfill must not flood it.
 const leiosBackfillConcurrency = 8
 
+// leiosRequiredConcurrency is a SEPARATE budget for mandatory certified
+// fetches, so a best-effort fetch can never starve one.
+//
+// spawn and fetchRequired used to share leiosBackfillConcurrency. A
+// best-effort spawn holds its slot for up to leiosBackfillMaxWait, so eight
+// slow ones could block a mandatory certified closure for two minutes and fail
+// the chunk -- and this path now dispatches near-head prefetches through spawn
+// as well, which makes that far more reachable than when only historical
+// backfill used it. Mandatory fetches are few (one certified closure per
+// certifying block) so a small dedicated budget is enough, and it is separate
+// rather than carved out of the same channel because reserving inside one
+// semaphore needs two acquisitions and can deadlock.
+const leiosRequiredConcurrency = 4
+
 // leiosBackfiller fetches historical Leios endorser blocks by point, paced one
 // block-application chunk at a time, so a from-scratch sync builds a complete
 // UTxO set. It dedups in-flight fetches by (slot, hash) -- not hash alone,
@@ -1216,6 +1251,7 @@ type leiosBackfiller struct {
 	provider EndorserBlockProviderFunc
 	logger   *slog.Logger
 	sem      chan struct{}
+	reqSem   chan struct{}
 	inflight sync.Map
 }
 
@@ -1235,6 +1271,7 @@ func newLeiosBackfiller(cfg LedgerStateConfig) *leiosBackfiller {
 		provider: cfg.EndorserBlockProvider,
 		logger:   logger,
 		sem:      make(chan struct{}, leiosBackfillConcurrency),
+		reqSem:   make(chan struct{}, leiosRequiredConcurrency),
 	}
 }
 
@@ -1397,6 +1434,21 @@ func (b *leiosBackfiller) fetchRequired(
 	if lastErr == nil {
 		lastErr = errors.New("certified endorser block fetch made no progress")
 	}
+	// The retry loop can also fall out of its last attempt with the parent
+	// already cancelled, which never reaches the in-loop budgetCtx branch
+	// above. Report that as the cancellation it is rather than as peers
+	// failing to serve.
+	if !errors.Is(budgetCtx.Err(), context.DeadlineExceeded) &&
+		budgetCtx.Err() != nil {
+		b.logger.Debug(
+			"certified leios endorser block fetch cancelled",
+			"component", "ledger",
+			"slot", r.slot,
+			"eb_hash", r.hash.String(),
+			"error", lastErr,
+		)
+		return lastErr
+	}
 	// Warn, not Debug: this is the evidence an operator needs to tell a peer
 	// that does not hold the endorser block from one whose leios-fetch protocol
 	// is broken, and it was previously logged at Debug and lost.
@@ -1429,12 +1481,14 @@ func (b *leiosBackfiller) fetchOnce(
 		return nil
 	}
 	defer b.inflight.Delete(key)
+	// Reserved budget: a mandatory certified fetch must never queue behind
+	// best-effort spawns, which can hold their slots for leiosBackfillMaxWait.
 	select {
-	case b.sem <- struct{}{}:
+	case b.reqSem <- struct{}{}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-	defer func() { <-b.sem }()
+	defer func() { <-b.reqSem }()
 	if endorserBlockAvailableAt(b.provider, r.hash.Bytes(), r.slot) {
 		return nil
 	}

--- a/ledger/leios_apply_test.go
+++ b/ledger/leios_apply_test.go
@@ -788,6 +788,7 @@ func TestLeiosBackfillerAwaitFetchDoesNotSkipFastOnDifferentSlotCompletion(
 			t.Context(),
 			leiosEbRef{slot: 200, hash: hash},
 			time.Millisecond,
+			leiosBackfillMaxWait,
 		)
 		close(done)
 	}()

--- a/ledger/leios_apply_wait_test.go
+++ b/ledger/leios_apply_wait_test.go
@@ -1,0 +1,1211 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"math/big"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// leiosWaitTestSlotLen is the Shelley slot length these tests pin, so the
+// slot-denominated diffusion window (EndorserBlockWaitSlots) converts to a
+// wall-clock window short enough to assert on but long enough to separate
+// "returned immediately" from "waited a window" without flaking.
+const leiosWaitTestSlotLen = 20 * time.Millisecond
+
+// leiosWaitTestWaitSlots matches the production default
+// (CertifyByDeadlineSlots), so the window under test is
+// leiosWaitTestWaitSlots * leiosWaitTestSlotLen = 400ms.
+const leiosWaitTestWaitSlots = 20
+
+const leiosWaitTestWindow = leiosWaitTestWaitSlots * leiosWaitTestSlotLen
+
+// leiosWaitTestLongWaitSlots gives a 10s window, used by tests where the wait
+// must be ended by something other than the deadline. It is far larger than
+// any plausible scheduling delay on a loaded runner, so the deadline can never
+// win the race against the event the test is actually exercising -- unlike a
+// timer racing a short window, which is the classic flake in this file's
+// shape. Nothing waits 10s: the wait ends as soon as that event fires.
+const leiosWaitTestLongWaitSlots = 500
+
+const leiosWaitTestLongWindow = leiosWaitTestLongWaitSlots * leiosWaitTestSlotLen
+
+// withLeiosWaitTestSlotLength gives a bare-constructed LedgerState a Shelley
+// slot length, which is what ensureReferencedEndorserBlocks converts the
+// slot-denominated wait window with. Without it the wait is disabled outright
+// and the timing assertions below would pass vacuously.
+//
+// It also pins the OTHER precondition every timing assertion in this file
+// depends on: that the fixture's blocks are classified near-head rather than
+// as settled backlog. classifyEndorserBlockFetches only calls a block
+// historical when the wall-clock slot is KNOWN and more than
+// EndorserBlockWaitSlots above it, and these fixtures deliberately leave
+// ls.slotClock nil so CurrentSlot errors and wallKnown is false, which makes
+// every block near-head no matter what slot the fixture uses. That is an
+// invariant, not a coincidence: give one of these states a slot clock reading
+// past the fixture slots and the near-head path stops being exercised --
+// the shared-window test would skip the wait entirely (ls.leiosBackfill is
+// nil) and the late-arrival test would reroute its closure to fetchRequired,
+// so both would pass or fail for reasons unrelated to what they assert.
+// Assert it here, once, where the fixture is established.
+func withLeiosWaitTestSlotLength(t *testing.T, ls *LedgerState) {
+	t.Helper()
+	if _, err := ls.CurrentSlot(); err == nil {
+		t.Fatal(
+			"these tests require an unknown wall-clock slot so every " +
+				"fixture block is classified near-head; a slot clock has " +
+				"been added, so pin the fixture slots relative to it before " +
+				"trusting any wait assertion in this file",
+		)
+	}
+	ls.timeConverter = NewSlotTimeConverter(SlotTimeConverterDeps{
+		ShelleyGenesis: func() *shelley.ShelleyGenesis {
+			return &shelley.ShelleyGenesis{
+				SlotLength: lcommon.GenesisRat{
+					Rat: big.NewRat(
+						int64(leiosWaitTestSlotLen/time.Millisecond),
+						1000,
+					),
+				},
+			}
+		},
+	})
+	ls.timeConverterOnce.Do(func() {})
+}
+
+// leiosWaitTestAnnouncingBlock builds a Dijkstra ranking block that announces
+// ebHash and certifies nothing.
+func leiosWaitTestAnnouncingBlock(
+	t *testing.T,
+	blockNumber, slot uint64,
+	ebHash lcommon.Blake2b256,
+) *dijkstra.DijkstraBlock {
+	t.Helper()
+	return &dijkstra.DijkstraBlock{
+		BlockHeader: &dijkstra.DijkstraBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: blockNumber,
+					Slot:        slot,
+				},
+			},
+			LeiosHeaderExtension: []cbor.RawMessage{
+				leiosTestRaw(t, false),
+				leiosTestRaw(t, []any{ebHash.Bytes(), uint64(4096)}),
+			},
+		},
+	}
+}
+
+// TestEnsureReferencedEndorserBlocksDoesNotBlockOnUnreadAnnouncement is the
+// apply-lag regression. On the Haskell-conformant (Musashi) path, ledger
+// application of a ranking block reads only the certified closure announced by
+// a certifying block's PARENT; a block's own announcement is never read when
+// that block is applied. Blocking the single ledger pipeline on it stalled
+// every block queued behind it for a whole diffusion window and then applied
+// the block unchanged anyway, which is where the multi-second apply lag and
+// the resulting stale-tip forge came from.
+//
+// Before the fix this returns after the full window; after it, immediately.
+func TestEnsureReferencedEndorserBlocksDoesNotBlockOnUnreadAnnouncement(
+	t *testing.T,
+) {
+	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xA1))
+	block := leiosWaitTestAnnouncingBlock(t, 1, 100, ebHash)
+
+	var fetched atomic.Int64
+	fetchedCh := make(chan struct{}, 1)
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			// The endorser block never arrives.
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			fetched.Add(1)
+			select {
+			case fetchedCh <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+		EndorserBlockWaitSlots: leiosWaitTestWaitSlots,
+		// Haskell-conformant path: application reads only certified closures.
+		LeiosApplyEndorserBlockTxs: false,
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+	withLeiosWaitTestSlotLength(t, ls)
+	require.Equal(t, leiosWaitTestSlotLen, ls.shelleySlotLength())
+
+	start := time.Now()
+	require.NoError(t, ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		[]gledger.Block{block},
+	))
+	elapsed := time.Since(start)
+	require.Less(
+		t,
+		elapsed,
+		leiosWaitTestWindow/2,
+		"apply gate blocked on an announcement ledger application never reads",
+	)
+
+	// The announcement is prefetched in the background rather than dropped, so
+	// it is cached before anything actually depends on it.
+	select {
+	case <-fetchedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background by-point fetch was never dispatched")
+	}
+	require.Positive(t, fetched.Load())
+}
+
+// leiosWaitTestPolledFromWait reports whether the current call stack passes
+// through waitForEndorserBlock, i.e. whether the endorser-block provider is
+// being polled by the WAIT itself rather than by one of the gate's
+// availability checks that run before the wait starts.
+//
+// A test that instead counts provider calls and flips availability on the Nth
+// one is silently coupled to how many pre-wait checks the gate happens to
+// make. If that count ever grows past the threshold, the endorser block
+// becomes available before the wait is entered, the reference is treated as
+// already cached, no wait happens at all -- and the test still passes, having
+// stopped testing the thing it names. Keying on the caller instead makes the
+// phase explicit and immune to that drift.
+func leiosWaitTestPolledFromWait() bool {
+	pcs := make([]uintptr, 64)
+	n := runtime.Callers(2, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		if strings.Contains(frame.Function, "waitForEndorserBlock") {
+			return true
+		}
+		if !more {
+			return false
+		}
+	}
+}
+
+// TestEnsureReferencedEndorserBlocksWaitsForCertifiedClosureArrivingLate pins
+// the other half of the contract: a certifying ranking block's closure IS read
+// at apply time and committing without it would permanently omit the endorser
+// block's effects, so that wait is load-bearing and is kept. An endorser block
+// that lands part-way through the window must be picked up, not skipped.
+//
+// The endorser block is unavailable to every check the gate makes before the
+// wait, and becomes available only on the wait's own Nth poll. That makes the
+// arrival late by construction -- it cannot be satisfied by a pre-wait check,
+// however many of those there are -- and it is driven by the wait's progress
+// rather than the wall clock, so it cannot lose a race with the deadline on a
+// loaded runner. The test then asserts that the arrival really was observed
+// inside the wait, which is what stops it passing vacuously if the wait is
+// skipped.
+func TestEnsureReferencedEndorserBlocksWaitsForCertifiedClosureArrivingLate(
+	t *testing.T,
+) {
+	parent, certifier, ebHash := leiosTestCertifiedBlockPair(t)
+	const arrivalWaitPoll = 3
+	var preWaitPolls, waitPolls atomic.Int64
+	var arrivedInsideWait atomic.Bool
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func(
+			hash []byte,
+			slot uint64,
+		) ([]cbor.RawMessage, bool) {
+			if slot != parent.SlotNumber() {
+				return nil, false
+			}
+			if string(hash) != string(ebHash.Bytes()) {
+				return nil, false
+			}
+			// Once it has arrived it stays available to every caller, as a
+			// real endorser block landing in the cache would -- including the
+			// gate's mandatory-closure checks, which run after the wait and
+			// outside its call stack.
+			if arrivedInsideWait.Load() {
+				return nil, true
+			}
+			if !leiosWaitTestPolledFromWait() {
+				// Every check before the wait sees it missing, so the wait is
+				// always entered and the arrival is always "late".
+				preWaitPolls.Add(1)
+				return nil, false
+			}
+			if waitPolls.Add(1) < arrivalWaitPoll {
+				return nil, false
+			}
+			arrivedInsideWait.Store(true)
+			return nil, true
+		},
+		EndorserBlockWaitSlots:     leiosWaitTestLongWaitSlots,
+		LeiosApplyEndorserBlockTxs: false,
+	}
+	ls := &LedgerState{config: cfg}
+	withLeiosWaitTestSlotLength(t, ls)
+
+	start := time.Now()
+	require.NoError(t, ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		[]gledger.Block{parent, certifier},
+	))
+	require.True(
+		t,
+		arrivedInsideWait.Load(),
+		"the closure must have been picked up by the wait; if it was never "+
+			"polled from inside waitForEndorserBlock the gate did not wait "+
+			"at all and this test would otherwise pass vacuously",
+	)
+	require.GreaterOrEqual(
+		t,
+		waitPolls.Load(),
+		int64(arrivalWaitPoll),
+		"mandatory certified closure must be waited for, not skipped",
+	)
+	require.Positive(
+		t,
+		preWaitPolls.Load(),
+		"the gate is expected to check availability before waiting; if it "+
+			"stops doing so this test's phase split needs revisiting",
+	)
+	require.Less(t, time.Since(start), leiosWaitTestLongWindow)
+}
+
+// TestEnsureReferencedEndorserBlocksSharesOneWindowAcrossMissingBlocks is the
+// serial-stacking regression. The per-endorser-block waits are independent --
+// none observes another's result -- so running them back to back charged the
+// ledger pipeline one full diffusion window per missing endorser block. A
+// batch referencing k missing endorser blocks cost k windows, which is the
+// long tail of the measured apply stalls. They must share one window.
+//
+// The CIP-conformant path is used because every reference there is read at
+// apply time, so all three stay blocking and only the concurrency changes.
+func TestEnsureReferencedEndorserBlocksSharesOneWindowAcrossMissingBlocks(
+	t *testing.T,
+) {
+	const missing = 3
+	blocks := make([]gledger.Block, 0, missing)
+	for i := range missing {
+		blocks = append(blocks, leiosWaitTestAnnouncingBlock(
+			t,
+			uint64(i+1),
+			uint64(100+i),
+			lcommon.NewBlake2b256(leiosTestHash(byte(0xB0+i))),
+		))
+	}
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		EndorserBlockWaitSlots: leiosWaitTestWaitSlots,
+		// CIP-conformant path: every announcement is read at apply time.
+		LeiosApplyEndorserBlockTxs: true,
+	}
+	ls := &LedgerState{config: cfg}
+	withLeiosWaitTestSlotLength(t, ls)
+
+	start := time.Now()
+	require.NoError(t, ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		blocks,
+	))
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(
+		t,
+		elapsed,
+		leiosWaitTestWindow,
+		"the window must still be honoured for references application reads",
+	)
+	require.Less(
+		t,
+		elapsed,
+		2*leiosWaitTestWindow,
+		"per-endorser-block waits stacked serially instead of sharing a window",
+	)
+}
+
+// TestSplitTipWaitByApplyDependency pins the apply-path contract itself,
+// independently of timing: on the CIP path every reference is read at apply
+// time and stays blocking; on the Musashi path only the mandatory certified
+// closures are read, and a block's own announcement is demoted to background
+// prefetch.
+func TestSplitTipWaitByApplyDependency(t *testing.T) {
+	certified := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xC1)),
+	}
+	announced := leiosEbRef{
+		slot: 140,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xC2)),
+	}
+	tipWait := []leiosEbRef{certified, announced}
+
+	blocking, prefetch := splitTipWaitByApplyDependency(
+		tipWait,
+		[]leiosEbRef{certified},
+		true,
+	)
+	require.Equal(t, []leiosEbRef{certified}, blocking)
+	require.Equal(t, []leiosEbRef{announced}, prefetch)
+
+	blocking, prefetch = splitTipWaitByApplyDependency(tipWait, nil, false)
+	require.Equal(t, tipWait, blocking)
+	require.Empty(t, prefetch)
+}
+
+// TestAwaitEndorserBlocksFetchesUpFront pins the second half of the wait fix:
+// a reference the batch does block on has its by-point fetch dispatched up
+// front, concurrently with the wait, instead of the wait polling passively and
+// only falling back to a fetch once the whole diffusion window had already been
+// spent. It also pins that an already-available reference costs neither a wait
+// nor a fetch.
+func TestAwaitEndorserBlocksFetchesUpFront(t *testing.T) {
+	var cached atomic.Bool
+	var fetches atomic.Int64
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, cached.Load()
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			fetches.Add(1)
+			// The fetch is what makes the endorser block available; nothing
+			// else will deliver it during this test.
+			cached.Store(true)
+			return nil
+		},
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+	ref := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xD1)),
+	}
+
+	start := time.Now()
+	ls.awaitEndorserBlocks(
+		t.Context(),
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+	)
+	require.Less(
+		t,
+		time.Since(start),
+		leiosWaitTestWindow/2,
+		"wait did not dispatch the by-point fetch until the window expired",
+	)
+	require.Equal(t, int64(1), fetches.Load())
+
+	// Already cached: no second fetch, no wait.
+	start = time.Now()
+	ls.awaitEndorserBlocks(
+		t.Context(),
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+	)
+	require.Less(t, time.Since(start), leiosWaitTestWindow/2)
+	require.Equal(t, int64(1), fetches.Load())
+}
+
+// leiosWaitTestHistogram returns the sample count of
+// dingo_metrics_leios_eb_wait_seconds for the given outcome label.
+func leiosWaitTestHistogram(
+	t *testing.T,
+	reg *prometheus.Registry,
+	outcome string,
+) uint64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "dingo_metrics_leios_eb_wait_seconds" {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "outcome" &&
+					label.GetValue() == outcome {
+					return m.GetHistogram().GetSampleCount()
+				}
+			}
+		}
+	}
+	t.Fatalf("no eb wait histogram series for outcome %q", outcome)
+	return 0
+}
+
+// TestLeiosEbWaitMetricsRecordOutcomeAndDuration covers the observability gap:
+// the apply-path endorser-block wait had no metric at all, only an Info log,
+// so a producer sitting in it for tens of seconds per block showed nothing in
+// monitoring. Both outcomes are recorded, and both label values exist before
+// any wait happens so a dashboard is not looking at an absent series.
+func TestLeiosEbWaitMetricsRecordOutcomeAndDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	var available atomic.Bool
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EndorserBlockProvider: func(
+				[]byte,
+				uint64,
+			) ([]cbor.RawMessage, bool) {
+				return nil, available.Load()
+			},
+		},
+	}
+	ls.metrics.init(reg)
+
+	// Every outcome series is pre-materialized at init, before any wait.
+	require.Equal(
+		t,
+		3,
+		testutil.CollectAndCount(ls.metrics.leiosEbWaitSeconds),
+	)
+	require.Zero(t, leiosWaitTestHistogram(t, reg, "arrived"))
+	require.Zero(t, leiosWaitTestHistogram(t, reg, "timeout"))
+	require.Zero(t, leiosWaitTestHistogram(t, reg, "cancelled"))
+	require.Zero(t, testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts))
+
+	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xE7))
+
+	// Expiry: recorded as a timeout, on both the histogram and the counter.
+	ls.waitForEndorserBlock(
+		t.Context(),
+		100,
+		ebHash,
+		leiosWaitTestWindow,
+		time.Millisecond,
+	)
+	require.Equal(t, uint64(1), leiosWaitTestHistogram(t, reg, "timeout"))
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts),
+	)
+	require.Zero(t, leiosWaitTestHistogram(t, reg, "arrived"))
+
+	// Arrival: recorded as arrived, and does not increment the timeout
+	// counter. The endorser block is made available by the provider's own
+	// second call rather than by a timer racing the deadline, and the window
+	// is long enough that the deadline cannot fire first regardless of load.
+	available.Store(true)
+	ls.waitForEndorserBlock(
+		t.Context(),
+		100,
+		ebHash,
+		leiosWaitTestLongWindow,
+		time.Millisecond,
+	)
+	require.Equal(t, uint64(1), leiosWaitTestHistogram(t, reg, "arrived"))
+	require.Equal(t, uint64(1), leiosWaitTestHistogram(t, reg, "timeout"))
+	require.Equal(
+		t,
+		float64(1),
+		testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts),
+	)
+}
+
+// TestLeiosEbWaitCancellationIsNotCountedAsTimeout covers the review finding:
+// the wait's context is a timeout CHILD of the block-processing context, so its
+// Done also closes when the parent is cancelled -- node shutdown, or the pass
+// being aborted and restarted. That is not a diffusion-window expiry, and
+// counting it as one inflates the timeout rate exactly when a node is shutting
+// down or restarting its pipeline, which is when the metric is most likely to
+// be read.
+//
+// Neither case uses a timer. Cancellation is either already in effect before
+// the wait starts, or is driven by the wait's own polling, and the window is
+// large enough that the deadline cannot win either race on a loaded runner.
+// A timer firing at a fraction of a short window is precisely the flake this
+// avoids: if it landed late the outcome would be "timeout" and the assertions
+// below would fail for reasons that have nothing to do with the code.
+func TestLeiosEbWaitCancellationIsNotCountedAsTimeout(t *testing.T) {
+	// cancelWhen selects how the parent context is cancelled relative to the
+	// wait: before it starts, or from inside the availability poll once the
+	// wait is already running.
+	for name, cancelOnPoll := range map[string]int64{
+		"cancelled before the wait starts": 0,
+		"cancelled during the wait":        3,
+	} {
+		t.Run(name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			var polls atomic.Int64
+			ls := &LedgerState{
+				config: LedgerStateConfig{
+					Logger: slog.New(
+						slog.NewJSONHandler(io.Discard, nil),
+					),
+					EndorserBlockProvider: func(
+						[]byte,
+						uint64,
+					) ([]cbor.RawMessage, bool) {
+						if cancelOnPoll > 0 &&
+							polls.Add(1) == cancelOnPoll {
+							cancel()
+						}
+						// Never arrives, so only a cancellation or the
+						// window can end the wait.
+						return nil, false
+					},
+				},
+			}
+			ls.metrics.init(reg)
+
+			// Every outcome series exists before any wait.
+			require.Equal(
+				t,
+				3,
+				testutil.CollectAndCount(ls.metrics.leiosEbWaitSeconds),
+			)
+
+			if cancelOnPoll == 0 {
+				cancel()
+			}
+
+			start := time.Now()
+			ls.waitForEndorserBlock(
+				ctx,
+				100,
+				lcommon.NewBlake2b256(leiosTestHash(0xE8)),
+				leiosWaitTestLongWindow,
+				time.Millisecond,
+			)
+			require.Less(
+				t,
+				time.Since(start),
+				leiosWaitTestLongWindow,
+				"the wait must end on parent cancellation, not run out the window",
+			)
+
+			require.Equal(
+				t,
+				uint64(1),
+				leiosWaitTestHistogram(t, reg, "cancelled"),
+			)
+			require.Zero(t, leiosWaitTestHistogram(t, reg, "timeout"))
+			require.Zero(t, leiosWaitTestHistogram(t, reg, "arrived"))
+			require.Zero(
+				t,
+				testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts),
+				"a cancelled pass must not be counted as a diffusion-window timeout",
+			)
+		})
+	}
+}
+
+// TestLeiosEbWaitCancellationLeavesCallerBehaviourUnchanged pins that the new
+// classification is only a classification: a cancelled pass still runs the
+// mandatory-closure check, so it still fails the chunk when a certified
+// closure is missing rather than silently committing without it.
+func TestLeiosEbWaitCancellationLeavesCallerBehaviourUnchanged(t *testing.T) {
+	parent, certifier, _ := leiosTestCertifiedBlockPair(t)
+	ls := &LedgerState{
+		config: LedgerStateConfig{
+			Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+			EndorserBlockProvider: func(
+				[]byte,
+				uint64,
+			) ([]cbor.RawMessage, bool) {
+				return nil, false
+			},
+			EndorserBlockWaitSlots:     leiosWaitTestWaitSlots,
+			LeiosApplyEndorserBlockTxs: false,
+		},
+	}
+	withLeiosWaitTestSlotLength(t, ls)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := ls.ensureReferencedEndorserBlocks(
+		ctx,
+		[]gledger.Block{parent, certifier},
+	)
+	require.ErrorIs(t, err, errCertifiedEndorserBlockUnavailable)
+}
+
+// leiosWaitTestPolledFromGrace reports whether the provider is being polled by
+// the post-window fetch wait (awaitInFlightEndorserFetches).
+//
+// It matches awaitInFlightEndorserFetches itself, NOT awaitFetch. awaitFetch is
+// shared: the certificate-driven path reaches it through fetchOnce's dedup
+// wait, so keying on it would make a cert-driven test report a grace phase that
+// never ran, depending on whether a fetch happened to be in flight. The waits
+// are dispatched from a goroutine per reference, and a closure carries its
+// enclosing function's name in the stack (…awaitInFlightEndorserFetches.func1),
+// so the enclosing frame is still visible from inside the poll.
+func leiosWaitTestPolledFromGrace() bool {
+	pcs := make([]uintptr, 64)
+	n := runtime.Callers(2, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		if strings.Contains(
+			frame.Function,
+			"awaitInFlightEndorserFetches",
+		) {
+			return true
+		}
+		if !more {
+			return false
+		}
+	}
+}
+
+// TestEnsureReferencedEndorserBlocksAwaitsLateFetchOnCIPPath covers the
+// regression the review found in the CIP-conformant path. Application there
+// reads each ranking block's own announcement and nothing re-applies an
+// endorser block that lands afterwards, so if the by-point fetch is still in
+// flight when the diffusion window elapses, the ranking block is applied
+// without the endorser-resident outputs and its spends fall through to the
+// interim trust path permanently.
+//
+// The previous code got this right by accident: it issued a SYNCHRONOUS
+// by-point fetch after the window, so however slow the fetch was it still
+// populated the cache before the batch reached ledgerProcessBlock. Dispatching
+// the fetch up front and asynchronously is better for latency but dropped that
+// guarantee. The grace phase restores it.
+//
+// The fetch is released by the grace phase's own first poll rather than by a
+// timer, so "slower than the window, faster than the grace" holds by
+// construction and cannot flake: until the grace phase runs, the fetch cannot
+// complete, so it is always later than the window.
+func TestEnsureReferencedEndorserBlocksAwaitsLateFetchOnCIPPath(t *testing.T) {
+	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xF1))
+	block := leiosWaitTestAnnouncingBlock(t, 1, 100, ebHash)
+
+	// gracePollsBeforeRelease is chosen so the fetch cannot complete until the
+	// wait has polled for materially longer than the soft-warn window: the poll
+	// interval is a tenth of a slot, so the window is worth about
+	// leiosWaitTestWaitSlots*10 polls and this is comfortably beyond it. A wait
+	// bounded BY that window -- which is what this test exists to reject --
+	// gives up before reaching this count, deterministically and regardless of
+	// machine load, because it is counting the wait's own polls rather than
+	// racing a clock.
+	const gracePollsBeforeRelease = leiosWaitTestWaitSlots * 20
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	var gracePolls atomic.Int64
+	var cached, sawGracePhase, fetchCompleted atomic.Bool
+
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func(
+			hash []byte,
+			slot uint64,
+		) ([]cbor.RawMessage, bool) {
+			if slot != 100 || string(hash) != string(ebHash.Bytes()) {
+				return nil, false
+			}
+			if leiosWaitTestPolledFromGrace() {
+				// The diffusion window has elapsed and the post-window wait is
+				// running. Hold the fetch for long enough that a wait bounded
+				// by one further window would have abandoned it.
+				sawGracePhase.Store(true)
+				if gracePolls.Add(1) >= gracePollsBeforeRelease {
+					releaseOnce.Do(func() { close(release) })
+				}
+			}
+			return nil, cached.Load()
+		},
+		EndorserBlockFetcher: func(
+			ctx context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(10 * time.Second):
+				// Backstop so a regression that never runs the grace phase
+				// fails the assertions below instead of hanging.
+				return nil
+			}
+			cached.Store(true)
+			fetchCompleted.Store(true)
+			return nil
+		},
+		// CIP-conformant path: application reads the announcement.
+		EndorserBlockWaitSlots:     leiosWaitTestWaitSlots,
+		LeiosApplyEndorserBlockTxs: true,
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+	withLeiosWaitTestSlotLength(t, ls)
+
+	require.NoError(t, ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		[]gledger.Block{block},
+	))
+
+	require.True(
+		t,
+		sawGracePhase.Load(),
+		"the post-window grace phase must run on the CIP path",
+	)
+	require.True(t, fetchCompleted.Load(), "the in-flight fetch must finish")
+	require.GreaterOrEqual(
+		t,
+		gracePolls.Load(),
+		int64(gracePollsBeforeRelease),
+		"the wait must outlast a single further diffusion window",
+	)
+	require.True(
+		t,
+		endorserBlockAvailableAt(
+			ls.config.EndorserBlockProvider,
+			ebHash.Bytes(),
+			100,
+		),
+		"the endorser block must be cached before the batch is applied; "+
+			"otherwise the ranking block commits without its endorser-resident "+
+			"outputs and nothing ever re-applies them",
+	)
+}
+
+// TestEnsureReferencedEndorserBlocksSkipsGraceOnCertDrivenPath pins that the
+// grace is CIP-only, exercised against a MANDATORY certified closure so the
+// blocking set is non-empty and the guard is what decides. On this path a
+// missing closure is already retried by the bounded fetch that follows, so
+// paying a second diffusion window here would add head-of-line blocking on the
+// pipeline for nothing -- exactly what this PR removes.
+func TestEnsureReferencedEndorserBlocksSkipsGraceOnCertDrivenPath(t *testing.T) {
+	parent, certifier, _ := leiosTestCertifiedBlockPair(t)
+
+	var sawGracePhase atomic.Bool
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			if leiosWaitTestPolledFromGrace() {
+				sawGracePhase.Store(true)
+			}
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			return nil
+		},
+		EndorserBlockWaitSlots:     leiosWaitTestWaitSlots,
+		LeiosApplyEndorserBlockTxs: false,
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+	withLeiosWaitTestSlotLength(t, ls)
+
+	// The closure never arrives, so the mandatory check fails -- which is the
+	// correct outcome and is what makes the grace pointless here.
+	err := ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		[]gledger.Block{parent, certifier},
+	)
+	require.ErrorIs(t, err, errCertifiedEndorserBlockUnavailable)
+	require.False(
+		t,
+		sawGracePhase.Load(),
+		"the post-window grace must not run on the certificate-driven path",
+	)
+}
+
+// TestEnsureReferencedEndorserBlocksProceedsWhenCIPFetchFindsNothing pins the
+// other arm of the CIP wait: when the by-point fetch finishes without caching
+// -- no connected peer holds the endorser block -- application proceeds without
+// it rather than failing the chunk.
+//
+// This is deliberate and is NOT a behaviour this change introduces: it is the
+// long-standing semantics of the CIP path. Failing the chunk instead would turn
+// an unfetchable endorser block into an unbounded pipeline retry, which is a
+// wedge this codebase has hit before. The wait exists to stop us abandoning a
+// fetch that was about to succeed, not to convert a genuine absence into a
+// stall.
+func TestEnsureReferencedEndorserBlocksProceedsWhenCIPFetchFindsNothing(
+	t *testing.T,
+) {
+	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xF3))
+	block := leiosWaitTestAnnouncingBlock(t, 1, 100, ebHash)
+
+	var fetches atomic.Int64
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			// Finishes promptly, having found nothing.
+			fetches.Add(1)
+			return errors.New("no peer holds this endorser block")
+		},
+		EndorserBlockWaitSlots:     leiosWaitTestWaitSlots,
+		LeiosApplyEndorserBlockTxs: true,
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+	withLeiosWaitTestSlotLength(t, ls)
+
+	start := time.Now()
+	require.NoError(t, ls.ensureReferencedEndorserBlocks(
+		t.Context(),
+		[]gledger.Block{block},
+	))
+	// One diffusion window, then the fetch's own prompt failure -- not the
+	// hard backstop.
+	require.Less(t, time.Since(start), leiosTipFetchHardBound)
+	require.Positive(t, fetches.Load())
+	require.False(t, endorserBlockAvailableAt(
+		ls.config.EndorserBlockProvider,
+		ebHash.Bytes(),
+		100,
+	))
+}
+
+// TestLeiosGraceDetectorIgnoresSharedAwaitFetch pins the property that makes
+// the certificate-driven test above meaningful rather than timing-dependent.
+//
+// awaitFetch is shared: the certificate-driven path reaches it through
+// fetchOnce's dedup wait whenever a spawned fetch for the same reference is
+// still in flight. A grace detector keyed on awaitFetch therefore reports a
+// post-window wait that never ran, but only when that race happens to occur --
+// so the cert-driven test would pass or fail depending on scheduling. Keying on
+// awaitInFlightEndorserFetches makes it positive and deterministic, and this
+// asserts exactly that: reached through awaitFetch alone, the detector is
+// false.
+func TestLeiosGraceDetectorIgnoresSharedAwaitFetch(t *testing.T) {
+	var sawGrace atomic.Bool
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			if leiosWaitTestPolledFromGrace() {
+				sawGrace.Store(true)
+			}
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			return nil
+		},
+	}
+	b := newLeiosBackfiller(cfg)
+	require.NotNil(t, b)
+
+	b.awaitFetch(
+		t.Context(),
+		leiosEbRef{
+			slot: 100,
+			hash: lcommon.NewBlake2b256(leiosTestHash(0xF4)),
+		},
+		time.Millisecond,
+		20*time.Millisecond,
+	)
+
+	require.False(
+		t,
+		sawGrace.Load(),
+		"awaitFetch alone must not be mistaken for the post-window wait",
+	)
+}
+
+// leiosWaitTestLogBuffer is a concurrency-safe log sink. The waits under test
+// dispatch a goroutine per reference and the backfiller logs from its own
+// fetch goroutine, so a bare bytes.Buffer is written from several goroutines
+// at once -- which the race detector correctly flags.
+type leiosWaitTestLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *leiosWaitTestLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *leiosWaitTestLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestFetchRequiredReportsCancellationNotBudgetExpiry covers the second site
+// with the same defect the diffusion wait had: the retry budget is a timeout
+// CHILD of the block-processing context, so its Done also closes when the
+// PARENT is cancelled -- node shutdown, or the pass being aborted. Reporting
+// that as "the retry budget elapsed" tells an operator that peers failed to
+// serve the endorser block when nothing was asked of them, and it is loudest
+// exactly when a node is shutting down.
+func TestFetchRequiredReportsCancellationNotBudgetExpiry(t *testing.T) {
+	var logs leiosWaitTestLogBuffer
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			return errors.New("no peer holds it")
+		},
+	}
+	b := newLeiosBackfiller(cfg)
+	require.NotNil(t, b)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := b.fetchRequired(
+		ctx,
+		leiosEbRef{
+			slot: 100,
+			hash: lcommon.NewBlake2b256(leiosTestHash(0xC7)),
+		},
+		time.Millisecond,
+	)
+	require.Error(t, err)
+	require.NotContains(
+		t,
+		logs.String(),
+		"certified leios endorser block fetch budget elapsed",
+		"a cancelled pass must not be reported as peers failing to serve",
+	)
+	require.Contains(
+		t,
+		logs.String(),
+		"certified leios endorser block fetch cancelled",
+	)
+}
+
+// TestCIPFetchWaitReportsCancellationNotFailure covers the third site. On the
+// CIP path a fetch that finishes without caching is reported as "could not be
+// fetched", which is a real diagnosis -- unless the pass was cancelled, in
+// which case nothing was learned about whether any peer holds the block and
+// the line would be a false diagnosis emitted on every shutdown.
+func TestCIPFetchWaitReportsCancellationNotFailure(t *testing.T) {
+	var logs leiosWaitTestLogBuffer
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			ctx context.Context,
+			_ uint64,
+			_ []byte,
+		) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+
+	ref := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xC8)),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	// Dispatch the fetch, then cancel: the fetch is in flight and will end
+	// only because of the cancellation.
+	ls.leiosBackfill.spawn(ctx, ref)
+	cancel()
+
+	ls.awaitInFlightEndorserFetches(
+		ctx,
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+		leiosTipFetchHardBound,
+	)
+
+	require.NotContains(
+		t,
+		logs.String(),
+		"endorser block could not be fetched",
+		"a cancelled pass must not be reported as an unfetchable endorser block",
+	)
+	require.Contains(
+		t,
+		logs.String(),
+		"endorser block fetch cancelled before it completed",
+	)
+}
+
+// TestCIPFetchWaitDoesNotWarnOnRoutineUnfetchableEndorserBlock pins the log
+// level of the CIP path's most common non-cached outcome.
+//
+// awaitFetch returns for two reasons that this wait cannot otherwise tell
+// apart: the all-peers fetch cleared its in-flight marker without caching (no
+// peer holds this endorser block), or it neither cached nor cleared before the
+// hard bound. Only the second is anomalous. The first is the expected,
+// long-standing behaviour of this path -- the code this replaced logged its
+// equivalent at Debug -- and on a CIP node where endorser blocks are routinely
+// unfetchable, a WARN per reference turns normal operation into alertable
+// volume.
+func TestCIPFetchWaitDoesNotWarnOnRoutineUnfetchableEndorserBlock(
+	t *testing.T,
+) {
+	var logs leiosWaitTestLogBuffer
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		// Fails immediately, the way a sweep that finds no peer holding the
+		// block does: the in-flight marker clears and awaitFetch returns
+		// without the hard bound ever being approached.
+		EndorserBlockFetcher: func(context.Context, uint64, []byte) error {
+			return errors.New("no peer holds it")
+		},
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+
+	ref := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xC9)),
+	}
+	ls.leiosBackfill.spawn(t.Context(), ref)
+
+	ls.awaitInFlightEndorserFetches(
+		t.Context(),
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+		leiosWaitTestLongWindow,
+	)
+
+	require.Contains(
+		t,
+		logs.String(),
+		"endorser block could not be fetched",
+		"the outcome must still be reported, just not at WARN",
+	)
+	require.NotContains(
+		t,
+		logs.String(),
+		`"level":"WARN"`,
+		"a fetch that swept every peer and found none holding the endorser "+
+			"block is this path's expected outcome, not an alert",
+	)
+}
+
+// TestCIPFetchWaitWarnsWhenAFetchNeitherCachesNorClears is the other half:
+// the case that IS anomalous must stay at WARN. A fetch that neither caches
+// nor clears its in-flight marker held the ledger pipeline for the whole hard
+// bound and produced nothing, which is a wedged fetch rather than an absent
+// endorser block.
+func TestCIPFetchWaitWarnsWhenAFetchNeitherCachesNorClears(t *testing.T) {
+	var logs leiosWaitTestLogBuffer
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		// Never returns while the wait runs, so the in-flight marker is still
+		// set when awaitFetch gives up at the hard bound. Released by the
+		// cleanup so the goroutine does not outlive the test.
+		EndorserBlockFetcher: func(context.Context, uint64, []byte) error {
+			<-release
+			return errors.New("released")
+		},
+	}
+	ls := &LedgerState{config: cfg}
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+
+	ref := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xCA)),
+	}
+	// A live parent context, so the wait can only end at the hard bound --
+	// never through the cancellation branch.
+	ls.leiosBackfill.spawn(t.Context(), ref)
+
+	ls.awaitInFlightEndorserFetches(
+		t.Context(),
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+		leiosWaitTestSlotLen,
+	)
+
+	require.Contains(
+		t,
+		logs.String(),
+		"endorser block fetch neither completed nor cached within the hard bound",
+	)
+	require.Contains(
+		t,
+		logs.String(),
+		`"level":"WARN"`,
+		"a fetch wedged for the whole hard bound is worth an alert",
+	)
+}

--- a/ledger/leios_apply_wait_test.go
+++ b/ledger/leios_apply_wait_test.go
@@ -145,11 +145,18 @@ func TestEnsureReferencedEndorserBlocksDoesNotBlockOnUnreadAnnouncement(
 	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xA1))
 	block := leiosWaitTestAnnouncingBlock(t, 1, 100, ebHash)
 
-	var fetched atomic.Int64
+	var fetched, waitPolls atomic.Int64
 	fetchedCh := make(chan struct{}, 1)
 	cfg := LedgerStateConfig{
 		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			// Counting polls that come from INSIDE waitForEndorserBlock is
+			// what makes this test's verdict event-driven: a gate that
+			// blocked on this announcement must poll from there, and one
+			// that correctly skips it never can.
+			if leiosWaitTestPolledFromWait() {
+				waitPolls.Add(1)
+			}
 			// The endorser block never arrives.
 			return nil, false
 		},
@@ -180,11 +187,23 @@ func TestEnsureReferencedEndorserBlocksDoesNotBlockOnUnreadAnnouncement(
 		[]gledger.Block{block},
 	))
 	elapsed := time.Since(start)
+	// The load-bearing assertion is event-driven, not a stopwatch: if the gate
+	// blocked on this announcement it would have polled from inside
+	// waitForEndorserBlock. Asserting that directly cannot flake on a loaded
+	// runner, whereas a short wall-clock budget has to cover goroutine
+	// scheduling as well as the absence of a window.
+	require.Zero(
+		t,
+		waitPolls.Load(),
+		"apply gate blocked on an announcement ledger application never reads",
+	)
+	// Clock kept only as a loose backstop against a full window being spent
+	// somewhere the poll counter cannot see. Generous on purpose.
 	require.Less(
 		t,
 		elapsed,
-		leiosWaitTestWindow/2,
-		"apply gate blocked on an announcement ledger application never reads",
+		leiosWaitTestWindow,
+		"apply gate spent a whole diffusion window",
 	)
 
 	// The announcement is prefetched in the background rather than dropped, so
@@ -432,13 +451,21 @@ func TestAwaitEndorserBlocksFetchesUpFront(t *testing.T) {
 		leiosWaitTestWindow,
 		time.Millisecond,
 	)
+	// The fetch count is the event that matters: it proves the by-point fetch
+	// was dispatched up front rather than after the window. Elapsed time is a
+	// loose backstop only, so a saturated scheduler cannot fail a correct wait.
+	require.Equal(
+		t,
+		int64(1),
+		fetches.Load(),
+		"wait did not dispatch the by-point fetch",
+	)
 	require.Less(
 		t,
 		time.Since(start),
-		leiosWaitTestWindow/2,
+		leiosWaitTestWindow,
 		"wait did not dispatch the by-point fetch until the window expired",
 	)
-	require.Equal(t, int64(1), fetches.Load())
 
 	// Already cached: no second fetch, no wait.
 	start = time.Now()
@@ -448,8 +475,13 @@ func TestAwaitEndorserBlocksFetchesUpFront(t *testing.T) {
 		leiosWaitTestWindow,
 		time.Millisecond,
 	)
-	require.Less(t, time.Since(start), leiosWaitTestWindow/2)
-	require.Equal(t, int64(1), fetches.Load())
+	require.Equal(
+		t,
+		int64(1),
+		fetches.Load(),
+		"an already-cached reference must not be fetched again",
+	)
+	require.Less(t, time.Since(start), leiosWaitTestWindow)
 }
 
 // leiosWaitTestHistogram returns the sample count of
@@ -1207,5 +1239,88 @@ func TestCIPFetchWaitWarnsWhenAFetchNeitherCachesNorClears(t *testing.T) {
 		logs.String(),
 		`"level":"WARN"`,
 		"a fetch wedged for the whole hard bound is worth an alert",
+	)
+}
+
+// TestMandatoryFetchIsNotStarvedByBestEffortSpawns pins the reserved budget.
+//
+// spawn (best-effort) and fetchRequired (mandatory certified closure) used to
+// share one semaphore. A best-effort fetch holds its slot for up to
+// leiosBackfillMaxWait, so filling the semaphore with slow ones blocked a
+// mandatory fetch behind them -- and this path now dispatches near-head
+// prefetches through spawn as well, so that is far more reachable than when
+// only historical backfill used it. A mandatory fetch must proceed regardless.
+func TestMandatoryFetchIsNotStarvedByBestEffortSpawns(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	var mandatoryRan atomic.Bool
+	spawned := make(chan struct{}, leiosBackfillConcurrency)
+
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		EndorserBlockFetcher: func(
+			_ context.Context,
+			slot uint64,
+			_ []byte,
+		) error {
+			if slot == 999 {
+				// The mandatory one. Reaching here at all is the point.
+				mandatoryRan.Store(true)
+				return errors.New("no peer holds it")
+			}
+			// Best-effort: occupy the slot until the test ends.
+			select {
+			case spawned <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
+	}
+	b := newLeiosBackfiller(cfg)
+	require.NotNil(t, b)
+
+	// Saturate the best-effort budget.
+	for i := range leiosBackfillConcurrency {
+		b.spawn(t.Context(), leiosEbRef{
+			slot: uint64(100 + i),
+			hash: lcommon.NewBlake2b256(leiosTestHash(byte(0xE0 + i))),
+		})
+	}
+	for range leiosBackfillConcurrency {
+		select {
+		case <-spawned:
+		case <-time.After(5 * time.Second):
+			t.Fatal("best-effort spawns never occupied the budget")
+		}
+	}
+
+	// The mandatory fetch must not queue behind them.
+	done := make(chan error, 1)
+	go func() {
+		done <- b.fetchRequired(
+			t.Context(),
+			leiosEbRef{
+				slot: 999,
+				hash: lcommon.NewBlake2b256(leiosTestHash(0xEF)),
+			},
+			time.Millisecond,
+		)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal(
+			"mandatory certified fetch was starved by best-effort spawns; " +
+				"it must have its own reserved budget",
+		)
+	}
+	require.True(
+		t,
+		mandatoryRan.Load(),
+		"the mandatory fetch never reached the fetcher",
 	)
 }

--- a/ledger/leios_apply_wait_test.go
+++ b/ledger/leios_apply_wait_test.go
@@ -535,12 +535,13 @@ func TestLeiosEbWaitMetricsRecordOutcomeAndDuration(t *testing.T) {
 	// Every outcome series is pre-materialized at init, before any wait.
 	require.Equal(
 		t,
-		3,
+		4,
 		testutil.CollectAndCount(ls.metrics.leiosEbWaitSeconds),
 	)
 	require.Zero(t, leiosWaitTestHistogram(t, reg, "arrived"))
 	require.Zero(t, leiosWaitTestHistogram(t, reg, "timeout"))
 	require.Zero(t, leiosWaitTestHistogram(t, reg, "cancelled"))
+	require.Zero(t, leiosWaitTestHistogram(t, reg, "unavailable"))
 	require.Zero(t, testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts))
 
 	ebHash := lcommon.NewBlake2b256(leiosTestHash(0xE7))
@@ -634,7 +635,7 @@ func TestLeiosEbWaitCancellationIsNotCountedAsTimeout(t *testing.T) {
 			// Every outcome series exists before any wait.
 			require.Equal(
 				t,
-				3,
+				4,
 				testutil.CollectAndCount(ls.metrics.leiosEbWaitSeconds),
 			)
 
@@ -1322,5 +1323,63 @@ func TestMandatoryFetchIsNotStarvedByBestEffortSpawns(t *testing.T) {
 		t,
 		mandatoryRan.Load(),
 		"the mandatory fetch never reached the fetcher",
+	)
+}
+
+// TestCIPGraceUnavailableIsNotRecordedAsATimeout pins the grace phase's metric
+// classification against the two ways inferring it after the fact goes wrong.
+//
+// Re-reading the cache and the context once awaitFetch has returned cannot
+// tell a fetch that COMPLETED without caching (routine on a CIP node: no peer
+// holds the block) from one that ran to the hard bound, so the routine case
+// was recorded as a timeout -- inflating both the timeout histogram and
+// dingo_metrics_leios_eb_wait_timeouts_total on every unfetchable block.
+// awaitFetch now reports its own termination cause instead.
+func TestCIPGraceUnavailableIsNotRecordedAsATimeout(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	cfg := LedgerStateConfig{
+		Logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		EndorserBlockProvider: func([]byte, uint64) ([]cbor.RawMessage, bool) {
+			return nil, false
+		},
+		// Completes immediately without caching: the in-flight marker clears
+		// long before the hard bound, so nothing timed out.
+		EndorserBlockFetcher: func(context.Context, uint64, []byte) error {
+			return errors.New("no peer holds it")
+		},
+	}
+	ls := &LedgerState{config: cfg}
+	ls.metrics.init(reg)
+	ls.leiosBackfill = newLeiosBackfiller(cfg)
+
+	ref := leiosEbRef{
+		slot: 100,
+		hash: lcommon.NewBlake2b256(leiosTestHash(0xF1)),
+	}
+	ls.leiosBackfill.spawn(t.Context(), ref)
+
+	ls.awaitInFlightEndorserFetches(
+		t.Context(),
+		[]leiosEbRef{ref},
+		leiosWaitTestWindow,
+		time.Millisecond,
+		leiosWaitTestLongWindow,
+	)
+
+	require.Equal(
+		t,
+		uint64(1),
+		leiosWaitTestHistogram(t, reg, "unavailable"),
+		"a fetch that completed without caching is its own outcome",
+	)
+	require.Zero(
+		t,
+		leiosWaitTestHistogram(t, reg, "timeout"),
+		"nothing timed out: the hard bound was never approached",
+	)
+	require.Zero(
+		t,
+		testutil.ToFloat64(ls.metrics.leiosEbWaitTimeouts),
+		"the timeout counter must not move for a routine unfetchable block",
 	)
 }

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"time"
+
 	"github.com/blinklabs-io/gouroboros/pipeline"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -36,6 +38,25 @@ type stateMetrics struct {
 	shelleyStartTime    prometheus.Gauge
 	epochLengthSlots    prometheus.Gauge
 	shadowGateDecisions *prometheus.CounterVec
+	// Wall-clock time the ledger apply path spent waiting for a referenced
+	// Leios endorser block, by outcome ("arrived", "timeout" or "cancelled"). This wait is
+	// taken ahead of the batch's DB transaction on the single ledger pipeline,
+	// so it is time every block queued behind the batch also spends waiting.
+	// Only references ledger application actually reads are waited on (see
+	// leiosApplyReadsOwnAnnouncement); the rest are prefetched in the
+	// background and never observed here.
+	leiosEbWaitSeconds *prometheus.HistogramVec
+	// Pre-materialized observers for the outcome label values, so the apply
+	// path does not resolve a label on every wait.
+	leiosEbWaitArrived   prometheus.Observer
+	leiosEbWaitTimedOut  prometheus.Observer
+	leiosEbWaitCancelled prometheus.Observer
+	// Waits that ran to the full diffusion window without the endorser block
+	// arriving. A rising value against a flat leios_eb_wait_seconds "arrived"
+	// count means the wait is buying nothing and is pure apply latency.
+	// Cancellations are deliberately excluded: they say nothing about
+	// endorser-block availability.
+	leiosEbWaitTimeouts prometheus.Counter
 	// Incremented when a stored governance proposal's CBOR fails to
 	// decode during the mid-epoch ratifiability check, so the failures
 	// surface as a metric instead of just log volume.
@@ -149,6 +170,49 @@ func (m *stateMetrics) observeLeaderThresholdMargin(margin float64) {
 		return
 	}
 	m.leaderThresholdMargin.Observe(margin)
+}
+
+// Outcome label values for dingo_metrics_leios_eb_wait_seconds.
+//
+//   - arrived:   the endorser block became available during the wait.
+//   - timeout:   the diffusion window elapsed without it. This is the outcome
+//     that means the wait cost apply latency and bought nothing.
+//   - cancelled: the wait ended because the block-processing context was
+//     cancelled (node shutdown, or the pass being aborted and restarted).
+//     Nothing was learned about the endorser block's availability, so this is
+//     kept out of the timeout counter: folding it in would inflate the
+//     timeout rate exactly when a node is shutting down or restarting its
+//     pipeline, which is when the metric is most likely to be read.
+const (
+	leiosEbWaitOutcomeArrived   = "arrived"
+	leiosEbWaitOutcomeTimeout   = "timeout"
+	leiosEbWaitOutcomeCancelled = "cancelled"
+)
+
+// observeLeiosEbWait records one apply-path endorser-block wait under the
+// given outcome. Recording the duration under every outcome (rather than only
+// timeouts) is what makes the metric answer the question that matters: whether
+// the wait is delivering endorser blocks or just costing apply latency before
+// proceeding without one.
+func (m *stateMetrics) observeLeiosEbWait(d time.Duration, outcome string) {
+	if m == nil {
+		return
+	}
+	var obs prometheus.Observer
+	switch outcome {
+	case leiosEbWaitOutcomeArrived:
+		obs = m.leiosEbWaitArrived
+	case leiosEbWaitOutcomeTimeout:
+		obs = m.leiosEbWaitTimedOut
+		if m.leiosEbWaitTimeouts != nil {
+			m.leiosEbWaitTimeouts.Inc()
+		}
+	case leiosEbWaitOutcomeCancelled:
+		obs = m.leiosEbWaitCancelled
+	}
+	if obs != nil {
+		obs.Observe(d.Seconds())
+	}
 }
 
 func (m *stateMetrics) incLeaderThresholdRejections() {
@@ -341,6 +405,32 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 			Help: "shadow blockfetch gate decisions, by path and cutoff source",
 		},
 		[]string{"path", "cutoff"},
+	)
+	m.leiosEbWaitSeconds = promautoFactory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "dingo_metrics_leios_eb_wait_seconds",
+			Help: "wall-clock time the ledger apply path spent waiting for a referenced Leios endorser block, by outcome",
+			// 5ms to ~82s: the wait is bounded by the certify-by deadline
+			// converted to wall clock, so the useful range spans sub-slot
+			// arrivals up to several stacked protocol windows.
+			Buckets: prometheus.ExponentialBuckets(0.005, 2, 15),
+		},
+		[]string{"outcome"},
+	)
+	m.leiosEbWaitArrived = m.leiosEbWaitSeconds.WithLabelValues(
+		leiosEbWaitOutcomeArrived,
+	)
+	m.leiosEbWaitTimedOut = m.leiosEbWaitSeconds.WithLabelValues(
+		leiosEbWaitOutcomeTimeout,
+	)
+	m.leiosEbWaitCancelled = m.leiosEbWaitSeconds.WithLabelValues(
+		leiosEbWaitOutcomeCancelled,
+	)
+	m.leiosEbWaitTimeouts = promautoFactory.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dingo_metrics_leios_eb_wait_timeouts_total",
+			Help: "ledger apply-path waits for a referenced Leios endorser block that ran to the full diffusion window without it arriving",
+		},
 	)
 	m.governanceProposalDecodeFailures = promautoFactory.NewCounter(
 		prometheus.CounterOpts{

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -48,9 +48,10 @@ type stateMetrics struct {
 	leiosEbWaitSeconds *prometheus.HistogramVec
 	// Pre-materialized observers for the outcome label values, so the apply
 	// path does not resolve a label on every wait.
-	leiosEbWaitArrived   prometheus.Observer
-	leiosEbWaitTimedOut  prometheus.Observer
-	leiosEbWaitCancelled prometheus.Observer
+	leiosEbWaitArrived     prometheus.Observer
+	leiosEbWaitTimedOut    prometheus.Observer
+	leiosEbWaitCancelled   prometheus.Observer
+	leiosEbWaitUnavailable prometheus.Observer
 	// Waits that ran to the full diffusion window without the endorser block
 	// arriving. A rising value against a flat leios_eb_wait_seconds "arrived"
 	// count means the wait is buying nothing and is pure apply latency.
@@ -187,6 +188,12 @@ const (
 	leiosEbWaitOutcomeArrived   = "arrived"
 	leiosEbWaitOutcomeTimeout   = "timeout"
 	leiosEbWaitOutcomeCancelled = "cancelled"
+	// leiosEbWaitOutcomeUnavailable is the CIP grace phase's routine ending:
+	// the by-point fetch COMPLETED without caching, because no peer holds the
+	// endorser block. Nothing timed out and nothing was cancelled, so folding
+	// it into either would overstate both -- and it is the most common ending
+	// on a CIP node, so it would overstate them badly.
+	leiosEbWaitOutcomeUnavailable = "unavailable"
 )
 
 // observeLeiosEbWait records one apply-path endorser-block wait under the
@@ -209,6 +216,8 @@ func (m *stateMetrics) observeLeiosEbWait(d time.Duration, outcome string) {
 		}
 	case leiosEbWaitOutcomeCancelled:
 		obs = m.leiosEbWaitCancelled
+	case leiosEbWaitOutcomeUnavailable:
+		obs = m.leiosEbWaitUnavailable
 	}
 	if obs != nil {
 		obs.Observe(d.Seconds())
@@ -425,6 +434,9 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	)
 	m.leiosEbWaitCancelled = m.leiosEbWaitSeconds.WithLabelValues(
 		leiosEbWaitOutcomeCancelled,
+	)
+	m.leiosEbWaitUnavailable = m.leiosEbWaitSeconds.WithLabelValues(
+		leiosEbWaitOutcomeUnavailable,
 	)
 	m.leiosEbWaitTimeouts = promautoFactory.NewCounter(
 		prometheus.CounterOpts{

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -39,9 +39,12 @@ type stateMetrics struct {
 	epochLengthSlots    prometheus.Gauge
 	shadowGateDecisions *prometheus.CounterVec
 	// Wall-clock time the ledger apply path spent waiting for a referenced
-	// Leios endorser block, by outcome ("arrived", "timeout" or "cancelled"). This wait is
-	// taken ahead of the batch's DB transaction on the single ledger pipeline,
-	// so it is time every block queued behind the batch also spends waiting.
+	// Leios endorser block, by outcome ("arrived", "timeout", "cancelled" or
+	// "unavailable"). It covers both waits the apply path can take: the
+	// diffusion window, and the CIP grace phase that waits out an in-flight
+	// by-point fetch. This wait is taken ahead of the batch's DB transaction
+	// on the single ledger pipeline, so it is time every block queued behind
+	// the batch also spends waiting.
 	// Only references ledger application actually reads are waited on (see
 	// leiosApplyReadsOwnAnnouncement); the rest are prefetched in the
 	// background and never observed here.
@@ -176,8 +179,14 @@ func (m *stateMetrics) observeLeaderThresholdMargin(margin float64) {
 // Outcome label values for dingo_metrics_leios_eb_wait_seconds.
 //
 //   - arrived:   the endorser block became available during the wait.
-//   - timeout:   the diffusion window elapsed without it. This is the outcome
-//     that means the wait cost apply latency and bought nothing.
+//   - timeout:   a bound elapsed without it -- the diffusion window, or the
+//     CIP grace phase's hard bound. This is the outcome that means the wait
+//     cost apply latency and bought nothing.
+//   - unavailable: the CIP grace phase's by-point fetch COMPLETED without
+//     caching, because no peer holds the endorser block. Nothing timed out,
+//     and this is the common ending on a CIP node, so it is deliberately not
+//     folded into timeout: doing so would inflate the timeout rate and its
+//     counter on routine operation.
 //   - cancelled: the wait ended because the block-processing context was
 //     cancelled (node shutdown, or the pass being aborted and restarted).
 //     Nothing was learned about the endorser block's availability, so this is
@@ -418,7 +427,7 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	m.leiosEbWaitSeconds = promautoFactory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "dingo_metrics_leios_eb_wait_seconds",
-			Help: "wall-clock time the ledger apply path spent waiting for a referenced Leios endorser block, by outcome",
+			Help: "wall-clock time the ledger apply path spent waiting for a referenced Leios endorser block, across both the diffusion window and the CIP in-flight-fetch grace phase, by outcome (arrived, timeout, cancelled, unavailable)",
 			// 5ms to ~82s: the wait is bounded by the certify-by deadline
 			// converted to wall clock, so the useful range spans sub-slot
 			// arrivals up to several stacked protocol windows.

--- a/ledger/metrics.go
+++ b/ledger/metrics.go
@@ -55,11 +55,15 @@ type stateMetrics struct {
 	leiosEbWaitTimedOut    prometheus.Observer
 	leiosEbWaitCancelled   prometheus.Observer
 	leiosEbWaitUnavailable prometheus.Observer
-	// Waits that ran to the full diffusion window without the endorser block
-	// arriving. A rising value against a flat leios_eb_wait_seconds "arrived"
-	// count means the wait is buying nothing and is pure apply latency.
-	// Cancellations are deliberately excluded: they say nothing about
-	// endorser-block availability.
+	// Waits that ran to a full bound without the endorser block arriving --
+	// the diffusion window, or the CIP grace phase's hard bound. A rising
+	// value against a flat leios_eb_wait_seconds "arrived" count means the
+	// wait is buying nothing and is pure apply latency.
+	//
+	// Two outcomes are deliberately excluded because neither is a bound
+	// expiring: "cancelled" says nothing about endorser-block availability,
+	// and "unavailable" means the fetch COMPLETED without caching, which is
+	// routine on a CIP node and would swamp the counter.
 	leiosEbWaitTimeouts prometheus.Counter
 	// Incremented when a stored governance proposal's CBOR fails to
 	// decode during the mid-epoch ratifiability check, so the failures
@@ -428,10 +432,14 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 		prometheus.HistogramOpts{
 			Name: "dingo_metrics_leios_eb_wait_seconds",
 			Help: "wall-clock time the ledger apply path spent waiting for a referenced Leios endorser block, across both the diffusion window and the CIP in-flight-fetch grace phase, by outcome (arrived, timeout, cancelled, unavailable)",
-			// 5ms to ~82s: the wait is bounded by the certify-by deadline
-			// converted to wall clock, so the useful range spans sub-slot
-			// arrivals up to several stacked protocol windows.
-			Buckets: prometheus.ExponentialBuckets(0.005, 2, 15),
+			// 5ms to ~164s. The lower end covers sub-slot arrivals; the
+			// upper end must clear the LONGEST wait this histogram now
+			// records, the CIP grace phase's leiosTipFetchHardBound
+			// (leiosBackfillMaxWait, 120s). At 15 buckets the top edge was
+			// ~82s, so every wedged-fetch wait -- the most anomalous ones,
+			// and the reason the grace phase is instrumented at all --
+			// collapsed into +Inf with no resolution.
+			Buckets: prometheus.ExponentialBuckets(0.005, 2, 16),
 		},
 		[]string{"outcome"},
 	)
@@ -450,7 +458,7 @@ func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
 	m.leiosEbWaitTimeouts = promautoFactory.NewCounter(
 		prometheus.CounterOpts{
 			Name: "dingo_metrics_leios_eb_wait_timeouts_total",
-			Help: "ledger apply-path waits for a referenced Leios endorser block that ran to the full diffusion window without it arriving",
+			Help: "ledger apply-path waits for a referenced Leios endorser block that ran to a full bound without it arriving: the diffusion window, or the CIP in-flight-fetch grace phase hard bound",
 		},
 	)
 	m.governanceProposalDecodeFailures = promautoFactory.NewCounter(


### PR DESCRIPTION
## Problem

Ledger application of a ranking block blocked on endorser blocks it never reads.

On the Haskell-conformant (Musashi) path, applying a ranking block reads only the certified closure announced by a certifying block's **parent**. A block's own announcement is not read when that block is applied. Waiting for it stalled the single ledger pipeline for a whole diffusion window — and every block queued behind it — and then applied the block unchanged anyway.

The wait was also charged per reference: the waits are independent, but ran back to back, so *k* missing endorser blocks cost *k* full windows.

## Changes

Four changes to `ensureReferencedEndorserBlocks`, each with its own regression test:

1. **Split the tip wait by apply dependency.** Only references application actually reads are blocking; the rest are dispatched as background prefetch so a later batch that does need them finds them cached. On the CIP path, where application does read a block's own announcement, behaviour is unchanged.
2. **Run the remaining waits concurrently** under one shared diffusion window, so a batch costs one window rather than one per reference.
3. **Dispatch an active by-point fetch up front**, and on the CIP path wait for that fetch to *finish* rather than for a second window. The window bounds how long to wait for the network to **push** a block; it says nothing about how long our own **pull** takes. An earlier revision waited one further window and returned with the fetch still running, which lost exactly the transactions the wait exists to protect, one window later.
4. **Distinguish a cancelled pass from an elapsed bound.** Both close the wait context, so a shutdown was recorded as a diffusion timeout. `DeadlineExceeded` is now the discriminator, in the direction that cannot misreport a real timeout as a cancellation.

A fetch that finishes without caching — no peer holds the block — is this path's expected, long-standing outcome and logs at `Debug`, matching the synchronous fallback it replaces. Only a fetch that neither caches nor clears before the hard bound logs at `WARN`.

## Worst-case bounds

On the CIP path the near-head worst case is now one diffusion window (`EndorserBlockWaitSlots x slotLen`) **plus** up to `leiosTipFetchHardBound` (= `leiosBackfillMaxWait`, 2 minutes) for this batch's own in-flight fetch to finish.

The synchronous `FetchEndorserBlockByPoint` this replaces was bounded by the caller's context and the per-connection leios-fetch timeouts, not by a fixed backstop, so "parity rather than a new cost" holds for the common case but not the worst one. `awaitFetch` returns as soon as the in-flight marker clears, so the hard bound is only reachable by a fetch that neither caches nor clears — which is also the only case that logs at `WARN`.

## Metrics

- `dingo_metrics_leios_eb_wait_seconds` with `arrived`, `timeout` and `cancelled` outcomes.
- `dingo_metrics_leios_eb_wait_timeouts_total`.

## Tests

`ledger/leios_apply_wait_test.go` (new). Every production change is mutation-checked red→green:

| Mutation | Test that catches it |
| --- | --- |
| revert the split so everything blocks again | `TestEnsureReferencedEndorserBlocksDoesNotBlockOnUnreadAnnouncement` |
| force the CIP in-flight branch always-true | `TestCIPFetchWaitDoesNotWarnOnRoutineUnfetchableEndorserBlock` |
| force the CIP in-flight branch always-false | `TestCIPFetchWaitWarnsWhenAFetchNeitherCachesNorClears` |
| invert the near-head fixture guard | all 7 tests that use `withLeiosWaitTestSlotLength` |

The fixture pins the invariant the timing assertions rest on: these states leave `ls.slotClock` nil, so `CurrentSlot()` errors, `wallKnown` is false and every fixture block is classified near-head. `withLeiosWaitTestSlotLength` fails loudly if that ever stops holding.

Verified on this branch: `go build ./...`, `go vet ./ledger/`, `golangci-lint run ./...` (0 issues), `go test ./ledger/`, `go test -race ./ledger/`.

## Related

- Fixes part of #3973 (self-filed): the apply-latency half.
- Supersedes the apply-path portion of #3972, which is being split on maintainer request; the forge-gate halves are in the sibling PRs linked there.
- Neighbouring prior work: #2950 (hold RB apply for EB completion), #2620 (skip waiting for old Leios EBs), #3607 (bind endorser-block entries to their announced point), #3038, #2866.

## Not done here

Not run: Leios devnet replay, conformance vectors, Antithesis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ledger apply path blocking on endorser blocks it never reads, which stalled block processing for a whole diffusion window and added a full window of latency per missing reference.

**What changed**
- Splits the endorser-block wait by apply dependency: only references ledger application actually reads block; the rest are background-prefetched.
- Runs remaining waits concurrently under one shared diffusion window and dispatches an active by-point fetch up front; on the CIP path it waits for that fetch to finish.
- Gives mandatory certified-closure fetches their own concurrency budget so best-effort prefetches can't starve them.
- Adds `dingo_metrics_leios_eb_wait_seconds` and `dingo_metrics_leios_eb_wait_timeouts_total`, sized to cover the CIP hard bound, recording `arrived`, `timeout`, `cancelled`, and `unavailable` from the fetch's own termination cause so shutdowns don't inflate timeout counts and routine unfetchable blocks aren't misreported as timeouts.

<sup>Written for commit a0473477569ba1e696ef5fb1e9366a1915d9fea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved ledger application by fetching required endorser blocks concurrently.
  * Reduced pipeline delays by handling non-blocking block prefetches in the background.
  * Reserved capacity for mandatory certified blocks to prevent contention.
  * Improved handling and reporting of unavailable blocks, timeouts, and cancellations.

* **Monitoring**
  * Added metrics for endorser-block wait durations and outcomes, including timeout counts.

* **Tests**
  * Expanded coverage for endorser-block waiting, prefetching, batching, cancellation, and concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->