### PR TITLE
fix(forging): account for encoded body size incrementally

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -673,6 +673,15 @@ graph TB
 
 The block production pipeline from leader election through broadcast.
 
+For Shelley through Conway, transaction selection accounts incrementally for
+the exact encoded body components: raw bodies and witnesses, array headers,
+auxiliary data with its transaction-index keys and map header, and the era's
+empty invalid-transaction list. Each candidate adds constant-time accounting;
+previously selected transactions are not re-encoded or hashed during selection.
+Selection stops before the first candidate that exceeds `MaxBlockBodySize`,
+preserving the accepted prefix. The final encoding and body hash still provide
+an independent size check. Dijkstra retains its separate inline-body sizing.
+
 Two invariants keep the forger from advertising or repeating a block it has
 not durably adopted:
 

--- a/ledger/forging/body_size.go
+++ b/ledger/forging/body_size.go
@@ -1,0 +1,34 @@
+package forging
+
+import "github.com/blinklabs-io/gouroboros/cbor"
+
+type segmentedBodySize struct {
+	payloadSize   uint64
+	txCount       int
+	metadataCount int
+}
+
+func (size segmentedBodySize) withTransaction(
+	body, witnesses, metadata cbor.RawMessage,
+) segmentedBodySize {
+	size.payloadSize += uint64(len(body)) + uint64(len(witnesses))
+	if metadata != nil {
+		size.payloadSize += uint64(cbor.ArrayHeaderSize(size.txCount)) +
+			uint64(len(metadata))
+		size.metadataCount++
+	}
+	size.txCount++
+	return size
+}
+
+func (size segmentedBodySize) size(era eraKind) uint64 {
+	total := size.payloadSize + 2*uint64(cbor.ArrayHeaderSize(size.txCount)) +
+		uint64(cbor.ArrayHeaderSize(size.metadataCount))
+	if era.hasInvalidTxs() {
+		total++
+		if era.usesIndefInvalidList() {
+			total++
+		}
+	}
+	return total
+}

