### PR TITLE
fix(mithril): tolerate missing account in historical backfill

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -952,15 +952,29 @@ snapshot, so it skips both the era-neutral upper-bound check and the
 `account.reward` debit -- the imported snapshot balance already reflects every
 credit and debit through the snapshot's boundary, and re-subtracting a
 pre-boundary withdrawal from it would double-count. The withdrawal is still
-required to resolve an `account` row for the credential during live ingestion;
-during historical backfill it is not, because a withdrawal that was valid on
-the canonical chain can have a stake credential that is absent from the
-imported snapshot's active accounts entirely (deregistered, or never active,
-before the snapshot was taken -- issue #3788). In that case the backfill
-records the `account_reward_delta` row with `previous_reward = 0` from the
-credential alone and neither creates nor reactivates an `account` row: the
-journal's join to `account` is already unenforced (see above), so the history
-is retained without fabricating current stake-registration state.
+required to resolve an *active* `account` row for the credential during live
+ingestion; during historical backfill it is not, because a withdrawal that was
+valid on the canonical chain can name a stake credential with no active
+account row for two distinct reasons (issue #3788), which are not treated
+alike:
+
+- No `account` row exists at all: the credential was deregistered before the
+  snapshot was taken, or never active in it. There is no real prior balance to
+  recover, so the backfill records the `account_reward_delta` row with
+  `previous_reward = 0` from the credential alone, and neither creates nor
+  reactivates an `account` row -- the journal's join to `account` is already
+  unenforced (see above), so the history is retained without fabricating
+  current stake-registration state.
+- A row exists but is inactive. `applyTransactionCertificates` runs
+  unconditionally regardless of `historicalBackfill`, so backfill's own
+  certificate replay can transiently deactivate a row Mithril imported active,
+  between a historical deregistration certificate and a later
+  re-registration certificate for the same credential; a deregistration's
+  account upsert never clears `reward`, so the row can still hold the
+  credential's real balance while inactive. The backfill falls back to an
+  inactive-inclusive lookup and journals that real `reward` as
+  `previous_reward` instead of discarding it as `0`, while still leaving the
+  row itself untouched.
 
 ### Pools
 

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -946,6 +946,22 @@ deletes those delta and withdrawal-witness rows and refreshes
 no stale logical withdrawal row and deterministically applies the subtraction
 again.
 
+API-mode Mithril historical metadata backfill (`historicalBackfill`) replays
+already-ledger-validated canonical withdrawals from before the imported
+snapshot, so it skips both the era-neutral upper-bound check and the
+`account.reward` debit -- the imported snapshot balance already reflects every
+credit and debit through the snapshot's boundary, and re-subtracting a
+pre-boundary withdrawal from it would double-count. The withdrawal is still
+required to resolve an `account` row for the credential during live ingestion;
+during historical backfill it is not, because a withdrawal that was valid on
+the canonical chain can have a stake credential that is absent from the
+imported snapshot's active accounts entirely (deregistered, or never active,
+before the snapshot was taken -- issue #3788). In that case the backfill
+records the `account_reward_delta` row with `previous_reward = 0` from the
+credential alone and neither creates nor reactivates an `account` row: the
+journal's join to `account` is already unenforced (see above), so the history
+is retained without fabricating current stake-registration state.
+
 ### Pools
 
 | Table | Columns | Keys / indexes | Relationships and notes |

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -239,20 +239,41 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 
 // TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount covers issue
 // #3788: a canonical withdrawal replayed during API-mode Mithril historical
-// backfill can name a stake credential that is absent from the imported
-// snapshot's active `account` rows entirely -- deregistered before the
-// snapshot was taken, or never active in it. Live ingestion must still
-// require an active account (`SetTransaction`, `historicalBackfill=false`);
-// historical backfill must record the withdrawal without fabricating or
-// reactivating a current stake-registration account.
+// backfill can name a stake credential with no *active* account row for two
+// distinct reasons, which must not be treated alike:
+//
+//   - No account row exists at all (deregistered before the imported
+//     snapshot, or never active in it). There is no real prior balance to
+//     record, so the journal's previous_reward is the unknown-value 0.
+//   - A row exists but is inactive. applyTransactionCertificates runs
+//     unconditionally (not gated on historicalBackfill), so backfill's own
+//     certificate replay can transiently deactivate a row Mithril imported
+//     active between a historical deregistration and a later
+//     re-registration certificate for the same credential -- and
+//     deregistration's account upsert never clears `reward`. The real
+//     reward must still be journaled, not discarded as 0, and the row must
+//     be neither mutated nor reactivated.
+//
+// Live ingestion must still require an active account (`SetTransaction`,
+// historicalBackfill=false) in both cases.
 func TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name           string
-		createInactive bool
+		name               string
+		createInactive     bool
+		inactiveReward     uint64
+		wantPreviousReward string
 	}{
-		{name: "no account row at all"},
-		{name: "account row present but inactive", createInactive: true},
+		{
+			name:               "no account row at all",
+			wantPreviousReward: "0",
+		},
+		{
+			name:               "account row present but inactive with a real balance",
+			createInactive:     true,
+			inactiveReward:     777,
+			wantPreviousReward: "777",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -261,7 +282,7 @@ func TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount(t *testing.T) 
 			if tc.createInactive {
 				require.NoError(t, store.CreateAccount(nil, &models.Account{
 					StakingKey: stakeKey,
-					Reward:     0,
+					Reward:     types.Uint64(tc.inactiveReward),
 					Active:     false,
 				}))
 			}
@@ -316,7 +337,7 @@ func TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount(t *testing.T) 
 			if tc.createInactive {
 				require.NotNil(t, account)
 				require.False(t, account.Active)
-				require.Zero(t, uint64(account.Reward))
+				require.Equal(t, tc.inactiveReward, uint64(account.Reward))
 			} else {
 				require.Nil(t, account)
 			}
@@ -328,7 +349,7 @@ func TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount(t *testing.T) 
 				backfillHash.Bytes(),
 			).Scan(&deltas, &previousReward))
 			require.Equal(t, 1, deltas)
