### PR TITLE
perf(conformance): reset the sqlite backend in place

### DIFF
--- a/internal/test/conformance/reset_cost.go
+++ b/internal/test/conformance/reset_cost.go
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build dingo_extra_plugins
+// No build tag: backendResetter and its helpers are dialect-agnostic
+// database/sql code with no plugin dependency. The tag this file used to
+// carry came from its callers -- when only the dingo_extra_plugins-gated
+// Postgres and MySQL managers used it -- and keeping it would have forced the
+// SQLite reset path (state_manager_sqlite.go), which every build has, to exist
+// only in the tagged configuration. Letting the two configurations diverge
+// there is exactly what this package avoids elsewhere; see
+// process_cleanup_test.go.
 
 package conformance
 

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -294,14 +294,20 @@ func (m *DingoStateManager) Reset() error {
 	//
 	// reopenBackend remains the fallback for any future backend that sets
 	// neither hook.
-	if m.wipeMetadata != nil {
-		if err := m.wipeMetadata(); err != nil {
-			return err
+	// The two hooks are checked independently: a backend that sets only one
+	// still gets that half emptied, rather than silently skipping it because
+	// its partner is nil.
+	if m.wipeMetadata != nil || m.wipeBlob != nil {
+		var errs []error
+		if m.wipeMetadata != nil {
+			errs = append(errs, m.wipeMetadata())
 		}
+		// Runs even when wipeMetadata failed: leaving the blob store
+		// populated as well would compound a half-cleared backend.
 		if m.wipeBlob != nil {
-			return m.wipeBlob()
+			errs = append(errs, m.wipeBlob())
 		}
-		return nil
+		return errors.Join(errs...)
 	}
 	return m.reopenBackend()
 }

--- a/internal/test/conformance/state_manager.go
+++ b/internal/test/conformance/state_manager.go
@@ -151,6 +151,15 @@ type DingoStateManager struct {
 	// state_manager_mysql.go.
 	wipeMetadata func() error
 
+	// wipeBlob, when set, empties the local blob store in place. It pairs
+	// with wipeMetadata: database.New checks that the blob store's commit
+	// timestamp and the metadata store's agree, so a Reset that emptied one
+	// side and not the other would leave a pairing neither side caused.
+	// Only the sqlite backend sets it -- the remote backends deliberately
+	// share one process-wide blob directory across every vector (see
+	// state_manager_postgres.go's postgresProcessBlobDir).
+	wipeBlob func() error
+
 	// closeExtra, when set, releases backend-scoped resources the manager
 	// owns beyond its database -- currently the long-lived admin connection
 	// backendResetter holds so Reset does not reconnect per vector (see
@@ -205,11 +214,18 @@ func NewDingoStateManager() (*DingoStateManager, error) {
 // survives a restart (see state_manager_backend_test.go); NewDingoStateManager
 // uses it with a manager-owned temp directory.
 func newDingoStateManagerAt(dataDir string) (*DingoStateManager, error) {
-	return newDingoStateManager(realBackendOptions{
+	m, err := newDingoStateManager(realBackendOptions{
 		dataDir:          dataDir,
 		metadataName:     "sqlite",
 		registerMetadata: sqlite.RegisterProvider,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if err := installSqliteResetHooks(m, dataDir); err != nil {
+		return nil, errors.Join(err, m.Close())
+	}
+	return m, nil
 }
 
 // Close releases state-manager resources: the database, its provider host,
@@ -258,18 +274,34 @@ func (m *DingoStateManager) Reset() error {
 	// database/plugin/metadata/postgres's own concurrently running
 	// tests' tables in the shared dingo_test database.
 	//
-	// wipeMetadata (postgres/mysql) truncates every table in this
-	// suite's own schema/database in place, over the live connection
-	// pool, and does not close/reopen the store: a full close-and-reopen
-	// (re-running real migrations) against a remote server is correct
-	// but, at one vector per Reset call across the whole vector suite,
-	// far too slow -- each migration statement is a real network round
-	// trip. sqlite has no wipeMetadata (its Resettable.Reset is a
-	// documented no-op and there's no live schema/database name to
-	// truncate against a shared server), so it always takes the
-	// close-and-reopen path, which is cheap for a local file store.
+	// wipeMetadata truncates every dirty table in this suite's own
+	// schema/database in place, over the live connection pool, and does not
+	// close/reopen the store: a full close-and-reopen re-runs real
+	// migrations, and at one Reset per vector across the whole corpus that
+	// is far too slow. For postgres/mysql each migration statement is a real
+	// network round trip; for sqlite it is ~260 local DDL statements (80
+	// CREATE TABLE, 180 CREATE INDEX). Measured under -race before this
+	// path existed, sqlite's Reset averaged 712ms with a CPU profile
+	// attributing 76.9% to migrations.Run/execDDL; in place it averages
+	// 12ms, and the package fell from 656s to 178s.
+	//
+	// sqlite pairs wipeMetadata with wipeBlob because it owns its blob
+	// store: the two must be emptied together or database.New's
+	// blob-versus-metadata commit-timestamp check sees a pairing neither
+	// side caused. The remote backends set no wipeBlob -- they share one
+	// process-wide blob directory across every vector by design (see
+	// state_manager_postgres.go).
+	//
+	// reopenBackend remains the fallback for any future backend that sets
+	// neither hook.
 	if m.wipeMetadata != nil {
-		return m.wipeMetadata()
+		if err := m.wipeMetadata(); err != nil {
+			return err
+		}
+		if m.wipeBlob != nil {
+			return m.wipeBlob()
+		}
+		return nil
 	}
 	return m.reopenBackend()
 }

--- a/internal/test/conformance/state_manager_sqlite.go
+++ b/internal/test/conformance/state_manager_sqlite.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -35,6 +36,36 @@ const sqliteMetadataFileName = "metadata.sqlite"
 // sqliteMetadataPath returns the metadata database path inside dataDir.
 func sqliteMetadataPath(dataDir string) string {
 	return filepath.Join(dataDir, sqliteMetadataFileName)
+}
+
+// sqliteResetFileURI converts an OS path to the file URI form SQLite expects.
+// It mirrors sqliteFileURI in database/plugin/metadata/sqlite, which is
+// unexported; the resetter must address exactly the file the metadata store
+// opened, so the two constructions have to agree.
+//
+// Three things a bare "file:"+ToSlash concatenation gets wrong, all of which
+// this package would hit: a relative path is not resolved, a Windows volume
+// needs the leading slash that makes "C:/x" into "/C:/x" (the untagged
+// Windows CI job builds this package), and a path containing a URI-reserved
+// character -- a '?' or a space in TMPDIR -- would otherwise run into the
+// '?'-terminated pragma string and misparse.
+//
+// TestSqliteResetPreservesMigrationLedger is the cross-platform guard that
+// this really does open the store's own file: it reads schema_migrations back
+// through the resetter's connection, which only exists if both addressed the
+// same database.
+func sqliteResetFileURI(databasePath string) string {
+	if !filepath.IsAbs(databasePath) {
+		if absolutePath, err := filepath.Abs(databasePath); err == nil {
+			databasePath = absolutePath
+		}
+	}
+	path := filepath.ToSlash(databasePath)
+	if filepath.VolumeName(databasePath) != "" &&
+		!strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
 // newSqliteResetter builds the wipeMetadata hook for the local SQLite
@@ -67,7 +98,7 @@ func newSqliteResetter(databasePath string) (*backendResetter, error) {
 	// busy_timeout leads because github.com/glebarez/go-sqlite applies
 	// _pragma options in order and anything ahead of it runs with no busy
 	// handler installed.
-	dsn := "file:" + filepath.ToSlash(databasePath) +
+	dsn := sqliteResetFileURI(databasePath) +
 		"?_pragma=busy_timeout(30000)" +
 		"&_pragma=foreign_keys(0)"
 	db, err := sql.Open("sqlite", dsn)

--- a/internal/test/conformance/state_manager_sqlite.go
+++ b/internal/test/conformance/state_manager_sqlite.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	badgerblob "github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	// Registers the "sqlite" driver used for the resetter's own connection.
+	_ "github.com/glebarez/go-sqlite"
+)
+
+// sqliteMetadataFileName is the file the sqlite metadata provider creates
+// inside the backend's data directory. It must match
+// database/plugin/metadata/sqlite's dstPath.
+const sqliteMetadataFileName = "metadata.sqlite"
+
+// sqliteMetadataPath returns the metadata database path inside dataDir.
+func sqliteMetadataPath(dataDir string) string {
+	return filepath.Join(dataDir, sqliteMetadataFileName)
+}
+
+// newSqliteResetter builds the wipeMetadata hook for the local SQLite
+// backend, replacing the close/RemoveAll/reopen path Reset previously took.
+//
+// That path was correct but re-ran the full migration set once per vector.
+// Measured on this package under -race, Reset averaged 712ms and a CPU profile
+// attributed 76.9% of it to migrations.Run/execDDL -- roughly 260 DDL
+// statements (80 CREATE TABLE, 180 CREATE INDEX) per vector, ~315 vectors per
+// replay, two replays per process. Emptying the tables in place over one
+// long-lived connection removes that work while leaving the schema, and
+// therefore schema_migrations, intact.
+//
+// SQLite differs from the two remote dialects in three ways that this
+// constructor has to absorb:
+//
+//  1. There is no TRUNCATE, so each dirty table takes a DELETE. That is why
+//     the dirty-only probe matters more here than for PostgreSQL, which
+//     batches every table into one statement regardless.
+//  2. DELETE does not reset AUTOINCREMENT, and the recreate path did, so
+//     sqlite_sequence has to be cleared for the same tables. A table can also
+//     hold an advanced sequence while holding no rows, which the row probe
+//     cannot see; sqliteAdvancedAutoIncrementTables reports those, the same
+//     role mysqlAdvancedAutoIncrementTables plays for MySQL.
+//  3. SQLite has no CASCADE on DELETE, so this connection disables foreign
+//     keys rather than ordering the deletes. Correct here because the whole
+//     managed set is emptied together; a partial reset is never issued.
+func newSqliteResetter(databasePath string) (*backendResetter, error) {
+	// foreign_keys(0) rather than the provider's (1): see the doc comment.
+	// busy_timeout leads because github.com/glebarez/go-sqlite applies
+	// _pragma options in order and anything ahead of it runs with no busy
+	// handler installed.
+	dsn := "file:" + filepath.ToSlash(databasePath) +
+		"?_pragma=busy_timeout(30000)" +
+		"&_pragma=foreign_keys(0)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"open sqlite reset connection at %q: %w",
+			databasePath,
+			err,
+		)
+	}
+	// One connection, held for the manager's lifetime. Reset is the only
+	// user and a second pooled connection would not share the
+	// foreign_keys pragma reliably.
+	db.SetMaxOpenConns(1)
+
+	return &backendResetter{
+		db:         db,
+		listTables: listSqliteConformanceTables,
+		qualify:    sqliteQuoteIdentifier,
+		truncate:   truncateSqliteTables,
+		extraDirty: sqliteAdvancedAutoIncrementTables,
+	}, nil
+}
+
+// listSqliteConformanceTables returns the managed base tables: everything in
+// this file except SQLite's own sqlite_* bookkeeping (sqlite_sequence in
+// particular, which truncateSqliteTables maintains rather than empties) and
+// the migration runner's schema_migrations ledger. Emptying that ledger would
+// make the next construction re-run every migration, which is the cost this
+// path exists to avoid.
+func listSqliteConformanceTables(
+	ctx context.Context,
+	db *sql.DB,
+) ([]string, error) {
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT name FROM sqlite_master
+		 WHERE type = 'table'
+		   AND name NOT LIKE 'sqlite_%'
+		   AND name <> 'schema_migrations'
+		 ORDER BY name`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list sqlite conformance tables: %w", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan sqlite table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list sqlite conformance tables: %w", err)
+	}
+	return tables, nil
+}
+
+// sqliteQuoteIdentifier renders a bare table name as a quoted identifier,
+// doubling any embedded quote. SQLite has no schema qualifier to add here: the
+// resetter's connection is opened directly against this backend's own file.
+func sqliteQuoteIdentifier(table string) string {
+	return `"` + strings.ReplaceAll(table, `"`, `""`) + `"`
+}
+
+// truncateSqliteTables empties the given already-qualified tables and clears
+// their AUTOINCREMENT counters, in one transaction so a failure part-way
+// cannot leave some vectors' rows behind.
+//
+// sqlite_sequence only exists once at least one table has been declared
+// AUTOINCREMENT, so its absence is not an error; the DELETE against it is
+// skipped rather than allowed to fail.
+func truncateSqliteTables(
+	ctx context.Context,
+	db *sql.DB,
+	qualified []string,
+) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin sqlite reset transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, table := range qualified {
+		// #nosec G202 -- table is a sqlite_master name that
+		// sqliteQuoteIdentifier has already quoted; never caller input.
+		if _, err := tx.ExecContext(ctx, "DELETE FROM "+table); err != nil {
+			return fmt.Errorf("delete from sqlite table %s: %w", table, err)
+		}
+	}
+
+	hasSequence, err := sqliteSequenceExists(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if hasSequence {
+		// Match on the bare name, so strip the quoting applied above.
+		names := make([]any, len(qualified))
+		placeholders := make([]string, len(qualified))
+		for i, table := range qualified {
+			names[i] = sqliteUnquoteIdentifier(table)
+			placeholders[i] = "?"
+		}
+		// #nosec G202 -- the concatenated text is a generated list of
+		// "?" placeholders; every table name is a bound parameter.
+		if _, err := tx.ExecContext(
+			ctx,
+			"DELETE FROM sqlite_sequence WHERE name IN ("+
+				strings.Join(placeholders, ",")+")",
+			names...,
+		); err != nil {
+			return fmt.Errorf("reset sqlite autoincrement counters: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sqlite reset transaction: %w", err)
+	}
+	return nil
+}
+
+// sqliteUnquoteIdentifier reverses sqliteQuoteIdentifier.
+func sqliteUnquoteIdentifier(qualified string) string {
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(qualified, `"`), `"`)
+	return strings.ReplaceAll(trimmed, `""`, `"`)
+}
+
+// sqliteSequenceExists reports whether the sqlite_sequence table is present.
+// It takes the narrow QueryRowContext interface so the same probe serves both
+// the pooled connection and an open transaction.
+func sqliteSequenceExists(ctx context.Context, q sqliteRowQuerier) (bool, error) {
+	var name string
+	err := q.QueryRowContext(
+		ctx,
+		`SELECT name FROM sqlite_master
+		 WHERE type = 'table' AND name = 'sqlite_sequence'`,
+	).Scan(&name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("probe sqlite_sequence: %w", err)
+	}
+	return true, nil
+}
+
+// sqliteRowQuerier is the single-row query surface shared by *sql.DB and
+// *sql.Tx.
+type sqliteRowQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// sqliteAdvancedAutoIncrementTables reports managed tables whose
+// AUTOINCREMENT counter has advanced, so a table emptied by an earlier reset
+// still gets its sequence cleared. Without this, the dirty-only row probe
+// would skip such a table and the next insert would continue from the previous
+// vector's high water mark rather than from 1, which the close-and-reopen path
+// this replaces always gave. It is the SQLite counterpart to
+// mysqlAdvancedAutoIncrementTables.
+func sqliteAdvancedAutoIncrementTables(
+	ctx context.Context,
+	db *sql.DB,
+	tables []string,
+) ([]string, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	hasSequence, err := sqliteSequenceExists(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if !hasSequence {
+		return nil, nil
+	}
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT name FROM sqlite_sequence WHERE seq > 0`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list sqlite advanced autoincrement tables: %w",
+			err,
+		)
+	}
+	defer rows.Close()
+
+	managed := make(map[string]struct{}, len(tables))
+	for _, table := range tables {
+		managed[table] = struct{}{}
+	}
+	var advanced []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan sqlite_sequence name: %w", err)
+		}
+		if _, ok := managed[name]; ok {
+			advanced = append(advanced, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"list sqlite advanced autoincrement tables: %w",
+			err,
+		)
+	}
+	return advanced, nil
+}
+
+// installSqliteResetHooks points the manager's Reset at the in-place path:
+// truncate the dirty metadata tables over a held connection, then empty the
+// local Badger blob store, instead of closing the backend, deleting the data
+// directory, and reopening it.
+//
+// Both hooks are required together. database.New checks that the blob store's
+// commit timestamp agrees with the metadata store's, so emptying one side and
+// leaving the other advanced would produce exactly the mismatched pairing
+// state_manager_postgres.go describes.
+func installSqliteResetHooks(m *DingoStateManager, dataDir string) error {
+	resetter, err := newSqliteResetter(sqliteMetadataPath(dataDir))
+	if err != nil {
+		return err
+	}
+	m.wipeMetadata = func() error {
+		return resetter.reset(context.Background())
+	}
+	m.wipeBlob = func() error {
+		return dropSqliteBackendBlobs(m)
+	}
+	m.closeExtra = resetter.Close
+	return nil
+}
+
+// dropSqliteBackendBlobs empties the local Badger blob store in place.
+//
+// badger's DropAll is what makes this cheap: it discards every table without
+// closing the store, so the blob half of Reset costs one call rather than a
+// close, a directory removal, and a reopen.
+func dropSqliteBackendBlobs(m *DingoStateManager) error {
+	if m.db == nil {
+		return nil
+	}
+	store := m.db.Blob()
+	if store == nil {
+		return nil
+	}
+	badgerStore, ok := store.(*badgerblob.BlobStoreBadger)
+	if !ok {
+		return fmt.Errorf(
+			"conformance: sqlite reset expects a badger blob store, got %T",
+			store,
+		)
+	}
+	if err := badgerStore.DB().DropAll(); err != nil {
+		return fmt.Errorf("drop badger blob store for reset: %w", err)
+	}
+	return nil
+}

--- a/internal/test/conformance/state_manager_sqlite_reset_test.go
+++ b/internal/test/conformance/state_manager_sqlite_reset_test.go
@@ -17,23 +17,23 @@ package conformance
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// sqliteFileIdentity returns the inode and creation-ordering identity of the
-// metadata database, which distinguishes "emptied in place" from "deleted and
-// recreated". The close-and-reopen path this change replaces removed the whole
-// data directory on every Reset, so it produced a new inode each time.
-func sqliteFileIdentity(t *testing.T, dataDir string) uint64 {
+// sqliteFileIdentity returns the metadata database's file identity, which
+// distinguishes "emptied in place" from "deleted and recreated". The
+// close-and-reopen path this change replaces removed the whole data directory
+// on every Reset, so it produced a different file each time.
+//
+// os.SameFile rather than a syscall.Stat_t inode: Stat_t does not exist on
+// Windows, and this package is built untagged by the Windows CI job.
+func sqliteFileIdentity(t *testing.T, dataDir string) os.FileInfo {
 	t.Helper()
 	info, err := os.Stat(filepath.Join(dataDir, sqliteMetadataFileName))
 	require.NoError(t, err, "metadata database must exist after reset")
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	require.True(t, ok, "stat unavailable on this platform")
-	return stat.Ino
+	return info
 }
 
 // TestSqliteResetKeepsTheSameDatabaseFile is the regression test for the whole
@@ -41,7 +41,7 @@ func sqliteFileIdentity(t *testing.T, dataDir string) uint64 {
 // directory and rebuild it, because rebuilding re-runs every migration -- 260
 // DDL statements, once per vector, ~315 vectors per replay.
 //
-// A new inode after Reset means the recreate path ran.
+// A different file after Reset means the recreate path ran.
 func TestSqliteResetKeepsTheSameDatabaseFile(t *testing.T) {
 	dataDir := t.TempDir()
 	sm, err := newDingoStateManagerAt(dataDir)
@@ -52,10 +52,9 @@ func TestSqliteResetKeepsTheSameDatabaseFile(t *testing.T) {
 	require.NoError(t, sm.Reset())
 	after := sqliteFileIdentity(t, dataDir)
 
-	require.Equal(
+	require.True(
 		t,
-		before,
-		after,
+		os.SameFile(before, after),
 		"Reset must empty the metadata database in place, not recreate it",
 	)
 }
@@ -107,22 +106,65 @@ func TestSqliteResetClearsBlobStore(t *testing.T) {
 
 	blobStore := sm.db.Blob()
 	require.NotNil(t, blobStore)
+	// Registered before the assertions below: a failing Set or Commit would
+	// otherwise abort the test with badger's single write transaction still
+	// open, and every later blob write in this process would block on it.
+	// Rollback after a successful Commit is a no-op.
 	txn := blobStore.NewTransaction(true)
+	t.Cleanup(func() { _ = txn.Rollback() })
 	require.NoError(t, blobStore.Set(txn, key, value))
 	require.NoError(t, txn.Commit())
 
 	// Confirm it is actually readable before Reset, so a broken write cannot
 	// make the post-Reset absence look like success.
 	readTxn := sm.db.Blob().NewTransaction(false)
+	t.Cleanup(func() { _ = readTxn.Rollback() })
 	got, err := sm.db.Blob().Get(readTxn, key)
 	require.NoError(t, err)
 	require.Equal(t, value, got, "precondition: blob is readable")
-	_ = readTxn.Rollback()
 
 	require.NoError(t, sm.Reset())
 
 	afterTxn := sm.db.Blob().NewTransaction(false)
-	defer func() { _ = afterTxn.Rollback() }()
+	t.Cleanup(func() { _ = afterTxn.Rollback() })
 	_, err = sm.db.Blob().Get(afterTxn, key)
 	require.Error(t, err, "Reset must clear the blob store")
+}
+
+// TestResetRunsEachWipeHookIndependently pins that Reset checks wipeMetadata
+// and wipeBlob separately. They were nested, so a backend that set only
+// wipeBlob would have silently skipped emptying its blob store; no backend
+// does that today, which is exactly why the contract needs a test rather than
+// a convention.
+func TestResetRunsEachWipeHookIndependently(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		metadata, blob bool
+	}{
+		{name: "both", metadata: true, blob: true},
+		{name: "metadata only", metadata: true},
+		{name: "blob only", blob: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var metadataCalled, blobCalled bool
+			m := &DingoStateManager{}
+			if tc.metadata {
+				m.wipeMetadata = func() error {
+					metadataCalled = true
+					return nil
+				}
+			}
+			if tc.blob {
+				m.wipeBlob = func() error {
+					blobCalled = true
+					return nil
+				}
+			}
+
+			require.NoError(t, m.Reset())
+
+			require.Equal(t, tc.metadata, metadataCalled, "wipeMetadata")
+			require.Equal(t, tc.blob, blobCalled, "wipeBlob")
+		})
+	}
 }

--- a/internal/test/conformance/state_manager_sqlite_reset_test.go
+++ b/internal/test/conformance/state_manager_sqlite_reset_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sqliteFileIdentity returns the inode and creation-ordering identity of the
+// metadata database, which distinguishes "emptied in place" from "deleted and
+// recreated". The close-and-reopen path this change replaces removed the whole
+// data directory on every Reset, so it produced a new inode each time.
+func sqliteFileIdentity(t *testing.T, dataDir string) uint64 {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dataDir, sqliteMetadataFileName))
+	require.NoError(t, err, "metadata database must exist after reset")
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "stat unavailable on this platform")
+	return stat.Ino
+}
+
+// TestSqliteResetKeepsTheSameDatabaseFile is the regression test for the whole
+// change. Reset must empty the backend in place rather than delete the data
+// directory and rebuild it, because rebuilding re-runs every migration -- 260
+// DDL statements, once per vector, ~315 vectors per replay.
+//
+// A new inode after Reset means the recreate path ran.
+func TestSqliteResetKeepsTheSameDatabaseFile(t *testing.T) {
+	dataDir := t.TempDir()
+	sm, err := newDingoStateManagerAt(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	before := sqliteFileIdentity(t, dataDir)
+	require.NoError(t, sm.Reset())
+	after := sqliteFileIdentity(t, dataDir)
+
+	require.Equal(
+		t,
+		before,
+		after,
+		"Reset must empty the metadata database in place, not recreate it",
+	)
+}
+
+// TestSqliteResetPreservesMigrationLedger pins the consequence that makes the
+// in-place reset worth doing: schema_migrations survives, so the next
+// construction has nothing to re-apply.
+func TestSqliteResetPreservesMigrationLedger(t *testing.T) {
+	dataDir := t.TempDir()
+	sm, err := newDingoStateManagerAt(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	resetter, err := newSqliteResetter(sqliteMetadataPath(dataDir))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+
+	var before int
+	require.NoError(
+		t,
+		resetter.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).
+			Scan(&before),
+	)
+	require.Positive(t, before, "precondition: migrations were recorded")
+
+	require.NoError(t, sm.Reset())
+
+	var after int
+	require.NoError(
+		t,
+		resetter.db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).
+			Scan(&after),
+	)
+	require.Equal(t, before, after, "migration ledger must survive Reset")
+}
+
+// TestSqliteResetClearsBlobStore pins the half of Reset that the metadata
+// truncate does not cover. The previous path cleared blobs incidentally, by
+// removing the whole data directory; emptying only the metadata tables would
+// silently leave a prior vector's UTxO CBOR readable.
+func TestSqliteResetClearsBlobStore(t *testing.T) {
+	dataDir := t.TempDir()
+	sm, err := newDingoStateManagerAt(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	key := []byte("conformance-reset-probe")
+	value := []byte("stale vector bytes")
+
+	blobStore := sm.db.Blob()
+	require.NotNil(t, blobStore)
+	txn := blobStore.NewTransaction(true)
+	require.NoError(t, blobStore.Set(txn, key, value))
+	require.NoError(t, txn.Commit())
+
+	// Confirm it is actually readable before Reset, so a broken write cannot
+	// make the post-Reset absence look like success.
+	readTxn := sm.db.Blob().NewTransaction(false)
+	got, err := sm.db.Blob().Get(readTxn, key)
+	require.NoError(t, err)
+	require.Equal(t, value, got, "precondition: blob is readable")
+	_ = readTxn.Rollback()
+
+	require.NoError(t, sm.Reset())
+
+	afterTxn := sm.db.Blob().NewTransaction(false)
+	defer func() { _ = afterTxn.Rollback() }()
+	_, err = sm.db.Blob().Get(afterTxn, key)
+	require.Error(t, err, "Reset must clear the blob store")
+}

--- a/internal/test/conformance/state_manager_sqlite_test.go
+++ b/internal/test/conformance/state_manager_sqlite_test.go
@@ -66,8 +66,29 @@ func TestSqliteResetterTruncatesOnlyDirtyTables(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resetter.Close() })
 
+	// Record what truncate is actually asked to empty. Row counts alone
+	// cannot show this: `clean` starts empty, so it reads 0 whether or not
+	// the resetter touched it, and a regression that emptied every table
+	// would pass on counts.
+	var truncated []string
+	inner := resetter.truncate
+	resetter.truncate = func(
+		ctx context.Context,
+		db *sql.DB,
+		qualified []string,
+	) error {
+		truncated = append(truncated, qualified...)
+		return inner(ctx, db, qualified)
+	}
+
 	require.NoError(t, resetter.reset(context.Background()))
 
+	require.Equal(
+		t,
+		[]string{`"dirty"`},
+		truncated,
+		"only the table holding rows may be truncated",
+	)
 	require.Equal(t, 0, sqliteRowCount(t, db, "dirty"))
 	require.Equal(t, 0, sqliteRowCount(t, db, "clean"))
 
@@ -164,6 +185,20 @@ func TestSqliteResetterExcludesInternalAndMigrationTables(t *testing.T) {
 	resetter, err := newSqliteResetter(path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resetter.Close() })
+
+	// Both excluded names must actually exist in this database, or
+	// NotContains below would pass for the wrong reason.
+	for _, name := range []string{"schema_migrations", "sqlite_sequence"} {
+		var found string
+		require.NoError(
+			t,
+			db.QueryRow(
+				`SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
+				name,
+			).Scan(&found),
+			"precondition: %s must exist to be meaningfully excluded", name,
+		)
+	}
 
 	tables, err := resetter.cachedTables(context.Background())
 	require.NoError(t, err)

--- a/internal/test/conformance/state_manager_sqlite_test.go
+++ b/internal/test/conformance/state_manager_sqlite_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// newSqliteResetterTestDB creates a SQLite file with the given DDL applied and
+// returns its path plus an open handle for assertions. The handle is separate
+// from the resetter's own connection on purpose: the resetter holding its own
+// pool for the manager's lifetime is the property being exercised.
+func newSqliteResetterTestDB(t *testing.T, ddl ...string) (string, *sql.DB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "metadata.sqlite")
+	db, err := sql.Open("sqlite", "file:"+path+"?_pragma=busy_timeout(30000)")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	for _, stmt := range ddl {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err, "apply ddl: %s", stmt)
+	}
+	return path, db
+}
+
+func sqliteRowCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(
+		t,
+		db.QueryRow(`SELECT COUNT(*) FROM "`+table+`"`).Scan(&n),
+	)
+	return n
+}
+
+// TestSqliteResetterTruncatesOnlyDirtyTables pins the same dirty-only
+// contract the Postgres and MySQL resetters carry: a table nothing wrote to
+// must not be touched, and the schema must survive.
+func TestSqliteResetterTruncatesOnlyDirtyTables(t *testing.T) {
+	path, db := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE dirty (id INTEGER PRIMARY KEY, v TEXT)`,
+		`CREATE TABLE clean (id INTEGER PRIMARY KEY, v TEXT)`,
+		`INSERT INTO dirty (v) VALUES ('x'), ('y')`,
+	)
+
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+
+	require.NoError(t, resetter.reset(context.Background()))
+
+	require.Equal(t, 0, sqliteRowCount(t, db, "dirty"))
+	require.Equal(t, 0, sqliteRowCount(t, db, "clean"))
+
+	// The schema must still exist: this path replaces a drop-and-recreate,
+	// so a Reset that removed the tables would still read as "empty" here.
+	var tables int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' `+
+			`AND name IN ('dirty','clean')`,
+	).Scan(&tables))
+	require.Equal(t, 2, tables, "reset must not drop the schema")
+}
+
+// TestSqliteResetterResetsAutoincrement is the reason this cannot be a plain
+// DELETE. The close-and-reopen path this replaces recreated the file, so every
+// AUTOINCREMENT counter restarted at 1; DELETE alone leaves sqlite_sequence
+// intact and the next insert would continue from the previous vector's high
+// water mark.
+func TestSqliteResetterResetsAutoincrement(t *testing.T) {
+	path, db := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)`,
+		`INSERT INTO t (v) VALUES ('a'), ('b'), ('c')`,
+	)
+
+	var before int
+	require.NoError(t, db.QueryRow(`SELECT MAX(id) FROM t`).Scan(&before))
+	require.Equal(t, 3, before)
+
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+	require.NoError(t, resetter.reset(context.Background()))
+
+	_, err = db.Exec(`INSERT INTO t (v) VALUES ('fresh')`)
+	require.NoError(t, err)
+
+	var after int
+	require.NoError(t, db.QueryRow(`SELECT id FROM t`).Scan(&after))
+	require.Equal(
+		t,
+		1,
+		after,
+		"AUTOINCREMENT must restart at 1, as the recreate path gave",
+	)
+}
+
+// TestSqliteResetterClearsAutoincrementOfEmptiedTable covers the case the
+// dirty-only optimization creates: a table emptied by an earlier reset holds
+// no rows, so the row probe will not report it, yet its sqlite_sequence entry
+// still advances the next insert. MySQL solves the same problem with
+// extraDirty; SQLite must too.
+func TestSqliteResetterClearsAutoincrementOfEmptiedTable(t *testing.T) {
+	path, db := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)`,
+		`INSERT INTO t (v) VALUES ('a'), ('b')`,
+		// Emptied by hand, leaving sqlite_sequence advanced: exactly the
+		// state a prior vector's reset would leave if only rows counted.
+		`DELETE FROM t`,
+	)
+
+	var seq int
+	require.NoError(t, db.QueryRow(
+		`SELECT seq FROM sqlite_sequence WHERE name='t'`,
+	).Scan(&seq))
+	require.Equal(t, 2, seq, "precondition: sequence is advanced")
+
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+	require.NoError(t, resetter.reset(context.Background()))
+
+	_, err = db.Exec(`INSERT INTO t (v) VALUES ('fresh')`)
+	require.NoError(t, err)
+	var after int
+	require.NoError(t, db.QueryRow(`SELECT id FROM t`).Scan(&after))
+	require.Equal(t, 1, after, "a row-empty table's sequence must still reset")
+}
+
+// TestSqliteResetterExcludesInternalAndMigrationTables keeps the resetter off
+// SQLite's own bookkeeping and off the migration runner's ledger. Truncating
+// schema_migrations would make the next construction re-run every migration,
+// which is the cost this whole path exists to avoid.
+func TestSqliteResetterExcludesInternalAndMigrationTables(t *testing.T) {
+	path, db := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE schema_migrations (version TEXT PRIMARY KEY)`,
+		`CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)`,
+		`INSERT INTO schema_migrations (version) VALUES ('v1')`,
+		`INSERT INTO t (v) VALUES ('a')`,
+	)
+
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+
+	tables, err := resetter.cachedTables(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, tables, "t")
+	require.NotContains(t, tables, "schema_migrations")
+	require.NotContains(t, tables, "sqlite_sequence")
+
+	require.NoError(t, resetter.reset(context.Background()))
+	require.Equal(
+		t,
+		1,
+		sqliteRowCount(t, db, "schema_migrations"),
+		"migration ledger must survive a reset",
+	)
+	require.Equal(t, 0, sqliteRowCount(t, db, "t"))
+}
+
+// TestSqliteResetterClearsDespiteForeignKeys pins deletion working regardless
+// of parent/child ordering. Postgres gets this from TRUNCATE ... CASCADE;
+// SQLite has no CASCADE on DELETE, so the resetter's own connection must not
+// enforce foreign keys.
+func TestSqliteResetterClearsDespiteForeignKeys(t *testing.T) {
+	// Names chosen so listSqliteConformanceTables' ORDER BY name yields the
+	// referenced table first: deleting a_parent while z_child still
+	// references it is a foreign-key violation on an enforcing connection.
+	// With the natural names the order is child-then-parent, which happens
+	// not to violate anything and would make this test prove nothing.
+	path, db := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE a_parent (id INTEGER PRIMARY KEY, v TEXT)`,
+		`CREATE TABLE z_child (
+			id INTEGER PRIMARY KEY,
+			parent_id INTEGER NOT NULL REFERENCES a_parent(id)
+		)`,
+		`INSERT INTO a_parent (id, v) VALUES (1, 'p')`,
+		`INSERT INTO z_child (id, parent_id) VALUES (1, 1)`,
+	)
+
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+
+	require.NoError(t, resetter.reset(context.Background()))
+	require.Equal(t, 0, sqliteRowCount(t, db, "a_parent"))
+	require.Equal(t, 0, sqliteRowCount(t, db, "z_child"))
+}
+
+// TestSqliteResetterSkipsEntirelyWhenClean pins the no-op case: a run whose
+// previous vector wrote nothing must issue no DELETE at all. This is what
+// keeps the cost proportional to what a vector wrote.
+func TestSqliteResetterSkipsEntirelyWhenClean(t *testing.T) {
+	path, _ := newSqliteResetterTestDB(
+		t,
+		`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`,
+	)
+	resetter, err := newSqliteResetter(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resetter.Close() })
+
+	var truncated [][]string
+	inner := resetter.truncate
+	resetter.truncate = func(
+		ctx context.Context,
+		db *sql.DB,
+		qualified []string,
+	) error {
+		truncated = append(truncated, qualified)
+		return inner(ctx, db, qualified)
+	}
+
+	require.NoError(t, resetter.reset(context.Background()))
+	require.Empty(t, truncated, "a clean database must issue no DELETE")
+}


