### PR TITLE
fix(database): rebuild the rollback cascade index on a critical rebuild

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5827,7 +5827,11 @@ nonce is passed through unchanged.
 In API storage mode, the shared SQL metadata providers can defer selected query
 indexes during bulk load. Deferred indexes are classified as critical or lazy in
 `database/plugin/metadata/deferred`: critical indexes cover startup API queries
-and rollback predicates, while lazy indexes cover secondary query paths. Only
+and rollback predicates -- including the child column of an `ON DELETE CASCADE`
+foreign key whose parent rows the rollback deletes, since the engine enforces
+such a cascade with an implicit per-parent-row child delete that the parent
+statement's query plan does not show -- while lazy indexes cover secondary
+query paths. Only
 indexes no import path filters on are eligible at all — an index a per-row
 import predicate needs stays resident, since dropping it turns that predicate
 into a full scan of a table the import is still growing. Those indexes are
@@ -5844,7 +5848,11 @@ critical subset before clearing `sync_status`, then leaves the pending
 sync-state marker set. API-mode `serve` verifies the critical subset before
 startup and runs the full lazy rebuild as background maintenance; the marker is
 cleared only after the full manifest has been rebuilt. Core-mode startup still
-repairs the full manifest synchronously before serving. On MySQL, InnoDB
+repairs the full manifest synchronously before serving. Both repair entry
+points also restore any missing critical index when no cycle is pending at all:
+the marker records that a cycle was interrupted, not which indexes exist, so a
+database whose marker an older binary cleared while its own critical subset was
+smaller would otherwise carry the gap permanently. On MySQL, InnoDB
 requires indexes supporting foreign-key child columns, so the dialect leaves
 those indexes in place while deferring the remaining manifest entries.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5846,13 +5846,24 @@ manifest. The metadata plugin exposes
 `BuildDeferredIndexes` for the full manifest. Mithril sync rebuilds the
 critical subset before clearing `sync_status`, then leaves the pending
 sync-state marker set. API-mode `serve` verifies the critical subset before
-startup and runs the full lazy rebuild as background maintenance; the marker is
-cleared only after the full manifest has been rebuilt. Core-mode startup still
+startup and runs the full lazy rebuild as background maintenance; the rebuild
+paths clear the marker only after the full manifest has been rebuilt, but they
+are not the only writer of that row. `ClearSyncState`
+(`DELETE FROM sync_state`, no `WHERE`) removes it too, and Mithril sync runs
+that clear through `updateMithrilReadyState` immediately after the critical
+rebuild. It therefore re-writes every row a completed sync still needs —
+`mithril_ledger_slot`, `mithril_ledger_hash`, and the deferred-index marker —
+back after the clear; without the last of those, every Mithril-bootstrapped
+database loses the marker moments after `BuildCritical` set it and never builds
+the lazy manifest entries at all. Core-mode startup still
 repairs the full manifest synchronously before serving. Both repair entry
 points also restore any missing critical index when no cycle is pending at all:
-the marker records that a cycle was interrupted, not which indexes exist, so a
-database whose marker an older binary cleared while its own critical subset was
-smaller would otherwise carry the gap permanently. On MySQL, InnoDB
+the marker records that a cycle was interrupted, not which indexes exist, and a
+database bootstrapped by a binary that predates the marker being carried across
+the clear has the critical subset built, the lazy remainder dropped, and no
+record of either — it would otherwise carry that gap permanently, since the
+schema migration that created those indexes is recorded complete and never
+re-runs. On MySQL, InnoDB
 requires indexes supporting foreign-key child columns, so the dialect leaves
 those indexes in place while deferring the remaining manifest entries.
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -779,6 +779,20 @@ That includes the critical rebuild: it is the last step before `serve` clears
 `sync_status` and the node accepts API writes, while the full rebuild that
 clears the pending marker can run as background maintenance long afterwards.
 
+The child column of an `ON DELETE CASCADE` foreign key whose parent rows the
+rollback path deletes is classified critical rather than lazy, which is the
+same rule at a different point in the cycle. The rollback sweep's
+`DELETE FROM "transaction" WHERE slot > ?` cascades into `utxo`, and SQLite
+enforces that cascade with an implicit
+`DELETE FROM utxo WHERE transaction_id = ?` per deleted parent row, so
+`idx_utxo_transaction_id` has to be resident from the moment the database is
+marked ready: a rollback can run as soon as live sync resumes, and without the
+index each deleted transaction scans the whole `utxo` table.
+`EXPLAIN QUERY PLAN` of the parent statement does not show this — it reports
+only the indexed search over `transaction`. InnoDB requires an index on every
+foreign-key child column and refuses to drop it, so only the SQLite (and
+PostgreSQL) dialects can reach the state where it is missing.
+
 Excluding an index from the manifest does not restore it on databases already
 on disk: a binary whose manifest still carried it dropped it at the start of a
 bulk-load cycle and recreates it only in the full rebuild, and the

--- a/cmd/dingo/serve_deferred_index_repair_test.go
+++ b/cmd/dingo/serve_deferred_index_repair_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
+	"github.com/blinklabs-io/dingo/internal/config"
+	"github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeCoreModeRepairsMissingCascadeIndex covers the composition serveRun
+// actually takes: a core-mode configuration reaches repairDeferredIndexes,
+// which is the only deferred-index entry point on that path.
+//
+// The state under test is the one two Mithril-bootstrapped preview nodes were
+// found in: idx_utxo_transaction_id absent with no pending marker to record
+// it, so every rollback's DELETE FROM "transaction" cascade scanned utxo once
+// per deleted transaction row.
+func TestServeCoreModeRepairsMissingCascadeIndex(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+	cfg := &config.Config{
+		DatabasePath:    dir,
+		DatabaseWorkers: 1,
+		Plugins:         testStoragePlugins(),
+	}
+	require.False(
+		t,
+		effectiveStorageMode(cfg).IsAPI(),
+		"serveRun sends this configuration down the core-mode branch, "+
+			"which is the branch repairDeferredIndexes is wired into",
+	)
+
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: dir,
+		Logger:  logger,
+	})
+	require.NoError(t, err)
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	_, err = raw.Exec("DROP INDEX IF EXISTS idx_utxo_transaction_id")
+	require.NoError(t, err)
+	_, err = raw.Exec(
+		"DELETE FROM sync_state WHERE sync_key = ?",
+		deferred.SyncStateKey,
+	)
+	require.NoError(t, err)
+	require.NoError(t, dbtest.CloseDatabase(db))
+
+	require.NoError(t, repairDeferredIndexes(cfg, logger))
+
+	var count int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+		"idx_utxo_transaction_id",
+	).Scan(&count))
+	require.Equal(
+		t,
+		1,
+		count,
+		"core-mode serve must restore the rollback cascade index before "+
+			"the node starts",
+	)
+}

--- a/database/plugin/metadata/deferred/deferred.go
+++ b/database/plugin/metadata/deferred/deferred.go
@@ -87,10 +87,17 @@ type Index struct {
 	//   - Any WHERE predicate used by the rollback path
 	//     (DeleteXAfterSlot), since rollbacks can occur as soon
 	//     as live sync resumes.
+	//   - The child column of any ON DELETE CASCADE foreign key
+	//     whose parent rows the rollback path deletes. SQLite
+	//     enforces such a cascade with an implicit
+	//     DELETE FROM child WHERE fk_column = ? per deleted parent
+	//     row, so without the child index each parent row scans the
+	//     whole child table. EXPLAIN QUERY PLAN of the parent
+	//     statement does not show it.
 	//
-	// Everything else is lazy: FK reverse-lookups,
-	// witness/redeemer secondary indexes, and any column that is
-	// only SELECTed or SET but never filtered.
+	// Everything else is lazy: FK reverse-lookups no cascade
+	// depends on, witness/redeemer secondary indexes, and any
+	// column that is only SELECTed or SET but never filtered.
 	Critical bool
 }
 
@@ -160,10 +167,20 @@ var Manifest = []Index{
 		Columns: []string{"added_slot"},
 		Notes:   "Rollback range scan", Critical: true,
 	},
