### PR TITLE
fix(txsubmission): reject oversized replies before decoding

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4429,6 +4429,12 @@ trip, which can reduce inbound throughput on high-latency peer links. This is
 required because gouroboros acknowledges every ID returned by a peer; support
 for acknowledging only the fetched prefix would permit batched requests.
 
+TxSubmission checks reply counts and aggregate body bytes against the
+outstanding request before decoding any transaction. Replies exceeding the
+advertised byte budget are classified and counted as size mismatches. Replies
+within that budget still require ordered hash/era matching and an exact body
+or wrapped-wire size match for each transaction before any mempool admission.
+
 The selected pool manages pending transactions:
 
 ```

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -121,12 +121,28 @@ func validateTxsubmissionReply(
 			len(returned),
 		)
 	}
-	ret := make([]validatedTxsubmissionBody, 0, len(returned))
 	var requestedBytes uint64
 	for _, requestedTx := range requested {
 		requestedBytes += uint64(requestedTx.Size)
 	}
-	var returnedBytes uint64
+	remainingBytes := requestedBytes
+	for index, txBody := range returned {
+		bodySize := uint64(len(txBody.TxBody))
+		if bodySize > remainingBytes {
+			return nil, fmt.Errorf(
+				"%w: reply exceeds byte limit at index %d: advertised total %d, remaining %d, body %d, wire %d, era %d",
+				errTxsubmissionReplySizeMismatch,
+				index,
+				requestedBytes,
+				remainingBytes,
+				bodySize,
+				txsubmissionWireSize(txBody.EraId, len(txBody.TxBody)),
+				txBody.EraId,
+			)
+		}
+		remainingBytes -= bodySize
+	}
+	ret := make([]validatedTxsubmissionBody, 0, len(returned))
 	nextRequested := 0
 	for i, txBody := range returned {
 		tx, err := ledger.NewTransactionFromCbor(
@@ -183,21 +199,6 @@ func validateTxsubmissionReply(
 				bodySize,
 				wireSize,
 				txBody.EraId,
-			)
-		}
-		// The aggregate budget is checked after the per-body size, so an
-		// advertisement smaller than the body it describes is reported and
-		// counted as the size mismatch it is instead of surfacing as an
-		// unattributed batch-budget error. Every accepted body is no larger
-		// than its own advertisement and each advertisement is consumed at
-		// most once, so this is an invariant backstop rather than a check
-		// a size advertisement alone can trip.
-		returnedBytes += bodySize
-		if returnedBytes > requestedBytes {
-			return nil, fmt.Errorf(
-				"txsubmission reply exceeds byte limit: requested %d, received at least %d",
-				requestedBytes,
-				returnedBytes,
 			)
 		}
 		nextRequested = matched + 1

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -755,6 +755,71 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 	}
 }
 
+func TestValidateTxsubmissionReplyChecksByteBudgetBeforeDecode(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		sizes     []uint32
+		bodies    [][]byte
+		overLimit bool
+	}{
+		{
+			name:      "single body exceeds budget",
+			sizes:     []uint32{1},
+			bodies:    [][]byte{{0xff, 0xff}},
+			overLimit: true,
+		},
+		{
+			name:      "later body exceeds aggregate before first decode",
+			sizes:     []uint32{1, 1},
+			bodies:    [][]byte{{0xff}, {0xff, 0xff}},
+			overLimit: true,
+		},
+		{
+			name:      "zero budget",
+			sizes:     []uint32{0},
+			bodies:    [][]byte{{0xff}},
+			overLimit: true,
+		},
+		{
+			name:   "exact budget still decodes",
+			sizes:  []uint32{1},
+			bodies: [][]byte{{0xff}},
+		},
+		{
+			name:   "below budget still decodes",
+			sizes:  []uint32{2},
+			bodies: [][]byte{{0xff}},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			requested := make([]txsubmission.TxIdAndSize, len(testCase.sizes))
+			returned := make([]txsubmission.TxBody, len(testCase.bodies))
+			for index, size := range testCase.sizes {
+				requested[index] = txsubmission.TxIdAndSize{
+					TxId: txsubmission.TxId{EraId: txsubmissionRelayTestEraId},
+					Size: size,
+				}
+				returned[index] = txsubmission.TxBody{
+					EraId:  txsubmissionRelayTestEraId,
+					TxBody: testCase.bodies[index],
+				}
+			}
+			validated, err := validateTxsubmissionReply(requested, returned)
+			require.Nil(t, validated)
+			if testCase.overLimit {
+				require.ErrorIs(t, err, errTxsubmissionReplySizeMismatch)
+				require.ErrorContains(t, err, "exceeds byte limit")
+			} else {
+				require.ErrorContains(t, err, "decode failed")
+				require.NotErrorIs(t, err, errTxsubmissionReplySizeMismatch)
+			}
+		})
+	}
+}
+
 func addTxSubmissionTestFixtures(
 	t *testing.T,
 	m mempool.Service,


### PR DESCRIPTION
Reject TxSubmission replies exceeding the advertised byte budget before decoding any transaction, preventing over-budget decoder work. Preserve exact body/wire-size checks and size-mismatch metrics.

Regression coverage checks zero, exact and exceeded budgets, including an oversized later body rejected before the first transaction is decoded.

Reference-devnet validation remains incomplete after a transaction-propagation timeout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects TxSubmission replies that exceed the advertised byte budget before decoding any transaction, preventing over-budget decoder work. Previously the aggregate budget was checked only after per-body size checks during decoding; now it's enforced upfront while preserving the existing exact body/wire-size checks and size-mismatch metrics.

**Regression coverage**
- Adds tests for zero, exact, and exceeded budgets, including a later body exceeding the aggregate before the first decode.
- Updates `ARCHITECTURE.md` to reflect the pre-decode budget check.

<sup>Written for commit 5ab6246f6689f8032c7f90edc65f0b982ff45d87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