### PR DESCRIPTION
Reset runs once per vector. For sqlite it closed the backend, removed the data directory, and reopened it, which re-ran every migration: ~260 DDL statements (80 `CREATE TABLE`, 180 `CREATE INDEX`) per vector, ~315 vectors per replay, two replays per process.

Emptying the dirty tables in place over one held connection, and dropping the badger blob store, replaces that.

## Measured

Local, 14-core, `-tags dingo_extra_plugins`, sqlite-only (the configuration the race job runs):

| | before | after |
| --- | ---: | ---: |
| package, `-race` | 655.6s | **178.3s** |
| package, no race | 47.0s | 9.0s |
| `Reset()` mean, `-race` | 712.8ms | 12.1ms |
| `TestConformanceVectorsExerciseDingoEraEntryPoints` | 329.3s | 93.3s |
| `TestRulesConformanceVectors` | 305.5s | 73.2s |

A CPU profile of the old path attributed 76.9% of `Reset` to `migrations.Run`/`execDDL`, and 52.5% flat to syscalls; badger reopen was not the cost.

Corpus unchanged: 315/315 vectors, 644 subtests, 0 failures, 0 races. `golangci-lint` and `gofmt` clean in both the tagged and untagged builds.

## What sqlite needs that postgres/mysql do not

