### PR TITLE
fix(chainsync): stop a late header callback recreating observed history

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -856,6 +856,18 @@ func (s *State) RecordObservedHeader(h ObservedHeader) {
 		return
 	}
 
+	// A raw header callback can still be in flight when the connection is
+	// removed. RemoveClientConnId deletes the tracked client and clears this
+	// history under clientConnIdMutex, so the tracked check is held across
+	// the observed-header write in the same order: a late callback for a
+	// connection that is gone would otherwise recreate an entry that nothing
+	// removes again, leaking one per disconnect.
+	s.clientConnIdMutex.RLock()
+	defer s.clientConnIdMutex.RUnlock()
+	if _, tracked := s.trackedClients[h.ConnectionId]; !tracked {
+		return
+	}
+
 	s.observedHeadersMutex.Lock()
 	defer s.observedHeadersMutex.Unlock()
 

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -1645,6 +1645,9 @@ func TestObservedHeaderLimitFollowsSelectionState(t *testing.T) {
 	}
 	s := newTestState(t, newTestEventBus(t), cfg)
 	conn := newTestConnId(43)
+	// Observed headers are recorded only for a tracked client, as production
+	// does; an untracked connection is the post-disconnect case.
+	require.True(t, s.AddClientConnId(conn))
 
 	var (
 		prevHash  []byte
@@ -1863,4 +1866,52 @@ func gaugeValueForLabels(
 		}
 	}
 	return 0, false
+}
+
+// A raw header callback still in flight when the connection is removed must
+// not recreate the observed-header history. RemoveClientConnId is the only
+// thing that clears it, so an entry created after that runs is never removed
+// again and leaks one per disconnect.
+func TestObservedHeader_LateCallbackDoesNotResurrectHistory(t *testing.T) {
+	bus := newTestEventBus(t)
+	s := newTestState(t, bus, chainsync.DefaultConfig())
+
+	conn := newTestConnId(7)
+	require.True(t, s.AddClientConnId(conn))
+
+	hash := []byte("late-hash")
+	prev := []byte("late-prev")
+	point := ocommon.NewPoint(300, hash)
+	observed := chainsync.ObservedHeader{
+		ConnectionId: conn,
+		BlockHeader: testBlockHeader{
+			hash:        lcommon.NewBlake2b256(hash),
+			prevHash:    lcommon.NewBlake2b256(prev),
+			blockNumber: 9,
+			slot:        300,
+		},
+		Point:       point,
+		Tip:         ochainsync.Tip{Point: point, BlockNumber: 9},
+		ArrivalTime: time.Now(),
+		BlockNumber: 9,
+		Type:        1,
+	}
+
+	// Recording while tracked is the control.
+	s.RecordObservedHeader(observed)
+	_, _, ok := s.LookupObservedHeader(conn, hash)
+	require.True(t, ok, "a tracked connection must record its headers")
+
+	s.RemoveClientConnId(conn)
+	_, _, ok = s.LookupObservedHeader(conn, hash)
+	require.False(t, ok, "disconnect must clear the observed history")
+
+	// The in-flight callback lands after cleanup.
+	s.RecordObservedHeader(observed)
+	_, _, ok = s.LookupObservedHeader(conn, hash)
+	require.False(
+		t,
+		ok,
+		"a late callback must not recreate observed history after disconnect",
+	)
 }


### PR DESCRIPTION
`State.RecordObservedHeader` created the per-connection observed-header history unconditionally:

```go
chainHistory := s.observedHeaders[h.ConnectionId]
if chainHistory == nil {
    chainHistory = &observedHeaderChain{...}
    s.observedHeaders[h.ConnectionId] = chainHistory
}
```

A raw header callback still in flight when the connection is removed recreated that entry after `RemoveClientConnId` had cleared it. The client is no longer tracked at that point, so nothing clears it again: one entry leaks per disconnect, and peer churn drives the count. Each entry is capped at the per-connection header limit; the number of entries was not.

The tracked-client check is now held across the observed-header write, in the same lock order `RemoveClientConnId` uses, so a late callback for a removed connection records nothing. `RecordBlockfetchLatency` already refuses an untracked connection this way.

`TestObservedHeaderLimitFollowsSelectionState` recorded against a connection it never tracked, which production does not do. It now tracks the client it records for.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak where a late header callback recreated the per-connection observed-header history after disconnect, leaving one entry that nothing ever cleared.

- Holds the tracked-client check across the observed-header write, matching `RemoveClientConnId`'s lock order, so late callbacks record nothing.
- Fixes `TestObservedHeaderLimitFollowsSelectionState` to track the client it records for, matching production behavior.

<sup>Written for commit f96b60233e2f6527b6d8d12ea45c683c060411b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where late connection callbacks could recreate cleared connection history after disconnecting.
  - Prevented stale observed-header data from accumulating after a connection is removed.

- **Tests**
  - Added coverage to verify that late callbacks do not restore removed connection history.
  - Updated header-limit testing to use a registered connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->