### PR TITLE
fix(ledger): fall back to the current DRep deposit when none is recorded

### DIFF
--- a/ledger/drep_deposit_unknown_fallback_test.go
+++ b/ledger/drep_deposit_unknown_fallback_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/require"
@@ -249,14 +250,33 @@ func TestDrepRegistrationsFallBackForUnrecordedDeposit(t *testing.T) {
 	require.Equal(t, uint64(drepRefundTestRecordedDeposit), *got)
 }
 
-// TestDrepRegistrationReportsAbsenceWithoutADrepDeposit keeps the fallback
-// from inventing a refund where the current era charges no DRep deposit. The
-// view must still report absence there and let gouroboros fail closed rather
-// than accept a zero refund.
-func TestDrepRegistrationReportsAbsenceWithoutADrepDeposit(t *testing.T) {
-	// newStakeRefundTestView leaves the era Shelley with no published
-	// snapshot, which is exactly the no-DRep-deposit case.
-	lv, db := newStakeRefundTestView(t)
+// TestDrepRegistrationReportsAbsenceInAPreConwayEra keeps the fallback from
+// inventing a refund where the current era charges no DRep deposit.
+//
+// The era has to be published for this to mean anything. CertDepositShelley
+// through CertDepositBabbage have no *RegistrationDrepCertificate case and
+// fall through to "default: return 0, nil", so before the drepDepositParams
+// guard this reported a non-nil zero and gouroboros accepted a zero refund
+// instead of failing closed.
+func TestDrepRegistrationReportsAbsenceInAPreConwayEra(t *testing.T) {
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.currentEra = eras.BabbageEraDesc
+	ls.currentPParams = &babbage.BabbageProtocolParameters{
+		KeyDeposit: 2_000_000,
+		MaxTxSize:  16_384,
+	}
+	ls.publishSnapshotsLocked()
+	lv := &LedgerView{ls: ls}
+	// The era's own deposit function really does answer zero-without-error
+	// for a DRep registration, which is what makes the guard load-bearing
+	// rather than defensive.
+	deposit, err := eras.BabbageEraDesc.CertDepositFunc(
+		&lcommon.RegistrationDrepCertificate{},
+		ls.currentPParams,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), deposit)
+
 	cred := drepRefundTestCredential(0xe7)
 	seedActiveDrepWithoutRegistration(t, db, cred, 100)
 
@@ -266,8 +286,49 @@ func TestDrepRegistrationReportsAbsenceWithoutADrepDeposit(t *testing.T) {
 	require.Nil(
 		t,
 		reg.Deposit,
-		"with no DRep deposit to fall back to, absence must be reported",
+		"a pre-Conway era has no DRep deposit to fall back to; absence must be reported",
 	)
+
+	registrations, err := lv.DRepRegistrations()
+	require.NoError(t, err)
+	require.Len(t, registrations, 1)
+	require.Nil(
+		t,
+		registrations[0].Deposit,
+		"the plural view must report absence in a pre-Conway era too",
+	)
+
+	require.ErrorContains(
+		t,
+		conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, drepRefundTestPparamDeposit),
+			200,
+			lv,
+			drepRefundTestPparams(),
+		),
+		inconsistentDepositSubstring,
+	)
+}
+
+// TestDrepRegistrationReportsAbsenceWithoutAPublishedSnapshot covers the other
+// way the fallback has nothing to report: no consensus snapshot has been
+// published yet, so there are no current parameters to read. Kept separate
+// from the pre-Conway case because newStakeRefundTestView reaches this branch
+// and never the era one -- the era field it sets is never read.
+func TestDrepRegistrationReportsAbsenceWithoutAPublishedSnapshot(t *testing.T) {
+	lv, db := newStakeRefundTestView(t)
+	require.Nil(
+		t,
+		lv.ls.loadConsensusSnapshot(),
+		"this fixture must leave the snapshot unpublished for this test to mean what it says",
+	)
+	cred := drepRefundTestCredential(0xe8)
+	seedActiveDrepWithoutRegistration(t, db, cred, 100)
+
+	reg, err := lv.DRepRegistration(cred.Credential)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.Nil(t, reg.Deposit)
 
 	require.ErrorContains(
 		t,

--- a/ledger/drep_deposit_unknown_fallback_test.go
+++ b/ledger/drep_deposit_unknown_fallback_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+// inconsistentDepositSubstring is the message
+// conway.DRepDepositStateInconsistentError renders when a registration
+// reports no recorded deposit. Matched on the message rather than on a rule
+// index, which moves whenever gouroboros inserts or reorders a rule.
+const inconsistentDepositSubstring = "registered DRep credential has no recorded deposit"
+
+// newDrepFallbackTestView returns a *LedgerView whose published consensus
+// snapshot is Conway with drepRefundTestPparams, so the unknown-deposit
+// fallback resolves through the same era certificate-deposit function the
+// certificate write path uses. newStakeRefundTestView leaves the snapshot
+// unpublished and the era Shelley, which is the "current era charges no DRep
+// deposit" case rather than this one.
+func newDrepFallbackTestView(
+	t *testing.T,
+) (*LedgerView, *database.Database) {
+	t.Helper()
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.currentEra = eras.ConwayEraDesc
+	ls.currentPParams = drepRefundTestPparams()
+	ls.publishSnapshotsLocked()
+	return &LedgerView{ls: ls}, db
+}
+
+// seedActiveDrepWithoutRegistration reproduces the state the vote-replay
+// recovery path leaves behind. ledger/governance/processing.go calls
+// InsertDrepIfAbsent when a valid DRep vote proves the credential exists
+// on-chain but the metadata row was lost during recovery or bootstrap; that
+// writes an active drep row and no registration_drep row at all, so the
+// credential is registered with no recorded deposit.
+func seedActiveDrepWithoutRegistration(
+	t *testing.T,
+	db *database.Database,
+	cred lcommon.Credential,
+	slot uint64,
+) {
+	t.Helper()
+	tag, err := models.CredentialTagFromUint(uint(cred.CredType))
+	require.NoError(t, err)
+	require.NoError(t, db.InsertDrepIfAbsent(
+		tag,
+		cred.Credential[:],
+		slot,
+		"",
+		nil,
+		true,
+		nil,
+	))
+	// The recovery path really does leave no registration row behind; if it
+	// ever starts writing one this test is measuring the wrong thing.
+	recorded, err := db.GetDrepLastRegistrationDeposit(
+		tag,
+		cred.Credential[:],
+		nil,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t,
+		recorded,
+		"the recovery path must leave no recorded deposit for this test to exercise the fallback",
+	)
+}
+
+// TestDrepDeregistrationFallsBackToCurrentDepositWhenUnrecorded is the
+// regression test. An active DRep with no registration_drep row reported
+// Deposit == nil, and gouroboros fails closed on that
+// (DRepDepositStateInconsistentError), so the deregistration was rejected and
+// a node reaching that block stopped making progress. The refund is now
+// judged against the DRep deposit the current protocol parameters charge,
+// which is what the certificate write path would have recorded.
+func TestDrepDeregistrationFallsBackToCurrentDepositWhenUnrecorded(
+	t *testing.T,
+) {
+	lv, db := newDrepFallbackTestView(t)
+	cred := drepRefundTestCredential(0xe1)
+	seedActiveDrepWithoutRegistration(t, db, cred, 100)
+
+	pp := drepRefundTestPparams()
+	tx := drepDeregistrationTx(cred, drepRefundTestPparamDeposit)
+	// The rule is invoked directly so a nil error means the refund
+	// comparison actually ran and matched, rather than that the substring
+	// was absent because an unrelated rule failed first.
+	require.NoError(
+		t,
+		conway.UtxoValidateCertificateDeposits(tx, 200, lv, pp),
+	)
+	if err := eras.ValidateTxConway(tx, 200, lv, pp); err != nil {
+		require.NotContains(t, err.Error(), inconsistentDepositSubstring)
+		require.NotContains(t, err.Error(), incorrectRefundSubstring)
+	}
+
+	// Supporting evidence for why the acceptance holds.
+	reg, err := lv.DRepRegistration(cred.Credential)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.NotNil(
+		t,
+		reg.Deposit,
+		"an unrecorded deposit must be reported as the current parameter, not as absence",
+	)
+	require.Equal(t, uint64(drepRefundTestPparamDeposit), *reg.Deposit)
+}
+
+// TestDrepDeregistrationRejectsWrongRefundWhenUnrecorded is the mandatory
+// negative case: the fallback must not become a licence to accept any refund.
+// A deregistration over the same unrecorded registration that supplies a
+// different amount is still rejected, including the zero the absence would
+// have been misread as.
+func TestDrepDeregistrationRejectsWrongRefundWhenUnrecorded(t *testing.T) {
+	lv, db := newDrepFallbackTestView(t)
+	cred := drepRefundTestCredential(0xe2)
+	seedActiveDrepWithoutRegistration(t, db, cred, 100)
+
+	pp := drepRefundTestPparams()
+	for _, refund := range []int64{0, drepRefundTestPparamDeposit + 1, -1} {
+		err := conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, refund),
+			200,
+			lv,
+			pp,
+		)
+		require.ErrorContains(t, err, incorrectRefundSubstring)
+	}
+}
+
+// TestDrepDeregistrationPrefersRecordedDepositOverFallback is the second
+// mandatory negative case. The recorded deposit and the current parameter are
+// deliberately different values, so the two possible answers give opposite
+// outcomes and the test cannot pass by accident: a recorded deposit must win,
+// and the fallback must not be reached.
+func TestDrepDeregistrationPrefersRecordedDepositOverFallback(t *testing.T) {
+	lv, db := newDrepFallbackTestView(t)
+	cred := drepRefundTestCredential(0xe3)
+	require.NotEqual(
+		t,
+		uint64(drepRefundTestPparamDeposit),
+		uint64(drepRefundTestRecordedDeposit),
+		"the recorded deposit must differ from the parameter to discriminate",
+	)
+	seedImportedDrep(t, db, cred, drepRefundTestRecordedDeposit, 100, true)
+
+	pp := drepRefundTestPparams()
+	require.NoError(t, conway.UtxoValidateCertificateDeposits(
+		drepDeregistrationTx(cred, drepRefundTestRecordedDeposit),
+		200,
+		lv,
+		pp,
+	))
+	require.ErrorContains(
+		t,
+		conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, drepRefundTestPparamDeposit),
+			200,
+			lv,
+			pp,
+		),
+		incorrectRefundSubstring,
+	)
+}
+
+// TestDrepDeregistrationKeepsRecordedZeroAuthoritative pins the distinction
+// the fallback must preserve. A zero dRepDeposit is a legitimate
+// configuration, so a recorded zero is a real value: folding it into the
+// unrecorded case would refund the current parameter and reject a valid
+// deregistration.
+func TestDrepDeregistrationKeepsRecordedZeroAuthoritative(t *testing.T) {
+	lv, db := newDrepFallbackTestView(t)
+	cred := drepRefundTestCredential(0xe4)
+	seedImportedDrep(t, db, cred, 0, 100, true)
+
+	reg, err := lv.DRepRegistration(cred.Credential)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.NotNil(
+		t,
+		reg.Deposit,
+		"a recorded zero must stay a value, not become absence",
+	)
+	require.Equal(t, uint64(0), *reg.Deposit)
+
+	pp := drepRefundTestPparams()
+	require.NoError(t, conway.UtxoValidateCertificateDeposits(
+		drepDeregistrationTx(cred, 0),
+		200,
+		lv,
+		pp,
+	))
+	require.ErrorContains(
+		t,
+		conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, drepRefundTestPparamDeposit),
+			200,
+			lv,
+			pp,
+		),
+		incorrectRefundSubstring,
+	)
+}
+
+// TestDrepRegistrationsFallBackForUnrecordedDeposit covers the plural view,
+// which builds its deposits from a batched map lookup and so has its own
+// absence path.
+func TestDrepRegistrationsFallBackForUnrecordedDeposit(t *testing.T) {
+	lv, db := newDrepFallbackTestView(t)
+	unrecorded := drepRefundTestCredential(0xe5)
+	recorded := drepRefundTestCredential(0xe6)
+	seedActiveDrepWithoutRegistration(t, db, unrecorded, 100)
+	seedImportedDrep(t, db, recorded, drepRefundTestRecordedDeposit, 101, true)
+
+	registrations, err := lv.DRepRegistrations()
+	require.NoError(t, err)
+	byCredential := map[string]*uint64{}
+	for _, reg := range registrations {
+		byCredential[string(reg.Credential[:])] = reg.Deposit
+	}
+
+	got := byCredential[string(unrecorded.Credential[:])]
+	require.NotNil(t, got, "the plural view must not report absence either")
+	require.Equal(t, uint64(drepRefundTestPparamDeposit), *got)
+
+	got = byCredential[string(recorded.Credential[:])]
+	require.NotNil(t, got)
+	require.Equal(t, uint64(drepRefundTestRecordedDeposit), *got)
+}
+
+// TestDrepRegistrationReportsAbsenceWithoutADrepDeposit keeps the fallback
+// from inventing a refund where the current era charges no DRep deposit. The
+// view must still report absence there and let gouroboros fail closed rather
+// than accept a zero refund.
+func TestDrepRegistrationReportsAbsenceWithoutADrepDeposit(t *testing.T) {
+	// newStakeRefundTestView leaves the era Shelley with no published
+	// snapshot, which is exactly the no-DRep-deposit case.
+	lv, db := newStakeRefundTestView(t)
+	cred := drepRefundTestCredential(0xe7)
+	seedActiveDrepWithoutRegistration(t, db, cred, 100)
+
+	reg, err := lv.DRepRegistration(cred.Credential)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.Nil(
+		t,
+		reg.Deposit,
+		"with no DRep deposit to fall back to, absence must be reported",
+	)
+
+	require.ErrorContains(
+		t,
+		conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, drepRefundTestPparamDeposit),
+			200,
+			lv,
+			drepRefundTestPparams(),
+		),
+		inconsistentDepositSubstring,
+	)
+}