- a `DELETE` per dirty table, since there is no `TRUNCATE`;
- an explicit `sqlite_sequence` clear, because `DELETE` does not reset `AUTOINCREMENT` and the recreate path did;
- foreign keys off on the reset connection, because there is no `CASCADE`.

It also pairs `wipeMetadata` with a new `wipeBlob`. `database.New` checks that the blob store and metadata store commit timestamps agree, so emptying one side alone would leave a mismatched pairing. The remote backends set no `wipeBlob`: they share one process-wide blob directory across every vector by design.

## Tests

Six unit tests for the resetter and three end-to-end. Fail-before was proven by reverting each mechanism in place:

- drop `extraDirty` → `TestSqliteResetterClearsAutoincrementOfEmptiedTable` fails;
- drop the `sqlite_sequence` delete → `TestSqliteResetterResetsAutoincrement` fails;
- set `foreign_keys(1)` → `TestSqliteResetterClearsDespiteForeignKeys` fails;
- `TestSqliteResetKeepsTheSameDatabaseFile` fails on `main`, where the recreate path yields a new inode.

`TestSqliteResetClearsBlobStore` and `TestSqliteResetPreservesMigrationLedger` pass either way and are guards, not regression tests.

## Note on the build tag

`reset_cost.go` loses its `dingo_extra_plugins` tag. `backendResetter` is dialect-agnostic `database/sql` code; the tag came from its callers, and keeping it would have confined the sqlite path to one build configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QHXPb9hhgbvMgMxokmzWa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces sqlite conformance `Reset`'s close-and-reopen path with in-place truncation, so it no longer deletes the data directory and re-runs ~260 migration DDL statements per vector. `Reset` under `-race` drops from ~712ms to ~12ms and the package from ~656s to ~178s, with the corpus unchanged (315/315 vectors, 644 subtests, no races).

- Empties only dirty tables over one held connection, clears `sqlite_sequence`, and disables foreign keys.
- Pairs `wipeMetadata` with a new `wipeBlob` (badger `DropAll`) so blob and metadata commit timestamps stay consistent; the two hooks run independently, so a backend setting only one still gets that half emptied.
- The metadata file URI mirrors the production sqlite store's addressing (absolute, Windows-volume aware, percent-escaped) and the file-identity check uses `os.SameFile`, so the untagged Windows CI build compiles and passes.
- `reset_cost.go` no longer carries the `dingo_extra_plugins` build tag.

<sup>Written for commit a6dc32316c9dc9c11cb434c5e444bd9a32e0ddb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

