### PR TITLE
fix(ledger): bound filtered account query requests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3116,10 +3116,12 @@ and go stake are all zero are omitted; without a pool filter, the result
 contains the union of pools present in those snapshots and the corresponding
 totals.
 
-Query paths that retain database work per resolved item are bounded by
-`ledger.MaxLocalStateQueryItems` (currently 1000). This applies to
-`GetDRepState` and `GetStakeDelegDeposits`. Explicit oversized filters are
-rejected before database or consensus-state access. The empty `GetDRepState`
+Credential filters are bounded by `ledger.MaxLocalStateQueryItems` (currently
+1000) for `GetDRepState`, `GetStakeDelegDeposits`,
+`GetFilteredDelegationsAndRewardAccounts`, and `GetFilteredVoteDelegatees`.
+Explicit oversized filters, including duplicate entries, are rejected before
+database or consensus-state access. Accepted results are never truncated.
+The empty `GetDRepState`
 form remains unrestricted: it loads active DReps once and obtains their
 delegators through chunked account reads instead of one read per DRep.
 `allDRepDelegators` (`ledger/queries.go`) additionally hydrates those
@@ -3131,11 +3133,12 @@ temporary hydrated-`Account`-row memory — the `GetAccountsByCredential`
 result map, the larger share of retained memory since it holds full rows
 rather than the two fields (`Drep`, `DrepType`) actually read — is bounded
 to the batch size instead of the active-account count. Filtered
