### PR TITLE
fix(database): stage UTxO blob deletes in the caller's transaction

### DIFF
--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -1138,3 +1138,49 @@ func TestRecoverConsumedUtxoRefusesOffPrimaryChainProducer(t *testing.T) {
 		"the gate must be the only thing refusing this producer")
 	require.ErrorContains(t, err, "decode transaction output")
 }
+
+// TestDeleteUtxoBlobsUsesCallerBlobTxn pins that UTxO blob deletes are staged
+// in the caller's transaction rather than committed on their own.
+//
+// UtxosDeleteRolledback and UtxosDeleteConsumed delete blobs before the
+// metadata delete they accompany. Committing the blob deletes separately let a
+// successful delete survive the caller's rollback, leaving metadata that points
+// at blob data which is already gone.
+func TestDeleteUtxoBlobsUsesCallerBlobTxn(t *testing.T) {
+	t.Parallel()
+
+	store := &mockBlobStore{}
+	db := &Database{
+		blobRef: newBlobStoreRef(store),
+		logger: slog.New(
+			slog.NewJSONHandler(
+				io.Discard,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			),
+		),
+	}
+	txn := db.Transaction(true)
+
+	utxos := []models.Utxo{
+		{TxId: []byte{0x01}, OutputIdx: 0},
+		{TxId: []byte{0x02}, OutputIdx: 1},
+		{TxId: []byte{0x03}, OutputIdx: 2},
+	}
+	require.NoError(t, deleteUtxoBlobs(db, utxos, txn))
+	require.Len(
+		t,
+		store.txns,
+		1,
+		"the deletes must not open a transaction of their own",
+	)
+	require.Equal(t, []int{1, 1, 1}, store.deleteUtxoTxnIDs,
+		"every delete must run through the caller's transaction")
+	require.Zero(t, store.txns[0].commitCount,
+		"a staged delete must not be committed before the caller commits")
+	require.Zero(t, store.txns[0].rollbackCount)
+
+	// The caller rolls back, so the staged deletes must go with it.
+	require.NoError(t, txn.Rollback())
+	require.Equal(t, 1, store.txns[0].rollbackCount,
+		"the caller's rollback must discard the staged blob deletes")
+}

--- a/database/utxo.go
+++ b/database/utxo.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -80,22 +81,14 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 	}
 
 	var deleteErrors int
-	for start := 0; start < len(utxos); start += batchSize {
-		end := min(start+batchSize, len(utxos))
-		batchTxn := NewBlobOnlyTxn(d, true)
-		// Take the store from the batch's own transaction rather than
-		// from the database once up front: each batch commits separately,
-		// so a replacement between batches would otherwise leave later
-		// batches deleting through a store that no longer owns their
-		// transaction handles.
-		blob := batchTxn.BlobStore()
-		if blob == nil {
-			batchTxn.Release()
-			return types.ErrBlobStoreUnavailable
-		}
+	deleteBatch := func(
+		store blob.BlobStore,
+		blobTxn types.Txn,
+		batch []models.Utxo,
+	) int {
 		var batchDeleteErrors int
-		for _, utxo := range utxos[start:end] {
-			if err := blob.DeleteUtxo(batchTxn.Blob(), utxo.TxId, utxo.OutputIdx); err != nil {
+		for _, utxo := range batch {
+			if err := store.DeleteUtxo(blobTxn, utxo.TxId, utxo.OutputIdx); err != nil {
 				deleteErrors++
 				batchDeleteErrors++
 				d.logger.Warn(
@@ -108,16 +101,55 @@ func deleteUtxoBlobs(d *Database, utxos []models.Utxo, txn *Txn) error {
 				)
 			}
 		}
-		if err := batchTxn.Commit(); err != nil {
-			deleteErrors += (end - start) - batchDeleteErrors
-			_ = batchTxn.Rollback()
-			d.logger.Warn(
-				"UTxO blob delete batch commit failed",
-				"batch_start", start,
-				"batch_end", end,
-				"batch_size", end-start,
-				"error", err,
-			)
+		return batchDeleteErrors
+	}
+
+	// The store used for each delete comes from whichever transaction owns
+	// the handle that delete runs through, so a concurrent SetBlobStore
+	// cannot leave a handle from one store being deleted through another.
+	if txn != nil && txn.Blob() != nil {
+		// Stage the deletes in the caller's transaction so they commit or
+		// roll back with the metadata delete they accompany. Committing
+		// them separately let a successful blob delete survive the
+		// caller's rollback, leaving metadata that points at blob data
+		// which is already gone.
+		blob := txn.BlobStore()
+		if blob == nil {
+			return types.ErrBlobStoreUnavailable
+		}
+		deleteBatch(blob, txn.Blob(), utxos)
+	} else {
+		for start := 0; start < len(utxos); start += batchSize {
+			end := min(start+batchSize, len(utxos))
+			batch := utxos[start:end]
+			batchTxn := NewBlobOnlyTxn(d, true)
+			// Take the store from the batch's own transaction rather than
+			// from the database once up front: each batch commits
+			// separately, so a replacement between batches would otherwise
+			// leave later batches deleting through a store that no longer
+			// owns their transaction handles.
+			blob := batchTxn.BlobStore()
+			if blob == nil {
+				batchTxn.Release()
+				return types.ErrBlobStoreUnavailable
+			}
+			batchBlobTxn := batchTxn.Blob()
+			if batchBlobTxn == nil {
+				batchTxn.Release()
+				return types.ErrNilTxn
+			}
+			batchDeleteErrors := deleteBatch(blob, batchBlobTxn, batch)
+			if err := batchTxn.Commit(); err != nil {
+				deleteErrors += len(batch) - batchDeleteErrors
+				_ = batchTxn.Rollback()
+				d.logger.Warn(
+					"UTxO blob delete batch commit failed",
+					"batch_start", start,
+					"batch_end", end,
+					"batch_size", len(batch),
+					"error", err,
+				)
+			}
 		}
 	}
 	if deleteErrors > 0 {


### PR DESCRIPTION
Refs #3659

`deleteUtxoBlobs` took the caller's transaction and ignored it, opening a blob-only transaction per batch and committing each one before the caller did any metadata work. A successful blob delete therefore survived the caller's rollback, leaving metadata that points at blob data which is already gone.

`UtxosDeleteRolledback` and `UtxosDeleteConsumed` both delete blobs before the metadata delete they accompany, so a failure after the blob commit left the two stores disagreeing.

When the caller supplies a transaction with a blob handle the deletes are staged in it and commit or roll back with the metadata, matching `deleteTxBlobs`. Callers that supply no blob handle keep the batched fallback.

This covers the issue's first acceptance criterion, that blob deletions participate in the caller's commit. The S3 and GCS compensation criteria are not addressed here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages UTxO blob deletes in the caller's transaction instead of committing them in separate batch transactions, so a rollback now discards them along with the metadata delete they accompany. This fixes the inconsistency where metadata could point to already-deleted blobs.

- Callers that supply a transaction without a blob handle keep the batched fallback.

<sup>Written for commit c98ef8c4667d4bb24072905711ba9cf8e31072a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

