### PR TITLE
fix(lint): clear the nilaway and modernize findings on main

### DIFF
--- a/bark/blob_test.go
+++ b/bark/blob_test.go
@@ -926,6 +926,11 @@ func TestUpstreamIterator_SurfacesTypedHistoryExpiredError(t *testing.T) {
 	}))
 
 	upstream := db.Blob()
+	// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+	// store (database/database.go), so the nil-receiver branch of
+	// blobStoreRef.blobStore that nilaway traces is unreachable for any
+	// constructed database.
+	//nolint:nilaway // database.New requires a non-nil blob store
 	rTxn := upstream.NewTransaction(false)
 	t.Cleanup(func() { _ = rTxn.Rollback() })
 	it := upstream.NewIterator(rTxn, types.BlobIteratorOptions{

--- a/bark/database.go
+++ b/bark/database.go
@@ -1309,6 +1309,13 @@ func (h *databaseServiceHandler) GetDatabaseInfo(
 	// (the s3/gcs blob plugins, which store nothing locally) returns
 	// (0, nil), so this degrades to 0 for those rather than erroring.
 	var sizeBytes uint64
+	// db.Blob() is non-nil here: database.New rejects a nil or typed-nil
+	// stores.Blob (database/database.go), and the only production
+	// SetBlobStore callers (node.go, node_lifecycle.go) install the non-nil
+	// wrapper bark.NewBarkBlobStore returns on a nil error. nilaway reports
+	// the nil-receiver branch of blobStoreRef.blobStore (database/
+	// blob_store.go) instead, which no installed database reaches.
+	//nolint:nilaway // database.New requires a non-nil blob store
 	if blobSize, err := db.Blob().DiskSize(); err == nil && blobSize > 0 {
 		sizeBytes += uint64(
 			blobSize,

--- a/chain/batch_restore_skip_log_test.go
+++ b/chain/batch_restore_skip_log_test.go
@@ -131,9 +131,7 @@ func TestSkippedBatchRestoreIsRecorded(t *testing.T) {
 		applying := make(chan struct{})
 		release := make(chan struct{})
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := pc.AddRawBlocksWithCallback(
 				[]chain.RawBlock{doomed},
 				func(_ chain.RawBlock, txn *database.Txn) error {
@@ -149,7 +147,7 @@ func TestSkippedBatchRestoreIsRecorded(t *testing.T) {
 			if err == nil {
 				t.Errorf("round %d: expected a commit failure", round)
 			}
-		}()
+		})
 		<-applying
 		if err := db.BlockCreate(models.Block{
 			ID:     conflictIndex,
@@ -162,11 +160,9 @@ func TestSkippedBatchRestoreIsRecorded(t *testing.T) {
 			t.Fatalf("round %d: conflicting write: %v", round, err)
 		}
 		moved := make(chan error, 1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			moved <- pc.AddBlock(mover, nil)
-		}()
+		})
 		// Release the batch only once the add is queued on the chain lock it
 		// holds, so the add runs before the batch's restore reacquires it.
 		waitUntilParkedIn(t, "chain.(*Chain).addBlockInternal")

--- a/chain/blocked_goroutine_test.go
+++ b/chain/blocked_goroutine_test.go
@@ -45,7 +45,7 @@ func waitUntilParkedIn(t *testing.T, symbol string) {
 		t,
 		func() bool {
 			dump := string(buf[:runtime.Stack(buf, true)])
-			for _, g := range strings.Split(dump, "\n\ngoroutine ") {
+			for g := range strings.SplitSeq(dump, "\n\ngoroutine ") {
 				if strings.Contains(g, semaphoreFrame) &&
 					strings.Contains(g, symbol) {
 					return true

--- a/chain/rollback_pending_commit_test.go
+++ b/chain/rollback_pending_commit_test.go
@@ -107,9 +107,7 @@ func TestRollbackDoesNotResolveUncommittedBlockIndex(t *testing.T) {
 		release := make(chan struct{})
 		var once sync.Once
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// The callback runs inside the batch transaction, under both
 			// chain locks, so it marks the point at which the in-memory
 			// chain has started moving ahead of the store.
@@ -125,14 +123,12 @@ func TestRollbackDoesNotResolveUncommittedBlockIndex(t *testing.T) {
 			); err != nil {
 				t.Errorf("round %d: AddRawBlocksWithCallback: %v", round, err)
 			}
-		}()
+		})
 		<-applying
 		var rollbackErr error
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			rollbackErr = pc.Rollback(ocommon.Point{})
-		}()
+		})
 		// Release the batch only once the rollback is queued on the lock it
 		// holds, so the rollback runs in the window between that lock being
 		// handed over and the batch's transaction committing.

--- a/chainselection/selector.go
+++ b/chainselection/selector.go
@@ -938,6 +938,12 @@ func (cs *ChainSelector) GetPeerSyncTarget(
 		return ochainsync.Tip{}, false
 	}
 	observed := peerTip.SelectionTip()
+	// peerTip is nil when connId has no entry, but isPeerSelectableLocked
+	// returns false for a nil tip through peerLiveEligibleNonStaleLocked
+	// (chainselection/genesis_corroboration.go), so the early return above
+	// covers the absent-key case. nilaway does not correlate that guard
+	// across the two functions.
+	//nolint:nilaway // guarded by isPeerSelectableLocked above
 	advertised := peerTip.Tip
 	if safeAddUint64(
 		observed.Point.Slot,

--- a/database/batch_skip_test.go
+++ b/database/batch_skip_test.go
@@ -151,6 +151,11 @@ func TestSetTransactionBatchedWithOpts_SkipsAllProducedUtxoWrites(
 	readTxn := db.Transaction(false)
 	defer readTxn.Release()
 	for ref, want := range sentinels {
+		// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+		// store (database/database.go), so the nil-receiver branch of
+		// blobStoreRef.blobStore that nilaway traces is unreachable for any
+		// constructed database.
+		//nolint:nilaway // database.New requires a non-nil blob store
 		got, err := readTxn.DB().Blob().GetUtxo(
 			readTxn.Blob(), ref.TxId[:], ref.OutputIdx,
 		)

--- a/database/blob_store_sync_test.go
+++ b/database/blob_store_sync_test.go
@@ -86,9 +86,7 @@ func TestSetBlobStoreConcurrentWithReaders(t *testing.T) {
 	start := make(chan struct{})
 
 	for range readers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for range iterations {
 				// Bare accessor read.
@@ -126,12 +124,10 @@ func TestSetBlobStoreConcurrentWithReaders(t *testing.T) {
 				txn := db.Transaction(false)
 				txn.Release()
 			}
-		}()
+		})
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		for i := range iterations {
 			if i%2 == 0 {
@@ -140,7 +136,7 @@ func TestSetBlobStoreConcurrentWithReaders(t *testing.T) {
 				db.SetBlobStore(base)
 			}
 		}
-	}()
+	})
 
 	close(start)
 	wg.Wait()

--- a/database/lifecycle/restore_remote_test.go
+++ b/database/lifecycle/restore_remote_test.go
@@ -223,6 +223,11 @@ func (d *remoteTestDatabase) close(t *testing.T) {
 
 func readBlobContents(t *testing.T, db *database.Database) map[string][]byte {
 	t.Helper()
+	// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+	// store (database/database.go), so the nil-receiver branch of
+	// blobStoreRef.blobStore that nilaway traces is unreachable for any
+	// constructed database.
+	//nolint:nilaway // database.New requires a non-nil blob store
 	txn := db.Blob().NewTransaction(false)
 	defer txn.Rollback() //nolint:errcheck
 	it := db.Blob().NewIterator(txn, types.BlobIteratorOptions{})

--- a/database/models/leios_block_dijkstra_test.go
+++ b/database/models/leios_block_dijkstra_test.go
@@ -151,15 +151,11 @@ func TestDecodeConwayBlockRejectsUnextendedDijkstraShape(t *testing.T) {
 	_, err := cbor.Decode(raw, &components)
 	require.NoError(t, err)
 	var headerParts []cbor.RawMessage
-	// components is the two-element array musashiDijkstraBlock builds, and
-	// the require.NoError above proves it decoded, so index 0 exists.
-	//nolint:nilaway // fixture decodes to a two-component block
+	require.Len(t, components, 2)
 	_, err = cbor.Decode(components[0], &headerParts)
 	require.NoError(t, err)
 	var bodyElems []cbor.RawMessage
-	// headerParts is the two-element header musashiDijkstraBlock builds,
-	// and the require.NoError above proves it decoded, so index 0 exists.
-	//nolint:nilaway // fixture decodes to a two-part header
+	require.Len(t, headerParts, 2)
 	_, err = cbor.Decode(headerParts[0], &bodyElems)
 	require.NoError(t, err)
 	require.Len(t, bodyElems, 12)

--- a/database/models/leios_block_dijkstra_test.go
+++ b/database/models/leios_block_dijkstra_test.go
@@ -151,9 +151,15 @@ func TestDecodeConwayBlockRejectsUnextendedDijkstraShape(t *testing.T) {
 	_, err := cbor.Decode(raw, &components)
 	require.NoError(t, err)
 	var headerParts []cbor.RawMessage
+	// components is the two-element array musashiDijkstraBlock builds, and
+	// the require.NoError above proves it decoded, so index 0 exists.
+	//nolint:nilaway // fixture decodes to a two-component block
 	_, err = cbor.Decode(components[0], &headerParts)
 	require.NoError(t, err)
 	var bodyElems []cbor.RawMessage
+	// headerParts is the two-element header musashiDijkstraBlock builds,
+	// and the require.NoError above proves it decoded, so index 0 exists.
+	//nolint:nilaway // fixture decodes to a two-part header
 	_, err = cbor.Decode(headerParts[0], &bodyElems)
 	require.NoError(t, err)
 	require.Len(t, bodyElems, 12)

--- a/database/plugin/metadata/sqlstore/account_bench_test.go
+++ b/database/plugin/metadata/sqlstore/account_bench_test.go
@@ -51,7 +51,7 @@ func seedAccountsForBench(
 	)
 	require.NoError(b, err)
 	refs := make([]models.StakeCredentialRef, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		key := make([]byte, 28)
 		key[0] = byte(i >> 16)
 		key[1] = byte(i >> 8)

--- a/database/plugin/metadata/sqlstore/account_by_credential_test.go
+++ b/database/plugin/metadata/sqlstore/account_by_credential_test.go
@@ -36,7 +36,7 @@ func TestGetAccountsByCredentialGroupedByTag(t *testing.T) {
 	// IN list for each tag must itself be chunked (twice over per tag).
 	const perTag = 1200
 	refs := make([]models.StakeCredentialRef, 0, perTag*2)
-	for tag := uint8(0); tag < 2; tag++ {
+	for tag := range uint8(2) {
 		for i := range perTag {
 			key := make([]byte, 28)
 			key[0] = tag

--- a/database/plugin/metadata/sqlstore/governance.go
+++ b/database/plugin/metadata/sqlstore/governance.go
@@ -747,10 +747,7 @@ func (s *Store) GetResignedCommitteeMembers(
 	// MAX(added_slot) >= termStart, so the term comparison still happens per
 	// credential, just in Go.
 	latest := make(map[string]uint64, len(coldCredentials))
-	chunkSize := s.dialect.ParameterLimit() / 2
-	if chunkSize < 1 {
-		chunkSize = 1
-	}
+	chunkSize := max(s.dialect.ParameterLimit()/2, 1)
 	for start := 0; start < len(coldCredentials); start += chunkSize {
 		end := min(start+chunkSize, len(coldCredentials))
 		chunk := coldCredentials[start:end]

--- a/internal/historyexpiry/pruner_test.go
+++ b/internal/historyexpiry/pruner_test.go
@@ -95,6 +95,11 @@ func TestPrunerExpiresBlocksOlderThanStabilityWindow(t *testing.T) {
 
 	txn := db.BlobTxn(false)
 	defer txn.Release()
+	// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+	// store (database/database.go), so the nil-receiver branch of
+	// blobStoreRef.blobStore that nilaway traces is unreachable for any
+	// constructed database.
+	//nolint:nilaway // database.New requires a non-nil blob store
 	_, _, err := db.Blob().GetBlock(txn.Blob(), 9, oldHash)
 	assert.ErrorIs(t, err, types.ErrHistoryExpired)
 	_, _, err = db.Blob().GetBlock(txn.Blob(), 10, boundaryHash)

--- a/internal/node/load_test.go
+++ b/internal/node/load_test.go
@@ -318,6 +318,11 @@ func TestCopyBlocksRawWithCallback_StoresUtxoOffsets(t *testing.T) {
 
 	blobTxn := db.BlobTxn(false)
 	defer blobTxn.Rollback() //nolint:errcheck
+	// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+	// store (database/database.go), so the nil-receiver branch of
+	// blobStoreRef.blobStore that nilaway traces is unreachable for any
+	// constructed database.
+	//nolint:nilaway // database.New requires a non-nil blob store
 	offsetData, err := db.Blob().GetUtxo(
 		blobTxn.Blob(),
 		expectedTxHash,

--- a/internal/test/devnet/isolation_test.go
+++ b/internal/test/devnet/isolation_test.go
@@ -790,7 +790,7 @@ done`
 	require.NoError(t, err)
 
 	result := map[string]int{}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
 			continue
 		}

--- a/internal/test/devnet/run_tests_script_test.go
+++ b/internal/test/devnet/run_tests_script_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -242,9 +243,7 @@ func runFakeDevnetWithEnv(
 		),
 		"TMPDIR": tempRoot,
 	}
-	for key, value := range envOverrides {
-		env[key] = value
-	}
+	maps.Copy(env, envOverrides)
 	cmd.Env = cleanRunnerEnv(env)
 	var output bytes.Buffer
 	cmd.Stdout = &output

--- a/internal/test/fixtures/fixtures.go
+++ b/internal/test/fixtures/fixtures.go
@@ -16,6 +16,8 @@
 package fixtures
 
 import (
+	"fmt"
+
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	mockfixtures "github.com/blinklabs-io/ouroboros-mock/fixtures"
@@ -60,32 +62,32 @@ func GenerateConwayChainWithPeriodicTransactions(
 	var previous common.Blake2b256
 	for i := range count {
 		withTransactions := i%(emptyRun+1) == emptyRun
-		var block ledger.Block
+		var generated []ledger.Block
 		var err error
 		if withTransactions {
-			generated, generateErr := mockfixtures.GenerateConwayChainWithTransactions(
+			generated, err = mockfixtures.GenerateConwayChainWithTransactions(
 				uint64(i+1),
 				previous,
 				uint64(2+i*20),
 				20,
 				1,
 			)
-			err = generateErr
-			if len(generated) > 0 {
-				block = generated[0]
-			}
 		} else {
-			generated, generateErr := mockfixtures.GenerateConwayChain(
+			generated, err = mockfixtures.GenerateConwayChain(
 				uint64(i+1), previous, uint64(2+i*20), 20, 1,
 			)
-			err = generateErr
-			if len(generated) > 0 {
-				block = generated[0]
-			}
 		}
 		if err != nil {
 			return nil, err
 		}
+		// Both generators return an empty slice only for a non-positive
+		// count and both calls above ask for one block, so an empty result
+		// means the generator contract changed. Report it instead of
+		// appending a nil Block and panicking on Hash below.
+		if len(generated) == 0 {
+			return nil, fmt.Errorf("no block generated for index %d", i)
+		}
+		block := generated[0]
 		blocks = append(blocks, block)
 		previous = block.Hash()
 	}

--- a/ledger/forging/opcert_width_test.go
+++ b/ledger/forging/opcert_width_test.go
@@ -43,6 +43,9 @@ func decodeCborArrayElementUint(
 	require.NoError(t, err)
 	require.Greater(t, len(elements), index)
 	var value uint64
+	// require.Greater above fails the test unless len(elements) > index,
+	// which nilaway does not model.
+	//nolint:nilaway // bounded by the require.Greater above
 	_, err = cbor.Decode(elements[index], &value)
 	require.NoError(t, err)
 	return value

--- a/ledger/forging/store_test.go
+++ b/ledger/forging/store_test.go
@@ -278,11 +278,9 @@ func TestSyncStateForgeFenceStoreConcurrentStoresKeepHighest(t *testing.T) {
 	const highest = 500
 	var wg sync.WaitGroup
 	for slot := 1; slot <= highest; slot++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			assert.NoError(t, store.StoreLastForgedSlot(uint64(slot)))
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/ledger/forging/store_test.go
+++ b/ledger/forging/store_test.go
@@ -99,6 +99,10 @@ func TestSyncStateForgeFenceStoreIsPerPool(t *testing.T) {
 	first := NewSyncStateForgeFenceStore(backing, storeTestPoolID("poolA"))
 	second := NewSyncStateForgeFenceStore(backing, storeTestPoolID("poolB"))
 
+	// NewSyncStateForgeFenceStore returns nil only for a nil store
+	// (ledger/forging/store.go), and newMockSyncStateStore never returns
+	// nil, so the fence stores built above are non-nil.
+	//nolint:nilaway // newMockSyncStateStore returns a non-nil store
 	require.NoError(t, first.StoreLastForgedSlot(500))
 
 	slot, ok, err := second.LoadLastForgedSlot()

--- a/ledger/governance/committee.go
+++ b/ledger/governance/committee.go
@@ -75,6 +75,12 @@ func ResolveCommitteeProposal(
 	if selected == nil {
 		return nil, 0, nil
 	}
+	// selectedAction is only ever assigned alongside selected, and only with
+	// a non-nil update: committeeActionMentionsCredential returns false for a
+	// nil action, so a nil update takes the continue in both loops. The
+	// selected == nil return above therefore also rules out a nil
+	// selectedAction, a correlation nilaway cannot make.
+	//nolint:nilaway // non-nil whenever selected is; see above
 	for _, credential := range selectedAction.Credentials {
 		if credential.CredType == coldCredential.CredType &&
 			credential.Credential == coldCredential.Credential {

--- a/ledger/governance/spo_nonvoter_test.go
+++ b/ledger/governance/spo_nonvoter_test.go
@@ -39,8 +39,9 @@ type spoNonVoterRatificationCase struct {
 	silentVote           *uint8
 }
 
+//go:fix inline
 func votePointer(vote uint8) *uint8 {
-	return &vote
+	return new(vote)
 }
 
 // TestProcessEpochSPONonVoterDenominators matches the same 60/40 stake

--- a/ledger/leios/manager.go
+++ b/ledger/leios/manager.go
@@ -1110,6 +1110,12 @@ func (m *VoteManager) CommitteeForEpoch(epoch uint64) (*Committee, error) {
 	if err != nil {
 		return nil, err
 	}
+	// committeeAndParamsForEpoch returns a nil entry only alongside a
+	// non-nil error: computeCommitteeEntry's nil-entry returns are all error
+	// returns, and completeCommitteeComputation memoizes an entry only when
+	// err is nil. The err check above therefore rules out a nil entry, which
+	// nilaway cannot correlate.
+	//nolint:nilaway // entry is non-nil whenever err is nil
 	return entry.committee, nil
 }
 

--- a/ledger/leios/manager_test.go
+++ b/ledger/leios/manager_test.go
@@ -1516,6 +1516,9 @@ func TestVoteManagerResolvesOnChainKeyWithoutRegistryEntry(t *testing.T) {
 		VoterId:           member.VoterId,
 		VoteSignature:     sig,
 	}))
+	// keyProvider is assigned by the customize closure the fixture builder
+	// above invokes synchronously; nilaway does not follow that callback.
+	//nolint:nilaway // assigned by the fixture closure above
 	keyProvider.mu.Lock()
 	resolvedSnapshotEpoch := keyProvider.snapshotEpoch
 	keyProvider.mu.Unlock()

--- a/ledger/leios_apply_double_consume_test.go
+++ b/ledger/leios_apply_double_consume_test.go
@@ -363,6 +363,9 @@ func leiosApplyTestApplyRankingDelta(
 	copy(ebHash[:], leiosApplyTestEbHash(0x00))
 	_, offsets, err := buildEndorserBlockBlob(
 		[]lcommon.Transaction{tx},
+		// elems holds the decoded array of the caller-built rawTx, which the
+		// require.NoError above proves decoded, so index 0 exists.
+		//nolint:nilaway // rawTx decodes to a non-empty CBOR array
 		[][]byte{[]byte(elems[0])},
 		rbPoint.Slot,
 		ebHash,

--- a/ledger/pending_publish.go
+++ b/ledger/pending_publish.go
@@ -15,6 +15,8 @@
 package ledger
 
 import (
+	"slices"
+
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/event"
 )
@@ -119,10 +121,8 @@ func (p *pendingPublishes) drainChain(c *chain.Chain) {
 		c.PublishPendingChainUpdates()
 		return
 	}
-	for _, existing := range p.chainDrains {
-		if existing == c {
-			return
-		}
+	if slices.Contains(p.chainDrains, c) {
+		return
 	}
 	p.chainDrains = append(p.chainDrains, c)
 }

--- a/ledger/protocol_params_for_slot_boundary_test.go
+++ b/ledger/protocol_params_for_slot_boundary_test.go
@@ -145,7 +145,7 @@ func TestProtocolParamsForSlot_UsesMultiEraEpochs(t *testing.T) {
 
 	cfg := newMultiEraForecastCfg(t, shelleyEpoch+1)
 	epochCache := make([]models.Epoch, 0, int(shelleyEpoch)+1)
-	for epoch := uint64(0); epoch < byronEpochs; epoch++ {
+	for epoch := range uint64(byronEpochs) {
 		epochCache = append(epochCache, models.Epoch{
 			EpochId:       epoch,
 			StartSlot:     epoch * uint64(byronEpochLength),

--- a/ledger/queries_limit_test.go
+++ b/ledger/queries_limit_test.go
@@ -46,6 +46,9 @@ func TestLocalStateQueryItemLimitBoundary(t *testing.T) {
 
 	var limitErr *LocalStateQueryLimitError
 	require.ErrorAs(t, err, &limitErr)
+	// require.ErrorAs above fails the test unless it assigned limitErr,
+	// which nilaway does not model.
+	//nolint:nilaway // assigned by the require.ErrorAs above
 	require.Equal(t, "boundary", limitErr.QueryName)
 	require.Equal(t, MaxLocalStateQueryItems+1, limitErr.SubmittedItemCount)
 	require.Equal(t, MaxLocalStateQueryItems, limitErr.MaximumAllowedItemCount)

--- a/ledger/queries_limit_test.go
+++ b/ledger/queries_limit_test.go
@@ -50,7 +50,9 @@ func TestLocalStateQueryItemLimitBoundary(t *testing.T) {
 	// which nilaway does not model.
 	//nolint:nilaway // assigned by the require.ErrorAs above
 	require.Equal(t, "boundary", limitErr.QueryName)
+	//nolint:nilaway // assigned by the require.ErrorAs above
 	require.Equal(t, MaxLocalStateQueryItems+1, limitErr.SubmittedItemCount)
+	//nolint:nilaway // assigned by the require.ErrorAs above
 	require.Equal(t, MaxLocalStateQueryItems, limitErr.MaximumAllowedItemCount)
 }
 

--- a/ledger/recovery_rewind_window_test.go
+++ b/ledger/recovery_rewind_window_test.go
@@ -401,6 +401,9 @@ func TestRecoveryRewindHaltsThoughTargetMovesAndDepthGrows(t *testing.T) {
 			validationErr,
 		)
 		require.ErrorIs(t, lastErr, chain.ErrRollbackExceedsSecurityParam)
+		// require.ErrorIs above fails the test on a nil lastErr, which nilaway
+		// does not model.
+		//nolint:nilaway // non-nil per the require.ErrorIs above
 		seenTargets[lastErr.Error()] = struct{}{}
 		if errors.Is(lastErr, errHaltLedgerPipeline) {
 			halted = true
@@ -445,6 +448,9 @@ func TestRecoveryRewindHaltsThoughTargetMovesAndDepthGrows(t *testing.T) {
 	)
 	require.Greater(
 		t,
+		// maxAttempts is a positive constant, so the loop above appended at
+		// least one tip; nilaway does not reason about the loop bound.
+		//nolint:nilaway // the loop above appends at least one entry
 		chainTips[len(chainTips)-1],
 		chainTips[0],
 		"the fork must extend while the applied ledger tip stays pinned",

--- a/ledger/recovery_rewind_window_test.go
+++ b/ledger/recovery_rewind_window_test.go
@@ -150,9 +150,7 @@ func TestWindowedRewindConvergesWhilePrimaryChainExtends(t *testing.T) {
 	// re-reads the live tip still converges.
 	stop := make(chan struct{})
 	var appender sync.WaitGroup
-	appender.Add(1)
-	go func() {
-		defer appender.Done()
+	appender.Go(func() {
 		lastPoint := pc.Tip().Point
 		for seq := 0; ; seq++ {
 			select {
@@ -182,7 +180,7 @@ func TestWindowedRewindConvergesWhilePrimaryChainExtends(t *testing.T) {
 			}
 			lastPoint = ocommon.NewPoint(next.Slot, next.Hash)
 		}
-	}()
+	})
 
 	target := ocommon.NewPoint(raw[0].Slot, raw[0].Hash)
 	rewindErr := ls.rollbackPrimaryChainInSecurityParamWindows(target)

--- a/ledger/snapshot/rotation_test.go
+++ b/ledger/snapshot/rotation_test.go
@@ -570,7 +570,7 @@ func TestCleanupOldSnapshotsRetentionDepthCapBounds(t *testing.T) {
 	)
 
 	firstRetained := currentEpoch - poolSnapshotRetentionMaxDepth
-	for epoch := uint64(0); epoch < firstRetained; epoch++ {
+	for epoch := range firstRetained {
 		snaps, err := meta.GetPoolStakeSnapshotsByEpoch(
 			epoch, models.PoolStakeSnapshotTypeMark, nil,
 		)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7214,8 +7214,7 @@ func (ls *LedgerState) ledgerProcessBlock(
 					err = nil
 				}
 				if err != nil {
-					var plutusErr conway.PlutusScriptFailedError
-					if errors.As(err, &plutusErr) {
+					if plutusErr, ok := errors.AsType[conway.PlutusScriptFailedError](err); ok {
 						ls.config.Logger.Warn(
 							"Plutus evaluation disagrees with block producer (rejecting transaction)",
 							"component",
@@ -8729,8 +8728,7 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 			// reconciliation attempt lands right back in this same
 			// branch and retries both.
 			if err := ls.rollbackWithoutResync(chainTip.Point); err != nil {
-				var committedErr *rollbackCommittedError
-				if errors.As(err, &committedErr) {
+				if _, ok := errors.AsType[*rollbackCommittedError](err); ok {
 					ls.emitRollbackTransactionEvents(undoBlocks)
 				}
 				return err
@@ -8983,8 +8981,7 @@ func (ls *LedgerState) reconcilePrimaryChainTipWithLedgerTip() error {
 		// A true durable, atomic handoff across every rollback path --
 		// not just this one -- is tracked as issue #3817.
 		if err := ls.rollbackWithoutResync(ancestor); err != nil {
-			var committedErr *rollbackCommittedError
-			if errors.As(err, &committedErr) {
+			if _, ok := errors.AsType[*rollbackCommittedError](err); ok {
 				ls.emitRollbackTransactionEvents(undoBlocks)
 			}
 			return err
@@ -9888,8 +9885,7 @@ func (ls *LedgerState) ProtocolParamsForSlot(
 	// forecast inputs. Calling ls.SlotToEpoch here would load a second snapshot
 	// and could mix its epoch cache with currentEpoch/currentEra/currentPParams
 	// across a concurrent rollover or rollback.
-	for i := len(snapshot.epochCache) - 1; i >= 0; i-- {
-		epoch := snapshot.epochCache[i]
+	for _, epoch := range slices.Backward(snapshot.epochCache) {
 		if slot < epoch.StartSlot {
 			continue
 		}

--- a/ledger/utxo_storage_test.go
+++ b/ledger/utxo_storage_test.go
@@ -253,6 +253,11 @@ func TestUtxoStorageAndRetrieval(t *testing.T) {
 		// Step 2: Check if blob data exists
 		blob := db.Blob()
 		blobTxn := txn.Blob()
+		// db.Blob() is non-nil: database.New rejects a nil or typed-nil blob
+		// store (database/database.go), so the nil-receiver branch of
+		// blobStoreRef.blobStore that nilaway traces is unreachable for any
+		// constructed database.
+		//nolint:nilaway // database.New requires a non-nil blob store
 		blobData, err := blob.GetUtxo(blobTxn, utxoRef.txId, utxoRef.outputIdx)
 		if err != nil {
 			t.Logf("Blob error for %s#%d: %v",

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -2127,11 +2127,11 @@ func (ls *LedgerState) PrunePoolSnapshotsWithRetentionFloor(
 // slotFromHeaderValidationKey extracts the slot from a deferred-header map key,
 // which headerValidationPointKey formats as "<slot>:<hex-hash>".
 func slotFromHeaderValidationKey(key string) (uint64, error) {
-	sep := strings.IndexByte(key, ':')
-	if sep < 0 {
+	before, _, ok := strings.Cut(key, ":")
+	if !ok {
 		return 0, fmt.Errorf("malformed header validation key %q", key)
 	}
-	return strconv.ParseUint(key[:sep], 10, 64)
+	return strconv.ParseUint(before, 10, 64)
 }
 
 // ensureEpochForSlot advances the epoch cache until it covers the target

--- a/ledger/verify_header_test.go
+++ b/ledger/verify_header_test.go
@@ -3557,7 +3557,7 @@ func TestPrunePoolSnapshotsWithRetentionFloor_UnmappableRetainsAll(
 		seenBefore,
 		"mappable deferred slot pins at StakeSnapshotEpoch(22)=21",
 	)
-	for epoch := uint64(0); epoch < 21; epoch++ {
+	for epoch := range uint64(21) {
 		snaps, err := db.Metadata().GetPoolStakeSnapshotsByEpoch(
 			epoch, models.PoolStakeSnapshotTypeMark, nil,
 		)

--- a/ledgerstate/imported_reward_inputs.go
+++ b/ledgerstate/imported_reward_inputs.go
@@ -698,10 +698,7 @@ func emptyRewardSeedFailureReason(snap *ParsedSnapShot) string {
 
 func boundRewardSeedFailureReasons(reasons []string) string {
 	sort.Strings(reasons)
-	shown := len(reasons)
-	if shown > maxRewardSeedFailurePools {
-		shown = maxRewardSeedFailurePools
-	}
+	shown := min(len(reasons), maxRewardSeedFailurePools)
 	bounded := append([]string(nil), reasons[:shown]...)
 	if omitted := len(reasons) - shown; omitted > 0 {
 		bounded = append(

--- a/ledgerstate/imported_reward_inputs_scope_test.go
+++ b/ledgerstate/imported_reward_inputs_scope_test.go
@@ -236,7 +236,7 @@ func TestDerivedRewardInputsBoundsIncompletePoolDiagnostic(t *testing.T) {
 		Delegations: make(map[string][]byte, poolCount),
 	}
 	params := make(map[string]*ParsedPool, poolCount)
-	for i := 0; i < poolCount; i++ {
+	for i := range poolCount {
 		credential := hash28(byte(i + 1))
 		poolKey := hash28(byte(i + 100))
 		credentialHex := hex.EncodeToString(credential)

--- a/ouroboros/blockfetch_musashi_test.go
+++ b/ouroboros/blockfetch_musashi_test.go
@@ -621,6 +621,9 @@ func TestDecodeBlockfetchBlockType8NeedsNoMusashiScope(t *testing.T) {
 		require.EqualValues(t, dijkstra.EraIdDijkstra, block.Era().Id)
 		hashes = append(hashes, block.Hash().String())
 	}
+	// The loop above ranges a two-element literal and appends once per
+	// iteration, so both indexes exist; nilaway does not track that.
+	//nolint:nilaway // the loop above appends exactly two entries
 	require.Equal(t, hashes[0], hashes[1])
 }
 


### PR DESCRIPTION
`make lint` fails on a clean `origin/main` at the nilaway stage: `nilaway ./...`
exits 3 with 28 findings. The modernize stage, which `make` never reaches,
reports 26 of its own. Partially addresses #3769 — this clears the existing
findings but does not gate or pin either tool in CI.

## nilaway

Twenty-one of the 28 findings are outside `ledger/view.go`. Each traces to a
nil that a guard already rules out, so each carries `//nolint:nilaway` with a
comment naming that guard. None was reachable.

**`Database.Blob()` (7 findings).** `blobStoreRef.blobStore` tolerates a nil
receiver and returns nil, which nilaway propagates to every `Blob()`
dereference. `database.New` rejects a nil or typed-nil `stores.Blob`, and the
only production `SetBlobStore` callers install the non-nil wrapper
`bark.NewBarkBlobStore` returns on a nil error, so no constructed database
reaches that branch. Sites: `bark/database.go`, `bark/blob_test.go`,
`database/batch_skip_test.go`, `database/lifecycle/restore_remote_test.go`,
`internal/historyexpiry/pruner_test.go`, `internal/node/load_test.go`,
`ledger/utxo_storage_test.go`.

**Two variables written together (5).** The guard tests one, the dereference
reads the other. `chainselection/selector.go` — `isPeerSelectableLocked`
rejects a nil `peerTip` via `peerLiveEligibleNonStaleLocked`.
`ledger/governance/committee.go` — `selectedAction` is assigned only alongside
`selected`, and only with a non-nil action, because
`committeeActionMentionsCredential` returns false for nil.
`ledger/leios/manager.go` — `committeeAndParamsForEpoch` returns a nil entry
only alongside a non-nil error. Also `ledger/leios/manager_test.go` and
`ledger/forging/store_test.go`.

**Testify assertion as the guard (3).** `require.ErrorAs`, `require.ErrorIs`,
and `require.Greater` fail the test before the dereference, which nilaway does
not model. Sites: `ledger/queries_limit_test.go`,
`ledger/recovery_rewind_window_test.go`, `ledger/forging/opcert_width_test.go`.

**Slice filled by a decode or loop nilaway does not track (5).**
`database/models/leios_block_dijkstra_test.go` (x2),
`ledger/leios_apply_double_consume_test.go`,
`ledger/recovery_rewind_window_test.go`, `ouroboros/blockfetch_musashi_test.go`.

**`internal/test/fixtures/fixtures.go`** is the one code change. The
periodic-transaction loop assigned `block` only when the generator returned a
block, then called `block.Hash()` unconditionally, so the half-guard fell
through to a nil interface. Both generators return an empty slice only for a
non-positive count and both calls ask for one block, so the path is
unreachable today; it now returns an error rather than falling through.

The 7 `ledger/view.go` findings are untouched and handled separately, so
`nilaway ./...` still exits 3 on those alone.

## modernize

`modernize -fix` over `MODERNIZE_PACKAGES`: `max`/`min` builtins,
`slices.Contains`, `slices.Backward`, `strings.Cut`, `errors.AsType`,
`maps.Copy`, range-over-int, `strings.SplitSeq`, and `sync.WaitGroup.Go`. All
behavior-preserving; the module already requires Go 1.26.

Two hand corrections to the tool's output: it left a stray blank line at the
top of the rewritten `slices.Backward` loop, and for the two
`rollbackCommittedError` checks — which use only the boolean — it emitted an
`AsType` binding that does not compile ("declared and not used"), so those
discard the value with `_`.

## Validation

- `nilaway ./...` — 7 findings, all `ledger/view.go` (28 before)
- `golangci-lint run ./...` — 0 issues in the root and both nested modules,
  and again under `GOOS=windows`
- `modernize $(MODERNIZE_PACKAGES)` — exit 0 (26 before)
- `go test ./internal/architecture ./internal/docsparity` — pass
- `go test -race` — `ledger`, `chain`, `database`, `database/models`,
  `database/lifecycle`, `database/plugin/metadata/sqlstore`, `ledger/forging`,
  `ledger/governance`, `ledger/leios`, `ledger/snapshot`
- `go test` — `bark`, `chainselection`, `internal/historyexpiry`,
  `internal/node`, `ledgerstate`, `ouroboros`, `internal/test/devnet`,
  `internal/test/fixtures`, `api/utxorpc`

golangci-lint prints `Found unknown linters in //nolint directives: nilaway`.
It is a warning, the exit code stays 0, and `//nolint:nilaway` is the only
suppression form nilaway honors.

No devnet, conformance, or Antithesis run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the nilaway and modernize findings that break `make lint` on a clean `main`: `nilaway` goes from 28 findings to 7 (all in `ledger/view.go`), and `modernize` from 26 to 0. Partially addresses #3769; neither tool is gated or pinned in CI.

**Nilaway fixes**
- 21 findings are nils a guard already rules out: 19 carry `//nolint:nilaway` naming that guard, and two in `database/models/leios_block_dijkstra_test.go` now assert the decoded fixture shape with `require.Len` before indexing.
- `internal/test/fixtures/fixtures.go` now returns an error when a generator returns an empty slice instead of dereferencing a nil block.
- The 7 `ledger/view.go` findings are untouched, so `nilaway ./...` still exits 3 on those alone.
- `golangci-lint` warns about the unknown `nilaway` linter in `//nolint` directives, but the exit code stays 0.

**Modernize rewrites**
- `modernize -fix` applied over `MODERNIZE_PACKAGES`; uses `max`/`min`, `slices.Contains`, `slices.Backward`, `strings.Cut`, `errors.AsType`, `maps.Copy`, range-over-int, `strings.SplitSeq`, and `sync.WaitGroup.Go`.
- Two manual corrections: a stray blank line in the `slices.Backward` loop, and two `errors.AsType` checks whose unused bindings didn't compile (now discarded with `_`).

<sup>Written for commit 1c43e5e90d1ee818df6f60fda81d38ec37857c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modernized internal code with standard Go helpers for iteration, slicing, error handling, string parsing, map copying, and collection checks.
  - Simplified several concurrency patterns using streamlined wait-group support.
  - Improved error handling when test fixture generation produces no blocks.

- **Tests**
  - Added coverage for cross-transaction UTxO double-consumption scenarios.
  - Updated test utilities and assertions without changing existing behavior.

- **Chores**
  - Added explanatory analysis suppressions and comments to clarify validated non-nil values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->