-`GetStakeSnapshots` and
-`GetFilteredVoteDelegatees` likewise use existing batch database operations,
-removing their per-item read
-amplification without a client-visible item limit. Existing result
-ordering and partial-result behavior remain unchanged.
+`GetStakeSnapshots` uses existing batch database operations without a
+client-visible item limit. `GetFilteredVoteDelegatees` and
+`GetFilteredDelegationsAndRewardAccounts` retain their batch database reads
+within the credential-filter limit, bounding temporary account maps as well
+as query work. Existing result ordering and unknown/inactive credential
+filtering remain unchanged.
 
 Both the empty `GetDRepState` form and `GetFilteredVoteDelegatees` batch
 through `MetadataStore.GetAccountsByCredential`, which groups the requested

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -34,9 +34,9 @@ import (
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
-// MaxLocalStateQueryItems bounds caller-controlled collections on query paths
-// that perform database work for each requested item. Explicit over-limit
-// filters are rejected before database access.
+// MaxLocalStateQueryItems bounds caller-controlled credential filters on query
+// paths that perform per-item work or build account maps from batched reads.
+// Explicit over-limit filters are rejected before database access.
 const MaxLocalStateQueryItems = 1000
 
 // ErrLocalStateQueryLimitExceeded identifies a LocalStateQuery request whose
@@ -1280,6 +1280,12 @@ func (ls *LedgerState) queryShelleyUtxoByAddress(
 func (ls *LedgerState) queryShelleyFilteredDelegationAndRewardAccounts(
 	creds []olocalstatequery.StakeCredential,
 ) (any, error) {
+	if err := checkLocalStateQueryItemLimit(
+		"GetFilteredDelegationsAndRewardAccounts",
+		len(creds),
+	); err != nil {
+		return nil, err
+	}
 	delegations := make(map[olocalstatequery.StakeCredential]ledger.Blake2b224)
 	rewards := make(map[olocalstatequery.StakeCredential]uint64)
 	if len(creds) == 0 {
@@ -1380,6 +1386,12 @@ func (ls *LedgerState) queryShelleyStakeDelegDeposits(
 func (ls *LedgerState) queryShelleyFilteredVoteDelegatees(
 	creds []lcommon.Credential,
 ) (any, error) {
+	if err := checkLocalStateQueryItemLimit(
+		"GetFilteredVoteDelegatees",
+		len(creds),
+	); err != nil {
+		return nil, err
+	}
 	ret := make(olocalstatequery.FilteredVoteDelegateesResult)
 	refs := make([]models.StakeCredentialRef, 0, len(creds))
 	// Carried alongside creds so the second loop can reuse the tag each

--- a/ledger/queries_limit_test.go
+++ b/ledger/queries_limit_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -56,6 +57,91 @@ func TestLocalStateQueryItemLimitBoundary(t *testing.T) {
 	require.Equal(t, MaxLocalStateQueryItems, limitErr.MaximumAllowedItemCount)
 }
 
+func TestLocalStateQueryFilteredAccountLimitBoundary(t *testing.T) {
+	db := newTestDB(t)
+	state := &LedgerState{db: db}
+	credentials := make([]lcommon.Credential, MaxLocalStateQueryItems+1)
+	stakeCredentials := make(
+		[]olocalstatequery.StakeCredential,
+		len(credentials),
+	)
+	poolKey := bytes.Repeat([]byte{0xAB}, 28)
+	drepKey := bytes.Repeat([]byte{0xCD}, 28)
+	transaction := db.MetadataTxn(true)
+	t.Cleanup(func() { _ = transaction.Rollback() })
+	for index := range credentials {
+		binary.BigEndian.PutUint64(
+			credentials[index].Credential[20:],
+			uint64(index),
+		)
+		credentials[index].CredType = uint(index % 2)
+		stakeCredentials[index] = olocalstatequery.StakeCredential{
+			Tag:   uint64(credentials[index].CredType),
+			Bytes: credentials[index].Credential,
+		}
+		require.NoError(t, db.CreateAccount(transaction, &models.Account{
+			StakingKey:    credentials[index].Credential[:],
+			CredentialTag: uint8(credentials[index].CredType),
+			Pool:          poolKey,
+			Reward:        types.Uint64(index + 1),
+			Drep:          drepKey,
+			DrepType:      models.DrepTypeAddrKeyHash,
+			Active:        true,
+		}))
+	}
+	require.NoError(t, transaction.Commit())
+	for _, count := range []int{0, MaxLocalStateQueryItems - 1, MaxLocalStateQueryItems, MaxLocalStateQueryItems + 1} {
+		for _, queryName := range []string{"GetFilteredDelegationsAndRewardAccounts", "GetFilteredVoteDelegatees"} {
+			t.Run(fmt.Sprintf("%s/%d", queryName, count), func(t *testing.T) {
+				var result any
+				var err error
+				if queryName == "GetFilteredVoteDelegatees" {
+					result, err = state.queryShelleyFilteredVoteDelegatees(
+						credentials[:count],
+					)
+				} else {
+					result, err = state.queryShelleyFilteredDelegationAndRewardAccounts(stakeCredentials[:count])
+				}
+				if count > MaxLocalStateQueryItems {
+					require.ErrorIs(t, err, ErrLocalStateQueryLimitExceeded)
+					require.Nil(t, result)
+					var limitErr *LocalStateQueryLimitError
+					require.True(t, errors.As(err, &limitErr))
+					require.Equal(t, &LocalStateQueryLimitError{
+						QueryName:               queryName,
+						SubmittedItemCount:      count,
+						MaximumAllowedItemCount: MaxLocalStateQueryItems,
+					}, limitErr)
+					return
+				}
+				require.NoError(t, err)
+				encoded, err := cbor.Encode(result)
+				require.NoError(t, err)
+				if queryName == "GetFilteredVoteDelegatees" {
+					var delegatees olocalstatequery.FilteredVoteDelegateesResult
+					_, err = cbor.Decode(encoded, &delegatees)
+					require.NoError(t, err)
+					require.Len(t, delegatees, count)
+					for _, credential := range stakeCredentials[:count] {
+						require.Equal(t, lcommon.Drep{
+							Type:       lcommon.DrepTypeAddrKeyHash,
+							Credential: drepKey,
+						}, delegatees[credential])
+					}
+				} else {
+					delegations, rewards := unwrapFilteredDelegationResult(t, result)
+					require.Len(t, delegations, count)
+					require.Len(t, rewards, count)
+					for index, credential := range stakeCredentials[:count] {
+						require.Equal(t, gledger.NewBlake2b224(poolKey), delegations[credential])
+						require.Equal(t, uint64(index+1), rewards[credential])
+					}
+				}
+			})
+		}
+	}
+}
+
 // TestLocalStateQueryPerItemHandlersRejectOverLimitBeforeWork verifies that
 // every query handler with per-item database work rejects oversized input
 // before accessing database or consensus state.
@@ -73,6 +159,22 @@ func TestLocalStateQueryPerItemHandlersRejectOverLimitBeforeWork(t *testing.T) {
 		query string
 		run   func() (any, error)
 	}{
+		{
+			name:  "filtered delegations and rewards",
+			query: "GetFilteredDelegationsAndRewardAccounts",
+			run: func() (any, error) {
+				return ls.queryShelleyFilteredDelegationAndRewardAccounts(
+					stakeCredentials,
+				)
+			},
+		},
+		{
+			name:  "filtered vote delegatees",
+			query: "GetFilteredVoteDelegatees",
+			run: func() (any, error) {
+				return ls.queryShelleyFilteredVoteDelegatees(credentials)
+			},
+		},
 		{
 			name:  "DRep state",
 			query: "GetDRepState",
@@ -266,7 +368,7 @@ func TestAllDRepDelegatorsCrossesBatchBoundary(t *testing.T) {
 }
 
 // TestLocalStateQueryLargeBatchHandlers verifies that handlers backed by batch
-// database primitives accept collections larger than the per-item work limit,
+// database primitives accept collections up to their respective limits,
 // and that the batched reads return the right value for every requested item
 // rather than merely succeeding. Delegated/seeded indices straddle the
 // chunk boundaries GetAccountsByCredential and GetPoolStakeSnapshotsForPools
@@ -276,14 +378,14 @@ func TestLocalStateQueryLargeBatchHandlers(t *testing.T) {
 	db := newTestDB(t)
 	itemCount := MaxLocalStateQueryItems + 1
 
-	credentials := make([]lcommon.Credential, itemCount)
+	credentials := make([]lcommon.Credential, MaxLocalStateQueryItems)
 	for i := range credentials {
 		binary.BigEndian.PutUint64(
 			credentials[i].Credential[20:],
 			uint64(i),
 		)
 	}
-	delegatedIdx := []int{0, 997, 998, 999, itemCount - 1}
+	delegatedIdx := []int{0, 996, 997, 998, len(credentials) - 1}
 	drepCredential := bytes.Repeat([]byte{0xAB}, 28)
 	for _, idx := range delegatedIdx {
 		require.NoError(t, db.CreateAccount(nil, &models.Account{


### PR DESCRIPTION
LocalStateQuery filtered account handlers accepted unbounded credential
filters, allowing oversized requests to allocate large result maps and perform
excessive database work.

- Reject filters larger than `ledger.MaxLocalStateQueryItems` (1,000) before
  database access.
- Preserve existing result and error semantics for accepted requests.
- Add boundary and result-shape regression coverage.

Validation: focused `ledger` race tests, architecture checks, docs parity, and
scoped lint pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds credential filters on `GetFilteredDelegationsAndRewardAccounts` and `GetFilteredVoteDelegatees` so oversized requests are rejected before database access. Previously these handlers accepted unbounded filters, allowing oversized requests to allocate large result maps and do excessive database work.

- Rejects filters larger than `ledger.MaxLocalStateQueryItems` (1,000) with the existing limit error.
- Preserves results and error semantics for accepted requests, including unknown and inactive credential filtering.
- Adds boundary and result-shape regression coverage across both handlers.

<sup>Written for commit 666fe2cb4500267759921e2ec3815b9e4bd8ae50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filtered delegation and vote-delegatee queries now reject oversized requests before accessing stored data.
  - Requests within the configured limit return complete results without truncation.
  - Boundary handling for credential filters and batched queries is now consistent and validated.

- **Documentation**
  - Clarified which local-state queries are subject to item limits, how duplicate or oversized filters are handled, and how batch-backed queries behave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->