### PR TITLE
build(deps): adopt gouroboros v0.204.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.203.0
+	github.com/blinklabs-io/gouroboros v0.204.0
 	github.com/blinklabs-io/ouroboros-mock v0.19.0
 	github.com/blinklabs-io/plutigo v0.5.1
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.202.10
+	github.com/blinklabs-io/gouroboros v0.203.0
 	github.com/blinklabs-io/ouroboros-mock v0.19.0
 	github.com/blinklabs-io/plutigo v0.5.1
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuv
 github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/gouroboros v0.203.0 h1:FtrHjFjvHZZM3Mc56hzDntRGpn6J6M0RI2sOKvEnIII=
 github.com/blinklabs-io/gouroboros v0.203.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
+github.com/blinklabs-io/gouroboros v0.204.0 h1:z3N2A+4UqERe5A8Okw5m650GKNOQkrZjzAYmUZIFyvQ=
+github.com/blinklabs-io/gouroboros v0.204.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/blinklabs-io/gouroboros v0.202.9 h1:eAR655rEVT2zdL7ogdBi+LKzIVpk/Qi6L
 github.com/blinklabs-io/gouroboros v0.202.9/go.mod h1:W7P6EkHff/4rbEPdtJVcjxvlbDFfbXWTUGoZqoioh4g=
 github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuvdoc0pqvC35s=
 github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
+github.com/blinklabs-io/gouroboros v0.203.0 h1:FtrHjFjvHZZM3Mc56hzDntRGpn6J6M0RI2sOKvEnIII=
+github.com/blinklabs-io/gouroboros v0.203.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.18.0 h1:m7f7jUhkxp6NlVF86BLxGDNaATjbhQXcWIFqJ4HFyh8=
 github.com/blinklabs-io/ouroboros-mock v0.18.0/go.mod h1:6YjKLLIaSTSrl8RJTg584f+W5NwniLNn/GHja2ijic0=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -127,7 +127,7 @@ func (ls *LedgerState) querySystemStart() (any, error) {
 		int64(utc.Nanosecond())*1000
 	ret := olocalstatequery.SystemStartResult{
 		Year:        *big.NewInt(int64(utc.Year())),
-		Day:         utc.YearDay(),
+		Day:         int64(utc.YearDay()),
 		Picoseconds: *big.NewInt(dayPicoseconds),
 	}
 	return ret, nil


### PR DESCRIPTION
Consume released Gouroboros v0.204.0, including the withdrawal-account security fix. Adapt the system-start query to the updated int64 API. Focused ledger and ledger/leader tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts `gouroboros` v0.204.0, which includes the withdrawal-account security fix, and updates the system-start query for the new int64 API.

- `SystemStartResult.Day` is now `int64`.
- Focused ledger and ledger/leader tests pass.

<sup>Written for commit 3c90a74e220d4f3abc6613eea1ad5cdc221f3798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

