### PR TITLE
fix(database): locate immutable chunk boundaries

### DIFF
--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -620,7 +620,6 @@ func (i *ImmutableDb) getChunk(chunkName string) (*chunk, error) {
 }
 
 func (i *ImmutableDb) GetTip() (*ocommon.Point, error) {
-	var ret *ocommon.Point
 	chunkNames, err := i.getChunkNames()
 	if err != nil {
 		return nil, err
@@ -628,12 +627,28 @@ func (i *ImmutableDb) GetTip() (*ocommon.Point, error) {
 	if len(chunkNames) == 0 {
 		return nil, nil
 	}
-	secondary, err := i.getChunkSecondaryIndex(chunkNames[len(chunkNames)-1])
+	for _, chunkName := range slices.Backward(chunkNames) {
+		tip, err := i.getChunkTip(chunkName)
+		if err != nil {
+			return nil, err
+		}
+		if tip != nil {
+			return tip, nil
+		}
+	}
+	return nil, nil
+}
+
+func (i *ImmutableDb) getChunkTip(
+	chunkName string,
+) (ret *ocommon.Point, retErr error) {
+	secondary, err := i.getChunkSecondaryIndex(chunkName)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = secondary.Close() }()
-	var tmpPoint ocommon.Point
+	defer func() {
+		retErr = errors.Join(retErr, secondary.Close())
+	}()
 	for {
 		next, err := secondary.Next()
 		if err != nil {
@@ -642,11 +657,11 @@ func (i *ImmutableDb) GetTip() (*ocommon.Point, error) {
 		if next == nil {
 			break
 		}
-		tmpPoint = ocommon.NewPoint(
+		tip := ocommon.NewPoint(
 			next.BlockOrEbb,
 			next.HeaderHash[:],
 		)
-		ret = &tmpPoint
+		ret = &tip
 	}
 	return ret, nil
 }

--- a/database/immutable/immutable.go
+++ b/database/immutable/immutable.go
@@ -15,6 +15,7 @@
 package immutable
 
 import (
+	"bytes"
 	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
@@ -431,60 +432,107 @@ func (i *ImmutableDb) getChunkNamesFromPoint(
 		)
 	}
 	// Return all chunks for the origin
-	if point.Slot == 0 {
+	if point.Slot == 0 && len(point.Hash) == 0 {
 		return chunkNames, nil
 	}
 	lowerBound := 0
 	upperBound := len(chunkNames) - 1
+	candidate := len(chunkNames)
 	for lowerBound <= upperBound {
-		// Get chunk in the middle of the current bounds
 		middlePoint := (lowerBound + upperBound) / 2
-		middleChunkName := chunkNames[middlePoint]
-		middleSecondary, err := i.getChunkSecondaryIndex(middleChunkName)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = middleSecondary.Close() }()
-		next, err := middleSecondary.Next()
-		if err != nil {
-			return nil, err
-		}
-		if next == nil {
-			break
-		}
-		startSlot := next.BlockOrEbb
-		var endSlot uint64
-		for {
-			next, err := middleSecondary.Next()
+		pivot := -1
+		var startSlot, endSlot uint64
+		// An immutable range can contain empty chunks. Find the nearest
+		// non-empty pivot without letting an empty midpoint terminate the
+		// search or become the first candidate returned to GetBlock.
+		for distance := 0; pivot < 0; distance++ {
+			left := middlePoint - distance
+			right := middlePoint + distance
+			if left < lowerBound && right > upperBound {
+				break
+			}
+			if left >= lowerBound {
+				start, end, found, err := i.chunkSlotRange(chunkNames[left])
+				if err != nil {
+					return nil, err
+				}
+				if found {
+					pivot = left
+					startSlot = start
+					endSlot = end
+					break
+				}
+			}
+			if distance == 0 || right > upperBound {
+				continue
+			}
+			start, end, found, err := i.chunkSlotRange(chunkNames[right])
 			if err != nil {
 				return nil, err
 			}
-			if next == nil {
-				break
+			if found {
+				pivot = right
+				startSlot = start
+				endSlot = end
 			}
-			endSlot = next.BlockOrEbb
+		}
+		if pivot < 0 {
+			break
 		}
 		if point.Slot < startSlot {
 			// The slot we're looking for is less than the first slot in the chunk, so
 			// we can eliminate all later chunks
-			upperBound = middlePoint - 1
+			candidate = pivot
+			upperBound = pivot - 1
 		} else if point.Slot > endSlot {
 			// The slot we're looking for is greater than the last slot in the chunk, so
 			// we can eliminate all earlier chunks
-			lowerBound = middlePoint + 1
+			lowerBound = pivot + 1
 		} else {
 			// We found the chunk that (probably) has the requested point
+			candidate = pivot
 			break
 		}
 	}
-	if lowerBound >= len(chunkNames) {
+	if candidate >= len(chunkNames) {
 		return nil, fmt.Errorf(
 			"immutable DB: slot %d is beyond the last chunk: %w",
 			point.Slot,
 			ErrPointBeyondLastChunk,
 		)
 	}
-	return chunkNames[lowerBound:], nil
+	return chunkNames[candidate:], nil
+}
+
+func (i *ImmutableDb) chunkSlotRange(
+	chunkName string,
+) (start uint64, end uint64, found bool, retErr error) {
+	secondary, err := i.getChunkSecondaryIndex(chunkName)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, secondary.Close())
+	}()
+	entry, err := secondary.Next()
+	if err != nil {
+		return 0, 0, false, err
+	}
+	if entry == nil {
+		return 0, 0, false, nil
+	}
+	start = entry.BlockOrEbb
+	end = start
+	for {
+		entry, err = secondary.Next()
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if entry == nil {
+			return start, end, true, nil
+		}
+		end = entry.BlockOrEbb
+	}
 }
 
 func (i *ImmutableDb) getChunkPrimaryIndex(
@@ -645,12 +693,18 @@ func (i *ImmutableDb) LastSlotInChunk(
 }
 
 func (i *ImmutableDb) GetBlock(point ocommon.Point) (*Block, error) {
-	var err error
 	chunkNames, err := i.getChunkNamesFromPoint(point)
 	if err != nil {
 		return nil, err
 	}
-	chunk, err := i.getChunk(chunkNames[0])
+	return i.getBlockFromChunk(chunkNames[0], point)
+}
+
+func (i *ImmutableDb) getBlockFromChunk(
+	chunkName string,
+	point ocommon.Point,
+) (*Block, error) {
+	chunk, err := i.getChunk(chunkName)
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +721,7 @@ func (i *ImmutableDb) GetBlock(point ocommon.Point) (*Block, error) {
 		if tmpBlock.Slot != point.Slot {
 			continue
 		}
-		if string(tmpBlock.Hash) != string(point.Hash) {
+		if !bytes.Equal(tmpBlock.Hash, point.Hash) {
 			continue
 		}
 		return tmpBlock, nil
@@ -680,15 +734,45 @@ func (i *ImmutableDb) TruncateChunksFromPoint(point ocommon.Point) error {
 	if err != nil {
 		return err
 	}
+	if point.Slot != 0 || len(point.Hash) != 0 {
+		block, err := i.getBlockFromChunk(chunkNames[0], point)
+		if err != nil {
+			return fmt.Errorf("validate immutable truncation point: %w", err)
+		}
+		if block == nil {
+			return fmt.Errorf(
+				"immutable DB: point at slot %d with hash %x not found; "+
+					"refusing truncation",
+				point.Slot,
+				point.Hash,
+			)
+		}
+	}
+	removedEntries := 0
 	for _, chunkName := range chunkNames {
-		if err := i.removeEntry(chunkName + chunkFileExtension); err != nil {
-			return err
-		}
-		if err := i.removeEntry(chunkName + secondaryFileExtension); err != nil {
-			return err
-		}
-		if err := i.removeEntry(chunkName + primaryFileExtension); err != nil {
-			return err
+		for _, suffix := range []string{
+			chunkFileExtension,
+			secondaryFileExtension,
+			primaryFileExtension,
+		} {
+			entryName := chunkName + suffix
+			if err := i.removeEntry(entryName); err != nil {
+				if removedEntries == 0 {
+					return fmt.Errorf(
+						"immutable DB: truncation did not start; remove %s: %w",
+						entryName,
+						err,
+					)
+				}
+				return fmt.Errorf(
+					"immutable DB: truncation is partial after removing %d "+
+						"entries; remove %s: %w",
+					removedEntries,
+					entryName,
+					err,
+				)
+			}
+			removedEntries++
 		}
 	}
 	return nil

--- a/database/immutable/index_validation_test.go
+++ b/database/immutable/index_validation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package immutable_test
+package immutable
 
 import (
 	"encoding/binary"
@@ -26,11 +26,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
-
-	"github.com/blinklabs-io/dingo/database/immutable"
 )
-
-const secondaryIndexEntrySize = 56
 
 type immutableIndexFixture struct {
 	dir    string
@@ -48,26 +44,57 @@ func writeImmutableIndexFixture(
 		t.Fatal("fixture requires at least one block")
 	}
 	dir := t.TempDir()
+	points := make([]ocommon.Point, len(blockOffsets))
+	for idx := range blockOffsets {
+		hash := make([]byte, 32)
+		for hashIdx := range hash {
+			hash[hashIdx] = byte(idx + 1)
+		}
+		points[idx] = ocommon.NewPoint(uint64(100+idx), hash)
+	}
+	writeImmutableChunkTrio(
+		t,
+		dir,
+		"00000",
+		version,
+		primaryOffsets,
+		blockOffsets,
+		points,
+	)
+	return immutableIndexFixture{dir: dir, points: points}
+}
+
+func writeImmutableChunkTrio(
+	t *testing.T,
+	dir string,
+	name string,
+	version byte,
+	primaryOffsets []uint32,
+	blockOffsets []uint64,
+	points []ocommon.Point,
+) {
+	t.Helper()
+	if blockOffsets != nil && len(blockOffsets) != len(points) {
+		t.Fatalf(
+			"fixture has %d block offsets for %d points",
+			len(blockOffsets),
+			len(points),
+		)
+	}
 	primary := make([]byte, 1+4*len(primaryOffsets))
 	primary[0] = version
 	for i, offset := range primaryOffsets {
 		binary.BigEndian.PutUint32(primary[1+i*4:], offset)
 	}
-	secondary := make([]byte, secondaryIndexEntrySize*len(blockOffsets))
+	secondary := make([]byte, secondaryIndexEntrySize*len(points))
 	var chunk []byte
-	points := make([]ocommon.Point, 0, len(blockOffsets))
-	for i, blockOffset := range blockOffsets {
-		base := i * secondaryIndexEntrySize
-		binary.BigEndian.PutUint64(secondary[base:], blockOffset)
-		hash := make([]byte, 32)
-		for j := range hash {
-			hash[j] = byte(i + 1)
+	for idx, point := range points {
+		if len(point.Hash) != 32 {
+			t.Fatalf(
+				"fixture point hash has length %d, want 32",
+				len(point.Hash),
+			)
 		}
-		copy(secondary[base+16:base+48], hash)
-		slot := uint64(100 + i)
-		binary.BigEndian.PutUint64(secondary[base+48:], slot)
-		points = append(points, ocommon.NewPoint(slot, hash))
-
 		block, err := cbor.Encode([]any{
 			uint64(1),
 			cbor.RawMessage{0x80},
@@ -75,24 +102,36 @@ func writeImmutableIndexFixture(
 		if err != nil {
 			t.Fatalf("encode fixture block: %s", err)
 		}
+		blockOffset := uint64(len(chunk))
+		if blockOffsets != nil {
+			blockOffset = blockOffsets[idx]
+		}
+
+		base := idx * secondaryIndexEntrySize
+		binary.BigEndian.PutUint64(secondary[base:], blockOffset)
+		copy(secondary[base+16:base+48], point.Hash)
+		binary.BigEndian.PutUint64(secondary[base+48:], point.Slot)
 		chunk = append(chunk, block...)
 	}
-	for name, data := range map[string][]byte{
-		"00000.chunk":     chunk,
-		"00000.primary":   primary,
-		"00000.secondary": secondary,
+	for suffix, data := range map[string][]byte{
+		chunkFileExtension:     chunk,
+		primaryFileExtension:   primary,
+		secondaryFileExtension: secondary,
 	} {
-		if err := os.WriteFile(filepath.Join(dir, name), data, 0o640); err != nil {
-			t.Fatalf("write %s: %s", name, err)
+		if err := os.WriteFile(
+			filepath.Join(dir, name+suffix),
+			data,
+			0o640,
+		); err != nil {
+			t.Fatalf("write %s%s: %s", name, suffix, err)
 		}
 	}
-	return immutableIndexFixture{dir: dir, points: points}
 }
 
 func getBlockRecoveringPanic(
-	imm *immutable.ImmutableDb,
+	imm *ImmutableDb,
 	point ocommon.Point,
-) (block *immutable.Block, err error, panicValue any) {
+) (block *Block, err error, panicValue any) {
 	defer func() {
 		panicValue = recover()
 	}()
@@ -106,7 +145,7 @@ func requireGetBlockError(
 	want string,
 ) {
 	t.Helper()
-	imm, err := immutable.New(fixture.dir)
+	imm, err := New(fixture.dir)
 	if err != nil {
 		t.Fatalf("open immutable DB: %s", err)
 	}
@@ -132,7 +171,7 @@ func requireGetBlockErrorIs(
 	wantSubstr string,
 ) {
 	t.Helper()
-	imm, err := immutable.New(fixture.dir)
+	imm, err := New(fixture.dir)
 	if err != nil {
 		t.Fatalf("open immutable DB: %s", err)
 	}
@@ -181,7 +220,7 @@ func TestImmutableIndexAcceptsValidSingleAndMultipleBlockChunks(t *testing.T) {
 			fixture := writeImmutableIndexFixture(
 				t, 1, test.primaryOffsets, test.blockOffsets,
 			)
-			imm, err := immutable.New(fixture.dir)
+			imm, err := New(fixture.dir)
 			if err != nil {
 				t.Fatalf("open immutable DB: %s", err)
 			}
@@ -237,7 +276,7 @@ func TestImmutableIndexRejectsLastBlockOffsetBeyondChunk(t *testing.T) {
 		t, 1, []uint32{0, secondaryIndexEntrySize}, []uint64{1000},
 	)
 	requireGetBlockErrorIs(
-		t, fixture, immutable.ErrInvalidChunkOffset, "beyond chunk size",
+		t, fixture, ErrInvalidChunkOffset, "beyond chunk size",
 	)
 }
 
@@ -251,7 +290,7 @@ func TestImmutableIndexRejectsDescendingBlockOffsets(t *testing.T) {
 	requireGetBlockErrorIs(
 		t,
 		fixture,
-		immutable.ErrInvalidChunkOffset,
+		ErrInvalidChunkOffset,
 		"does not follow current block offset",
 	)
 }
@@ -284,7 +323,7 @@ func TestImmutableIndexRejectsBlockOffsetOverflow(t *testing.T) {
 				t, 1, primaryOffsets, test.blockOffsets,
 			)
 			requireGetBlockErrorIs(
-				t, fixture, immutable.ErrInvalidChunkOffset, "overflows int64",
+				t, fixture, ErrInvalidChunkOffset, "overflows int64",
 			)
 		})
 	}

--- a/database/immutable/point_lookup_internal_test.go
+++ b/database/immutable/point_lookup_internal_test.go
@@ -16,14 +16,12 @@ package immutable
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
@@ -38,54 +36,19 @@ func writePointLookupChunk(
 	points []ocommon.Point,
 ) {
 	t.Helper()
-	primary := make([]byte, 1+4*(len(points)+1))
-	primary[0] = primaryIndexVersion
-	secondary := make([]byte, secondaryIndexEntrySize*len(points))
-	var chunkData []byte
-	for idx, point := range points {
-		if len(point.Hash) != 32 {
-			t.Fatalf("fixture point hash has length %d, want 32", len(point.Hash))
-		}
-		secondaryOffset := idx * secondaryIndexEntrySize
-		binary.BigEndian.PutUint32(
-			primary[1+idx*4:],
-			uint32(secondaryOffset),
-		)
-		binary.BigEndian.PutUint64(
-			secondary[secondaryOffset:],
-			uint64(len(chunkData)),
-		)
-		copy(secondary[secondaryOffset+16:secondaryOffset+48], point.Hash)
-		binary.BigEndian.PutUint64(
-			secondary[secondaryOffset+48:],
-			point.Slot,
-		)
-		encoded, err := cbor.Encode([]any{
-			uint64(1),
-			cbor.RawMessage{0x80},
-		})
-		if err != nil {
-			t.Fatalf("encode fixture block: %s", err)
-		}
-		chunkData = append(chunkData, encoded...)
+	primaryOffsets := make([]uint32, len(points)+1)
+	for idx := range primaryOffsets {
+		primaryOffsets[idx] = uint32(idx * secondaryIndexEntrySize)
 	}
-	binary.BigEndian.PutUint32(
-		primary[1+len(points)*4:],
-		uint32(len(points)*secondaryIndexEntrySize),
+	writeImmutableChunkTrio(
+		t,
+		dir,
+		name,
+		primaryIndexVersion,
+		primaryOffsets,
+		nil,
+		points,
 	)
-	for suffix, data := range map[string][]byte{
-		chunkFileExtension:     chunkData,
-		primaryFileExtension:   primary,
-		secondaryFileExtension: secondary,
-	} {
-		if err := os.WriteFile(
-			filepath.Join(dir, name+suffix),
-			data,
-			0o640,
-		); err != nil {
-			t.Fatalf("write %s%s: %s", name, suffix, err)
-		}
-	}
 }
 
 func writePointLookupFixture(t *testing.T) (string, []ocommon.Point) {
@@ -232,6 +195,13 @@ func TestGetChunkNamesFromPointSkipsEmptyChunks(t *testing.T) {
 			)
 		}
 	}
+	tip, err := imm.GetTip()
+	if err != nil {
+		t.Fatalf("get tip through trailing empty chunk: %s", err)
+	}
+	if tip == nil || tip.Slot != second.Slot || !bytes.Equal(tip.Hash, second.Hash) {
+		t.Fatalf("tip = %#v, want slot %d hash %x", tip, second.Slot, second.Hash)
+	}
 	_, err = imm.getChunkNamesFromPoint(ocommon.NewPoint(401, nil))
 	if !errors.Is(err, ErrPointBeyondLastChunk) {
 		t.Fatalf("trailing-empty lookup error = %v, want beyond-last error", err)
@@ -246,6 +216,13 @@ func TestGetChunkNamesFromPointSkipsEmptyChunks(t *testing.T) {
 	_, err = empty.getChunkNamesFromPoint(ocommon.NewPoint(1, nil))
 	if !errors.Is(err, ErrPointBeyondLastChunk) {
 		t.Fatalf("empty-chunk lookup error = %v, want beyond-last error", err)
+	}
+	tip, err = empty.GetTip()
+	if err != nil {
+		t.Fatalf("get tip from all-empty DB: %s", err)
+	}
+	if tip != nil {
+		t.Fatalf("all-empty DB tip = %#v, want nil", tip)
 	}
 }
 

--- a/database/immutable/point_lookup_internal_test.go
+++ b/database/immutable/point_lookup_internal_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+func pointLookupPoint(slot uint64, value byte) ocommon.Point {
+	return ocommon.NewPoint(slot, bytes.Repeat([]byte{value}, 32))
+}
+
+func writePointLookupChunk(
+	t *testing.T,
+	dir string,
+	name string,
+	points []ocommon.Point,
+) {
+	t.Helper()
+	primary := make([]byte, 1+4*(len(points)+1))
+	primary[0] = primaryIndexVersion
+	secondary := make([]byte, secondaryIndexEntrySize*len(points))
+	var chunkData []byte
+	for idx, point := range points {
+		if len(point.Hash) != 32 {
+			t.Fatalf("fixture point hash has length %d, want 32", len(point.Hash))
+		}
+		secondaryOffset := idx * secondaryIndexEntrySize
+		binary.BigEndian.PutUint32(
+			primary[1+idx*4:],
+			uint32(secondaryOffset),
+		)
+		binary.BigEndian.PutUint64(
+			secondary[secondaryOffset:],
+			uint64(len(chunkData)),
+		)
+		copy(secondary[secondaryOffset+16:secondaryOffset+48], point.Hash)
+		binary.BigEndian.PutUint64(
+			secondary[secondaryOffset+48:],
+			point.Slot,
+		)
+		encoded, err := cbor.Encode([]any{
+			uint64(1),
+			cbor.RawMessage{0x80},
+		})
+		if err != nil {
+			t.Fatalf("encode fixture block: %s", err)
+		}
+		chunkData = append(chunkData, encoded...)
+	}
+	binary.BigEndian.PutUint32(
+		primary[1+len(points)*4:],
+		uint32(len(points)*secondaryIndexEntrySize),
+	)
+	for suffix, data := range map[string][]byte{
+		chunkFileExtension:     chunkData,
+		primaryFileExtension:   primary,
+		secondaryFileExtension: secondary,
+	} {
+		if err := os.WriteFile(
+			filepath.Join(dir, name+suffix),
+			data,
+			0o640,
+		); err != nil {
+			t.Fatalf("write %s%s: %s", name, suffix, err)
+		}
+	}
+}
+
+func writePointLookupFixture(t *testing.T) (string, []ocommon.Point) {
+	t.Helper()
+	dir := t.TempDir()
+	points := []ocommon.Point{
+		pointLookupPoint(100, 0x10),
+		pointLookupPoint(110, 0x11),
+		pointLookupPoint(200, 0x20),
+		pointLookupPoint(210, 0x21),
+		pointLookupPoint(300, 0x30),
+		pointLookupPoint(310, 0x31),
+		pointLookupPoint(400, 0x40),
+		pointLookupPoint(410, 0x41),
+		pointLookupPoint(500, 0x50),
+		pointLookupPoint(510, 0x51),
+	}
+	for idx := range 5 {
+		writePointLookupChunk(
+			t,
+			dir,
+			ChunkName(uint64(idx)),
+			points[idx*2:idx*2+2],
+		)
+	}
+	return dir, points
+}
+
+func TestGetChunkNamesFromPointReturnsContainingChunk(t *testing.T) {
+	dir, points := writePointLookupFixture(t)
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	tests := []struct {
+		name      string
+		point     ocommon.Point
+		wantChunk string
+	}{
+		{name: "first", point: points[0], wantChunk: "00000"},
+		{name: "middle", point: points[5], wantChunk: "00002"},
+		{name: "last", point: points[9], wantChunk: "00004"},
+		{
+			name:      "missing before first",
+			point:     ocommon.NewPoint(99, nil),
+			wantChunk: "00000",
+		},
+		{
+			name:      "adjacent after chunk",
+			point:     ocommon.NewPoint(211, nil),
+			wantChunk: "00002",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := imm.getChunkNamesFromPoint(test.point)
+			if err != nil {
+				t.Fatalf("locate chunk: %s", err)
+			}
+			if len(got) == 0 || got[0] != test.wantChunk {
+				t.Fatalf("first candidate = %v, want %s", got, test.wantChunk)
+			}
+		})
+	}
+	_, err = imm.getChunkNamesFromPoint(ocommon.NewPoint(511, nil))
+	if !errors.Is(err, ErrPointBeyondLastChunk) {
+		t.Fatalf("beyond-tip lookup error = %v, want ErrPointBeyondLastChunk", err)
+	}
+}
+
+func TestGetBlockChecksHashAfterLocatingContainingChunk(t *testing.T) {
+	dir, points := writePointLookupFixture(t)
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	want := points[4]
+	got, err := imm.GetBlock(want)
+	if err != nil {
+		t.Fatalf("get exact point: %s", err)
+	}
+	if got == nil || got.Slot != want.Slot || !bytes.Equal(got.Hash, want.Hash) {
+		t.Fatalf("exact point lookup = %#v, want slot %d hash %x", got, want.Slot, want.Hash)
+	}
+	wrongHash := pointLookupPoint(want.Slot, 0xFF)
+	got, err = imm.GetBlock(wrongHash)
+	if err != nil {
+		t.Fatalf("get wrong-hash point: %s", err)
+	}
+	if got != nil {
+		t.Fatalf("wrong-hash lookup returned %#v, want nil", got)
+	}
+}
+
+func TestGetBlockFindsExactPointInSingleEntryChunk(t *testing.T) {
+	dir := t.TempDir()
+	want := pointLookupPoint(777, 0x77)
+	writePointLookupChunk(t, dir, "00000", []ocommon.Point{want})
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	got, err := imm.GetBlock(want)
+	if err != nil {
+		t.Fatalf("get exact point: %s", err)
+	}
+	if got == nil || got.Slot != want.Slot || !bytes.Equal(got.Hash, want.Hash) {
+		t.Fatalf("exact point lookup = %#v, want slot %d hash %x", got, want.Slot, want.Hash)
+	}
+}
+
+func TestGetChunkNamesFromPointSkipsEmptyChunks(t *testing.T) {
+	dir := t.TempDir()
+	writePointLookupChunk(t, dir, "00000", nil)
+	first := pointLookupPoint(200, 0x20)
+	writePointLookupChunk(t, dir, "00001", []ocommon.Point{first})
+	writePointLookupChunk(t, dir, "00002", nil)
+	second := pointLookupPoint(400, 0x40)
+	writePointLookupChunk(t, dir, "00003", []ocommon.Point{second})
+	writePointLookupChunk(t, dir, "00004", nil)
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	tests := []struct {
+		point     ocommon.Point
+		wantChunk string
+	}{
+		{point: first, wantChunk: "00001"},
+		{point: ocommon.NewPoint(300, nil), wantChunk: "00003"},
+		{point: second, wantChunk: "00003"},
+	}
+	for _, test := range tests {
+		got, err := imm.getChunkNamesFromPoint(test.point)
+		if err != nil {
+			t.Fatalf("locate slot %d: %s", test.point.Slot, err)
+		}
+		if len(got) == 0 || got[0] != test.wantChunk {
+			t.Fatalf(
+				"slot %d first candidate = %v, want %s",
+				test.point.Slot,
+				got,
+				test.wantChunk,
+			)
+		}
+	}
+	_, err = imm.getChunkNamesFromPoint(ocommon.NewPoint(401, nil))
+	if !errors.Is(err, ErrPointBeyondLastChunk) {
+		t.Fatalf("trailing-empty lookup error = %v, want beyond-last error", err)
+	}
+
+	emptyDir := t.TempDir()
+	writePointLookupChunk(t, emptyDir, "00000", nil)
+	empty, err := New(emptyDir)
+	if err != nil {
+		t.Fatalf("open empty immutable DB: %s", err)
+	}
+	_, err = empty.getChunkNamesFromPoint(ocommon.NewPoint(1, nil))
+	if !errors.Is(err, ErrPointBeyondLastChunk) {
+		t.Fatalf("empty-chunk lookup error = %v, want beyond-last error", err)
+	}
+}
+
+func requireChunkTrioState(
+	t *testing.T,
+	dir string,
+	name string,
+	wantPresent bool,
+) {
+	t.Helper()
+	for _, suffix := range []string{
+		chunkFileExtension,
+		primaryFileExtension,
+		secondaryFileExtension,
+	} {
+		_, err := os.Stat(filepath.Join(dir, name+suffix))
+		if wantPresent && err != nil {
+			t.Fatalf("expected %s%s to remain: %s", name, suffix, err)
+		}
+		if !wantPresent && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected %s%s to be removed, got %v", name, suffix, err)
+		}
+	}
+}
+
+func TestTruncateChunksFromPointKeepsChunksBeforeExactBoundary(t *testing.T) {
+	dir, points := writePointLookupFixture(t)
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	if err := imm.TruncateChunksFromPoint(points[4]); err != nil {
+		t.Fatalf("truncate from exact point: %s", err)
+	}
+	for idx := range 5 {
+		requireChunkTrioState(t, dir, ChunkName(uint64(idx)), idx < 2)
+	}
+}
+
+func TestTruncateChunksFromPointRefusesMissingExactPoint(t *testing.T) {
+	dir, points := writePointLookupFixture(t)
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	missing := pointLookupPoint(points[4].Slot, 0xFF)
+	err = imm.TruncateChunksFromPoint(missing)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("wrong-hash truncate error = %v, want point-not-found error", err)
+	}
+	for idx := range 5 {
+		requireChunkTrioState(t, dir, ChunkName(uint64(idx)), true)
+	}
+}
+
+func TestTruncateChunksFromPointReportsPartialDeletion(t *testing.T) {
+	dir, points := writePointLookupFixture(t)
+	failingPath := filepath.Join(dir, "00004"+secondaryFileExtension)
+	if err := os.Remove(failingPath); err != nil {
+		t.Fatalf("remove fixture secondary: %s", err)
+	}
+	if err := os.Mkdir(failingPath, 0o750); err != nil {
+		t.Fatalf("replace secondary with directory: %s", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(failingPath, "keep"),
+		[]byte("x"),
+		0o640,
+	); err != nil {
+		t.Fatalf("make secondary directory non-empty: %s", err)
+	}
+
+	imm, err := New(dir)
+	if err != nil {
+		t.Fatalf("open immutable DB: %s", err)
+	}
+	err = imm.TruncateChunksFromPoint(points[4])
+	if err == nil || !strings.Contains(err.Error(), "truncation is partial") {
+		t.Fatalf("truncate error = %v, want explicit partial-deletion report", err)
+	}
+	if !strings.Contains(err.Error(), "after removing 7 entries") {
+		t.Fatalf("truncate error = %v, want removed-entry count", err)
+	}
+	for idx := range 2 {
+		requireChunkTrioState(t, dir, ChunkName(uint64(idx)), true)
+	}
+	for idx := 2; idx < 4; idx++ {
+		requireChunkTrioState(t, dir, ChunkName(uint64(idx)), false)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "00004"+chunkFileExtension)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected 00004 chunk to be removed, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "00004"+primaryFileExtension)); err != nil {
+		t.Fatalf("expected 00004 primary to remain: %s", err)
+	}
+}


### PR DESCRIPTION
Fixes #3415.

- locate the containing non-empty immutable chunk at point boundaries
- validate the exact slot and hash before truncating chunk files
- report partial truncation with the number of entries already removed
- keep tip discovery correct when trailing chunks are empty