-			require.Equal(t, "0", previousReward)
+			require.Equal(t, tc.wantPreviousReward, previousReward)
 
 			// Replaying the same backfill transaction must not duplicate the
 			// journal row.

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -237,6 +237,120 @@ func TestSharedSQLStoreWithdrawalRejectsExcessiveBalance(t *testing.T) {
 	require.Equal(t, 1, deltas)
 }
 
+// TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount covers issue
+// #3788: a canonical withdrawal replayed during API-mode Mithril historical
+// backfill can name a stake credential that is absent from the imported
+// snapshot's active `account` rows entirely -- deregistered before the
+// snapshot was taken, or never active in it. Live ingestion must still
+// require an active account (`SetTransaction`, `historicalBackfill=false`);
+// historical backfill must record the withdrawal without fabricating or
+// reactivating a current stake-registration account.
+func TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		createInactive bool
+	}{
+		{name: "no account row at all"},
+		{name: "account row present but inactive", createInactive: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store, raw := newSharedSQLStore(t)
+			stakeKey := bytes.Repeat([]byte{0xa1}, lcommon.AddressHashSize)
+			if tc.createInactive {
+				require.NoError(t, store.CreateAccount(nil, &models.Account{
+					StakingKey: stakeKey,
+					Reward:     0,
+					Active:     false,
+				}))
+			}
+			address, err := lcommon.NewAddressFromParts(
+				lcommon.AddressTypeNoneKey,
+				lcommon.AddressNetworkTestnet,
+				nil,
+				stakeKey,
+			)
+			require.NoError(t, err)
+
+			// Live ingestion of the same withdrawal must still fail: an
+			// active account is required outside historical backfill.
+			liveHash := lcommon.Blake2b256{0xa2}
+			liveTx := &mockTransaction{
+				hash:        liveHash,
+				isValid:     true,
+				withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(500)},
+			}
+			err = store.SetTransaction(
+				liveTx,
+				ocommon.Point{Slot: 50, Hash: bytes.Repeat([]byte{0xa3}, 32)},
+				0,
+				nil,
+				true,
+				nil,
+			)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "account not found")
+
+			// Historical backfill of the same shape must succeed, record the
+			// withdrawal, and neither create nor reactivate an account row.
+			backfillHash := lcommon.Blake2b256{0xa4}
+			backfillTx := &mockTransaction{
+				hash:        backfillHash,
+				isValid:     true,
+				withdrawals: map[*lcommon.Address]*big.Int{&address: big.NewInt(500)},
+			}
+			require.NoError(t, store.SetTransactionBatchedHistorical(
+				backfillTx,
+				ocommon.Point{Slot: 51, Hash: bytes.Repeat([]byte{0xa5}, 32)},
+				0,
+				nil,
+				true,
+				true,
+				store.NewBatchAccumulator(),
+				nil,
+			))
+
+			account, err := store.GetAccountByCredential(0, stakeKey, true, nil)
+			require.NoError(t, err)
+			if tc.createInactive {
+				require.NotNil(t, account)
+				require.False(t, account.Active)
+				require.Zero(t, uint64(account.Reward))
+			} else {
+				require.Nil(t, account)
+			}
+
+			var deltas int
+			var previousReward string
+			require.NoError(t, raw.QueryRow(
+				"SELECT COUNT(*), previous_reward FROM account_reward_delta WHERE tx_hash = ?",
+				backfillHash.Bytes(),
+			).Scan(&deltas, &previousReward))
+			require.Equal(t, 1, deltas)
+			require.Equal(t, "0", previousReward)
+
+			// Replaying the same backfill transaction must not duplicate the
+			// journal row.
+			require.NoError(t, store.SetTransactionBatchedHistorical(
+				backfillTx,
+				ocommon.Point{Slot: 51, Hash: bytes.Repeat([]byte{0xa5}, 32)},
+				0,
+				nil,
+				true,
+				true,
+				store.NewBatchAccumulator(),
+				nil,
+			))
+			require.NoError(t, raw.QueryRow(
+				"SELECT COUNT(*) FROM account_reward_delta WHERE tx_hash = ?",
+				backfillHash.Bytes(),
+			).Scan(&deltas))
+			require.Equal(t, 1, deltas)
+		})
+	}
+}
+
 func TestSharedSQLStoreWithdrawalCredentialTagsRemainDistinct(t *testing.T) {
 	t.Parallel()
 	store, _ := newSharedSQLStore(t)

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -911,17 +912,36 @@ WHERE credential_tag = ? AND staking_key = ? AND active = TRUE`,
 			// merely-inactive row can still hold the credential's real
 			// balance; only fall back to an unknown (zero) previous balance
 			// when no row exists at all, rather than discarding a real one.
+			var fallbackActive sql.NullBool
 			err = db.QueryRowContext(ctx, `
-SELECT id, reward FROM account
+SELECT id, reward, active FROM account
 WHERE credential_tag = ? AND staking_key = ?`,
 				tag,
 				stakeKey.Bytes(),
-			).Scan(&accountID, &reward)
+			).Scan(&accountID, &reward, &fallbackActive)
+			rowExists := true
 			if errors.Is(err, sql.ErrNoRows) {
+				rowExists = false
 				reward = sql.NullString{}
 			} else if err != nil {
 				return err
 			}
+			// TEMPORARY DIAGNOSTIC for issue #3788: distinguish "no account
+			// row exists at all" from "a row exists but is inactive" at the
+			// exact moment a historical-backfill withdrawal can't resolve an
+			// active account. Remove once the real cause is confirmed.
+			s.logger.Warn(
+				"historical backfill withdrawal found no active account",
+				"component", "backfill",
+				"credential_tag", tag,
+				"staking_key", hex.EncodeToString(stakeKey.Bytes()),
+				"tx_hash", hex.EncodeToString(txHash),
+				"slot", slot,
+				"amount", amount.String(),
+				"account_row_exists", rowExists,
+				"account_active", fallbackActive.Bool,
+				"account_reward", reward.String,
+			)
 		} else if err != nil {
 			return err
 		}

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -897,13 +897,31 @@ WHERE credential_tag = ? AND staking_key = ? AND active = TRUE`,
 			if !historicalBackfill {
 				return models.ErrAccountNotFound
 			}
-			// Historical API backfill can replay a withdrawal whose stake
-			// credential was valid on the canonical chain at the time but is
-			// absent from the imported Mithril snapshot's active accounts
-			// (e.g. deregistered before the snapshot was taken). Record the
-			// withdrawal history without fabricating or reactivating a
-			// current stake-registration account.
 			accountFound = false
+			// Historical API backfill can replay a withdrawal whose stake
+			// credential has no *active* account row for one of two reasons:
+			// no account row exists at all (deregistered before the imported
+			// Mithril snapshot, or never active in it -- issue #3788), or
+			// backfill's own certificate replay (applyTransactionCertificates
+			// runs unconditionally, historicalBackfill or not) has
+			// temporarily deactivated a row Mithril imported active, between
+			// a historical deregistration certificate and a later
+			// re-registration certificate for the same credential.
+			// Deregistration's account upsert never clears `reward`, so a
+			// merely-inactive row can still hold the credential's real
+			// balance; only fall back to an unknown (zero) previous balance
+			// when no row exists at all, rather than discarding a real one.
+			err = db.QueryRowContext(ctx, `
+SELECT id, reward FROM account
+WHERE credential_tag = ? AND staking_key = ?`,
+				tag,
+				stakeKey.Bytes(),
+			).Scan(&accountID, &reward)
+			if errors.Is(err, sql.ErrNoRows) {
+				reward = sql.NullString{}
+			} else if err != nil {
+				return err
+			}
 		} else if err != nil {
 			return err
 		}

