### PR TITLE
fix(connmanager): bound node-to-client connection admission

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -610,6 +610,18 @@ peer credentials) unwrap through the wrapper, so wrapping an accepted connection
 never silently disables them. Cancellation closes an in-flight bearer, and failed
 setup releases its reserved inbound and per-IP slots.
 
+Node-to-client listeners share a separate admission budget across all their
+transports: `ConnectionManagerConfig.MaxNtCConns` defaults to 100 pending or
+established sessions. TCP clients also share a separate per-source budget,
+`MaxNtCConnectionsPerIP`, defaulting to five sessions per IPv4 address or IPv6
+/64. Nonpositive settings use these defaults. Unix sockets and named pipes
+consume the total NtC budget without per-IP accounting. NtC admission never
+consumes N2N slots or N2N per-IP capacity. Admission reserves both budgets
+before launching a handshake worker; failed setup releases the reservation,
+and successful setup transfers its release to the connection's close watcher.
+The `cardano_node_metrics_connectionManager_ntcRejectedConns_total` counter
+records rejections with `total_limit` or `per_ip_limit` as its `reason` label.
+
 ```mermaid
 graph TB
     subgraph "Peer Governor"

--- a/connmanager/connection_collision_test.go
+++ b/connmanager/connection_collision_test.go
@@ -134,11 +134,11 @@ func TestSameDirectionCollisionNotifiesEvictedConnection(t *testing.T) {
 
 	require.True(
 		t,
-		cm.addNtCConnectionWithIPKey(first, true, "127.0.0.1:3002", ""),
+		cm.addConnectionImpl(first, true, true, "127.0.0.1:3002", "", nil),
 	)
 	require.True(
 		t,
-		cm.addNtCConnectionWithIPKey(second, true, "127.0.0.1:3002", ""),
+		cm.addConnectionImpl(second, true, true, "127.0.0.1:3002", "", nil),
 	)
 	require.Same(t, second, cm.GetConnectionById(second.Id()))
 

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -45,7 +45,9 @@ const (
 	// simultaneous inbound connections accepted by the connection manager.
 	// This prevents resource exhaustion from malicious or accidental
 	// connection floods.
-	DefaultMaxInboundConnections = 100
+	DefaultMaxInboundConnections  = 100
+	DefaultMaxNtCConnections      = 100
+	DefaultMaxNtCConnectionsPerIP = 5
 )
 
 type connectionInfo struct {
@@ -85,6 +87,9 @@ type ConnectionManager struct {
 	duplexPeers          int
 	prunableConns        int
 	trackedConnCount     int
+	ntcAdmissionMutex    sync.Mutex
+	ntcCount             int
+	ntcIPConns           map[string]int
 }
 
 // DefaultMaxConnectionsPerIP is the default maximum number of concurrent
@@ -118,7 +123,9 @@ type ConnectionManagerConfig struct {
 	// MaxConnectionsPerIP limits the number of concurrent inbound
 	// connections from the same IP address. IPv6 addresses are grouped
 	// by /64 prefix. A value of 0 means use DefaultMaxConnectionsPerIP.
-	MaxConnectionsPerIP int
+	MaxConnectionsPerIP    int
+	MaxNtCConns            int
+	MaxNtCConnectionsPerIP int
 }
 
 type connectionManagerMetrics struct {
@@ -128,6 +135,7 @@ type connectionManagerMetrics struct {
 	duplexConns         prometheus.Gauge
 	fullDuplexConns     prometheus.Gauge
 	prunableConns       prometheus.Gauge
+	ntcRejectedConns    *prometheus.CounterVec
 }
 
 type peerConnectionSummary struct {
@@ -176,6 +184,12 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 	if cfg.MaxConnectionsPerIP <= 0 {
 		cfg.MaxConnectionsPerIP = DefaultMaxConnectionsPerIP
 	}
+	if cfg.MaxNtCConns <= 0 {
+		cfg.MaxNtCConns = DefaultMaxNtCConnections
+	}
+	if cfg.MaxNtCConnectionsPerIP <= 0 {
+		cfg.MaxNtCConnectionsPerIP = DefaultMaxNtCConnectionsPerIP
+	}
 	c := &ConnectionManager{
 		config: cfg,
 		connections: make(
@@ -185,6 +199,7 @@ func NewConnectionManager(cfg ConnectionManagerConfig) *ConnectionManager {
 		peerConnectivity: make(map[string]peerConnectionSummary),
 		pendingConns:     make(map[net.Conn]struct{}),
 		ipConns:          make(map[string]int),
+		ntcIPConns:       make(map[string]int),
 	}
 	if cfg.PromRegistry != nil {
 		c.initMetrics()
@@ -243,6 +258,13 @@ func (c *ConnectionManager) consumeInboundSlot() {
 func (c *ConnectionManager) initMetrics() {
 	promautoFactory := promauto.With(c.config.PromRegistry)
 	c.metrics = &connectionManagerMetrics{}
+	c.metrics.ntcRejectedConns = promautoFactory.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: metricNamePrefix + "ntcRejectedConns_total",
+			Help: "number of node-to-client connections rejected by admission limits",
+		},
+		[]string{"reason"},
+	)
 	c.metrics.incomingConns = promautoFactory.NewGauge(prometheus.GaugeOpts{
 		Name: metricNamePrefix + "incomingConns",
 		Help: "number of incoming connections",
@@ -661,7 +683,7 @@ func (c *ConnectionManager) AddConnection(
 	isInbound bool,
 	peerAddr string,
 ) bool {
-	return c.addConnectionImpl(conn, isInbound, false, peerAddr, "")
+	return c.addConnectionImpl(conn, isInbound, false, peerAddr, "", nil)
 }
 
 func (c *ConnectionManager) addConnectionWithIPKey(
@@ -670,7 +692,7 @@ func (c *ConnectionManager) addConnectionWithIPKey(
 	peerAddr string,
 	ipKey string,
 ) bool {
-	return c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey)
+	return c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey, nil)
 }
 
 func (c *ConnectionManager) addNtCConnectionWithIPKey(
@@ -679,7 +701,7 @@ func (c *ConnectionManager) addNtCConnectionWithIPKey(
 	peerAddr string,
 	ipKey string,
 ) bool {
-	return c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey)
+	return c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey, nil)
 }
 
 func (c *ConnectionManager) addConnectionImpl(
@@ -688,6 +710,7 @@ func (c *ConnectionManager) addConnectionImpl(
 	isNtC bool,
 	peerAddr string,
 	ipKey string,
+	onClose func(),
 ) bool {
 	// Check if shutting down before adding to WaitGroup to prevent panic
 	// during Stop()'s Wait() call. Must hold the same lock used to set closing.
@@ -844,6 +867,9 @@ func (c *ConnectionManager) addConnectionImpl(
 	c.updateConnectionMetrics()
 	go func() {
 		defer c.goroutineWg.Done()
+		if onClose != nil {
+			defer onClose()
+		}
 		err := <-conn.ErrorChan()
 		// Remove connection (also releases IP slot)
 		if !c.RemoveConnection(connId, conn) {

--- a/connmanager/connection_manager.go
+++ b/connmanager/connection_manager.go
@@ -695,15 +695,6 @@ func (c *ConnectionManager) addConnectionWithIPKey(
 	return c.addConnectionImpl(conn, isInbound, false, peerAddr, ipKey, nil)
 }
 
-func (c *ConnectionManager) addNtCConnectionWithIPKey(
-	conn *ouroboros.Connection,
-	isInbound bool,
-	peerAddr string,
-	ipKey string,
-) bool {
-	return c.addConnectionImpl(conn, isInbound, true, peerAddr, ipKey, nil)
-}
-
 func (c *ConnectionManager) addConnectionImpl(
 	conn *ouroboros.Connection,
 	isInbound bool,
@@ -867,13 +858,21 @@ func (c *ConnectionManager) addConnectionImpl(
 	c.updateConnectionMetrics()
 	go func() {
 		defer c.goroutineWg.Done()
-		if onClose != nil {
-			defer onClose()
-		}
+		defer func() {
+			if onClose != nil {
+				onClose()
+			}
+		}()
 		err := <-conn.ErrorChan()
 		// Remove connection (also releases IP slot)
 		if !c.RemoveConnection(connId, conn) {
 			return
+		}
+		// Release admission before invoking user callbacks. A callback may
+		// block while the listener still needs to admit a replacement.
+		if onClose != nil {
+			onClose()
+			onClose = nil
 		}
 		// Generate event, but only for node-to-node connections. Every
 		// subscriber to this event does node-to-node peer management --

--- a/connmanager/listener.go
+++ b/connmanager/listener.go
@@ -262,9 +262,17 @@ func (c *ConnectionManager) startListener(
 				continue
 			}
 
-			// NtC connections bypass the inbound slot budget and per-IP
-			// limiting. Their handshake is still moved off the accept loop.
 			if l.UseNtC {
+				releaseNtCSlot := c.reserveNtCSlot(conn.RemoteAddr())
+				if releaseNtCSlot == nil {
+					closeConnAndLog(
+						c.config.Logger,
+						conn,
+						"listener: close rejected NtC connection failed",
+					)
+					c.untrackPendingConnection(conn)
+					continue
+				}
 				c.goroutineWg.Go(func() {
 					c.setupAcceptedConnection(
 						ctx,
@@ -272,6 +280,7 @@ func (c *ConnectionManager) startListener(
 						l,
 						defaultConnOpts,
 						false,
+						releaseNtCSlot,
 					)
 				})
 				continue
@@ -316,6 +325,7 @@ func (c *ConnectionManager) startListener(
 					l,
 					defaultConnOpts,
 					true,
+					nil,
 				)
 			})
 		}
@@ -357,9 +367,15 @@ func (c *ConnectionManager) setupAcceptedConnection(
 	l ListenerConfig,
 	defaultConnOpts []ouroboros.ConnectionOptionFunc,
 	inboundSlotReserved bool,
+	releaseNtCSlot func(),
 ) {
 	pendingConn := conn
 	defer c.untrackPendingConnection(pendingConn)
+	defer func() {
+		if releaseNtCSlot != nil {
+			releaseNtCSlot()
+		}
+	}()
 	stopOnCancel := context.AfterFunc(ctx, func() {
 		_ = pendingConn.Close()
 	})
@@ -469,9 +485,17 @@ func (c *ConnectionManager) setupAcceptedConnection(
 			"remote_addr",
 			peerAddr,
 		)
-		if !c.addNtCConnectionWithIPKey(oConn, true, peerAddr, "") {
+		if !c.addConnectionImpl(
+			oConn,
+			true,
+			true,
+			peerAddr,
+			"",
+			releaseNtCSlot,
+		) {
 			return
 		}
+		releaseNtCSlot = nil
 	} else {
 		c.config.Logger.Info("listener: inbound connection", "remote_addr", peerAddr)
 		c.consumeInboundSlot()

--- a/connmanager/ntc_admission.go
+++ b/connmanager/ntc_admission.go
@@ -1,0 +1,50 @@
+package connmanager
+
+import (
+	"net"
+	"sync"
+)
+
+func (c *ConnectionManager) reserveNtCSlot(addr net.Addr) func() {
+	ipKey := ""
+	if addr != nil &&
+		(addr.Network() == "tcp" || addr.Network() == "tcp4" || addr.Network() == "tcp6") {
+		ipKey = ipKeyFromAddr(addr)
+	}
+	c.ntcAdmissionMutex.Lock()
+	reason := ""
+	switch {
+	case c.ntcCount >= c.config.MaxNtCConns:
+		reason = "total_limit"
+	case ipKey != "" && c.ntcIPConns[ipKey] >= c.config.MaxNtCConnectionsPerIP:
+		reason = "per_ip_limit"
+	default:
+		c.ntcCount++
+		if ipKey != "" {
+			c.ntcIPConns[ipKey]++
+		}
+	}
+	c.ntcAdmissionMutex.Unlock()
+	if reason != "" {
+		if c.metrics != nil {
+			c.metrics.ntcRejectedConns.WithLabelValues(reason).Inc()
+		}
+		c.config.Logger.Warn(
+			"listener: node-to-client connection limit reached",
+			"reason", reason,
+			"remote_addr", addr,
+		)
+		return nil
+	}
+	return sync.OnceFunc(func() {
+		c.ntcAdmissionMutex.Lock()
+		defer c.ntcAdmissionMutex.Unlock()
+		c.ntcCount--
+		if ipKey != "" {
+			c.ntcIPConns[ipKey]--
+			if c.ntcIPConns[ipKey] == 0 {
+				delete(c.ntcIPConns, ipKey)
+			}
+		}
+	})
+}

--- a/connmanager/ntc_admission_test.go
+++ b/connmanager/ntc_admission_test.go
@@ -1,0 +1,251 @@
+package connmanager
+
+import (
+	"context"
+	"io"
+	"net"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func startNtCAdmissionManager(
+	t *testing.T,
+	cfg ConnectionManagerConfig,
+	listeners ...net.Listener,
+) *ConnectionManager {
+	t.Helper()
+	cfg.PromRegistry = prometheus.NewRegistry()
+	for _, listener := range listeners {
+		t.Cleanup(func() { _ = listener.Close() })
+		cfg.Listeners = append(cfg.Listeners, ListenerConfig{
+			Listener: listener,
+			UseNtC:   true,
+			ConnectionOpts: []ouroboros.ConnectionOptionFunc{
+				ouroboros.WithNetworkMagic(1),
+			},
+		})
+	}
+	manager := NewConnectionManager(cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		require.NoError(t, manager.Stop(ctx))
+	})
+	require.NoError(t, manager.Start(t.Context()))
+	return manager
+}
+
+func dialNtCAdmissionClient(t *testing.T, listener net.Listener) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout(
+		listener.Addr().Network(), listener.Addr().String(), 2*time.Second,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func connectNtCAdmissionClient(
+	t *testing.T,
+	listener net.Listener,
+) *ouroboros.Connection {
+	t.Helper()
+	conn := dialNtCAdmissionClient(t, listener)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(2*time.Second)))
+	client, err := ouroboros.NewConnection(
+		ouroboros.WithConnection(conn),
+		ouroboros.WithNetworkMagic(1),
+		ouroboros.WithNodeToNode(false),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	require.NoError(t, conn.SetDeadline(time.Time{}))
+	return client
+}
+
+func requireNtCAdmissionCount(
+	t *testing.T,
+	manager *ConnectionManager,
+	count int,
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		manager.ntcAdmissionMutex.Lock()
+		defer manager.ntcAdmissionMutex.Unlock()
+		return manager.ntcCount == count
+	}, 2*time.Second, time.Millisecond, "unexpected NtC admission count")
+}
+
+func requireNtCAdmissionRejected(t *testing.T, listener net.Listener) {
+	t.Helper()
+	conn := dialNtCAdmissionClient(t, listener)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var data [1]byte
+	_, err := conn.Read(data[:])
+	require.ErrorIs(
+		t,
+		err,
+		io.EOF,
+		"over-limit NtC connection must close before handshake",
+	)
+}
+
+func TestNtCAdmissionPendingAndEstablished(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		total int
+		perIP int
+	}{
+		{name: "total_limit", total: 2, perIP: 3},
+		{name: "per_ip_limit", total: 3, perIP: 2},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			firstListener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = firstListener.Close() })
+			secondListener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			manager := startNtCAdmissionManager(t, ConnectionManagerConfig{
+				MaxNtCConns:            testCase.total,
+				MaxNtCConnectionsPerIP: testCase.perIP,
+				MaxInboundConns:        1,
+				MaxConnectionsPerIP:    1,
+			}, firstListener, secondListener)
+			first := connectNtCAdmissionClient(t, firstListener)
+			requireNtCAdmissionCount(t, manager, 1)
+			require.Eventually(t, func() bool {
+				manager.connectionsMutex.Lock()
+				defer manager.connectionsMutex.Unlock()
+				return len(manager.connections) == 1
+			}, 2*time.Second, time.Millisecond)
+			silent := dialNtCAdmissionClient(t, secondListener)
+			requireNtCAdmissionCount(t, manager, 2)
+			requireNtCAdmissionRejected(t, firstListener)
+			require.Equal(t, float64(1), testutil.ToFloat64(
+				manager.metrics.ntcRejectedConns.WithLabelValues(testCase.name),
+			))
+			require.Eventually(t, func() bool {
+				manager.listenersMutex.Lock()
+				defer manager.listenersMutex.Unlock()
+				return len(manager.pendingConns) == 1
+			}, 2*time.Second, time.Millisecond, "rejected NtC connection remained pending")
+
+			require.Zero(t, manager.InboundCount())
+			require.True(t, manager.tryReserveInboundSlot())
+			t.Cleanup(manager.releaseInboundSlot)
+			require.True(t, manager.acquireIPSlot("127.0.0.1"))
+			t.Cleanup(func() { manager.releaseIPSlot("127.0.0.1") })
+
+			require.NoError(t, first.Close())
+			requireNtCAdmissionCount(t, manager, 1)
+			connectNtCAdmissionClient(t, secondListener)
+			requireNtCAdmissionCount(t, manager, 2)
+			require.NoError(t, silent.Close())
+			requireNtCAdmissionCount(t, manager, 1)
+			silent = dialNtCAdmissionClient(t, firstListener)
+			requireNtCAdmissionCount(t, manager, 2)
+
+			stopCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+			require.NoError(t, manager.Stop(stopCtx))
+			manager.ntcAdmissionMutex.Lock()
+			count, sourceCount := manager.ntcCount, len(manager.ntcIPConns)
+			manager.ntcAdmissionMutex.Unlock()
+			require.Zero(t, count, "shutdown leaked NtC slots")
+			require.Zero(t, sourceCount, "shutdown leaked NtC source slots")
+			require.NoError(
+				t,
+				silent.SetReadDeadline(time.Now().Add(time.Second)),
+			)
+			var data [1]byte
+			_, err = silent.Read(data[:])
+			require.ErrorIs(t, err, io.EOF)
+		})
+	}
+}
+
+func TestNtCAdmissionUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-domain sockets are not the Windows NtC transport")
+	}
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "ntc.sock"))
+	require.NoError(t, err)
+	manager := startNtCAdmissionManager(t, ConnectionManagerConfig{
+		MaxNtCConns: 2, MaxNtCConnectionsPerIP: 1,
+	}, listener)
+	first := connectNtCAdmissionClient(t, listener)
+	connectNtCAdmissionClient(t, listener)
+	requireNtCAdmissionCount(t, manager, 2)
+	requireNtCAdmissionRejected(t, listener)
+	manager.ntcAdmissionMutex.Lock()
+	sources := len(manager.ntcIPConns)
+	manager.ntcAdmissionMutex.Unlock()
+	require.Zero(t, sources, "Unix sockets must not consume IP slots")
+	require.NoError(t, first.Close())
+	requireNtCAdmissionCount(t, manager, 1)
+	connectNtCAdmissionClient(t, listener)
+	requireNtCAdmissionCount(t, manager, 2)
+}
+
+func TestNtCAdmissionConcurrentReservations(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		total       int
+		perIP       int
+		addressByte int
+	}{
+		{name: "total_limit", total: 2, perIP: 3, addressByte: 7},
+		{name: "per_ip_limit", total: 3, perIP: 2, addressByte: 15},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			manager := NewConnectionManager(ConnectionManagerConfig{
+				MaxNtCConns: testCase.total, MaxNtCConnectionsPerIP: testCase.perIP,
+			})
+			var workers sync.WaitGroup
+			var accepted atomic.Int32
+			start := make(chan struct{})
+			releases := make(chan func(), 64)
+			for index := range 64 {
+				workers.Go(func() {
+					<-start
+					address := net.ParseIP("2001:db8::").To16()
+					address[testCase.addressByte] = byte(index)
+					release := manager.reserveNtCSlot(&net.TCPAddr{
+						IP: address, Port: index + 1000,
+					})
+					if release != nil {
+						accepted.Add(1)
+						releases <- release
+					}
+				})
+			}
+			close(start)
+			workers.Wait()
+			close(releases)
+			require.Equal(
+				t,
+				int32(2),
+				accepted.Load(),
+				"concurrent sources exceeded their NtC budget",
+			)
+			for release := range releases {
+				release()
+				release()
+			}
+			requireNtCAdmissionCount(t, manager, 0)
+			manager.ntcAdmissionMutex.Lock()
+			sources := len(manager.ntcIPConns)
+			manager.ntcAdmissionMutex.Unlock()
+			require.Zero(t, sources)
+		})
+	}
+}

--- a/connmanager/ntc_admission_test.go
+++ b/connmanager/ntc_admission_test.go
@@ -2,6 +2,7 @@ package connmanager
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"path/filepath"
@@ -16,6 +17,41 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNtCAdmissionSlotReleasedBeforeCloseCallback(t *testing.T) {
+	closeErr := errors.New("closed")
+	callbackEntered := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	var releaseCallbackOnce sync.Once
+	releaseCallbackFunc := func() {
+		releaseCallbackOnce.Do(func() { close(releaseCallback) })
+	}
+	defer releaseCallbackFunc()
+	manager := NewConnectionManager(ConnectionManagerConfig{
+		MaxNtCConns: 1,
+		ConnClosedFunc: func(_ ouroboros.ConnectionId, _ bool, _ error) {
+			close(callbackEntered)
+			<-releaseCallback
+		},
+	})
+	conn := newUnstartedConnection(t)
+	release := manager.reserveNtCSlot(nil)
+	require.NotNil(t, release)
+	require.True(t, manager.addConnectionImpl(conn, true, true, "local", "", release))
+
+	conn.ErrorChan() <- closeErr
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("close callback was not invoked")
+	}
+	manager.ntcAdmissionMutex.Lock()
+	count := manager.ntcCount
+	manager.ntcAdmissionMutex.Unlock()
+	require.Zero(t, count, "NtC admission slot remained held by a blocking callback")
+	releaseCallbackFunc()
+	waitForConnectionManagerWatchers(t, manager)
+}
 
 func startNtCAdmissionManager(
 	t *testing.T,

--- a/connmanager/ntc_conn_closed_callback_test.go
+++ b/connmanager/ntc_conn_closed_callback_test.go
@@ -49,7 +49,7 @@ func TestConnClosedFunc_ReceivesIsNtCTrueForNtCClose(t *testing.T) {
 	conn := newUnstartedConnection(t)
 	require.True(
 		t,
-		cm.addNtCConnectionWithIPKey(conn, true, "127.0.0.1:3002", ""),
+		cm.addConnectionImpl(conn, true, true, "127.0.0.1:3002", "", nil),
 	)
 
 	closeErr := errors.New("ntc connection closed")

--- a/connmanager/ntc_conn_closed_test.go
+++ b/connmanager/ntc_conn_closed_test.go
@@ -59,7 +59,7 @@ func TestNtCConnectionCloseDoesNotPublishPeerEvent(t *testing.T) {
 
 	require.True(
 		t,
-		cm.addNtCConnectionWithIPKey(conn, true, "127.0.0.1:3002", ""),
+		cm.addConnectionImpl(conn, true, true, "127.0.0.1:3002", "", nil),
 	)
 
 	conn.ErrorChan() <- errors.New("ntc connection closed")
@@ -105,7 +105,7 @@ func TestNtCConnectionCloseStillRemovesConnection(t *testing.T) {
 
 	require.True(
 		t,
-		cm.addNtCConnectionWithIPKey(conn, true, "127.0.0.1:3002", ""),
+		cm.addConnectionImpl(conn, true, true, "127.0.0.1:3002", "", nil),
 	)
 	require.NotNil(t, cm.GetConnectionById(conn.Id()))
 


### PR DESCRIPTION
Bound pending and established NtC connections separately from N2N peers, with TCP per-source limits and rejection metrics. Release reservations on failed setup and connection shutdown; Unix sockets retain separate total-limit accounting.

Adds regression coverage for concurrent admission, TCP and Unix limits, shutdown cleanup, and N2N budget isolation.

Fixes #2268 (S10-5).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2268 by giving node-to-client (NtC) connections their own admission budget. Previously NtC connections bypassed inbound slot and per-IP limiting; now they are capped by dedicated limits, and over-limit connections are closed before handshake and counted in a rejection metric.

**Details**

- `MaxNtCConns` defaults to 100 and `MaxNtCConnectionsPerIP` defaults to 5; nonpositive settings use the defaults.
- TCP sources are limited per IPv4 address or IPv6 /64, while Unix sockets and named pipes only consume the total NtC budget.
- Reservations are released on failed handshake setup and before close callbacks run on connection close or shutdown.
- Rejections increment `cardano_node_metrics_connectionManager_ntcRejectedConns_total` with `total_limit` or `per_ip_limit` as the `reason` label.
- Adds regression tests for concurrent admission, TCP and Unix limits, shutdown cleanup, and N2N budget isolation.

<sup>Written for commit 5707e0414531af762f571985b56b7346e77bb57f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admission limits for node-to-client connections, including total and per-IP thresholds.
  - Added configurable defaults of 100 total connections and five connections per IP.
  - Unix sockets and named pipes count toward the total limit without per-IP restrictions.
  - Connection rejections are recorded with metrics and categorized by limit type.

- **Bug Fixes**
  - Ensured admission capacity is released correctly when connections close or setup fails.

- **Tests**
  - Added coverage for limits, concurrent connection attempts, Unix sockets, pending connections, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->