### PR TITLE
fix(security): revalidate dev-mode forge candidates

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -11181,6 +11181,9 @@ func (ls *LedgerState) forgeBlock() {
 			"tx_count", len(mempoolTxs),
 		)
 
+		consumedInputs := make(map[string]struct{})
+		createdOutputs := make(map[string]lcommon.Utxo)
+
 		// Iterate through transactions and add them until we hit limits
 		for _, mempoolTx := range mempoolTxs {
 			// Use raw CBOR from the mempool transaction
@@ -11216,6 +11219,20 @@ func (ls *LedgerState) forgeBlock() {
 				ls.config.Logger.Debug(
 					"failed to decode full transaction, skipping",
 					"component", "ledger",
+					"error", err,
+				)
+				continue
+			}
+
+			if err := ls.ValidateTxWithOverlay(
+				fullTx,
+				consumedInputs,
+				createdOutputs,
+			); err != nil {
+				ls.config.Logger.Debug(
+					"skipping transaction - failed re-validation",
+					"component", "ledger",
+					"tx_hash", mempoolTx.Hash,
 					"error", err,
 				)
 				continue
@@ -11305,6 +11322,22 @@ func (ls *LedgerState) forgeBlock() {
 				transactionMetadataSet[uint(len(transactionBodies))-1] = metadataCbor
 			}
 			blockSize += txSize
+			for _, input := range fullTx.Consumed() {
+				key := fmt.Sprintf(
+					"%s:%d",
+					input.Id().String(),
+					input.Index(),
+				)
+				consumedInputs[key] = struct{}{}
+			}
+			for _, output := range fullTx.Produced() {
+				key := fmt.Sprintf(
+					"%s:%d",
+					output.Id.Id().String(),
+					output.Id.Index(),
+				)
+				createdOutputs[key] = output
+			}
 			// Safe to assign: overflow was already checked
 			// via SafeAddExUnits when computing
 			// candidateExUnits above.


### PR DESCRIPTION
## Summary

- Revalidate each dev-mode forge candidate against the current ledger state.
- Track consumed inputs and created outputs across the candidate block.
- Skip stale, conflicting, or otherwise invalid mempool transactions before inclusion.

## Security impact

Closes the Dingo `CONS2-01` / `DINGO-ROOT-02` producer-path residual where dev-mode forging could select transactions that were no longer valid together at block construction time.

## Validation

- Focused local race-enabled ledger/forging tests passed.
- Commit retains the DCO sign-off.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revalidates dev-mode forge candidates against current ledger state so forged blocks no longer include mempool transactions that became invalid together at construction time. Closes the Dingo `CONS2-01` / `DINGO-ROOT-02` producer-path residual.

- Tracks consumed inputs and created outputs across the candidate block.
- Skips stale, conflicting, or otherwise invalid transactions before inclusion.

<sup>Written for commit 180c77a59949f99b1f33deb0b1eb937ed2053690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