--- a/ledger/drep_deposit_unknown_fallback_test.go
+++ b/ledger/drep_deposit_unknown_fallback_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -329,6 +330,67 @@ func TestDrepRegistrationReportsAbsenceWithoutAPublishedSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, reg)
 	require.Nil(t, reg.Deposit)
+
+	require.ErrorContains(
+		t,
+		conway.UtxoValidateCertificateDeposits(
+			drepDeregistrationTx(cred, drepRefundTestPparamDeposit),
+			200,
+			lv,
+			drepRefundTestPparams(),
+		),
+		inconsistentDepositSubstring,
+	)
+}
+
+// TestDrepRegistrationReportsAbsenceForTypedNilParams covers the other way the
+// capability assertion can be satisfied without a usable deposit behind it.
+//
+// A typed-nil *DijkstraProtocolParameters implements drepDepositParams, so the
+// call-site guard admits it; CertDepositDijkstra then asserted the type
+// successfully and dereferenced nil, panicking inside DRep view construction.
+// It now reports ErrIncompatibleProtocolParams, which currentDRepDeposit turns
+// into absence, so gouroboros fails closed as it does for every other
+// no-deposit-available case.
+//
+// The two guards are complementary and both are asserted here: the era helper
+// is what stops the panic, and the call-site capability check is what keeps a
+// pre-Conway era from reaching it at all.
+func TestDrepRegistrationReportsAbsenceForTypedNilParams(t *testing.T) {
+	ls, db := newRewardCalculationTestLedger(t)
+	ls.currentEra = eras.DijkstraEraDesc
+	ls.currentPParams = (*dijkstra.DijkstraProtocolParameters)(nil)
+	ls.publishSnapshotsLocked()
+	lv := &LedgerView{ls: ls}
+
+	// The typed nil really does satisfy the capability the call-site guard
+	// tests, so this case reaches the era helper rather than stopping early.
+	_, implements := ls.currentPParams.(drepDepositParams)
+	require.True(
+		t,
+		implements,
+		"a typed-nil pointer must still satisfy drepDepositParams for this test to exercise the era helper",
+	)
+
+	cred := drepRefundTestCredential(0xe9)
+	seedActiveDrepWithoutRegistration(t, db, cred, 100)
+
+	require.NotPanics(t, func() {
+		reg, err := lv.DRepRegistration(cred.Credential)
+		require.NoError(t, err)
+		require.NotNil(t, reg)
+		require.Nil(
+			t,
+			reg.Deposit,
+			"unusable parameters must report absence, not a fabricated deposit",
+		)
+	})
+	require.NotPanics(t, func() {
+		registrations, err := lv.DRepRegistrations()
+		require.NoError(t, err)
+		require.Len(t, registrations, 1)
+		require.Nil(t, registrations[0].Deposit)
+	})
 
 	require.ErrorContains(
 		t,

--- a/ledger/eras/cert_deposit_typed_nil_test.go
+++ b/ledger/eras/cert_deposit_typed_nil_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eras
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCertDepositRejectsTypedNilParams pins the guard both Conway-era and
+// Dijkstra-era deposit functions need.
+//
+// A typed-nil parameter pointer satisfies the type assertion, so testing only
+// the ok result lets every case in the switch dereference nil. Conway has
+// always checked for it; Dijkstra checked only ok and panicked instead of
+// reporting incompatible parameters. Both are asserted here so the pair cannot
+// drift apart again.
+func TestCertDepositRejectsTypedNilParams(t *testing.T) {
+	certificates := map[string]lcommon.Certificate{
+		"drep registration":  &lcommon.RegistrationDrepCertificate{},
+		"pool registration":  &lcommon.PoolRegistrationCertificate{},
+		"stake registration": &lcommon.StakeRegistrationCertificate{},
+	}
+	eras := map[string]struct {
+		fn     func(lcommon.Certificate, lcommon.ProtocolParameters) (uint64, error)
+		params lcommon.ProtocolParameters
+	}{
+		"conway": {
+			fn:     CertDepositConway,
+			params: (*conway.ConwayProtocolParameters)(nil),
+		},
+		"dijkstra": {
+			fn:     CertDepositDijkstra,
+			params: (*gdijkstra.DijkstraProtocolParameters)(nil),
+		},
+	}
+	for eraName, era := range eras {
+		for certName, cert := range certificates {
+			t.Run(eraName+"/"+certName, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					deposit, err := era.fn(cert, era.params)
+					require.ErrorIs(t, err, ErrIncompatibleProtocolParams)
+					require.Zero(t, deposit)
+				})
+			})
+		}
+	}
+}

