### PR TITLE
ci: separate release service and race tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,25 +63,14 @@ jobs:
         ports:
           - 9000:9000
           - 9001:9001
-    env:
-      POSTGRES_HOST: localhost
-      POSTGRES_PORT: '5432'
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DATABASE: dingo_test
-      MYSQL_HOST: localhost
-      MYSQL_PORT: '3306'
-      MYSQL_USER: mysql
-      MYSQL_PASSWORD: mysql
-      MYSQL_DATABASE: dingo_test
-      MYSQL_ROOT_PASSWORD: mysql
-      AWS_ACCESS_KEY_ID: minioadmin
-      AWS_SECRET_ACCESS_KEY: minioadmin
-      AWS_ENDPOINT: "http://127.0.0.1:9000/"
-      AWS_REGION: us-east-1
-      DINGO_TEST_S3_BUCKET: dingo-test
     steps:
       - name: setup-s3-bucket
+        env:
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_ENDPOINT: "http://127.0.0.1:9000/"
+          AWS_REGION: us-east-1
+          DINGO_TEST_S3_BUCKET: dingo-test
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
@@ -95,10 +84,34 @@ jobs:
         run: go build -tags dingo_extra_plugins ./cmd/dingo
       - name: go-build-minimal
         run: go build ./cmd/dingo
-      - name: go-test
-        # The ledger package legitimately approaches 20 minutes under the race
-        # detector on hosted runners. Keep a finite package-level hang guard
-        # while leaving enough headroom for the complete release suite.
+      - name: go-test-services
+        # Keep the real PostgreSQL, MySQL, and S3 coverage from the Linux
+        # pull-request gate. The conformance package alone approaches the 30m
+        # package timeout when PostgreSQL and MySQL run alongside SQLite under
+        # -race, so service-backed coverage and race coverage are separate
+        # release gates just as they are in go-test.yml.
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: '5432'
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DATABASE: dingo_test
+          MYSQL_HOST: localhost
+          MYSQL_PORT: '3306'
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: dingo_test
+          MYSQL_ROOT_PASSWORD: mysql
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_ENDPOINT: "http://127.0.0.1:9000/"
+          AWS_REGION: us-east-1
+          DINGO_TEST_S3_BUCKET: dingo-test
+        run: go test -tags dingo_extra_plugins -ldflags="-s -w" -timeout 30m ./...
+      - name: go-test-race
+        # Optional service backends are deliberately unconfigured here. This
+        # matches go-test.yml's race job while retaining a finite package-level
+        # hang guard for the complete SQLite-backed race suite.
         run: go test -tags dingo_extra_plugins -ldflags="-s -w" -race -timeout 30m ./...
       - name: govulncheck
         run: make govulncheck

--- a/internal/docsparity/release_test_coverage_test.go
+++ b/internal/docsparity/release_test_coverage_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsparity_test
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const publishWorkflow = ".github/workflows/publish.yml"
+
+var releaseServiceTestTriggers = []string{
+	"POSTGRES_PASSWORD",
+	"POSTGRES_DSN",
+	"MYSQL_ROOT_PASSWORD",
+	"MYSQL_DSN",
+	"DINGO_TEST_S3_BUCKET",
+}
+
+type releaseWorkflowStep struct {
+	Name string            `yaml:"name"`
+	Run  string            `yaml:"run"`
+	Env  map[string]string `yaml:"env"`
+}
+
+type releaseWorkflowJob struct {
+	Env   map[string]string     `yaml:"env"`
+	Steps []releaseWorkflowStep `yaml:"steps"`
+}
+
+type releaseWorkflow struct {
+	Env  map[string]string             `yaml:"env"`
+	Jobs map[string]releaseWorkflowJob `yaml:"jobs"`
+}
+
+func releaseStepEnv(
+	workflow releaseWorkflow,
+	job releaseWorkflowJob,
+	step releaseWorkflowStep,
+) map[string]string {
+	env := make(map[string]string)
+	for key, value := range workflow.Env {
+		env[key] = value
+	}
+	for key, value := range job.Env {
+		env[key] = value
+	}
+	for key, value := range step.Env {
+		env[key] = value
+	}
+	return env
+}
+
+// TestReleaseValidationSeparatesServicesFromRace keeps the tagged release
+// gate aligned with the two Linux jobs in go-test.yml: the service-backed
+// suite covers PostgreSQL and MySQL without race instrumentation, while the
+// race suite covers the same packages with those optional backends disabled.
+// Running all three conformance backends under the race detector exceeds the
+// package timeout without identifying a stuck test.
+func TestReleaseValidationSeparatesServicesFromRace(t *testing.T) {
+	root := repoRoot(t)
+	raw := readRepoFile(t, root, publishWorkflow)
+	var workflow releaseWorkflow
+	if err := yaml.Unmarshal([]byte(raw), &workflow); err != nil {
+		t.Fatalf("parse %s: %v", publishWorkflow, err)
+	}
+
+	job, ok := workflow.Jobs["ci"]
+	if !ok {
+		t.Fatalf("%s has no ci job", publishWorkflow)
+	}
+
+	serviceRun := false
+	raceRun := false
+	for _, step := range job.Steps {
+		if !strings.Contains(step.Run, "go test") ||
+			!strings.Contains(step.Run, "./...") {
+			continue
+		}
+		env := releaseStepEnv(workflow, job, step)
+		if strings.Contains(step.Run, "-race") {
+			raceRun = true
+			for _, key := range releaseServiceTestTriggers {
+				if env[key] != "" {
+					t.Errorf(
+						"release race step %q exposes %s; run service-backed conformance without -race",
+						step.Name,
+						key,
+					)
+				}
+			}
+			continue
+		}
+
+		if env["POSTGRES_PASSWORD"] != "" &&
+			env["MYSQL_ROOT_PASSWORD"] != "" &&
+			env["DINGO_TEST_S3_BUCKET"] != "" {
+			serviceRun = true
+		}
+	}
+
+	if !serviceRun {
+		t.Errorf(
+			"%s ci job has no service-backed uninstrumented full test run",
+			publishWorkflow,
+		)
+	}
+	if !raceRun {
+		t.Errorf("%s ci job has no full race test run", publishWorkflow)
+	}
+}


### PR DESCRIPTION
The v0.70.7 publish gate combined PostgreSQL, MySQL, and S3 coverage with race instrumentation, causing a healthy conformance replay to exhaust its package timeout.

- run service-backed release tests without race instrumentation
- run the full race suite with optional service backends unconfigured
- guard the release split with a docs-parity test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release CI timeout by splitting service-backed tests from the race suite, matching the split already used in the pull-request gate.

- Runs PostgreSQL, MySQL, and S3 coverage without race instrumentation.
- Runs the full race suite with optional service backends unconfigured.
- Adds a docs-parity test that keeps the release workflow aligned with `go-test.yml`.

<sup>Written for commit 5480e07589e42276b54268f90939e1f5ab615079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

