### PR TITLE
build(deps): adopt Plutigo v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
 	github.com/blinklabs-io/gouroboros v0.204.0
 	github.com/blinklabs-io/ouroboros-mock v0.19.0
-	github.com/blinklabs-io/plutigo v0.5.1
+	github.com/blinklabs-io/plutigo v0.6.0
 	github.com/blockfrost/blockfrost-go v0.5.0
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/consensys/gnark-crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/blinklabs-io/gouroboros v0.204.0 h1:z3N2A+4UqERe5A8Okw5m650GKNOQkrZjz
 github.com/blinklabs-io/gouroboros v0.204.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
 github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
-github.com/blinklabs-io/plutigo v0.5.1 h1:cHmv2LII0fZggrOfp6wzW9t644HzTB6s7/vzHVpHJs8=
-github.com/blinklabs-io/plutigo v0.5.1/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
+github.com/blinklabs-io/plutigo v0.6.0 h1:kfIMM+SKcRO8tMj96IAN8EOvjrCnGZ1hsm0+qn8xLL0=
+github.com/blinklabs-io/plutigo v0.6.0/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
 github.com/blockfrost/blockfrost-go v0.5.0 h1:I+qEQw5Re9UHolKZGJE0FtuQL3a7L0WqEYkEO4GisIw=
 github.com/blockfrost/blockfrost-go v0.5.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.7
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
 	github.com/blinklabs-io/gouroboros v0.202.10
-	github.com/blinklabs-io/plutigo v0.5.0
+	github.com/blinklabs-io/plutigo v0.6.0
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/test/antithesis/go.sum
+++ b/internal/test/antithesis/go.sum
@@ -8,8 +8,8 @@ github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuv
 github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
 github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
-github.com/blinklabs-io/plutigo v0.5.0 h1:qDb6ADY5f0LWfQBdr3tZTYGqJGgFdmDQI/iyjSz8CJs=
-github.com/blinklabs-io/plutigo v0.5.0/go.mod h1:ceskOZD5ZkkxhctkfvzRe3XEYdOzFYoxp11RqiG6oeU=
+github.com/blinklabs-io/plutigo v0.6.0 h1:kfIMM+SKcRO8tMj96IAN8EOvjrCnGZ1hsm0+qn8xLL0=
+github.com/blinklabs-io/plutigo v0.6.0/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0/go.mod h1:+K/MYXcLBtHEQjRbjHuJChuybk4LCgjdjgRwil+e+Kk=
 github.com/btcsuite/btcd/btcutil v1.2.0 h1:p3+S2g3Q+7G5NOh4Ji+2UrBOrg5Z0Q4ykzShWG1Dhgs=


### PR DESCRIPTION
Closes #4089.

v0.5.1's `BuiltinCosts.Clone` delegated to `copier.CopyWithOption(..., DeepCopy: true)`, but `jinzhu/copier` only copies exported fields and every cost model's `intercept`/`slope` are unexported. The clone held the same pointers as the package-level `DefaultBuiltinCosts`, so `costModelFromList`'s `update` wrote through them into process-global state.

Verified by pointer identity:

```
v0.5.1  non-nil entries: 104  identical to the global: 104
v0.6.0  non-nil entries: 104  identical to the global: 0
```

Two consequences on v0.5.1: cost model parameters from one evaluation persisted into the next, and concurrent validation raced on the shared model. The path is live here, `gouroboros` v0.204.0 `ledger/conway.UtxoValidatePlutusScripts` → `cek.NewEvalContext` → `costModelFromList`.

Fixed upstream by [plutigo#396](https://github.com/blinklabs-io/plutigo/pull/396), "fix(cek): give each cost model its own builtin costs", which replaces the `copier` call with an explicit per-entry clone.

## Validation

| check | result |
| --- | --- |
| `go build ./...`, untagged and `dingo_extra_plugins`, both modules | pass |
| `go vet -tags dingo_extra_plugins ./...` | pass |
| `golangci-lint run --build-tags dingo_extra_plugins ./ledger/...` | 0 issues |
| `go test -race ./ledger/... ./internal/test/conformance/` | pass, **0 races** |
| `gofmt -l .` | only the 3 files already unformatted on `main` |

`./ledger` covers the direct consumers of this dependency, including `ledger/eras/conway_plutus_budget_test.go`, `cost_models_test.go`, and `conway_plutus_script_failure_test.go`. The conformance corpus replayed 315/315.

Running the two conformance corpus replays concurrently under `-race` reported 59 races on v0.5.1, all rooted at `cek.(*BuiltinCosts).update`, and none on v0.6.0. That parallelisation is not part of this PR.

## Scope

v0.6.0 also carries an evaluator error-class fix, a bounded JSON parse tree, and an additive `data.Normalize`. No dingo source changes were needed.

The nested `internal/test/antithesis` module moves from v0.5.0 for the same reason; `./...` from the root does not cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QHXPb9hhgbvMgMxokmzWa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts `plutigo` v0.6.0 to fix a bug where cost model clones shared pointers, causing cost parameters to leak between evaluations and races during concurrent validation.

- The leak came from `BuiltinCosts.Clone` using `copier`, which only copies exported fields, so the clone still pointed to the global defaults' unexported `intercept`/`slope` fields.
- v0.6.0 replaces that with an explicit per-entry clone, and also includes an evaluator error-class fix, a bounded JSON parse tree, and an additive `data.Normalize`.
- The nested `internal/test/antithesis` module is updated from v0.5.0 to v0.6.0 for the same fix.

<sup>Written for commit 19573cdc99863dc85c20c67a6090a0f40f69e06f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