--- a/database/plugin/metadata/sqlstore/transaction_write.go
+++ b/database/plugin/metadata/sqlstore/transaction_write.go
@@ -892,10 +892,19 @@ WHERE credential_tag = ? AND staking_key = ? AND active = TRUE`,
 			tag,
 			stakeKey.Bytes(),
 		).Scan(&accountID, &reward)
+		accountFound := true
 		if errors.Is(err, sql.ErrNoRows) {
-			return models.ErrAccountNotFound
-		}
-		if err != nil {
+			if !historicalBackfill {
+				return models.ErrAccountNotFound
+			}
+			// Historical API backfill can replay a withdrawal whose stake
+			// credential was valid on the canonical chain at the time but is
+			// absent from the imported Mithril snapshot's active accounts
+			// (e.g. deregistered before the snapshot was taken). Record the
+			// withdrawal history without fabricating or reactivating a
+			// current stake-registration account.
+			accountFound = false
+		} else if err != nil {
 			return err
 		}
 		var exists bool
@@ -932,7 +941,11 @@ SELECT EXISTS (
 		// Historical API backfill replays withdrawals before the imported
 		// snapshot balance's intervening credits are available. Record the
 		// withdrawal history, but leave that trusted boundary balance untouched.
-		if !historicalBackfill {
+		// accountFound is guaranteed true here whenever historicalBackfill is
+		// false (the account lookup above returns early otherwise); the extra
+		// check keeps this update from ever reactivating or fabricating a
+		// current stake-registration account.
+		if !historicalBackfill && accountFound {
 			rewardAfter := previous - amount.Uint64()
 			if _, err := db.ExecContext(ctx, `
 UPDATE account SET reward = ? WHERE id = ?`,


### PR DESCRIPTION
## Summary

`applyTransactionWithdrawals` required an active `account` row for every
withdrawal's stake credential, including API-mode Mithril historical backfill.
A canonical withdrawal replayed from before the imported snapshot can name a
credential that is absent or inactive at the snapshot boundary, aborting the
backfill with `account not found`.

Historical backfill now records the `account_reward_delta` journal row instead
of failing when the credential has no active account, without creating or
reactivating an `account` row. Live ingestion (`historicalBackfill = false`)
still requires an active account.

The two historical cases remain distinct:

- No account row exists: journal `previous_reward = 0`.
- An inactive row exists: preserve its real reward as `previous_reward`.

Fixes #3788

## Validation

- Rebased onto current `origin/main` and preserved the existing branch history
  with a merge commit.
- `go test ./database/plugin/metadata/sqlite -run '^TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount$' -count=1`
- `go test -race ./database/plugin/metadata/sqlite -run '^TestSharedSQLStoreHistoricalBackfillWithdrawalMissingAccount$' -count=1`
- `go test ./database/plugin/metadata/sqlstore` passed.

The full metadata-store race suite reached its existing ten-minute test timeout
in the large committee-pruning scale test; the focused regression passed under
the race detector.

## Documentation

`DATABASE.md` documents the historical-backfill withdrawal cases and their
journal behavior.