--- a/ledger/eras/dijkstra.go
+++ b/ledger/eras/dijkstra.go
@@ -203,7 +203,11 @@ func CertDepositDijkstra(
 	pp lcommon.ProtocolParameters,
 ) (uint64, error) {
 	tmpPparams, ok := pp.(*gdijkstra.DijkstraProtocolParameters)
-	if !ok {
+	// The nil check is part of the guard, not redundant with it: a typed-nil
+	// *DijkstraProtocolParameters satisfies the assertion, so testing only ok
+	// lets every case below dereference nil. CertDepositConway has always
+	// spelled it this way; this one had not.
+	if !ok || tmpPparams == nil {
 		return 0, ErrIncompatibleProtocolParams
 	}
 	switch cert.(type) {

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -1258,7 +1258,18 @@ func (lv *LedgerView) CommitteeMembers() ([]lcommon.CommitteeMember, error) {
 // so the value equals what a registration applied now would store. Absence is
 // still reported when the current era charges no DRep deposit, which leaves
 // gouroboros to fail closed rather than inventing a zero refund.
-func (lv *LedgerView) drepRegistrationDeposit(recorded *uint64) *uint64 {
+//
+// The substitution is logged because it is not free. The recorded deposit is
+// historical and this one is current, so the two agree only while dRepDeposit
+// has not changed since the DRep registered. If it has, gouroboros compares
+// the block's refund against the wrong expected value and reports
+// CertificateRefundIncorrectError, which reads as a bad block rather than as
+// the local state gap it actually is. The log line is what keeps that
+// distinguishable from a node serving a genuinely recorded deposit.
+func (lv *LedgerView) drepRegistrationDeposit(
+	credential lcommon.Blake2b224,
+	recorded *uint64,
+) *uint64 {
 	if recorded != nil {
 		return recorded
 	}
@@ -1266,18 +1277,42 @@ func (lv *LedgerView) drepRegistrationDeposit(recorded *uint64) *uint64 {
 	if !ok {
 		return nil
 	}
+	if lv.ls != nil && lv.ls.config.Logger != nil {
+		lv.ls.config.Logger.Warn(
+			"registered DRep has no recorded registration deposit; substituting the current protocol parameter",
+			"component", "ledger",
+			"drep_credential", hex.EncodeToString(credential[:]),
+			"substituted_deposit", deposit,
+		)
+	}
 	return &deposit
 }
 
 // currentDRepDeposit returns the DRep registration deposit under the current
 // era and protocol parameters, read from a single published consensus
 // snapshot so the era and the parameters cannot be torn apart. The second
-// return is false when the current era charges no DRep deposit (pre-Conway)
-// or the protocol parameters do not belong to that era.
+// return is false when there is no current DRep deposit to report.
+//
+// Whether the era carries a DRep deposit is decided by asking the protocol
+// parameters for one, not by inferring it from what the era's
+// certificate-deposit function happens to return. CertDepositShelley through
+// CertDepositBabbage have no *RegistrationDrepCertificate case and fall
+// through to "default: return 0, nil", so a pre-Conway snapshot would
+// otherwise yield (0, true) and hand gouroboros a fabricated zero refund
+// where it must fail closed instead.
+//
+// drepDepositParams is the same capability
+// conway.UtxoValidateCertificateDeposits asserts to obtain the deposit it
+// compares against, so this guard admits exactly the eras whose parameters
+// that rule can read, and a future era gains it by implementing the accessor
+// rather than by being added to a list here.
 func (lv *LedgerView) currentDRepDeposit() (uint64, bool) {
 	snapshot := lv.ls.loadConsensusSnapshot()
 	if snapshot == nil || snapshot.currentPParams == nil ||
 		snapshot.currentEra.CertDepositFunc == nil {
+		return 0, false
+	}
+	if _, ok := snapshot.currentPParams.(drepDepositParams); !ok {
 		return 0, false
 	}
 	deposit, err := snapshot.currentEra.CertDepositFunc(
@@ -1288,6 +1323,14 @@ func (lv *LedgerView) currentDRepDeposit() (uint64, bool) {
 		return 0, false
 	}
 	return deposit, true
+}
+
+// drepDepositParams is implemented by the protocol parameters of every era
+// that charges a DRep registration deposit. It mirrors the assertion
+// conway.UtxoValidateCertificateDeposits makes to read drepDeposit, so the
+// two agree on which eras have one.
+type drepDepositParams interface {
+	DRepDepositAmount() *big.Int
 }
 
 // DRepRegistration returns a DRep registration by credential.
@@ -1312,7 +1355,7 @@ func (lv *LedgerView) DRepRegistration(
 	}
 	reg := &lcommon.DRepRegistration{
 		Credential: credential,
-		Deposit:    lv.drepRegistrationDeposit(deposit),
+		Deposit:    lv.drepRegistrationDeposit(credential, deposit),
 	}
 	if drep.AnchorURL != "" || len(drep.AnchorHash) > 0 {
 		if len(drep.AnchorHash) != 32 {
@@ -1366,7 +1409,10 @@ func (lv *LedgerView) DRepRegistrations() ([]lcommon.DRepRegistration, error) {
 		}
 		reg := lcommon.DRepRegistration{
 			Credential: lcommon.NewBlake2b224(drep.Credential),
-			Deposit:    lv.drepRegistrationDeposit(depositPtr),
+			Deposit: lv.drepRegistrationDeposit(
+				lcommon.NewBlake2b224(drep.Credential),
+				depositPtr,
+			),
 		}
 		if drep.AnchorURL != "" || len(drep.AnchorHash) > 0 {
 			if len(drep.AnchorHash) != 32 {

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -1233,6 +1233,63 @@ func (lv *LedgerView) CommitteeMembers() ([]lcommon.CommitteeMember, error) {
 	return members, nil
 }
 
+// drepRegistrationDeposit resolves the deposit reported to gouroboros for a
+// DRep registration.
+//
+// A recorded deposit -- including a recorded zero -- is authoritative and is
+// passed through unchanged. When nothing is recorded, this reports the DRep
+// deposit under the current era and protocol parameters instead of the
+// absence.
+//
+// The absence is not a harmless nil. gouroboros fails closed on it: a
+// DeregistrationDrepCertificate against a registration with Deposit == nil
+// returns DRepDepositStateInconsistentError, so the block is rejected and a
+// node that reaches it stops making progress. The reference ledger's DRepState
+// carries a non-optional deposit, so a registration without one is a state
+// only this implementation can produce -- and it does: InsertDrepIfAbsent
+// (ledger/governance/processing.go, the vote-replay recovery path) writes an
+// active drep row and no registration_drep row at all when a valid DRep vote
+// proves a credential exists but the metadata row was lost. That DRep is
+// active, can be deregistered, and has no recorded deposit.
+//
+// Reporting the current parameter is the same answer the write path would have
+// recorded: it runs the era's certificate-deposit function over the same
+// registration certificate type that ledger.calculateCertificateDeposit does,
+// so the value equals what a registration applied now would store. Absence is
+// still reported when the current era charges no DRep deposit, which leaves
+// gouroboros to fail closed rather than inventing a zero refund.
+func (lv *LedgerView) drepRegistrationDeposit(recorded *uint64) *uint64 {
+	if recorded != nil {
+		return recorded
+	}
+	deposit, ok := lv.currentDRepDeposit()
+	if !ok {
+		return nil
+	}
+	return &deposit
+}
+
+// currentDRepDeposit returns the DRep registration deposit under the current
+// era and protocol parameters, read from a single published consensus
+// snapshot so the era and the parameters cannot be torn apart. The second
+// return is false when the current era charges no DRep deposit (pre-Conway)
+// or the protocol parameters do not belong to that era.
+func (lv *LedgerView) currentDRepDeposit() (uint64, bool) {
+	snapshot := lv.ls.loadConsensusSnapshot()
+	if snapshot == nil || snapshot.currentPParams == nil ||
+		snapshot.currentEra.CertDepositFunc == nil {
+		return 0, false
+	}
+	deposit, err := snapshot.currentEra.CertDepositFunc(
+		&lcommon.RegistrationDrepCertificate{},
+		snapshot.currentPParams,
+	)
+	if err != nil {
+		return 0, false
+	}
+	return deposit, true
+}
+
 // DRepRegistration returns a DRep registration by credential.
 // Returns nil if the credential is not registered as an active DRep.
 func (lv *LedgerView) DRepRegistration(
@@ -1255,7 +1312,7 @@ func (lv *LedgerView) DRepRegistration(
 	}
 	reg := &lcommon.DRepRegistration{
 		Credential: credential,
-		Deposit:    deposit,
+		Deposit:    lv.drepRegistrationDeposit(deposit),
 	}
 	if drep.AnchorURL != "" || len(drep.AnchorHash) > 0 {
 		if len(drep.AnchorHash) != 32 {
@@ -1309,7 +1366,7 @@ func (lv *LedgerView) DRepRegistrations() ([]lcommon.DRepRegistration, error) {
 		}
 		reg := lcommon.DRepRegistration{
 			Credential: lcommon.NewBlake2b224(drep.Credential),
-			Deposit:    depositPtr,
+			Deposit:    lv.drepRegistrationDeposit(depositPtr),
 		}
 		if drep.AnchorURL != "" || len(drep.AnchorHash) > 0 {
 			if len(drep.AnchorHash) != 32 {


### PR DESCRIPTION
## Problem

#4035 wired the recorded registration deposit into `LedgerView.DRepRegistration` / `DRepRegistrations`, and the gouroboros v0.204.0 bump it carried made `common.DRepRegistration.Deposit` a `*uint64` so absence is distinct from a recorded zero.

Absence is not inert on that path. `conway.UtxoValidateCertificateDeposits` fails closed on it:

```go
// gouroboros v0.204.0, ledger/conway/rules.go
if registration.Deposit == nil {
    return DRepDepositStateInconsistentError{Credential: c.DrepCredential}
}
```

```
registered DRep credential has no recorded deposit: type 0 hash <...>
```

That is the correct default for gouroboros — the reference ledger's `DRepState` carries a non-optional `drepDeposit`, so a registration without one is internally inconsistent and there is no refund to compare against. But it means a DRep that reaches this state deterministically rejects its own deregistration block, and a node that reaches that block stops making progress.

**Dingo can produce that state.** `ledger/governance/processing.go` calls `InsertDrepIfAbsent(..., active = true, ...)` on the vote-replay recovery path when a valid DRep vote proves the credential exists on-chain but the metadata row was lost during recovery or bootstrap. That writes a row in `drep` and **no `registration_drep` row at all**, so `GetDrepLastRegistrationDeposit` returns nil. The DRep is active, is deregisterable, and has no recorded deposit.

This is the follow-up @chrisguiney asked for in his review of #4035, which dispositioned the three-states-collapsed-to-one issue as non-blocking there and named this exact path:
https://github.com/blinklabs-io/dingo/pull/4035#discussion_r3945923931

> `ledger/governance/processing.go:306` calls `InsertDrepIfAbsent(..., active=true, ...)` on the vote-replay recovery path, and that writes only the `drep` table. It leaves an **active** DRep with no `registration_drep` row [...] Not a blocker [...] Better as a follow-up issue than as growth in this PR.

The store side landed in #4035 already returns `*uint64`, so this is purely the view's answer for the nil case.

## Change

`ledger/view.go` only, +59/-2. A recorded deposit is passed through unchanged; when nothing is recorded, the view reports the DRep deposit under the current era and protocol parameters instead of the absence.

That value is not invented. `currentDRepDeposit` runs the current era's `CertDepositFunc` over a `RegistrationDrepCertificate` — the same function `ledger.calculateCertificateDeposit` runs on the certificate write path — so the fallback equals what a registration applied now would have recorded. Era and parameters are read from a single published consensus snapshot so they cannot be torn apart.

Two things it deliberately does not do:

- **A recorded zero stays authoritative.** A zero `dRepDeposit` is a legitimate configuration; folding zero into the unrecorded case would refund the current parameter and reject a valid deregistration. This is the same distinction `LedgerView.StakeCredentialDeposit` keeps for the stake analogue (#3829).
- **Absence is still reported when the current era charges no DRep deposit** (pre-Conway, or parameters that do not belong to the era). gouroboros fails closed there rather than being handed an invented zero refund. Whether an era has a DRep deposit is decided by asking the parameters for one (`drepDepositParams`, the same capability `conway.UtxoValidateCertificateDeposits` asserts), not by inferring it from what the era's `CertDepositFunc` returns: `CertDepositShelley` through `CertDepositBabbage` have no `*RegistrationDrepCertificate` case and fall through to `default: return 0, nil`, so inference yielded a fabricated zero. Fixed in 1174ea92 after @chrisguiney caught it in review; the original revision of this description claimed the guard without it existing.

## Tests

`ledger/drep_deposit_unknown_fallback_test.go`, reusing #4035's existing fixtures (`drepRefundTestPparams`, `drepDeregistrationTx`, `seedImportedDrep`). Assertions are on the validation outcome through `conway.UtxoValidateCertificateDeposits` and `eras.ValidateTxConway` with a real `*LedgerView` over a real database, not on the helper's return value.

The unrecorded case is seeded through `InsertDrepIfAbsent` itself rather than by hand, and the helper asserts that path really does leave no registration row — if recovery ever starts writing one, the test says so instead of silently measuring nothing.

- `TestDrepDeregistrationFallsBackToCurrentDepositWhenUnrecorded` — the regression
- `TestDrepDeregistrationRejectsWrongRefundWhenUnrecorded` — the fallback is not a licence to accept any refund (0, +1, and a negative amount all still rejected)
- `TestDrepDeregistrationPrefersRecordedDepositOverFallback` — recorded and parameter values are deliberately different, so the two answers give opposite outcomes
- `TestDrepDeregistrationKeepsRecordedZeroAuthoritative`
- `TestDrepRegistrationsFallBackForUnrecordedDeposit` — the plural view has its own absence path
- `TestDrepRegistrationReportsAbsenceInAPreConwayEra` — the era guard, on a *published* Babbage snapshot, first asserting that era's deposit function really does answer zero-without-error
- `TestDrepRegistrationReportsAbsenceWithoutAPublishedSnapshot` — the other absence branch, asserting the fixture leaves the snapshot unpublished

Each is load-bearing. Removing the fallback fails 3; ignoring the recorded value fails 5 (including two of #4035's own); removing the `drepDepositParams` guard fails `TestDrepRegistrationReportsAbsenceInAPreConwayEra` and leaves the unpublished-snapshot test green, which is the discrimination the earlier single test did not have.

The substitution is also logged at WARN with the credential and the value used, so a node serving a fabricated deposit is distinguishable from one serving a recorded one.

## Verification

Rebased on `main` at c6488d37 (#4035).

| check | result |
|---|---|
| `go build ./...`, `go build -tags dingo_extra_plugins ./cmd/dingo` | pass |
| `go vet ./...` | pass |
| `golangci-lint run ./ledger/...` | 0 issues |
| `gofmt -l ledger/` | empty |
| `go test ./ledger/...` | pass, all 9 packages (`ledger` 102.5s) |
| `go test -race ./ledger/` | pass, 405.2s |

Related: #4035, #4055, #3829