--- a/ledger/forging/body_size_test.go
+++ b/ledger/forging/body_size_test.go
@@ -1,0 +1,87 @@
+package forging
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSegmentedBodySizeSparseMetadata(t *testing.T) {
+	for _, count := range []int{0, 23, 24, 25, 255, 256, 257} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			var size segmentedBodySize
+			transactions := make([]MempoolTransaction, count)
+			for index := range transactions {
+				transaction := bodyBudgetTransaction(
+					t, eraConway, index, index == count-1,
+				)
+				transactions[index] = transaction
+				var parts []cbor.RawMessage
+				_, err := cbor.Decode(transaction.Cbor, &parts)
+				require.NoError(t, err)
+				var metadata cbor.RawMessage
+				if index == count-1 {
+					metadata = parts[3]
+				}
+				size = size.withTransaction(parts[0], parts[1], metadata)
+			}
+			require.Equal(t, bodyBudgetEncodedSize(t, eraConway, transactions),
+				size.size(eraConway))
+		})
+	}
+}
+
+func TestSegmentedBodySizeCandidateDoesNotAllocate(t *testing.T) {
+	body := cbor.RawMessage{0xa0}
+	witnesses := cbor.RawMessage{0xa0}
+	metadata := cbor.RawMessage{0xa0}
+	var size segmentedBodySize
+	allocations := testing.AllocsPerRun(100, func() {
+		size = segmentedBodySize{}
+		for range 1024 {
+			size = size.withTransaction(body, witnesses, metadata)
+		}
+	})
+	require.Equal(t, float64(0), allocations)
+	require.Equal(t, 1024, size.txCount)
+}
+
+func BenchmarkSegmentedBodySize(b *testing.B) {
+	for _, count := range []int{64, 256, 1024} {
+		b.Run(fmt.Sprintf("incremental/%d", count), func(b *testing.B) {
+			body := cbor.RawMessage{0xa0}
+			witnesses := cbor.RawMessage{0xa0}
+			metadata := cbor.RawMessage{0xa0}
+			b.ReportAllocs()
+			for b.Loop() {
+				var size segmentedBodySize
+				for range count {
+					size = size.withTransaction(body, witnesses, metadata)
+					if size.size(eraConway) == 0 {
+						b.Fatal("empty candidate size")
+					}
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("reencode/%d", count), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				bodies := []cbor.RawMessage{}
+				witnesses := []cbor.RawMessage{}
+				metadata := map[uint]cbor.RawMessage{}
+				for index := range count {
+					bodies = append(bodies, cbor.RawMessage{0xa0})
+					witnesses = append(witnesses, cbor.RawMessage{0xa0})
+					metadata[uint(index)] = cbor.RawMessage{0xa0}
+					for _, component := range []any{bodies, witnesses, metadata} {
+						if _, err := cbor.Encode(component); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/ledger/forging/builder.go
+++ b/ledger/forging/builder.go
@@ -319,6 +319,7 @@ func (b *DefaultBlockBuilder) buildBlock(
 		transactionWitnessSets = []cbor.RawMessage{}
 		transactionMetadataSet = make(map[uint]cbor.RawMessage)
 		blockSize              uint64
+		encodedBodySize        segmentedBodySize
 		totalExUnits           lcommon.ExUnits
 		maxTxSize              = limits.maxTxSize
 		maxBlockSize           = limits.maxBlockSize
@@ -386,20 +387,6 @@ func (b *DefaultBlockBuilder) buildBlock(
 					"max_tx_size", maxTxSize,
 				)
 				continue
-			}
-
-			// Check MaxBlockSize limit. Dijkstra's block body is not the
-			// segmented tx-body/witness/metadata layout, so it gets an exact
-			// candidate block-body size check after tx decoding below.
-			if limits.era != eraDijkstra && blockSize+txSize > maxBlockSize {
-				b.logger.Debug(
-					"block size limit reached",
-					"component", "forging",
-					"current_size", blockSize,
-					"tx_size", txSize,
-					"max_block_size", maxBlockSize,
-				)
-				break
 			}
 
 			// Decode the transaction CBOR into a typed era-specific
@@ -590,6 +577,21 @@ func (b *DefaultBlockBuilder) buildBlock(
 					)
 					break
 				}
+			}
+			if limits.era != eraDijkstra {
+				candidateSize := encodedBodySize.withTransaction(
+					bodyBytes, witnessBytes, metadataCbor,
+				)
+				if candidateSize.size(limits.era) > maxBlockSize {
+					b.logger.Debug(
+						"block body size limit reached",
+						"component", "forging",
+						"candidate_body_size", candidateSize.size(limits.era),
+						"max_block_body_size", maxBlockSize,
+					)
+					break
+				}
+				encodedBodySize = candidateSize
 			}
 			transactionBodies = append(transactionBodies, bodyBytes)
 			transactionWitnessSets = append(

--- a/ledger/forging/builder_body_budget_test.go
+++ b/ledger/forging/builder_body_budget_test.go
@@ -1,0 +1,226 @@
+package forging
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+func bodyBudgetParams(era eraKind, limit uint) lcommon.ProtocolParameters {
+	switch era {
+	case eraShelley, eraAllegra:
+		return &shelley.ShelleyProtocolParameters{
+			MaxTxSize: 16384, MaxBlockBodySize: limit,
+			ProtocolMajor: uint(era) + 1,
+		}
+	case eraMary:
+		return &mary.MaryProtocolParameters{
+			MaxTxSize: 16384, MaxBlockBodySize: limit, ProtocolMajor: 4,
+		}
+	case eraAlonzo:
+		return &alonzo.AlonzoProtocolParameters{
+			MaxTxSize: 16384, MaxBlockBodySize: limit, ProtocolMajor: 5,
+		}
+	case eraBabbage:
+		return &babbage.BabbageProtocolParameters{
+			MaxTxSize: 16384, MaxBlockBodySize: limit, ProtocolMajor: 7,
+		}
+	default:
+		return &conway.ConwayProtocolParameters{
+			MaxTxSize: 16384, MaxBlockBodySize: limit,
+		}
+	}
+}
+
+func bodyBudgetTransaction(
+	t testing.TB,
+	era eraKind,
+	index int,
+	withMetadata bool,
+) MempoolTransaction {
+	t.Helper()
+	var auxiliary any
+	if withMetadata {
+		metadata := map[uint]any{0: bytes.Repeat([]byte{0xab}, 64)}
+		scripts := []any{[]any{uint(0), make([]byte, 28)}}
+		switch era {
+		case eraShelley:
+			auxiliary = metadata
+		case eraAllegra, eraMary:
+			auxiliary = []any{metadata, scripts}
+		default:
+			auxiliary = cbor.Tag{
+				Number: 259,
+				Content: map[uint]any{
+					0: metadata, 1: scripts, 2: []any{[]byte{1, 2, 3}},
+				},
+			}
+		}
+	}
+	body := map[uint]any{
+		0: []any{[]any{make([]byte, 32), uint(index)}},
+		2: uint(200000),
+	}
+	if auxiliary != nil {
+		encoded, err := cbor.Encode(auxiliary)
+		require.NoError(t, err)
+		body[7] = lcommon.Blake2b256Hash(encoded).Bytes()
+	}
+	parts := []any{body, map[uint]any{}}
+	if era >= eraAlonzo {
+		parts = append(parts, true)
+	}
+	parts = append(parts, auxiliary)
+	encoded, err := cbor.Encode(parts)
+	require.NoError(t, err)
+	transaction := MempoolTransaction{
+		Cbor: encoded, Type: uint(era),
+	}
+	decoded, err := decodeMempoolTx(transaction)
+	require.NoError(t, err)
+	transaction.Hash = decoded.Hash().String()
+	return transaction
+}
+
+func bodyBudgetEncodedSize(
+	t testing.TB,
+	era eraKind,
+	transactions []MempoolTransaction,
+) uint64 {
+	t.Helper()
+	bodies := []cbor.RawMessage{}
+	witnesses := []cbor.RawMessage{}
+	metadata := map[uint]cbor.RawMessage{}
+	for index, transaction := range transactions {
+		var parts []cbor.RawMessage
+		_, err := cbor.Decode(transaction.Cbor, &parts)
+		require.NoError(t, err)
+		bodies = append(bodies, parts[0])
+		witnesses = append(witnesses, parts[1])
+		auxiliary := parts[len(parts)-1]
+		if !bytes.Equal(auxiliary, []byte{0xf6}) {
+			metadata[uint(index)] = auxiliary
+		}
+	}
+	components := []any{bodies, witnesses, metadata}
+	if era == eraAlonzo {
+		components = append(components, cbor.IndefLengthList{})
+	} else if era > eraAlonzo {
+		components = append(components, []uint{})
+	}
+	var size uint64
+	for _, component := range components {
+		encoded, err := cbor.Encode(component)
+		require.NoError(t, err)
+		size += uint64(len(encoded))
+	}
+	return size
+}
+
+func TestBuildBlockEncodedBodyBudget(t *testing.T) {
+	credentials := setupTestCredentials(t)
+	for _, era := range []eraKind{
+		eraShelley, eraAllegra, eraMary, eraAlonzo, eraBabbage, eraConway,
+	} {
+		for _, metadata := range []bool{false, true} {
+			for _, count := range []int{1, 3, 24, 25, 256, 257} {
+				transactions := make([]MempoolTransaction, count)
+				for index := range transactions {
+					transactions[index] = bodyBudgetTransaction(
+						t, era, index, metadata,
+					)
+				}
+				exactSize := bodyBudgetEncodedSize(t, era, transactions)
+				for _, delta := range []int{-1, 0, 1} {
+					t.Run(fmt.Sprintf(
+						"era=%d/metadata=%t/count=%d/delta=%d",
+						era, metadata, count, delta,
+					), func(t *testing.T) {
+						limit := uint(int(exactSize) + delta)
+						builder := setupCredentialValidationBuilder(t, credentials)
+						builder.mempool = &mockMempool{transactions: transactions}
+						builder.pparamsProvider = &mockPParamsProvider{
+							pparams: bodyBudgetParams(era, limit),
+						}
+						block, encoded, err := builder.BuildBlock(1001, 0)
+						require.NoError(t, err, "size overflow must retain the fitting prefix")
+						wantCount := count
+						if delta < 0 {
+							wantCount--
+						}
+						require.Len(t, block.Transactions(), wantCount,
+							"admission must use encoded bytes, not raw transaction sizes")
+						for index, transaction := range block.Transactions() {
+							require.Equal(t, transactions[index].Hash,
+								transaction.Hash().String())
+						}
+						var fields []cbor.RawMessage
+						_, err = cbor.Decode(encoded, &fields)
+						require.NoError(t, err)
+						var wireSize uint64
+						for _, field := range fields[1:] {
+							wireSize += uint64(len(field))
+						}
+						require.Equal(t, bodyBudgetEncodedSize(
+							t, era, transactions[:wantCount],
+						), wireSize)
+						require.Equal(t, wireSize, block.BlockBodySize())
+						require.LessOrEqual(t, wireSize, uint64(limit))
+						var actualMetadata map[uint]cbor.RawMessage
+						_, err = cbor.Decode(fields[3], &actualMetadata)
+						require.NoError(t, err)
+						wantMetadata := 0
+						if metadata {
+							wantMetadata = wantCount
+						}
+						require.Len(t, actualMetadata, wantMetadata)
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestBuildBlockEncodedBudgetRetainsPrefixAfterSkippedTransaction(
+	t *testing.T,
+) {
+	transactions := []MempoolTransaction{
+		bodyBudgetTransaction(t, eraConway, 0, false),
+		bodyBudgetTransaction(t, eraConway, 1, true),
+		bodyBudgetTransaction(t, eraConway, 2, true),
+		bodyBudgetTransaction(t, eraConway, 3, true),
+	}
+	selected := []MempoolTransaction{transactions[0], transactions[2]}
+	limit := bodyBudgetEncodedSize(t, eraConway, selected)
+	builder := setupCredentialValidationBuilder(t, setupTestCredentials(t))
+	builder.mempool = &mockMempool{transactions: transactions}
+	builder.pparamsProvider = &mockPParamsProvider{
+		pparams: bodyBudgetParams(eraConway, uint(limit)),
+	}
+	builder.txValidator = &mockTxValidator{
+		rejectHashes: map[string]struct{}{transactions[1].Hash: {}},
+	}
+	block, encoded, err := builder.BuildBlock(1001, 0)
+	require.NoError(t, err)
+	require.Len(t, block.Transactions(), 2)
+	require.Equal(t, selected[0].Hash, block.Transactions()[0].Hash().String())
+	require.Equal(t, selected[1].Hash, block.Transactions()[1].Hash().String())
+	require.Equal(t, limit, block.BlockBodySize())
+	var fields []cbor.RawMessage
+	_, err = cbor.Decode(encoded, &fields)
+	require.NoError(t, err)
+	var metadata map[uint]cbor.RawMessage
+	_, err = cbor.Decode(fields[3], &metadata)
+	require.NoError(t, err)
+	require.Len(t, metadata, 1)
+	require.Contains(t, metadata, uint(1))
+}


### PR DESCRIPTION
Account incrementally for exact Shelley–Conway block-body bytes, including auxiliary data and CBOR framing. This admits encoded-fitting transactions and preserves the accepted prefix when the next candidate exceeds the limit, without repeatedly encoding the growing body. Dijkstra behavior is unchanged.

Adds metadata, exact-limit, retention, and allocation regression coverage.

Related to #3528 (block-body budgeting).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes block forging so transaction selection accounts for the exact encoded Shelley–Conway block-body size incrementally, instead of using raw transaction sizes. This admits encoded-fitting transactions and preserves the accepted prefix when the next candidate exceeds `MaxBlockBodySize`, without re-encoding the growing body. Dijkstra behavior is unchanged. Related to #3528.

**Bug Fixes**
- Adds constant-time accounting per candidate for bodies, witnesses, array headers, auxiliary data with transaction-index keys and its map header, and the era's empty invalid-transaction list.
- Adds regression coverage for metadata, exact-limit, prefix retention, and allocation behavior.

<sup>Written for commit 624ee74699e30043960a5e579ea4b9c34daaf9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