+	// idx_utxo_transaction_id is critical because the rollback sweep's
+	// DELETE FROM "transaction" WHERE slot > ? cascades through
+	// fk_transaction_outputs, and SQLite resolves that cascade with one
+	// DELETE FROM utxo WHERE transaction_id = ? per deleted transaction
+	// row. Deferred, each of those is a full scan of utxo: measured on a
+	// preview relay, a 1,001-transaction rollback against a 3.2M row utxo
+	// table took 556s with the index absent and 0.095s with it present,
+	// with no log output in between.
 	{
 		Name: "idx_utxo_transaction_id", Table: "utxo",
 		Columns: []string{"transaction_id"},
-		Notes:   "Foreign-key reverse lookup",
+		Notes: "Rollback DELETE cascade into utxo " +
+			"(fk_transaction_outputs)",
+		Critical: true,
 	},
 	{
 		Name: "idx_utxo_deleted_staking_amount", Table: "utxo",

--- a/database/plugin/metadata/deferred/deferred_test.go
+++ b/database/plugin/metadata/deferred/deferred_test.go
@@ -75,7 +75,10 @@ func TestCriticalManifestNotEmpty(t *testing.T) {
 	// idx_utxo_staking_deleted_amount left the manifest entirely: the
 	// API-backfill per-batch live-stake SUM needs it during bulk load,
 	// so it is never dropped and no longer needs a critical rebuild slot.
-	const wantCritical = 12
+	// idx_utxo_transaction_id joined the critical subset: the rollback's
+	// DELETE FROM "transaction" cascades through it, and a rollback can
+	// run as soon as the database is marked ready.
+	const wantCritical = 13
 	if len(critical) != wantCritical {
 		t.Errorf(
 			"CriticalManifest: got %d entries, want %d — update this constant if the classification changed intentionally",

--- a/database/plugin/metadata/deferred_indexes.go
+++ b/database/plugin/metadata/deferred_indexes.go
@@ -48,3 +48,21 @@ type DeferredIndexManager interface {
 	BuildDeferredIndexes() error
 	HasDeferredIndexesPending() (bool, error)
 }
+
+// MissingCriticalDeferredIndexLister is an optional companion to
+// DeferredIndexManager: it answers which critical manifest entries are absent
+// without building anything.
+//
+// BuildCriticalDeferredIndexes is silent while it runs, and building one index
+// on a multi-million-row table takes long enough that an operator watching
+// startup sees nothing at all until it finishes. A caller that can name the
+// missing entries first can attribute that wait while it is happening.
+//
+// Stores that do not implement this report nothing and fall back to logging
+// after the fact.
+type MissingCriticalDeferredIndexLister interface {
+	// MissingCriticalDeferredIndexes returns the names of the
+	// Critical=true manifest entries missing from the schema, in
+	// manifest order. It performs no DDL.
+	MissingCriticalDeferredIndexes() ([]string, error)
+}

--- a/database/plugin/metadata/sqlite/shared_sqlstore_fk_cascade_index_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_fk_cascade_index_test.go
@@ -1,0 +1,329 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// utxoCascadeDeleteSQL is the statement SQLite runs to enforce
+// fk_transaction_outputs, once for every "transaction" row the rollback
+// deletes.
+//
+// It appears nowhere in the store: ON DELETE CASCADE is an action the engine
+// takes, not a statement the code issues. It is spelled out here because that
+// action is the whole cost of a deep rollback and because it is invisible from
+// the parent statement -- EXPLAIN QUERY PLAN of
+// DELETE FROM "transaction" WHERE slot > ? reports only the indexed search
+// over "transaction" and says nothing about the child table it cascades into.
+const utxoCascadeDeleteSQL = `DELETE FROM utxo WHERE transaction_id = ?`
+
+// cascadeForeignKey is one ON DELETE CASCADE foreign key as the live schema
+// declares it.
+type cascadeForeignKey struct {
+	table  string
+	column string
+	parent string
+}
+
+func (fk cascadeForeignKey) String() string {
+	return fmt.Sprintf("%s.%s -> %s", fk.table, fk.column, fk.parent)
+}
+
+// newCoreModeSQLStore opens a core-mode store on its own data directory. Core
+// is the mode a block producer or relay runs, and the mode the rollback sweep
+// that motivates these tests runs in.
+func newCoreModeSQLStore(t *testing.T) (*sqlstore.Store, *sql.DB) {
+	t.Helper()
+	store, writeDB, _, err := openSQLStore(
+		Config{DataDir: t.TempDir()},
+		metadata.ProviderDependencies{StorageMode: types.StorageModeCore},
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.Start(t.Context()))
+	t.Cleanup(func() {
+		// Logged rather than asserted: require calls FailNow, which stops
+		// the remaining cleanup callbacks and leaks the t.TempDir removal
+		// registered before this one.
+		if err := store.Close(); err != nil {
+			t.Logf("closing store: %v", err)
+		}
+	})
+	return store, writeDB
+}
+
+// cascadeForeignKeys reads every ON DELETE CASCADE foreign key out of the
+// schema the migrations produced, rather than restating a list that a later
+// migration could add to without anyone revisiting this file.
+func cascadeForeignKeys(t *testing.T, db *sql.DB) []cascadeForeignKey {
+	t.Helper()
+	rows, err := db.Query(`
+SELECT m.name, fk."from", fk."table"
+FROM sqlite_master m
+JOIN pragma_foreign_key_list(m.name) fk
+WHERE m.type = 'table' AND fk.on_delete = 'CASCADE'
+ORDER BY m.name, fk."from"`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []cascadeForeignKey
+	for rows.Next() {
+		var fk cascadeForeignKey
+		require.NoError(t, rows.Scan(&fk.table, &fk.column, &fk.parent))
+		out = append(out, fk)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(
+		t,
+		out,
+		"the schema must declare cascading foreign keys for this to test "+
+			"anything",
+	)
+	return out
+}
+
+// coveringIndexes names the indexes whose leftmost column is column, which are
+// the ones SQLite can use to answer the cascade's lookup. An index that
+// mentions the column in any later position cannot.
+func coveringIndexes(
+	t *testing.T,
+	db *sql.DB,
+	table, column string,
+) []string {
+	t.Helper()
+	rows, err := db.Query(`
+SELECT il.name
+FROM pragma_index_list(?) il
+JOIN pragma_index_info(il.name) ii ON ii.seqno = 0
+WHERE ii.name = ?`, table, column)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		out = append(out, name)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// requireCascadeChildColumnsIndexed asserts that every cascading foreign key
+// can be enforced by an index lookup rather than a scan of the child table.
+func requireCascadeChildColumnsIndexed(
+	t *testing.T,
+	db *sql.DB,
+	fks []cascadeForeignKey,
+	when string,
+) {
+	t.Helper()
+	for _, fk := range fks {
+		require.NotEmpty(
+			t,
+			coveringIndexes(t, db, fk.table, fk.column),
+			"%s: %s is ON DELETE CASCADE with no index on the child "+
+				"column, so deleting one parent row scans all of %s",
+			when,
+			fk,
+			fk.table,
+		)
+	}
+}
+
+// TestCascadeChildColumnsIndexedAfterCriticalRebuild is the manifest
+// classification this file exists for.
+//
+// mithril/sync.go rebuilds only the critical subset of the deferred-index
+// manifest before it marks the database ready, and the rollback sweep the node
+// runs from its first reconciliation onward deletes "transaction" rows whose
+// children cascade. A cascading child column left without an index at that
+// point turns each deleted parent row into a full scan of the child table:
+// measured on a preview relay, one 1,001-transaction rollback against a 3.2M
+// row utxo table took 556s with idx_utxo_transaction_id absent and 0.095s with
+// it present.
+//
+// The invariant is asserted over the schema's own foreign keys rather than
+// over the one index that motivated it, so a new cascading foreign key whose
+// child index is classified lazy fails here instead of in production.
+func TestCascadeChildColumnsIndexedAfterCriticalRebuild(t *testing.T) {
+	t.Parallel()
+	store, db := newCoreModeSQLStore(t)
+	fks := cascadeForeignKeys(t, db)
+	require.Contains(
+		t,
+		fks,
+		cascadeForeignKey{
+			table:  "utxo",
+			column: "transaction_id",
+			parent: "transaction",
+		},
+		"the rollback's DELETE FROM \"transaction\" must still cascade "+
+			"into utxo for this test to cover the sweep it describes",
+	)
+	requireCascadeChildColumnsIndexed(t, db, fks, "before deferring indexes")
+
+	// The Mithril bootstrap sequence: drop the manifest for the bulk load,
+	// then rebuild only the critical subset before the database is marked
+	// ready. The lazy remainder is finished later, or on a core-mode node
+	// whose pending marker an older binary already cleared, never.
+	require.NoError(t, store.DropDeferredIndexes())
+	require.NoError(t, store.BuildCriticalDeferredIndexes())
+
+	requireCascadeChildColumnsIndexed(
+		t,
+		db,
+		fks,
+		"after BuildCriticalDeferredIndexes",
+	)
+}
+
+// seedUtxoRows adds count transactions, each owning two utxo rows, and runs
+// ANALYZE so the planner assertions below see the statistics a live database
+// has.
+//
+// Written as set-based SQL rather than through SetTransaction because the
+// planner only needs representative table shapes, not faithful transaction
+// contents.
+func seedUtxoRows(t *testing.T, db *sql.DB, count int) {
+	t.Helper()
+	_, err := db.Exec(`
+WITH RECURSIVE seq(n) AS (
+    SELECT 0
+    UNION ALL
+    SELECT n + 1 FROM seq WHERE n + 1 < ?
+)
+INSERT INTO "transaction" (
+    hash, block_hash, slot, type, fee, collateral_fee, ttl, block_index, valid
+)
+SELECT CAST(n AS BLOB), CAST(n AS BLOB), n, 0, '0', '0', '0', 0, TRUE
+FROM seq`, count)
+	require.NoError(t, err)
+	for _, outputIdx := range []int{0, 1} {
+		_, err := db.Exec(`
+INSERT INTO utxo (
+    transaction_id, tx_id, output_idx, payment_key, staking_key,
+    credential_tag, amount, added_slot, deleted_slot
+)
+SELECT id, hash, ?, hash, hash, 0, '1000000', slot, 0
+FROM "transaction"`, outputIdx)
+		require.NoError(t, err)
+	}
+	_, err = db.Exec("ANALYZE")
+	require.NoError(t, err)
+}
+
+// TestUtxoCascadeDeleteIndexedAfterCriticalRebuild pins the plan of the
+// cascade itself.
+//
+// The negative case is asserted first: with the manifest dropped, the cascade
+// scans utxo. Without it, a rebuild that restored nothing would still satisfy
+// the positive assertion if the index had never been missing.
+func TestUtxoCascadeDeleteIndexedAfterCriticalRebuild(t *testing.T) {
+	t.Parallel()
+	store, db := newCoreModeSQLStore(t)
+	seedUtxoRows(t, db, 2000)
+
+	require.NoError(t, store.DropDeferredIndexes())
+	plan := queryPlan(t, db, utxoCascadeDeleteSQL, 1)
+	require.Contains(
+		t,
+		plan,
+		"SCAN utxo",
+		"the dropped manifest must leave the cascade unindexed for this "+
+			"test to have teeth:\n%s",
+		plan,
+	)
+
+	require.NoError(t, store.BuildCriticalDeferredIndexes())
+	plan = queryPlan(t, db, utxoCascadeDeleteSQL, 1)
+	require.Contains(
+		t,
+		plan,
+		"SEARCH utxo USING",
+		"the rollback cascade must be an indexed search after the "+
+			"critical rebuild:\n%s",
+		plan,
+	)
+	require.Contains(
+		t,
+		plan,
+		"INDEX idx_utxo_transaction_id (transaction_id=?)",
+		"the cascade must resolve transaction_id through "+
+			"idx_utxo_transaction_id:\n%s",
+		plan,
+	)
+	require.NotContains(
+		t,
+		plan,
+		"SCAN utxo",
+		"the cascade must not scan utxo:\n%s",
+		plan,
+	)
+}
+
+// TestRollbackDeleteCascadesIntoUtxo grounds the plan assertion above: the
+// cascade is on the rollback's path, so the index the manifest classifies is
+// the one the rollback sweep depends on.
+//
+// Reproduces database/plugin/metadata/sqlstore/transaction_write.go's
+// DELETE FROM "transaction" WHERE slot > ?, on a connection carrying the
+// foreign_keys(1) pragma the store opens every connection with.
+func TestRollbackDeleteCascadesIntoUtxo(t *testing.T) {
+	t.Parallel()
+	_, db := newCoreModeSQLStore(t)
+	seedUtxoRows(t, db, 200)
+
+	var enforced int
+	require.NoError(
+		t,
+		db.QueryRow("PRAGMA foreign_keys").Scan(&enforced),
+	)
+	require.Equal(
+		t,
+		1,
+		enforced,
+		"the store opens every connection with foreign_keys(1); without "+
+			"it the cascade this file measures would not run at all",
+	)
+
+	var before int
+	require.NoError(
+		t,
+		db.QueryRow("SELECT COUNT(*) FROM utxo WHERE added_slot > 99").
+			Scan(&before),
+	)
+	require.Positive(t, before)
+
+	_, err := db.Exec(`DELETE FROM "transaction" WHERE slot > ?`, 99)
+	require.NoError(t, err)
+
+	var after int
+	require.NoError(
+		t,
+		db.QueryRow("SELECT COUNT(*) FROM utxo WHERE added_slot > 99").
+			Scan(&after),
+	)
+	require.Zero(
+		t,
+		after,
+		"deleting the parent transactions must cascade into utxo",
+	)
+}

--- a/database/plugin/metadata/sqlite/shared_sqlstore_fk_cascade_index_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_fk_cascade_index_test.go
@@ -182,8 +182,10 @@ func TestCascadeChildColumnsIndexedAfterCriticalRebuild(t *testing.T) {
 
 	// The Mithril bootstrap sequence: drop the manifest for the bulk load,
 	// then rebuild only the critical subset before the database is marked
-	// ready. The lazy remainder is finished later, or on a core-mode node
-	// whose pending marker an older binary already cleared, never.
+	// ready. The lazy remainder is finished by later maintenance, and on a
+	// database whose pending marker the sync's own ClearSyncState wiped,
+	// never — so whatever the rollback path needs has to be in this
+	// subset.
 	require.NoError(t, store.DropDeferredIndexes())
 	require.NoError(t, store.BuildCriticalDeferredIndexes())
 

--- a/database/plugin/metadata/sqlstore/deferred_indexes.go
+++ b/database/plugin/metadata/sqlstore/deferred_indexes.go
@@ -25,7 +25,10 @@ import (
 	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
 )
 
-var _ metadata.DeferredIndexManager = (*Store)(nil)
+var (
+	_ metadata.DeferredIndexManager               = (*Store)(nil)
+	_ metadata.MissingCriticalDeferredIndexLister = (*Store)(nil)
+)
 
 // withDeferredIndexWrite runs fn in one write transaction, with every
 // deferred.Retained index guaranteed resident before fn sees the database.
@@ -247,6 +250,33 @@ WHERE type = 'index' AND name = ? LIMIT 1`
 		return false, nil
 	}
 	return found != 0, err
+}
+
+// MissingCriticalDeferredIndexes reports the Critical=true manifest entries
+// absent from the schema, in manifest order, using the read connection and no
+// DDL. Callers use it to name the indexes a rebuild is about to build before
+// the rebuild starts.
+func (s *Store) MissingCriticalDeferredIndexes() ([]string, error) {
+	if err := s.ensureReady(); err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	db := newDialectQueryer(s.readDB, s.dialect.Name())
+	var missing []string
+	for _, index := range deferred.CriticalManifest() {
+		exists, err := s.deferredIndexExists(ctx, db, index)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"check deferred index %s: %w",
+				index.Name,
+				err,
+			)
+		}
+		if !exists {
+			missing = append(missing, index.Name)
+		}
+	}
+	return missing, nil
 }
 
 // HasDeferredIndexesPending reports whether a prior drop/rebuild cycle still

--- a/internal/node/deferred_index_repair_test.go
+++ b/internal/node/deferred_index_repair_test.go
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"bytes"
 	"database/sql"
 	"io"
 	"log/slog"
@@ -34,11 +35,14 @@ const rollbackCascadeIndex = "idx_utxo_transaction_id"
 // two Mithril-bootstrapped preview nodes were found in: a critical manifest
 // index absent, and no pending marker to say so.
 //
-// A binary whose critical subset did not yet include the index cleared the
-// marker when it finished its own rebuild, and the migration that created the
-// index is recorded complete, so its CREATE INDEX IF NOT EXISTS never runs
-// again. Dropping the index directly is the only way to reproduce that: no
-// store method can express "manifest incomplete, cycle finished".
+// Mithril sync produced it: BuildCritical leaves the marker set for the lazy
+// remainder, and updateMithrilReadyState then runs ClearSyncState, an
+// unqualified DELETE FROM sync_state, which removes it (fixed for new syncs in
+// mithril/sync_import.go; databases bootstrapped before that fix stay in this
+// state). The migration that created the index is recorded complete, so its
+// CREATE INDEX IF NOT EXISTS never runs again. Dropping the index directly is
+// the only way to reproduce it here: no store method can express "manifest
+// incomplete, cycle finished".
 func seedClearedMarkerWithMissingCriticalIndex(
 	t *testing.T,
 	db *database.Database,
@@ -78,8 +82,8 @@ func metadataIndexExists(t *testing.T, raw *sql.DB, name string) bool {
 //
 // The pending marker records that a bulk-load cycle was interrupted. It does
 // not record which indexes exist, so it cannot answer the question the
-// rollback path asks. A database whose marker was cleared by a binary with a
-// smaller critical set carries the gap permanently: nothing else recreates an
+// rollback path asks. A database whose marker a Mithril sync wiped after the
+// critical rebuild carries the gap permanently: nothing else recreates an
 // index the schema migration already claims to have built.
 func TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker(
 	t *testing.T,
@@ -185,4 +189,115 @@ func lazyManifestIndex(t *testing.T) string {
 	}
 	t.Fatal("the manifest must keep at least one lazy entry")
 	return ""
+}
+
+// namedMissingManager is a DeferredIndexManager that also lists its missing
+// critical entries, and records what had already been logged when the rebuild
+// was entered.
+type namedMissingManager struct {
+	missing []string
+	logged  string
+	log     *bytes.Buffer
+}
+
+func (m *namedMissingManager) DropDeferredIndexes() error { return nil }
+
+func (m *namedMissingManager) BuildCriticalDeferredIndexes() error {
+	m.logged = m.log.String()
+	return nil
+}
+
+func (m *namedMissingManager) BuildDeferredIndexes() error { return nil }
+
+func (m *namedMissingManager) HasDeferredIndexesPending() (bool, error) {
+	return false, nil
+}
+
+func (m *namedMissingManager) MissingCriticalDeferredIndexes() (
+	[]string,
+	error,
+) {
+	return m.missing, nil
+}
+
+// TestEnsureCriticalDeferredIndexesNamesMissingBeforeBuilding pins the
+// ordering: the names are logged before the rebuild is entered, not after it
+// returns.
+//
+// A rebuild of one index on a multi-million-row table takes minutes and emits
+// nothing while it runs, which is the silence the reported incident opened
+// with. The assertion reads the log as the rebuild sees it, so a message moved
+// back below the build fails here.
+func TestEnsureCriticalDeferredIndexesNamesMissingBeforeBuilding(
+	t *testing.T,
+) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	manager := &namedMissingManager{
+		missing: []string{rollbackCascadeIndex, "idx_utxo_added_slot"},
+		log:     &buf,
+	}
+
+	require.NoError(t, ensureCriticalDeferredIndexes(manager, logger))
+
+	require.Contains(
+		t,
+		manager.logged,
+		"rebuilding missing critical deferred metadata indexes",
+		"the rebuild must be announced before it starts",
+	)
+	require.Contains(t, manager.logged, rollbackCascadeIndex)
+	require.Contains(t, manager.logged, "idx_utxo_added_slot")
+	require.Contains(
+		t,
+		buf.String(),
+		"critical deferred metadata index check complete",
+		"the completion line still reports the outcome",
+	)
+	require.Contains(
+		t,
+		buf.String(),
+		"duration_covers",
+		"the reported duration must say what it covers: the rebuild "+
+			"runs inside withDeferredIndexWrite, which restores missing "+
+			"retained indexes in the same write transaction",
+	)
+}
+
+// TestEnsureCriticalDeferredIndexesQuietWhenManifestComplete keeps the healthy
+// path silent: a complete manifest is one catalog lookup per entry and must
+// not add a startup log line.
+func TestEnsureCriticalDeferredIndexesQuietWhenManifestComplete(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	manager := &namedMissingManager{log: &buf}
+
+	require.NoError(t, ensureCriticalDeferredIndexes(manager, logger))
+
+	require.Empty(t, buf.String())
+}
+
+// TestRepairDeferredIndexesNamesMissingIndexAgainstRealStore runs the same
+// path against the SQLite store, so the listing is exercised through
+// MissingCriticalDeferredIndexes and the real catalog rather than a fake.
+func TestRepairDeferredIndexesNamesMissingIndexAgainstRealStore(t *testing.T) {
+	db := newFileTestDB(t)
+	raw := seedClearedMarkerWithMissingCriticalIndex(t, db)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	require.NoError(t, RepairDeferredIndexes(db, logger))
+
+	require.True(t, metadataIndexExists(t, raw, rollbackCascadeIndex))
+	require.Contains(
+		t,
+		buf.String(),
+		"rebuilding missing critical deferred metadata indexes",
+	)
+	require.Contains(
+		t,
+		buf.String(),
+		rollbackCascadeIndex,
+		"the operator must be told which index the wait is for",
+	)
 }

--- a/internal/node/deferred_index_repair_test.go
+++ b/internal/node/deferred_index_repair_test.go
@@ -54,7 +54,7 @@ func seedClearedMarkerWithMissingCriticalIndex(
 	require.NoError(t, err)
 	require.False(
 		t,
-		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		dbtest.MetadataIndexExists(t, raw, rollbackCascadeIndex),
 		"%s must be absent for this to test the repair",
 		rollbackCascadeIndex,
 	)
@@ -64,16 +64,6 @@ func seedClearedMarkerWithMissingCriticalIndex(
 	)
 	require.NoError(t, err)
 	return raw
-}
-
-func metadataIndexExists(t *testing.T, raw *sql.DB, name string) bool {
-	t.Helper()
-	var count int
-	require.NoError(t, raw.QueryRow(
-		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
-		name,
-	).Scan(&count))
-	return count == 1
 }
 
 // TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker covers the
@@ -96,7 +86,7 @@ func TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker(
 
 	require.True(
 		t,
-		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		dbtest.MetadataIndexExists(t, raw, rollbackCascadeIndex),
 		"core-mode serve must restore %s before the node can roll back",
 		rollbackCascadeIndex,
 	)
@@ -118,7 +108,7 @@ func TestRepairCriticalDeferredIndexesRestoresCriticalIndexWithoutMarker(
 
 	require.True(
 		t,
-		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		dbtest.MetadataIndexExists(t, raw, rollbackCascadeIndex),
 		"the critical repair must restore %s",
 		rollbackCascadeIndex,
 	)
@@ -150,7 +140,7 @@ func TestRepairDeferredIndexesFinishesPendingCycle(t *testing.T) {
 	db := newFileTestDB(t)
 	raw, err := dbtest.RawSQLiteMetadata(t, db)
 	require.NoError(t, err)
-	lazy := lazyManifestIndex(t)
+	lazy := dbtest.LazyManifestIndex(t)
 	for _, name := range []string{rollbackCascadeIndex, lazy} {
 		_, err = raw.Exec("DROP INDEX IF EXISTS " + name)
 		require.NoError(t, err)
@@ -168,27 +158,13 @@ func TestRepairDeferredIndexesFinishesPendingCycle(t *testing.T) {
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 	))
 
-	require.True(t, metadataIndexExists(t, raw, rollbackCascadeIndex))
+	require.True(t, dbtest.MetadataIndexExists(t, raw, rollbackCascadeIndex))
 	require.True(
 		t,
-		metadataIndexExists(t, raw, lazy),
+		dbtest.MetadataIndexExists(t, raw, lazy),
 		"a pending cycle must still finish the lazy remainder",
 	)
 	requireNoPendingMarker(t, raw)
-}
-
-// lazyManifestIndex returns the name of a non-critical manifest entry, so the
-// test above distinguishes the full rebuild from the critical subset without
-// pinning a specific index the manifest may reclassify later.
-func lazyManifestIndex(t *testing.T) string {
-	t.Helper()
-	for _, index := range deferred.Manifest {
-		if !index.Critical {
-			return index.Name
-		}
-	}
-	t.Fatal("the manifest must keep at least one lazy entry")
-	return ""
 }
 
 // namedMissingManager is a DeferredIndexManager that also lists its missing
@@ -288,7 +264,7 @@ func TestRepairDeferredIndexesNamesMissingIndexAgainstRealStore(t *testing.T) {
 
 	require.NoError(t, RepairDeferredIndexes(db, logger))
 
-	require.True(t, metadataIndexExists(t, raw, rollbackCascadeIndex))
+	require.True(t, dbtest.MetadataIndexExists(t, raw, rollbackCascadeIndex))
 	require.Contains(
 		t,
 		buf.String(),

--- a/internal/node/deferred_index_repair_test.go
+++ b/internal/node/deferred_index_repair_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"database/sql"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+// rollbackCascadeIndex is the child index for fk_transaction_outputs, the
+// foreign key the rollback's DELETE FROM "transaction" cascades through.
+const rollbackCascadeIndex = "idx_utxo_transaction_id"
+
+// seedClearedMarkerWithMissingCriticalIndex leaves the database in the state
+// two Mithril-bootstrapped preview nodes were found in: a critical manifest
+// index absent, and no pending marker to say so.
+//
+// A binary whose critical subset did not yet include the index cleared the
+// marker when it finished its own rebuild, and the migration that created the
+// index is recorded complete, so its CREATE INDEX IF NOT EXISTS never runs
+// again. Dropping the index directly is the only way to reproduce that: no
+// store method can express "manifest incomplete, cycle finished".
+func seedClearedMarkerWithMissingCriticalIndex(
+	t *testing.T,
+	db *database.Database,
+) *sql.DB {
+	t.Helper()
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	_, err = raw.Exec("DROP INDEX IF EXISTS " + rollbackCascadeIndex)
+	require.NoError(t, err)
+	require.False(
+		t,
+		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		"%s must be absent for this to test the repair",
+		rollbackCascadeIndex,
+	)
+	_, err = raw.Exec(
+		"DELETE FROM sync_state WHERE sync_key = ?",
+		deferred.SyncStateKey,
+	)
+	require.NoError(t, err)
+	return raw
+}
+
+func metadataIndexExists(t *testing.T, raw *sql.DB, name string) bool {
+	t.Helper()
+	var count int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+		name,
+	).Scan(&count))
+	return count == 1
+}
+
+// TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker covers the
+// core-mode serve path: cmd/dingo/serve.go calls RepairDeferredIndexes for
+// every non-API storage mode.
+//
+// The pending marker records that a bulk-load cycle was interrupted. It does
+// not record which indexes exist, so it cannot answer the question the
+// rollback path asks. A database whose marker was cleared by a binary with a
+// smaller critical set carries the gap permanently: nothing else recreates an
+// index the schema migration already claims to have built.
+func TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker(
+	t *testing.T,
+) {
+	db := newFileTestDB(t)
+	raw := seedClearedMarkerWithMissingCriticalIndex(t, db)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	require.NoError(t, RepairDeferredIndexes(db, logger))
+
+	require.True(
+		t,
+		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		"core-mode serve must restore %s before the node can roll back",
+		rollbackCascadeIndex,
+	)
+	requireNoPendingMarker(t, raw)
+}
+
+// TestRepairCriticalDeferredIndexesRestoresCriticalIndexWithoutMarker covers
+// the API-mode path: resumeBackfill calls RepairCriticalDeferredIndexes both
+// when it runs a backfill and when it finds none needed, and a node in either
+// state begins rolling back as soon as live sync resumes.
+func TestRepairCriticalDeferredIndexesRestoresCriticalIndexWithoutMarker(
+	t *testing.T,
+) {
+	db := newFileTestDB(t)
+	raw := seedClearedMarkerWithMissingCriticalIndex(t, db)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	require.NoError(t, RepairCriticalDeferredIndexes(db, logger))
+
+	require.True(
+		t,
+		metadataIndexExists(t, raw, rollbackCascadeIndex),
+		"the critical repair must restore %s",
+		rollbackCascadeIndex,
+	)
+	requireNoPendingMarker(t, raw)
+}
+
+// requireNoPendingMarker asserts the repair did not invent a bulk-load cycle:
+// the marker means "a drop/rebuild is outstanding", and setting it on a
+// database with a complete manifest would send the next startup through a
+// rebuild it does not need.
+func requireNoPendingMarker(t *testing.T, raw *sql.DB) {
+	t.Helper()
+	var count int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM sync_state WHERE sync_key = ?",
+		deferred.SyncStateKey,
+	).Scan(&count))
+	require.Zero(
+		t,
+		count,
+		"repairing a missing index must not mark a rebuild pending",
+	)
+}
+
+// TestRepairDeferredIndexesFinishesPendingCycle keeps the marker's existing
+// meaning intact: when a cycle really was interrupted, the core-mode repair
+// still rebuilds the whole manifest and clears it.
+func TestRepairDeferredIndexesFinishesPendingCycle(t *testing.T) {
+	db := newFileTestDB(t)
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	lazy := lazyManifestIndex(t)
+	for _, name := range []string{rollbackCascadeIndex, lazy} {
+		_, err = raw.Exec("DROP INDEX IF EXISTS " + name)
+		require.NoError(t, err)
+	}
+	_, err = raw.Exec(
+		`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)
+		 ON CONFLICT (sync_key) DO UPDATE SET value = excluded.value`,
+		deferred.SyncStateKey,
+		deferred.SyncStateValue,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, RepairDeferredIndexes(
+		db,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	))
+
+	require.True(t, metadataIndexExists(t, raw, rollbackCascadeIndex))
+	require.True(
+		t,
+		metadataIndexExists(t, raw, lazy),
+		"a pending cycle must still finish the lazy remainder",
+	)
+	requireNoPendingMarker(t, raw)
+}
+
+// lazyManifestIndex returns the name of a non-critical manifest entry, so the
+// test above distinguishes the full rebuild from the critical subset without
+// pinning a specific index the manifest may reclassify later.
+func lazyManifestIndex(t *testing.T) string {
+	t.Helper()
+	for _, index := range deferred.Manifest {
+		if !index.Critical {
+			return index.Name
+		}
+	}
+	t.Fatal("the manifest must keep at least one lazy entry")
+	return ""
+}

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -379,10 +379,50 @@ func WithDeferredIndexes(
 	return &DeferredIndexRebuilder{manager: manager}
 }
 
+// criticalIndexRebuildLogThreshold is how long the critical-index check
+// may take before it is reported. A complete manifest costs one catalog
+// lookup per entry and stays well under it; anything slower built an index,
+// which is work an operator watching a startup should see attributed.
+const criticalIndexRebuildLogThreshold = time.Second
+
+// ensureCriticalDeferredIndexes rebuilds every missing critical manifest
+// entry, whether or not a drop/rebuild cycle is outstanding.
+//
+// The pending marker records that a cycle was interrupted; it does not
+// record which indexes exist. A binary whose critical subset was smaller
+// than this one's clears the marker with an index this manifest calls
+// critical still missing, and nothing else recreates it: the schema
+// migration that created it is recorded complete, so its
+// CREATE INDEX IF NOT EXISTS never runs again, and the newer manifest is
+// only consulted by a cycle that is no longer pending. Two
+// Mithril-bootstrapped preview nodes were found in exactly that state,
+// missing the utxo child index the rollback DELETE cascades through.
+//
+// BuildCriticalDeferredIndexes skips indexes that are present, so this is a
+// catalog lookup per entry on a healthy database, and it never touches the
+// marker.
+func ensureCriticalDeferredIndexes(
+	manager metadata.DeferredIndexManager,
+	logger *slog.Logger,
+) error {
+	start := time.Now()
+	if err := manager.BuildCriticalDeferredIndexes(); err != nil {
+		return err
+	}
+	elapsed := time.Since(start)
+	if elapsed >= criticalIndexRebuildLogThreshold {
+		logger.Info(
+			"rebuilt missing critical deferred metadata indexes",
+			"duration", elapsed,
+		)
+	}
+	return nil
+}
+
 // RepairCriticalDeferredIndexes rebuilds the API/rollback-critical
-// subset if a prior run left deferred indexes pending. It leaves the
-// pending marker in place so RepairDeferredIndexes can finish the
-// lazy remainder later.
+// subset, and reports when a prior run left deferred indexes pending. It
+// leaves the pending marker in place so RepairDeferredIndexes can finish
+// the lazy remainder later.
 func RepairCriticalDeferredIndexes(
 	db *database.Database,
 	logger *slog.Logger,
@@ -395,20 +435,23 @@ func RepairCriticalDeferredIndexes(
 	if err != nil {
 		return err
 	}
-	if !pending {
-		return nil
+	if pending {
+		logger.Warn(
+			"critical deferred metadata indexes pending from a prior run; " +
+				"rebuilding before serving API traffic",
+		)
 	}
-	logger.Warn(
-		"critical deferred metadata indexes pending from a prior run; " +
-			"rebuilding before serving API traffic",
-	)
-	return manager.BuildCriticalDeferredIndexes()
+	return ensureCriticalDeferredIndexes(manager, logger)
 }
 
 // RepairDeferredIndexes rebuilds any deferred indexes that were
 // recorded as pending by a prior interrupted run. It is safe to call
 // when no rebuild is outstanding: BuildDeferredIndexes is itself
 // idempotent and clears the marker.
+//
+// With no cycle outstanding it still restores any missing critical index,
+// because the rollback path the node is about to run depends on those and
+// the marker cannot answer whether they exist.
 func RepairDeferredIndexes(
 	db *database.Database,
 	logger *slog.Logger,
@@ -422,7 +465,7 @@ func RepairDeferredIndexes(
 		return err
 	}
 	if !pending {
-		return nil
+		return ensureCriticalDeferredIndexes(manager, logger)
 	}
 	logger.Warn(
 		"deferred metadata indexes pending from a prior run; " +

--- a/internal/node/load.go
+++ b/internal/node/load.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -380,23 +381,30 @@ func WithDeferredIndexes(
 }
 
 // criticalIndexRebuildLogThreshold is how long the critical-index check
-// may take before it is reported. A complete manifest costs one catalog
-// lookup per entry and stays well under it; anything slower built an index,
-// which is work an operator watching a startup should see attributed.
+// may take before it is reported even though nothing in the critical subset
+// was missing. A complete manifest costs one catalog lookup per entry and
+// stays well under it; anything slower did work an operator watching a
+// startup should see attributed.
 const criticalIndexRebuildLogThreshold = time.Second
 
 // ensureCriticalDeferredIndexes rebuilds every missing critical manifest
 // entry, whether or not a drop/rebuild cycle is outstanding.
 //
 // The pending marker records that a cycle was interrupted; it does not
-// record which indexes exist. A binary whose critical subset was smaller
-// than this one's clears the marker with an index this manifest calls
-// critical still missing, and nothing else recreates it: the schema
-// migration that created it is recorded complete, so its
-// CREATE INDEX IF NOT EXISTS never runs again, and the newer manifest is
-// only consulted by a cycle that is no longer pending. Two
-// Mithril-bootstrapped preview nodes were found in exactly that state,
-// missing the utxo child index the rollback DELETE cascades through.
+// record which indexes exist, and it is not durable across a Mithril sync:
+// mithril/sync.go rebuilds the critical subset and then calls
+// updateMithrilReadyState, whose db.ClearSyncState is an unqualified
+// DELETE FROM sync_state. Until that clear learned to carry
+// deferred.SyncStateKey across it (mithril/sync_import.go), every completed
+// Mithril sync erased the marker moments after BuildCritical set it, leaving
+// the database with the critical subset built, the lazy remainder dropped,
+// and nothing recording either — the state two Mithril-bootstrapped preview
+// nodes were found in, missing the utxo child index the rollback DELETE
+// cascades through. Databases bootstrapped by any binary released so far are
+// still in it, and nothing else recreates those indexes: the schema migration
+// that created them is recorded complete, so its CREATE INDEX IF NOT EXISTS
+// never runs again, and the manifest is only consulted by a cycle that is no
+// longer pending.
 //
 // BuildCriticalDeferredIndexes skips indexes that are present, so this is a
 // catalog lookup per entry on a healthy database, and it never touches the
@@ -405,18 +413,71 @@ func ensureCriticalDeferredIndexes(
 	manager metadata.DeferredIndexManager,
 	logger *slog.Logger,
 ) error {
+	missing, listed := missingCriticalDeferredIndexes(manager, logger)
+	if listed && len(missing) > 0 {
+		// Logged before the build: building one index on a
+		// multi-million-row table takes minutes, and the rebuild itself
+		// is silent while it runs.
+		logger.Info(
+			"rebuilding missing critical deferred metadata indexes",
+			"indexes", strings.Join(missing, ","),
+			"count", len(missing),
+		)
+	}
 	start := time.Now()
 	if err := manager.BuildCriticalDeferredIndexes(); err != nil {
 		return err
 	}
 	elapsed := time.Since(start)
-	if elapsed >= criticalIndexRebuildLogThreshold {
-		logger.Info(
-			"rebuilt missing critical deferred metadata indexes",
+	if (listed && len(missing) > 0) ||
+		elapsed >= criticalIndexRebuildLogThreshold {
+		attrs := []any{
 			"duration", elapsed,
+			// The store runs the critical rebuild inside
+			// withDeferredIndexWrite, which restores any missing
+			// deferred.Retained index first. Both halves are inside
+			// this measurement.
+			"duration_covers",
+			"critical rebuild and retained-index restore",
+		}
+		if listed {
+			indexes := "none"
+			if len(missing) > 0 {
+				indexes = strings.Join(missing, ",")
+			}
+			attrs = append(attrs, "critical_indexes_built", indexes)
+		}
+		logger.Info(
+			"critical deferred metadata index check complete",
+			attrs...,
 		)
 	}
 	return nil
+}
+
+// missingCriticalDeferredIndexes names the critical manifest entries absent
+// from the schema. The second return reports whether the store could answer:
+// stores that do not implement the lister, and read errors on the catalog
+// query, fall back to logging after the rebuild rather than failing a startup
+// over a log line.
+func missingCriticalDeferredIndexes(
+	manager metadata.DeferredIndexManager,
+	logger *slog.Logger,
+) ([]string, bool) {
+	lister, ok := manager.(metadata.MissingCriticalDeferredIndexLister)
+	if !ok {
+		return nil, false
+	}
+	missing, err := lister.MissingCriticalDeferredIndexes()
+	if err != nil {
+		logger.Warn(
+			"could not list missing critical deferred metadata indexes; "+
+				"rebuilding without naming them",
+			"error", err,
+		)
+		return nil, false
+	}
+	return missing, true
 }
 
 // RepairCriticalDeferredIndexes rebuilds the API/rollback-critical

--- a/internal/test/dbtest/deferred_indexes.go
+++ b/internal/test/dbtest/deferred_indexes.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbtest
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
+)
+
+// MetadataIndexExists reports whether the named index is present in the
+// SQLite catalog behind raw (see RawSQLiteMetadata). Deferred-index tests in
+// several packages assert against the catalog rather than a store method,
+// because the state under test is "the manifest disagrees with the schema",
+// which no store method can express.
+func MetadataIndexExists(tb testing.TB, raw *sql.DB, name string) bool {
+	tb.Helper()
+	var count int
+	if err := raw.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+		name,
+	).Scan(&count); err != nil {
+		tb.Fatalf("query sqlite_master for index %s: %v", name, err)
+	}
+	return count == 1
+}
+
+// LazyManifestIndex returns the name of a non-critical deferred-index manifest
+// entry, so a test can distinguish the full rebuild from the critical subset
+// without pinning an index the manifest may reclassify later.
+func LazyManifestIndex(tb testing.TB) string {
+	tb.Helper()
+	for _, index := range deferred.Manifest {
+		if !index.Critical {
+			return index.Name
+		}
+	}
+	tb.Fatal("the manifest must keep at least one lazy entry")
+	return ""
+}

--- a/mithril/sync_import.go
+++ b/mithril/sync_import.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
 	"github.com/blinklabs-io/dingo/internal/node"
 	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/blinklabs-io/dingo/ledgerstate"
@@ -129,8 +130,38 @@ func updateMithrilReadyState(
 	txn := db.MetadataTxn(true)
 	if err := txn.Do(func(txn *database.Txn) error {
 		if clearSyncState {
+			// ClearSyncState is an unqualified DELETE FROM sync_state, so
+			// every row a completed sync still needs has to be carried
+			// across it explicitly — mithril_ledger_slot and
+			// mithril_ledger_hash below, and the deferred-index marker
+			// here. Mithril sync rebuilds only the critical subset
+			// (BuildCritical, sync.go) and deliberately leaves
+			// deferred.SyncStateKey set so the first serve's maintenance
+			// pass finishes the lazy manifest. Dropping it here erases
+			// that instruction moments after it was written, and the lazy
+			// entries are then never built on a Mithril-bootstrapped
+			// database.
+			deferredIndexesPending, err := db.GetSyncState(
+				deferred.SyncStateKey, txn,
+			)
+			if err != nil {
+				return fmt.Errorf(
+					"reading deferred-index marker: %w", err,
+				)
+			}
 			if err := db.ClearSyncState(txn); err != nil {
 				return fmt.Errorf("cleaning up sync state: %w", err)
+			}
+			if deferredIndexesPending != "" {
+				if err := db.SetSyncState(
+					deferred.SyncStateKey,
+					deferredIndexesPending,
+					txn,
+				); err != nil {
+					return fmt.Errorf(
+						"restoring deferred-index marker: %w", err,
+					)
+				}
 			}
 		} else if syncStatus != "" {
 			if err := db.SetSyncState(

--- a/mithril/sync_import_deferred_marker_test.go
+++ b/mithril/sync_import_deferred_marker_test.go
@@ -16,7 +16,6 @@ package mithril
 
 import (
 	"bytes"
-	"database/sql"
 	"io"
 	"log/slog"
 	"testing"
@@ -107,19 +106,6 @@ func newMithrilFileTestDB(t *testing.T) *database.Database {
 	return db
 }
 
-// lazyManifestIndex names a manifest entry the critical rebuild does not
-// build, so the test states the property rather than one index name.
-func lazyManifestIndex(t *testing.T) string {
-	t.Helper()
-	for _, index := range deferred.Manifest {
-		if !index.Critical {
-			return index.Name
-		}
-	}
-	t.Fatal("manifest has no lazy entry to test with")
-	return ""
-}
-
 // TestMithrilSyncLeavesLazyManifestForTheFirstServe walks the composition a
 // Mithril-bootstrapped node actually takes: sync drops the manifest, rebuilds
 // the critical subset, and calls updateMithrilReadyState; the first
@@ -135,7 +121,7 @@ func TestMithrilSyncLeavesLazyManifestForTheFirstServe(t *testing.T) {
 	db := newMithrilFileTestDB(t)
 	raw, err := dbtest.RawSQLiteMetadata(t, db)
 	require.NoError(t, err)
-	lazy := lazyManifestIndex(t)
+	lazy := dbtest.LazyManifestIndex(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	// The sync: drop for the bulk load, rebuild the critical subset only.
@@ -143,7 +129,7 @@ func TestMithrilSyncLeavesLazyManifestForTheFirstServe(t *testing.T) {
 	require.NoError(t, deferredIndexes.BuildCritical())
 	require.False(
 		t,
-		metadataIndexExists(t, raw, lazy),
+		dbtest.MetadataIndexExists(t, raw, lazy),
 		"precondition: %s is lazy and the critical rebuild skips it",
 		lazy,
 	)
@@ -161,7 +147,7 @@ func TestMithrilSyncLeavesLazyManifestForTheFirstServe(t *testing.T) {
 
 	require.True(
 		t,
-		metadataIndexExists(t, raw, lazy),
+		dbtest.MetadataIndexExists(t, raw, lazy),
 		"the first serve after a Mithril sync must finish the lazy "+
 			"manifest entry %s",
 		lazy,
@@ -174,14 +160,4 @@ func TestMithrilSyncLeavesLazyManifestForTheFirstServe(t *testing.T) {
 		t, pending,
 		"the full rebuild clears the marker it consumed",
 	)
-}
-
-func metadataIndexExists(t *testing.T, raw *sql.DB, name string) bool {
-	t.Helper()
-	var count int
-	require.NoError(t, raw.QueryRow(
-		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
-		name,
-	).Scan(&count))
-	return count == 1
 }

--- a/mithril/sync_import_deferred_marker_test.go
+++ b/mithril/sync_import_deferred_marker_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mithril
+
+import (
+	"bytes"
+	"database/sql"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/deferred"
+	"github.com/blinklabs-io/dingo/internal/node"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateMithrilReadyStateKeepsDeferredIndexPendingMarker pins the
+// interaction between the deferred-index rebuild and the sync-state clear
+// that ends a Mithril sync.
+//
+// mithril sync rebuilds only the critical subset and deliberately leaves
+// deferred.SyncStateKey set so the first serve finishes the lazy manifest.
+// updateMithrilReadyState then runs db.ClearSyncState, which is an
+// unqualified DELETE FROM sync_state: without carrying the marker across
+// the clear, every completed Mithril sync erases it moments after
+// BuildCritical set it, and the lazy manifest entries are never built on
+// any Mithril-bootstrapped database.
+func TestUpdateMithrilReadyStateKeepsDeferredIndexPendingMarker(t *testing.T) {
+	t.Parallel()
+	db := newMithrilTestDB(t)
+	manager, ok := db.Metadata().(metadata.DeferredIndexManager)
+	require.True(t, ok, "sqlite metadata store must manage deferred indexes")
+
+	// The Mithril sequence: drop the manifest, bulk load, rebuild the
+	// critical subset only.
+	require.NoError(t, manager.DropDeferredIndexes())
+	require.NoError(t, manager.BuildCriticalDeferredIndexes())
+	pending, err := manager.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(
+		t, pending,
+		"precondition: the critical rebuild leaves the lazy remainder pending",
+	)
+
+	ledgerStateHash := bytes.Repeat([]byte{0x55}, 32)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(30, ledgerStateHash),
+	}, nil))
+	require.NoError(t, db.SetSyncState("sync_status", "bootstrap", nil))
+
+	require.NoError(t, updateMithrilReadyState(
+		db,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+		30,
+		ledgerStateHash,
+		"",
+		true,
+	))
+
+	pending, err = manager.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.True(
+		t, pending,
+		"the deferred-index pending marker must survive ClearSyncState "+
+			"so the first serve builds the lazy manifest entries",
+	)
+	marker, err := db.GetSyncState(deferred.SyncStateKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, deferred.SyncStateValue, marker)
+
+	// The clear still does its job for everything else.
+	status, err := db.GetSyncState("sync_status", nil)
+	require.NoError(t, err)
+	require.Empty(t, status, "sync_status must still be cleared")
+}
+
+// newMithrilFileTestDB is newMithrilTestDB with a data directory, so the
+// SQLite catalog can be inspected directly.
+func newMithrilFileTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{
+		DataDir: t.TempDir(),
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbtest.CloseDatabase(db))
+	})
+	return db
+}
+
+// lazyManifestIndex names a manifest entry the critical rebuild does not
+// build, so the test states the property rather than one index name.
+func lazyManifestIndex(t *testing.T) string {
+	t.Helper()
+	for _, index := range deferred.Manifest {
+		if !index.Critical {
+			return index.Name
+		}
+	}
+	t.Fatal("manifest has no lazy entry to test with")
+	return ""
+}
+
+// TestMithrilSyncLeavesLazyManifestForTheFirstServe walks the composition a
+// Mithril-bootstrapped node actually takes: sync drops the manifest, rebuilds
+// the critical subset, and calls updateMithrilReadyState; the first
+// `dingo serve` then calls node.RepairDeferredIndexes, which finishes the
+// manifest only if the pending marker survived the sync's sync-state clear.
+//
+// Without the marker carried across the clear, RepairDeferredIndexes takes its
+// no-cycle-pending branch, every lazy manifest entry stays absent for the life
+// of the database, and Node.startDeferredIndexMaintenance reads the same wiped
+// marker and logs "deferred-index maintenance not needed".
+func TestMithrilSyncLeavesLazyManifestForTheFirstServe(t *testing.T) {
+	t.Parallel()
+	db := newMithrilFileTestDB(t)
+	raw, err := dbtest.RawSQLiteMetadata(t, db)
+	require.NoError(t, err)
+	lazy := lazyManifestIndex(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// The sync: drop for the bulk load, rebuild the critical subset only.
+	deferredIndexes := node.WithDeferredIndexes(db, logger)
+	require.NoError(t, deferredIndexes.BuildCritical())
+	require.False(
+		t,
+		metadataIndexExists(t, raw, lazy),
+		"precondition: %s is lazy and the critical rebuild skips it",
+		lazy,
+	)
+
+	ledgerStateHash := bytes.Repeat([]byte{0x66}, 32)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(30, ledgerStateHash),
+	}, nil))
+	require.NoError(t, updateMithrilReadyState(
+		db, logger, nil, 30, ledgerStateHash, "", true,
+	))
+
+	// The first serve on a core-mode node.
+	require.NoError(t, node.RepairDeferredIndexes(db, logger))
+
+	require.True(
+		t,
+		metadataIndexExists(t, raw, lazy),
+		"the first serve after a Mithril sync must finish the lazy "+
+			"manifest entry %s",
+		lazy,
+	)
+	manager, ok := db.Metadata().(metadata.DeferredIndexManager)
+	require.True(t, ok)
+	pending, err := manager.HasDeferredIndexesPending()
+	require.NoError(t, err)
+	require.False(
+		t, pending,
+		"the full rebuild clears the marker it consumed",
+	)
+}
+
+func metadataIndexExists(t *testing.T, raw *sql.DB, name string) bool {
+	t.Helper()
+	var count int
+	require.NoError(t, raw.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?",
+		name,
+	).Scan(&count))
+	return count == 1
+}


### PR DESCRIPTION
## What

`TruncateAfterSlot` ends in `DELETE FROM "transaction" WHERE slot > ?`
(`database/plugin/metadata/sqlstore/transaction_write.go`). `utxo.transaction_id`
is the child column of `fk_transaction_outputs` (`ON DELETE CASCADE`, migration
v1 `expand.sql`), and `shared_sqlstore.go` opens every connection with
`foreign_keys(1)`, so SQLite enforces that cascade with an implicit
`DELETE FROM utxo WHERE transaction_id = ?` per deleted parent row.

`idx_utxo_transaction_id` was the only `utxo` entry in the deferred-index
manifest without `Critical: true`. The rebuild that runs before a
Mithril-bootstrapped database is marked ready (`mithril/sync.go` →
`DeferredIndexRebuilder.BuildCritical`) therefore leaves it out, and a rollback
in that state scans the whole `utxo` table once per rolled-back transaction —
`O(rolled-back transactions x utxo rows)`.

Measured on a read-only copy of a preview relay's own database (3,167,422 `utxo`
rows, 1,001 `transaction` rows in the rolled-back window, warm page cache, C
SQLite; the shipped pure-Go driver is slower):

| statement | index absent | index present |
| --- | --- | --- |
| `DELETE FROM "transaction" WHERE slot > 122071241` (1,001 rows) | 556.646 s | 0.095 s |
| `CREATE INDEX idx_utxo_transaction_id ON utxo(transaction_id)` | — | 1.729 s (one-off) |

The same node's instrumented sweeps for comparable rollbacks ran 10m44s, 10m45s,
11m07s and 31m52s, with no log output at all between "rolling back" and "sweep
complete". The classification survived review because the parent statement's
plan does not show the cascade:

```
EXPLAIN QUERY PLAN DELETE FROM "transaction" WHERE slot > 122071241;
SEARCH transaction USING INDEX idx_transaction_slot (slot>?)   -- looks fine

EXPLAIN QUERY PLAN DELETE FROM utxo WHERE transaction_id = 1;
SCAN utxo                                                      -- the real cost
```

## Why the deferred manifest is never finished on a Mithril-bootstrapped node

Corrected in review (thanks @chrisguiney): the earlier description blamed the
missing indexes on an older binary whose critical subset was smaller. That is
wrong, and the real cause is current `main` on every sync.

`mithril/sync.go` calls `deferredIndexes.BuildCritical()`, which deliberately
leaves `deferred.SyncStateKey` (`metadata_indexes_pending`) set so the lazy
remainder is finished by later maintenance. It then calls
`updateMithrilReadyState(..., clearSyncState=true)` → `db.ClearSyncState(txn)`,
which is `DELETE FROM sync_state` with no `WHERE`
(`queries/sqlite/operational.sql`). The marker is deleted moments after it was
written. The clear already re-writes `mithril_ledger_slot` and
`mithril_ledger_hash` after it for exactly this reason; the deferred-index
marker was not on that list.

Consequences on every Mithril-bootstrapped database, API mode included: all
twelve lazy manifest entries (`idx_asset_name_hex`, `idx_asset_fingerprint`,
`idx_asset_amount`, `idx_datum_added_slot`, `idx_certs_block_hash`,
`idx_certs_certificate_id`, `idx_certs_cert_type`, `idx_redeemer_index`,
`idx_redeemer_tag`, `idx_key_witness_type`, `idx_witness_scripts_script_hash`,
`idx_witness_scripts_type`) stay absent for the life of the database.
`RepairDeferredIndexes` takes its no-cycle-pending branch and
`Node.startDeferredIndexMaintenance` logs "deferred-index maintenance not
needed", both reading the same wiped row.

## Fix

1. `deferred.Manifest`: `idx_utxo_transaction_id` is now `Critical: true`. The
   `Critical` criteria comment gains the rule that produced the gap: the child
   column of any `ON DELETE CASCADE` foreign key whose parent rows the rollback
   path deletes belongs in the critical subset, because the engine's implicit
   per-parent-row child delete is a scan without it and is invisible from the
   parent statement's plan. The pinned critical count moves 12 → 13.
2. `updateMithrilReadyState` (`mithril/sync_import.go`) carries
   `deferred.SyncStateKey` across the clear, the same way `mithril_ledger_slot`
   and `mithril_ledger_hash` are re-written after it. `mithril/sync.go` still
   calls `BuildCritical()` only — building the API-only remainder inside the
   sync would spend that time on core-mode nodes that never query those indexes,
   which is the cost the deferral exists to avoid — but the marker it leaves now
   survives, so the first `serve` runs the existing `BuildDeferredIndexes`
   maintenance and finishes the manifest. That is the entry point the
   `RepairDeferredIndexes`/`startDeferredIndexMaintenance` paths were written
   for; nothing new is introduced to carry it.
3. `RepairDeferredIndexes` and `RepairCriticalDeferredIndexes` restore a missing
   critical index even when no drop/rebuild cycle is pending. This is what
   repairs databases already on disk: their marker was wiped by the sync that
   built them, the schema migration that created the index is recorded complete
   so its `CREATE INDEX IF NOT EXISTS` never runs again, and the manifest is
   only consulted by a cycle that is no longer pending. Without it the gap is
   permanent — and that is the state two Mithril-bootstrapped preview nodes were
   found in (every `Critical` index present, every lazy one absent, no
   `metadata_indexes_pending` row). `BuildCriticalDeferredIndexes` skips indexes
   that are present, so on a healthy database this is one catalog lookup per
   critical entry inside the write transaction the repair already opens.
4. Startup logging: the missing critical entries are now named *before* the
   rebuild starts, through a new optional
   `metadata.MissingCriticalDeferredIndexLister` the SQL store implements
   (catalog reads, no DDL). A rebuild on a multi-million-row table is otherwise
   silent for as long as it runs — the symptom this PR opens with. The
   completion line reports `duration_covers="critical rebuild and retained-index
   restore"`, because `BuildCriticalDeferredIndexes` goes through
   `withDeferredIndexWrite`, which runs `ensureRetainedIndexes` in the same
   transaction. That reachability is a deliberate gain: `deferred.Retained`
   self-healing previously never ran on a start with no cycle pending, and now
   runs on every core-mode start. A healthy database logs nothing.

## Tests

Which tests fail on `main`, and which are guards that pass either way:

Fail on `main`, pass with the change:

`database/plugin/metadata/sqlite/shared_sqlstore_fk_cascade_index_test.go`

- `TestCascadeChildColumnsIndexedAfterCriticalRebuild` — reads every
  `ON DELETE CASCADE` foreign key out of the live schema via
  `pragma_foreign_key_list` and asserts each child column still has a covering
  index after `DropDeferredIndexes` + `BuildCriticalDeferredIndexes` (the
  Mithril sequence). Stated over the schema rather than over the one index, so
  a future cascading foreign key whose child index is classified lazy fails
  here instead of in production.
- `TestUtxoCascadeDeleteIndexedAfterCriticalRebuild` — pins the plan of the
  cascade's own delete, asserting the `SCAN utxo` first with the manifest
  dropped so the positive assertion has teeth.

`mithril/sync_import_deferred_marker_test.go`

- `TestUpdateMithrilReadyStateKeepsDeferredIndexPendingMarker` — after
  `DropDeferredIndexes` + `BuildCriticalDeferredIndexes`,
  `HasDeferredIndexesPending()` is still true once
  `updateMithrilReadyState(..., clearSyncState=true)` has run, and
  `sync_status` is still cleared.
- `TestMithrilSyncLeavesLazyManifestForTheFirstServe` — the composition a
  bootstrapped node takes: sync's drop + `BuildCritical` +
  `updateMithrilReadyState`, then `node.RepairDeferredIndexes` as the first
  `serve`, after which a lazy manifest entry exists and the marker is cleared.

`internal/node/deferred_index_repair_test.go`,
`cmd/dingo/serve_deferred_index_repair_test.go`

- `TestRepairDeferredIndexesRestoresCriticalIndexWithoutMarker`,
  `TestRepairCriticalDeferredIndexesRestoresCriticalIndexWithoutMarker` —
  the cleared-marker state, repaired, with no marker invented.
- `TestServeCoreModeRepairsMissingCascadeIndex` — the same at the entry point
  `serveRun` actually takes: a core-mode configuration reaches
  `repairDeferredIndexes`, and the index is back afterwards.
- `TestEnsureCriticalDeferredIndexesNamesMissingBeforeBuilding` — the names are
  logged before the rebuild is entered (asserted from inside the rebuild), and
  the completion line says what its duration covers.
- `TestRepairDeferredIndexesNamesMissingIndexAgainstRealStore` — the same
  through the SQLite store and its real catalog rather than a fake.
- `TestEnsureCriticalDeferredIndexesQuietWhenManifestComplete` — a complete
  manifest stays silent.

Guards, which pass on `main` and with either production hunk reverted; they
hold the surrounding facts the change depends on rather than the change itself:

- `TestRollbackDeleteCascadesIntoUtxo` — the rollback's parent `DELETE` really
  does cascade into `utxo`, with `foreign_keys(1)` enforced.
- `TestRepairDeferredIndexesFinishesPendingCycle` — the marker keeps its
  existing meaning: a genuinely interrupted cycle still rebuilds the whole
  manifest and clears it.

```
go build ./... && go vet ./...
go test ./database/plugin/metadata/... ./internal/node/ ./cmd/dingo/ ./database/ ./mithril/... -count=1
go test -race ./database/plugin/metadata/deferred/ ./database/plugin/metadata/sqlite/ ./internal/node/ ./cmd/dingo/ ./mithril/ -count=1
golangci-lint run ./internal/node/... ./database/plugin/metadata/... ./mithril/... ./cmd/dingo/...
```

All green on the rebased head, lint 0 issues. Each production hunk was also
reverted on its own and the corresponding tests re-run: the manifest
classification, the marker carry in `updateMithrilReadyState`, the no-marker
repair, the pre-build log line, and the store's missing-index lister each fail
their own tests when reverted alone.

Operationally, a database already in this state can also be repaired online with
`CREATE INDEX IF NOT EXISTS idx_utxo_transaction_id ON utxo(transaction_id);`
(1.7 s on 3.2M rows); this change does it for the operator on the next start.

No separate issue: the analysis is inline above, and the field evidence it
came from is below.

## How this was found

A relay bootstrapped with `dingo mithril sync` (storage mode `core`, preview,
`metadata.sqlite` 1.6 GB, `utxo` 3,167,422 rows, `transaction` 2,472 rows)
produced no log output for 24 minutes at startup after an in-place image swap.
These are consecutive lines; nothing was elided between the last two:

```
INFO  database worker pool initialized workers=5 queue_size=50
WARN  ledger tip ahead of primary chain tip at startup, rolling back
      metadata to chain tip
      chain_tip_slot=122071241 ledger_tip_slot=122084222
<no further output for 24 minutes>
```

One core pegged at ~105%, RSS flat at 170 MiB, block I/O static, and the
write-ahead log held a single 4,096-byte frame — a read/scan phase, not write
progress, on a database already warm in the page cache. The container could not
be stopped gracefully (`docker stop -t 120` returned 137): the sweep runs on a
database worker-pool goroutine inside the ledger's async transaction, which
shutdown waits to drain and cannot cancel.

The rollback window held 1,001 `transaction` rows. Reproduced against a
read-only copy of that database (the timings in the table above), the single
`DELETE FROM "transaction" WHERE slot > ?` took 556.6 s, and a one-off
`CREATE INDEX idx_utxo_transaction_id ON utxo(transaction_id)` (1.7 s) brought
the same statement to 0.095 s. Per-parent-row cost scales linearly: 1 row
0.65 s, 9 rows 4.9 s (~0.55 s each).

The same node's own instrumented sweeps, previous container generation, show
both regimes:

```
rollback_slot=122087673  duration=21.665s
rollback_slot=122093634  duration=23.909s
...
rollback_slot=122097167  duration=11m07.882s
rollback_slot=122097057  duration=10m45.275s
rollback_slot=122097167  duration=10m44.876s
rollback_slot=122084222  duration=31m52.587s
```

The ~22-26 s baseline is #4015 (fixed by #4022 plus an ordering fix); the
10-32 minute outliers are the deep rollbacks, where the transaction count in
the window is large. Note the pattern of a multi-minute sweep followed
immediately by a ~24 s sweep at the same slot: the deep one is the cascade, the
retry finds nothing left to cascade.

A/B across four nodes, read directly from each `metadata.sqlite`:

| node | bootstrap | mode | `utxo` rows | `idx_utxo_transaction_id` | deep-rollback sweep |
| --- | --- | --- | --- | --- | --- |
| preview relay (subject) | `dingo mithril sync` | core | 3.2M | absent | 24 min, killed |
| preview block producer | `dingo mithril sync` | core | 3.2M | absent | — |
| devnet node A | full sync | core | 32.1M | present | ~12 s |
| devnet node B | full sync | core | 32.1M | present | ~12 s |

The two nodes with a ten times larger `utxo` table are the fast ones: neither
rollback depth nor table size is the discriminator, the index is. On both
Mithril-bootstrapped databases every `Critical` manifest index was present,
every lazy one absent, and `sync_state` held no `metadata_indexes_pending` row
— exactly what the unqualified `DELETE FROM sync_state` above produces, fixed
going forward by item 2 and repaired on existing databases by item 3.

## Related

- #4015 — sibling of this bug: the same rollback sweep, the
  `SELECT DISTINCT credential_tag, staking_key ... WHERE added_slot > ?` full
  scans. Different mechanism; this FK cascade is what remains once that one is
  fixed.
- #4022 — the fix for #4015 (open).
- #3253 / #3298 — the same hazard class on the witness `transaction_id`
  indexes: an index the bulk-load manifest deferred turned a per-row delete
  into a full scan. `deferred.Retained` and its self-healing came from that,
  and this change follows the precedent.
- #2450 — introduced the deferred-index manifest, the critical subset, and the
  core-mode serve repair this change extends.
- #2457, #2460 — earlier deferred-index classification and rebuild-cost fixes.
- #3967 — the `TruncateAfterSlot` duration instrumentation that made the
  31m52s measurement available.


## CI status

Rebased onto `main` at `aa088149` (2026-09-09); all 4 commits carried through
byte-identical (`git range-diff`, no conflicts). Re-verified the touched
packages on the rebased head — `go build ./...`, `go vet`, and `go test` clean
across `cmd/dingo`, `database/...` (including `sqlstore/migrations`),
`internal/node`, `internal/test/dbtest`, and `mithril`, none of which this PR's
diff misses.

Two red checks on this head, both unrelated to this branch's diff:

- `go-test (Linux) (1.26.x)`: failed in the `install-mariadb-client` setup
  step (`apt-get` exit 100, hash-sum mismatch fetching an unrelated
  `dl.google.com/linux/chrome-stable` package index) — never reached `go test`.
  Runner/mirror infra, not this branch.
- `go-test (macOS) (1.26.x)`: failed on `ledger.TestScheduler_ChangeInterval`,
  a fixed-timing test in `ledger/timer_test.go` this PR does not touch. Ran
  `go test ./ledger -run TestScheduler_ChangeInterval -count=10` locally:
  10/10 green. Timing-sensitive assertion (expects 1-3 ticks in a 500ms window
  after an interval change) flaking under CI runner load, not a regression
  from this diff.
