### PR TITLE
fix(ledger): enforce block reference script budgets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2455,6 +2455,16 @@ because prior pot transitions cannot be repaired safely without replay.
 
 ### Era-Specific Validation
 
+Validated Conway and Dijkstra block admission checks the aggregate consumed
+reference-script size before validating the block's individual transactions.
+Imported blocks use the same database transaction as application, after any
+applicable endorser transactions and before the ranking block's own mutations.
+Forged blocks check a read view of the pre-block state even when full
+self-validation is disabled. The upstream era rules
+provide protocol-version-aware input accounting, intra-block output handling,
+and the era's aggregate limit. The explicit non-validating Musashi profile
+retains its Dijkstra validation bypass.
+
 The `ledger/eras/` package provides era-specific validation rules for each Cardano era. The default active era table is Byron through Conway. Experimental Dijkstra support is added to the active table when Dingo starts on the `musashi` network (the IOG Leios prototype testnet, matched by network name or magic 164), with `runMode: "leios"`, or with `startEra: "dijkstra"` — see `Config.experimentalDijkstraEnabled`. Keying on the network lets `dingo -n musashi` follow the Musashi testnet past the Conway-to-Dijkstra hard fork without an explicit run mode. The Dijkstra descriptor uses `github.com/blinklabs-io/gouroboros/ledger/dijkstra`, including that release's generated CDDL shape for the nullable Leios/Peras certificate slots.
 
 Several eras replace or drop an upstream `UtxoValidationRules` entry so Dingo
@@ -4781,7 +4791,7 @@ When Dijkstra/Leios is active, `DefaultBlockBuilder` emits the Musashi prototype
 
 #### Optional Self-Validation (`DINGO_VALIDATE_FORGED_BLOCK`)
 
-When `validateForgedBlock` is enabled in config, the forger invokes `LedgerState.ValidateForgedBlock` between steps 5 and 7. This runs three checks: (a) VRF proof and KES signature verification of the block header, (b) body-hash non-zero guard, and (c) per-transaction ledger rule validation against the current UTxO state with an intra-block overlay so outputs created by earlier transactions in the same block are visible to later ones. A failing block is logged, counted in `dingo_forge_validation_failed_total`, and dropped without being adopted or diffused. Validation wall-clock time is recorded in the `dingo_forge_validation_duration_seconds` histogram. Disabled by default; intended for block producers who want defence-in-depth against builder bugs at the cost of additional forge-to-diffusion latency.
+The node always validates the aggregate reference-script budget between steps 5 and 7, before adoption or diffusion. When `validateForgedBlock` is enabled, `LedgerState.ValidateForgedBlock` additionally runs VRF/KES header verification, the body-hash non-zero guard, and per-transaction ledger rules with an intra-block UTxO overlay. A failing block is logged, counted in `dingo_forge_validation_failed_total`, and dropped. Validation duration is recorded in `dingo_forge_validation_duration_seconds`. Full self-validation is disabled by default; the aggregate budget check is mandatory in node wiring and retains the explicit Musashi prototype bypass.
 
 ### Pool Credentials (`ledger/forging/keys.go`, `keystore/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3001,6 +3001,10 @@ large-DB startup for minutes (#2771).
 
 The `LedgerView` interface provides query access to ledger state:
 - UTXO lookups by address or output reference
+- Block reference-script budget checks use a narrow PV10 aggregate-accounting
+  view: a genuinely absent reference UTxO contributes zero, matching Conway's
+  pre-block restricted-map rule, while storage/decode errors and normal
+  per-transaction validation remain fail-closed.
 - Protocol parameter queries
 - Stake distribution queries
 - Account registration checks

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2460,7 +2460,9 @@ reference-script size before validating the block's individual transactions.
 Imported blocks use the same database transaction as application, after any
 applicable endorser transactions and before the ranking block's own mutations.
 Forged blocks check a read view of the pre-block state even when full
-self-validation is disabled. The upstream era rules
+self-validation is disabled. Aggregate dispatch rejects missing or typed-nil
+era parameters with an error before the upstream rule dereferences them.
+The upstream era rules
 provide protocol-version-aware input accounting, intra-block output handling,
 and the era's aggregate limit. The explicit non-validating Musashi profile
 retains its Dijkstra validation bypass.

--- a/ledger/block_reference_script_test.go
+++ b/ledger/block_reference_script_test.go
@@ -140,6 +140,7 @@ func TestBlockReferenceScriptLimitAdmission(t *testing.T) {
 						ConwayProtocolParameters: *pp,
 						MaxRefScriptSizePerBlock: 1,
 					}
+					currentParams.ProtocolVersion.Major = dijkstra.MinProtocolVersionDijkstra
 					return db.Transaction(true).Do(func(txn *database.Txn) error {
 						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, eras.DijkstraEraDesc, currentParams, pp, 0)
 						return err

--- a/ledger/block_reference_script_test.go
+++ b/ledger/block_reference_script_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockReferenceScriptLimitAdmission(t *testing.T) {
+	for _, over := range []bool{false, true} {
+		name := "at limit"
+		if over {
+			name = "over limit"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newTestDB(t)
+			address, err := lcommon.NewAddressFromParts(
+				lcommon.AddressTypeKeyNone,
+				0,
+				bytes.Repeat([]byte{1}, 28),
+				nil,
+			)
+			require.NoError(t, err)
+			block := &conway.ConwayBlock{
+				BlockHeader: &conway.ConwayBlockHeader{},
+			}
+			block.BlockHeader.Body.BlockNumber = 1
+			block.BlockHeader.Body.Slot = 1
+			block.BlockHeader.Body.ProtoVersion.Major = 11
+			for i := range 6 {
+				size := int(conway.MaxRefScriptSizePerBlock / 6)
+				if i == 5 {
+					size += int(conway.MaxRefScriptSizePerBlock % 6)
+					if over {
+						size++
+					}
+				}
+				require.Less(t, uint64(size), conway.MaxRefScriptSizePerTx)
+				txID := bytes.Repeat([]byte{byte(i + 1)}, 32)
+				input := shelley.ShelleyTransactionInput{
+					TxId: lcommon.NewBlake2b256(txID),
+				}
+				output := &babbage.BabbageTransactionOutput{
+					OutputAddress: address,
+					TxOutScriptRef: &lcommon.ScriptRef{
+						Type:   lcommon.ScriptRefTypePlutusV3,
+						Script: make(lcommon.PlutusV3Script, size),
+					},
+				}
+				encoded, err := cbor.Encode(output)
+				require.NoError(t, err)
+				require.NoError(
+					t,
+					db.Transaction(true).Do(func(txn *database.Txn) error {
+						if err := db.CreateUtxo(txn, &models.Utxo{TxId: txID, OutputIdx: 0, AddedSlot: 0}); err != nil {
+							return err
+						}
+						return db.Blob().SetUtxo(txn.Blob(), txID, 0, encoded)
+					}),
+				)
+				block.TransactionBodies = append(
+					block.TransactionBodies,
+					conway.ConwayTransactionBody{
+						TxReferenceInputs: cbor.NewSetType(
+							[]shelley.ShelleyTransactionInput{input},
+							false,
+						),
+					},
+				)
+				block.TransactionWitnessSets = append(
+					block.TransactionWitnessSets,
+					conway.ConwayTransactionWitnessSet{},
+				)
+			}
+			encodedBlock, err := cbor.EncodeGeneric(block)
+			require.NoError(t, err)
+			block.SetCbor(encodedBlock)
+			bodySize, err := serializedBlockBodySize(block)
+			require.NoError(t, err)
+			block.BlockHeader.Body.BlockBodySize = bodySize
+			encodedBlock, err = cbor.EncodeGeneric(block)
+			require.NoError(t, err)
+			block.SetCbor(encodedBlock)
+			pp := &conway.ConwayProtocolParameters{
+				MaxBlockBodySize:   100000,
+				MaxBlockHeaderSize: 100000,
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: 11,
+				},
+			}
+			sentinel := errors.New("transaction validator reached")
+			era := eras.ConwayEraDesc
+			era.ValidateTxFunc = func(lcommon.Transaction, uint64, lcommon.LedgerState, lcommon.ProtocolParameters) error {
+				return sentinel
+			}
+			nodeConfig := newTestShelleyGenesisCfg(t)
+			nodeConfig.ShelleyGenesis().NetworkId = "Testnet"
+			ls := &LedgerState{
+				db:             db,
+				activeEras:     []eras.EraDesc{era},
+				currentEra:     era,
+				currentPParams: pp,
+				config: LedgerStateConfig{
+					Logger:            testLogger(),
+					CardanoNodeConfig: nodeConfig,
+				},
+			}
+			ls.metrics.init(prometheus.NewRegistry())
+			ls.publishSnapshotsLocked()
+			for path, run := range map[string]func() error{
+				"imported": func() error {
+					return db.Transaction(true).Do(func(txn *database.Txn) error {
+						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0)
+						return err
+					})
+				},
+				"forged": func() error { return ls.validateForgedTxs(block) },
+			} {
+				t.Run(path, func(t *testing.T) {
+					err := run()
+					if over {
+						var limit lcommon.RefScriptSizePerBlockTooLargeError
+						require.ErrorAs(
+							t,
+							err,
+							&limit,
+							"aggregate reference-script limit must reject before transaction validation",
+						)
+						require.Equal(
+							t,
+							conway.MaxRefScriptSizePerBlock+1,
+							limit.BlockSize,
+						)
+					} else {
+						require.ErrorIs(t, err, sentinel, "exact block limit must reach later transaction validation")
+					}
+				})
+			}
+		})
+	}
+}

--- a/ledger/block_reference_script_test.go
+++ b/ledger/block_reference_script_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -123,7 +124,7 @@ func TestBlockReferenceScriptLimitAdmission(t *testing.T) {
 			nodeConfig.ShelleyGenesis().NetworkId = "Testnet"
 			ls := &LedgerState{
 				db:             db,
-				activeEras:     []eras.EraDesc{era},
+				activeEras:     []eras.EraDesc{era, eras.DijkstraEraDesc},
 				currentEra:     era,
 				currentPParams: pp,
 				config: LedgerStateConfig{
@@ -134,6 +135,16 @@ func TestBlockReferenceScriptLimitAdmission(t *testing.T) {
 			ls.metrics.init(prometheus.NewRegistry())
 			ls.publishSnapshotsLocked()
 			for path, run := range map[string]func() error{
+				"imported_previous_era": func() error {
+					currentParams := &dijkstra.DijkstraProtocolParameters{
+						ConwayProtocolParameters: *pp,
+						MaxRefScriptSizePerBlock: 1,
+					}
+					return db.Transaction(true).Do(func(txn *database.Txn) error {
+						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, eras.DijkstraEraDesc, currentParams, pp, 0)
+						return err
+					})
+				},
 				"imported": func() error {
 					return db.Transaction(true).Do(func(txn *database.Txn) error {
 						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0)

--- a/ledger/block_reference_scripts.go
+++ b/ledger/block_reference_scripts.go
@@ -52,13 +52,28 @@ func validateBlockReferenceScripts(
 ) error {
 	switch b := block.(type) {
 	case *conway.ConwayBlock:
-		if conwayPParams, ok := pp.(*conway.ConwayProtocolParameters); ok &&
-			state != nil &&
+		conwayPParams, ok := pp.(*conway.ConwayProtocolParameters)
+		if !ok || conwayPParams == nil {
+			return errors.New("pparams are not expected type")
+		}
+		if state != nil &&
 			conwayPParams.ProtocolVersion.Major <= lcommon.ProtocolVersionPlomin {
 			state = pv10ReferenceScriptState{state: state}
 		}
 		return conway.ValidateRefScriptSizePerBlock(b, pp, state)
 	case *dijkstra.DijkstraBlock:
+		// The upstream rule accepts both parameter shapes, but dereferences
+		// either pointer. Reject typed nils before delegating.
+		switch p := pp.(type) {
+		case *dijkstra.DijkstraProtocolParameters:
+			if p == nil {
+				return errors.New("pparams are not expected type")
+			}
+		case *conway.ConwayProtocolParameters:
+			if p == nil {
+				return errors.New("pparams are not expected type")
+			}
+		}
 		return dijkstra.ValidateRefScriptSizePerBlock(b, pp, state)
 	default:
 		return nil

--- a/ledger/block_reference_scripts.go
+++ b/ledger/block_reference_scripts.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+)
+
+// validateBlockReferenceScripts checks the aggregate against the UTxO state
+// before this block's own transactions. The era helpers apply protocol-version
+// rules for preceding outputs and include phase-2-invalid transactions.
+func validateBlockReferenceScripts(
+	block ledger.Block,
+	pp lcommon.ProtocolParameters,
+	state lcommon.UtxoState,
+) error {
+	switch b := block.(type) {
+	case *conway.ConwayBlock:
+		return conway.ValidateRefScriptSizePerBlock(b, pp, state)
+	case *dijkstra.DijkstraBlock:
+		return dijkstra.ValidateRefScriptSizePerBlock(b, pp, state)
+	default:
+		return nil
+	}
+}

--- a/ledger/block_reference_scripts.go
+++ b/ledger/block_reference_scripts.go
@@ -15,11 +15,32 @@
 package ledger
 
 import (
+	"errors"
+
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 )
+
+// pv10ReferenceScriptState applies Conway's pre-PV11 restricted-map behavior
+// only to aggregate block reference-script accounting. A missing reference
+// input contributes zero to that accounting; transaction validation still
+// resolves it through the original state and owns validity.
+type pv10ReferenceScriptState struct {
+	state lcommon.UtxoState
+}
+
+func (s pv10ReferenceScriptState) UtxoById(
+	input lcommon.TransactionInput,
+) (lcommon.Utxo, error) {
+	utxo, err := s.state.UtxoById(input)
+	if errors.Is(err, database.ErrUtxoNotFound) {
+		return lcommon.Utxo{}, nil
+	}
+	return utxo, err
+}
 
 // validateBlockReferenceScripts checks the aggregate against the UTxO state
 // before this block's own transactions. The era helpers apply protocol-version
@@ -31,6 +52,11 @@ func validateBlockReferenceScripts(
 ) error {
 	switch b := block.(type) {
 	case *conway.ConwayBlock:
+		if conwayPParams, ok := pp.(*conway.ConwayProtocolParameters); ok &&
+			state != nil &&
+			conwayPParams.ProtocolVersion.Major <= lcommon.ProtocolVersionPlomin {
+			state = pv10ReferenceScriptState{state: state}
+		}
 		return conway.ValidateRefScriptSizePerBlock(b, pp, state)
 	case *dijkstra.DijkstraBlock:
 		return dijkstra.ValidateRefScriptSizePerBlock(b, pp, state)

--- a/ledger/block_reference_scripts_additional_test.go
+++ b/ledger/block_reference_scripts_additional_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func additionalReferenceOutput(
+	t *testing.T,
+	size int,
+) *babbage.BabbageTransactionOutput {
+	t.Helper()
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		0,
+		bytes.Repeat([]byte{1}, 28),
+		nil,
+	)
+	require.NoError(t, err)
+	return &babbage.BabbageTransactionOutput{
+		OutputAddress: address,
+		TxOutScriptRef: &lcommon.ScriptRef{
+			Type: lcommon.ScriptRefTypePlutusV3, Script: make(lcommon.PlutusV3Script, size),
+		},
+	}
+}
+
+func additionalReferenceAdmission(
+	t *testing.T,
+	db *database.Database,
+	block gledger.Block,
+	era eras.EraDesc,
+	pp lcommon.ProtocolParameters,
+	wantSize uint64,
+	wantLookupError bool,
+) {
+	t.Helper()
+	// Encode real era bodies so envelope admission reaches the aggregate rule.
+	encode := func() {
+		encoded, err := cbor.EncodeGeneric(block)
+		require.NoError(t, err)
+		switch b := block.(type) {
+		case *conway.ConwayBlock:
+			b.SetCbor(encoded)
+		case *dijkstra.DijkstraBlock:
+			b.SetCbor(encoded)
+		}
+	}
+	encode()
+	size, err := serializedBlockBodySize(block)
+	require.NoError(t, err)
+	switch b := block.(type) {
+	case *conway.ConwayBlock:
+		b.BlockHeader.Body.BlockBodySize = size
+		b.SetCbor(nil)
+	case *dijkstra.DijkstraBlock:
+		b.BlockHeader.Body.BlockBodySize = size
+		b.SetCbor(nil)
+	}
+	encode()
+	sentinel := errors.New("later transaction validator reached")
+	era.ValidateTxFunc = func(lcommon.Transaction, uint64, lcommon.LedgerState, lcommon.ProtocolParameters) error {
+		return sentinel
+	}
+	cfg := newTestShelleyGenesisCfg(t)
+	cfg.ShelleyGenesis().NetworkId = "Testnet"
+	ls := &LedgerState{
+		db:             db,
+		activeEras:     []eras.EraDesc{era},
+		currentEra:     era,
+		currentPParams: pp,
+		config: LedgerStateConfig{
+			Logger:            testLogger(),
+			CardanoNodeConfig: cfg,
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.publishSnapshotsLocked()
+	for path, run := range map[string]func() error{
+		"imported": func() error {
+			return db.Transaction(true).Do(func(txn *database.Txn) error {
+				_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0)
+				return err
+			})
+		},
+		"forged": func() error { return ls.validateForgedTxs(block) },
+	} {
+		t.Run(path, func(t *testing.T) {
+			err := run()
+			switch {
+			case wantLookupError:
+				require.ErrorContains(
+					t,
+					err,
+					"resolve consumed reference-script input",
+					"reference lookup failure must reject before transaction validation",
+				)
+			case wantSize != 0:
+				var limit lcommon.RefScriptSizePerBlockTooLargeError
+				require.ErrorAs(
+					t,
+					err,
+					&limit,
+					"aggregate rule must reject before transaction validation",
+				)
+				require.Equal(t, wantSize, limit.BlockSize)
+			default:
+				require.ErrorIs(
+					t,
+					err,
+					sentinel,
+					"valid aggregate must reach later transaction validation",
+				)
+			}
+		})
+	}
+}
+
+func TestDijkstraBlockReferenceScriptCustomLimitAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		lastSize int
+		invalid  bool
+	}{
+		{"below", 59, false}, {"exact", 60, false}, {"above", 61, false}, {"phase_invalid_exact", 60, true}, {"phase_invalid_above", 61, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			block := &dijkstra.DijkstraBlock{
+				BlockHeader: &dijkstra.DijkstraBlockHeader{},
+			}
+			block.BlockHeader.Body.BlockNumber = 1
+			block.BlockHeader.Body.Slot = 1
+			block.BlockHeader.Body.ProtoVersion.Major = 12
+			for i, size := range []int{60, tc.lastSize} {
+				id := bytes.Repeat([]byte{byte(i + 1)}, 32)
+				encoded, err := cbor.Encode(additionalReferenceOutput(t, size))
+				require.NoError(t, err)
+				require.NoError(
+					t,
+					db.Transaction(true).Do(func(txn *database.Txn) error {
+						if err := db.CreateUtxo(txn, &models.Utxo{TxId: id}); err != nil {
+							return err
+						}
+						return db.Blob().SetUtxo(txn.Blob(), id, 0, encoded)
+					}),
+				)
+				block.BlockBody.Transactions = append(
+					block.BlockBody.Transactions,
+					dijkstra.DijkstraTransaction{
+						TxIsValid: !(tc.invalid && i == 1),
+						Body: dijkstra.DijkstraTransactionBody{
+							TxReferenceInputs: cbor.NewSetType(
+								[]shelley.ShelleyTransactionInput{
+									{TxId: lcommon.NewBlake2b256(id)},
+								},
+								false,
+							),
+						},
+					},
+				)
+			}
+			if tc.invalid {
+				block.BlockBody.InvalidTransactions = []uint{1}
+			}
+			pp := &dijkstra.DijkstraProtocolParameters{
+				ConwayProtocolParameters: conway.ConwayProtocolParameters{
+					MaxBlockBodySize: 2000000, MaxBlockHeaderSize: 100000,
+					ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+						Major: 12,
+					},
+				},
+				MaxRefScriptSizePerBlock: 120,
+				MaxRefScriptSizePerTx:    100,
+			}
+			var want uint64
+			if tc.lastSize > 60 {
+				want = uint64(60 + tc.lastSize)
+			}
+			additionalReferenceAdmission(
+				t,
+				db,
+				block,
+				eras.DijkstraEraDesc,
+				pp,
+				want,
+				false,
+			)
+		})
+	}
+}
+
+func TestBlockReferenceScriptProducedOutputAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		name                           string
+		proto                          uint
+		over, invalidProducer, missing bool
+	}{
+		{name: "pv11_below", proto: 11}, {name: "pv11_above", proto: 11, over: true},
+		{name: "pv10_no_overlay", proto: 10}, {name: "invalid_producer", proto: 11, invalidProducer: true},
+		{name: "missing_reference", proto: 11, missing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			size := int(conway.MaxRefScriptSizePerBlock / 6)
+			if tc.over {
+				size++
+			}
+			require.Less(t, uint64(size), conway.MaxRefScriptSizePerTx)
+			block := &conway.ConwayBlock{
+				BlockHeader: &conway.ConwayBlockHeader{},
+			}
+			block.BlockHeader.Body.BlockNumber = 1
+			block.BlockHeader.Body.Slot = 1
+			block.BlockHeader.Body.ProtoVersion.Major = uint64(tc.proto)
+			block.TransactionBodies = []conway.ConwayTransactionBody{
+				{
+					TxOutputs: []babbage.BabbageTransactionOutput{
+						*additionalReferenceOutput(t, size),
+					},
+				},
+			}
+			block.TransactionWitnessSets = []conway.ConwayTransactionWitnessSet{
+				{},
+			}
+			id := block.Transactions()[0].Hash()
+			if tc.missing {
+				id = lcommon.NewBlake2b256(bytes.Repeat([]byte{9}, 32))
+			}
+			for i := range 6 {
+				block.TransactionBodies = append(
+					block.TransactionBodies,
+					conway.ConwayTransactionBody{
+						TxFee: uint64(i),
+						TxReferenceInputs: cbor.NewSetType(
+							[]shelley.ShelleyTransactionInput{{TxId: id}},
+							false,
+						),
+					},
+				)
+				block.TransactionWitnessSets = append(
+					block.TransactionWitnessSets,
+					conway.ConwayTransactionWitnessSet{},
+				)
+			}
+			if tc.invalidProducer {
+				block.InvalidTransactions = []uint{0}
+			}
+			pp := &conway.ConwayProtocolParameters{
+				MaxBlockBodySize:   2000000,
+				MaxBlockHeaderSize: 100000,
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: tc.proto,
+				},
+			}
+			var want uint64
+			if tc.over {
+				want = uint64(size * 6)
+			}
+			additionalReferenceAdmission(
+				t,
+				db,
+				block,
+				eras.ConwayEraDesc,
+				pp,
+				want,
+				tc.proto < 11 || tc.invalidProducer || tc.missing,
+			)
+		})
+	}
+}
+
+func TestValidateBlockReferenceScriptsEntryControls(t *testing.T) {
+	t.Run("nil_and_empty", func(t *testing.T) {
+		ls := &LedgerState{}
+		require.ErrorContains(
+			t,
+			ls.ValidateBlockReferenceScripts(nil),
+			"nil block",
+		)
+		require.NoError(
+			t,
+			ls.ValidateBlockReferenceScripts(&conway.ConwayBlock{}),
+		)
+		require.NoError(
+			t,
+			ls.ValidateBlockReferenceScripts(&dijkstra.DijkstraBlock{}),
+		)
+	})
+	for _, tc := range []struct {
+		name                string
+		previous, prototype bool
+	}{
+		{name: "conway"}, {name: "conway_prototype_flag", prototype: true},
+		{name: "previous_era_parameters", previous: true},
+		{name: "active_dijkstra_prototype_compatibility", previous: true, prototype: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			block := &conway.ConwayBlock{
+				BlockHeader: &conway.ConwayBlockHeader{},
+				TransactionBodies: []conway.ConwayTransactionBody{
+					{
+						TxReferenceInputs: cbor.NewSetType(
+							[]shelley.ShelleyTransactionInput{
+								{
+									TxId: lcommon.NewBlake2b256(
+										bytes.Repeat([]byte{7}, 32),
+									),
+								},
+							},
+							false,
+						),
+					},
+				},
+				TransactionWitnessSets: []conway.ConwayTransactionWitnessSet{
+					{},
+				},
+			}
+			pp := &conway.ConwayProtocolParameters{
+				ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+					Major: 11,
+				},
+			}
+			ls := &LedgerState{
+				db:             db,
+				currentEra:     eras.ConwayEraDesc,
+				currentPParams: pp,
+				config: LedgerStateConfig{
+					SkipDijkstraTxValidation: tc.prototype,
+				},
+			}
+			if tc.previous {
+				ls.currentEra = eras.DijkstraEraDesc
+				ls.currentPParams = &dijkstra.DijkstraProtocolParameters{
+					ConwayProtocolParameters: *pp,
+					MaxRefScriptSizePerBlock: 120,
+				}
+				ls.prevEraPParams = pp
+			}
+			ls.publishSnapshotsLocked()
+			if tc.previous && tc.prototype {
+				// The active Dijkstra prototype may decode blocks using
+				// the concrete Conway type; its explicit bypass policy
+				// follows the active era rather than that block type.
+				require.NoError(t, ls.ValidateBlockReferenceScripts(block))
+				return
+			}
+			require.ErrorContains(
+				t,
+				ls.ValidateBlockReferenceScripts(block),
+				"resolve consumed reference-script input",
+				"Conway input lookup must not bypass aggregate validation or use Dijkstra parameters",
+			)
+		})
+	}
+}

--- a/ledger/block_reference_scripts_additional_test.go
+++ b/ledger/block_reference_scripts_additional_test.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -293,10 +294,94 @@ func TestBlockReferenceScriptProducedOutputAdmission(t *testing.T) {
 				eras.ConwayEraDesc,
 				pp,
 				want,
-				tc.proto < 11 || tc.invalidProducer || tc.missing,
+				tc.invalidProducer || tc.missing,
 			)
 		})
 	}
+}
+
+type referenceScriptStateFunc func(
+	lcommon.TransactionInput,
+) (lcommon.Utxo, error)
+
+func (f referenceScriptStateFunc) UtxoById(
+	input lcommon.TransactionInput,
+) (lcommon.Utxo, error) {
+	return f(input)
+}
+
+func TestPV10ReferenceScriptStateOnlySuppressesMissing(t *testing.T) {
+	input := &shelley.ShelleyTransactionInput{}
+	wrappedMissing := fmt.Errorf("lookup: %w", database.ErrUtxoNotFound)
+	state := pv10ReferenceScriptState{
+		state: referenceScriptStateFunc(
+			func(lcommon.TransactionInput) (lcommon.Utxo, error) {
+				return lcommon.Utxo{}, wrappedMissing
+			},
+		),
+	}
+	utxo, err := state.UtxoById(input)
+	require.NoError(t, err)
+	require.Equal(t, lcommon.Utxo{}, utxo)
+
+	storageErr := errors.New("database unavailable")
+	state.state = referenceScriptStateFunc(
+		func(lcommon.TransactionInput) (lcommon.Utxo, error) {
+			return lcommon.Utxo{}, storageErr
+		},
+	)
+	_, err = state.UtxoById(input)
+	require.ErrorIs(t, err, storageErr)
+}
+
+func TestPV10AggregateReferenceScriptLookupErrors(t *testing.T) {
+	newBlock := func() *conway.ConwayBlock {
+		return &conway.ConwayBlock{
+			BlockHeader: &conway.ConwayBlockHeader{},
+			TransactionBodies: []conway.ConwayTransactionBody{{
+				TxReferenceInputs: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{{
+						TxId: lcommon.NewBlake2b256(
+							bytes.Repeat([]byte{7}, 32),
+						),
+					}},
+					false,
+				),
+			}},
+			TransactionWitnessSets: []conway.ConwayTransactionWitnessSet{{}},
+		}
+	}
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{Major: 10},
+	}
+	missing := referenceScriptStateFunc(
+		func(lcommon.TransactionInput) (lcommon.Utxo, error) {
+			return lcommon.Utxo{}, fmt.Errorf(
+				"lookup wrapper: %w",
+				database.ErrUtxoNotFound,
+			)
+		},
+	)
+	require.NoError(t, validateBlockReferenceScripts(newBlock(), pp, missing))
+
+	decodeErr := errors.New("reference output decode failed")
+	failing := referenceScriptStateFunc(
+		func(lcommon.TransactionInput) (lcommon.Utxo, error) {
+			return lcommon.Utxo{}, decodeErr
+		},
+	)
+	require.ErrorIs(
+		t,
+		validateBlockReferenceScripts(newBlock(), pp, failing),
+		decodeErr,
+	)
+
+	pp.ProtocolVersion.Major = 11
+	require.ErrorContains(
+		t,
+		validateBlockReferenceScripts(newBlock(), pp, missing),
+		"resolve consumed reference-script input",
+	)
 }
 
 func TestValidateBlockReferenceScriptsEntryControls(t *testing.T) {

--- a/ledger/block_reference_scripts_params_test.go
+++ b/ledger/block_reference_scripts_params_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockReferenceScriptsRejectNilParameters(t *testing.T) {
+	state := referenceScriptStateFunc(
+		func(lcommon.TransactionInput) (lcommon.Utxo, error) {
+			t.Fatal("parameter rejection must precede UTxO lookup")
+			return lcommon.Utxo{}, nil
+		},
+	)
+	for _, block := range []struct {
+		name  string
+		value ledger.Block
+	}{
+		{"conway", &conway.ConwayBlock{}},
+		{"dijkstra", &dijkstra.DijkstraBlock{}},
+	} {
+		for _, params := range []struct {
+			name  string
+			value lcommon.ProtocolParameters
+		}{
+			{"nil", nil},
+			{"typed_nil_conway", (*conway.ConwayProtocolParameters)(nil)},
+			{"typed_nil_dijkstra", (*dijkstra.DijkstraProtocolParameters)(nil)},
+		} {
+			t.Run(block.name+"/"+params.name, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					err := validateBlockReferenceScripts(
+						block.value, params.value, state,
+					)
+					require.Error(t, err)
+				})
+			})
+		}
+	}
+}
+
+func TestBlockReferenceScriptsAcceptParameterShapes(t *testing.T) {
+	conwayParams := &conway.ConwayProtocolParameters{
+		ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{Major: 10},
+	}
+	for _, tc := range []struct {
+		name  string
+		block ledger.Block
+		pp    lcommon.ProtocolParameters
+	}{
+		{"conway", &conway.ConwayBlock{}, conwayParams},
+		{"dijkstra_conway", &dijkstra.DijkstraBlock{}, conwayParams},
+		{
+			"dijkstra", &dijkstra.DijkstraBlock{},
+			&dijkstra.DijkstraProtocolParameters{
+				ConwayProtocolParameters: *conwayParams,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, validateBlockReferenceScripts(tc.block, tc.pp, nil))
+		})
+	}
+}

--- a/ledger/eras/conway_utxo_divergence_test.go
+++ b/ledger/eras/conway_utxo_divergence_test.go
@@ -51,6 +51,22 @@ func newConwayDivergenceTx(
 	fee uint64,
 	outputAmount uint64,
 ) *conway.ConwayTransaction {
+	return newConwayDivergenceTxWithReference(
+		t,
+		inputHashByte,
+		fee,
+		outputAmount,
+		nil,
+	)
+}
+
+func newConwayDivergenceTxWithReference(
+	t *testing.T,
+	inputHashByte byte,
+	fee uint64,
+	outputAmount uint64,
+	referenceHash []byte,
+) *conway.ConwayTransaction {
 	t.Helper()
 
 	inputHash := make([]byte, 32)
@@ -72,6 +88,12 @@ func newConwayDivergenceTx(
 		addr[0] = 0x60
 		bodyMap[1] = []any{
 			[]any{addr, outputAmount},
+		}
+	}
+	if referenceHash != nil {
+		bodyMap[18] = cbor.Tag{
+			Number:  258,
+			Content: []any{[]any{referenceHash, uint64(0)}},
 		}
 	}
 	txCbor, err := cbor.Encode([]any{bodyMap, map[uint]any{}, true, nil})
@@ -188,6 +210,42 @@ func TestValidateTxConwayGenuinelyMissingInputStillRejected(t *testing.T) {
 		err.Error(),
 		fmt.Sprintf("conway utxo validation rule %d:", badInputsIndex),
 	)
+}
+
+// TestValidateTxConwayGenuinelyMissingReferenceInputStillRejected confirms
+// that the ordinary Conway transaction rules still reject an absent reference
+// input. Block-level PV10 accounting may omit that key for its size total, but
+// it must not make the transaction itself valid.
+func TestValidateTxConwayGenuinelyMissingReferenceInputStillRejected(
+	t *testing.T,
+) {
+	referenceHash := make([]byte, 32)
+	tx := newConwayDivergenceTxWithReference(
+		t,
+		0xab,
+		200_000,
+		4_800_000,
+		referenceHash,
+	)
+	referenceID := lcommon.NewBlake2b256(referenceHash)
+
+	ls := newMockLedgerState()
+	ls.addUtxo(tx.Inputs()[0], newTestOutput(5_000_000))
+
+	err := ValidateTxConway(
+		tx,
+		0,
+		ls,
+		func() *conway.ConwayProtocolParameters {
+			pp := conwayDivergencePparams()
+			pp.ProtocolVersion.Major = lcommon.ProtocolVersionPlomin
+			return pp
+		}(),
+	)
+	require.Error(t, err)
+	var referenceInput lcommon.ReferenceInputResolutionError
+	require.ErrorAs(t, err, &referenceInput)
+	assert.Contains(t, err.Error(), referenceID.String())
 }
 
 // TestValidateTxConwayGenuinelyUnbalancedStillRejected is the negative case for

--- a/ledger/forging/forger.go
+++ b/ledger/forging/forger.go
@@ -374,10 +374,10 @@ type ForgerConfig struct {
 	// chain tip is far ahead of the slot clock. Zero uses the default.
 	ForgeStaleGapThresholdSlots uint64
 
-	// BlockValidator, when non-nil, validates the forged block (VRF/KES
-	// header crypto, body-hash consistency, per-tx ledger rules) before
-	// AddBlock is called. A validation failure drops the block without
-	// adopting or diffusing it. Nil disables self-validation (default).
+	// BlockValidator runs its implementation's checks before AddBlock.
+	// A failure prevents adoption and diffusion. The node always supplies
+	// aggregate reference-script validation and optionally full validation.
+	// Nil disables validation for callers embedding this package directly.
 	BlockValidator BlockValidator
 
 	// Prometheus metrics registry (optional)

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7123,6 +7123,16 @@ func (ls *LedgerState) ledgerProcessBlock(
 	if err := ls.verifyDeferredBlockHeaderState(txn, point, block); err != nil {
 		return nil, err
 	}
+	// Check the ranking block after any applicable endorser transactions,
+	// using their resulting state but before its own transaction mutations.
+	// The explicitly non-validating Musashi prototype keeps its trust policy.
+	if shouldValidate && !ls.skipDijkstraTxValidation(currentEra.Id) {
+		if err := validateBlockReferenceScripts(block, pparams, &LedgerView{
+			txn: txn, ls: ls,
+		}); err != nil {
+			return nil, err
+		}
+	}
 	// Process transactions
 	var delta *LedgerDelta
 	// Steady-state, at-tip, validated application refuses to recover an absent

--- a/ledger/state.go
+++ b/ledger/state.go
@@ -7127,7 +7127,11 @@ func (ls *LedgerState) ledgerProcessBlock(
 	// using their resulting state but before its own transaction mutations.
 	// The explicitly non-validating Musashi prototype keeps its trust policy.
 	if shouldValidate && !ls.skipDijkstraTxValidation(currentEra.Id) {
-		if err := validateBlockReferenceScripts(block, pparams, &LedgerView{
+		referenceParams := pparams
+		if uint(block.Era().Id)+1 == currentEra.Id && prevEraPParams != nil {
+			referenceParams = prevEraPParams
+		}
+		if err := validateBlockReferenceScripts(block, referenceParams, &LedgerView{
 			txn: txn, ls: ls,
 		}); err != nil {
 			return nil, err

--- a/ledger/validate_forged.go
+++ b/ledger/validate_forged.go
@@ -18,9 +18,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
 
 // ValidateForgedBlock validates a locally-forged block before it is adopted
@@ -30,7 +32,8 @@ import (
 //     Byron-era blocks which use PBFT consensus and have no VRF/KES fields).
 //  2. Body-hash consistency — verifies that the body hash in the header is
 //     non-zero, catching any builder bug that would embed an all-zero hash.
-//  3. Per-transaction ledger rules — each transaction in the block is
+//  3. Aggregate reference-script limits, then per-transaction ledger rules.
+//     Each transaction in the block is
 //     validated against the current UTxO state. An intra-block overlay
 //     is maintained so that transactions spending outputs created earlier
 //     in the same block are correctly resolved.
@@ -108,6 +111,10 @@ func (ls *LedgerState) validateForgedTxs(block ledger.Block) error {
 		return nil
 	}
 
+	if err := ls.ValidateBlockReferenceScripts(block); err != nil {
+		return err
+	}
+
 	// consumedUtxos: inputs spent within this block (prevents intra-block
 	// double-spend); key: "<txId>:<outputIndex>".
 	// createdUtxos: outputs produced within this block and not yet in the
@@ -149,4 +156,32 @@ func (ls *LedgerState) validateForgedTxs(block ledger.Block) error {
 	}
 
 	return nil
+}
+
+// ValidateBlockReferenceScripts checks a locally built block's aggregate
+// reference-script budget before adoption. It does not run header crypto or
+// transaction scripts, and is required even when full self-validation is off.
+func (ls *LedgerState) ValidateBlockReferenceScripts(block ledger.Block) error {
+	if block == nil {
+		return errors.New("nil block")
+	}
+	if block.Era().Id < conway.EraIdConway || len(block.Transactions()) == 0 {
+		return nil
+	}
+	snapshot := ls.loadConsensusSnapshot()
+	if ls.skipDijkstraTxValidation(snapshot.currentEra.Id) {
+		return nil
+	}
+	pp := snapshot.currentPParams
+	if uint(block.Era().Id)+1 == snapshot.currentEra.Id &&
+		snapshot.prevEraPParams != nil {
+		pp = snapshot.prevEraPParams
+	}
+	return ls.db.Transaction(false).Do(func(txn *database.Txn) error {
+		return validateBlockReferenceScripts(
+			block,
+			pp,
+			&LedgerView{txn: txn, ls: ls},
+		)
+	})
 }

--- a/node_forging.go
+++ b/node_forging.go
@@ -358,14 +358,12 @@ func (n *Node) initBlockForger(
 		)
 	}
 
-	// Wire self-validation when the operator opts in. The validator runs
-	// header crypto, body-hash, and per-tx ledger checks before AddBlock.
-	var blockValidator forging.BlockValidator
-	if n.config.validateForgedBlock {
-		blockValidator = &forgedBlockValidatorAdapter{
-			ledgerState: n.ledgerState,
-		}
-	}
+	// Always enforce aggregate reference-script limits before AddBlock.
+	// Header crypto and per-transaction self-validation remain opt-in.
+	blockValidator := newForgedBlockValidator(
+		n.ledgerState,
+		n.config.validateForgedBlock,
+	)
 
 	// Create the block forger with the real leader election
 	forger, err := forging.NewBlockForger(forging.ForgerConfig{
@@ -875,13 +873,32 @@ func (a *leiosPipelineAdapter) ParentLeiosAnnouncement() (
 // forging.BlockValidator so the forger can self-validate blocks before
 // adoption without importing the ledger package from within forging.
 type forgedBlockValidatorAdapter struct {
-	ledgerState *ledger.LedgerState
+	ledgerState    forgedBlockValidationState
+	fullValidation bool
+}
+
+type forgedBlockValidationState interface {
+	ValidateForgedBlock(gledger.Block, []byte) error
+	ValidateBlockReferenceScripts(gledger.Block) error
+}
+
+func newForgedBlockValidator(
+	state forgedBlockValidationState,
+	fullValidation bool,
+) forging.BlockValidator {
+	return &forgedBlockValidatorAdapter{
+		ledgerState:    state,
+		fullValidation: fullValidation,
+	}
 }
 
 func (a *forgedBlockValidatorAdapter) ValidateForgedBlock(
 	block gledger.Block,
 	blockCbor []byte,
 ) error {
+	if !a.fullValidation {
+		return a.ledgerState.ValidateBlockReferenceScripts(block)
+	}
 	return a.ledgerState.ValidateForgedBlock(block, blockCbor)
 }
 

--- a/node_forging_validation_test.go
+++ b/node_forging_validation_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"errors"
+	"testing"
+
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+type forgedValidationRecorder struct {
+	aggregateCalls int
+	fullCalls      int
+	err            error
+}
+
+func (v *forgedValidationRecorder) ValidateForgedBlock(
+	gledger.Block,
+	[]byte,
+) error {
+	v.fullCalls++
+	return v.err
+}
+
+func (v *forgedValidationRecorder) ValidateBlockReferenceScripts(
+	gledger.Block,
+) error {
+	v.aggregateCalls++
+	return v.err
+}
+
+func TestForgedBlockValidatorDefaultAndFullModes(t *testing.T) {
+	for _, full := range []bool{false, true} {
+		name := "default"
+		if full {
+			name = "full"
+		}
+		t.Run(name, func(t *testing.T) {
+			failure := errors.New("aggregate reference-script budget exceeded")
+			state := &forgedValidationRecorder{err: failure}
+			validator := newForgedBlockValidator(state, full)
+			require.NotNil(
+				t,
+				validator,
+				"default mode must retain aggregate validation",
+			)
+			require.ErrorIs(
+				t,
+				validator.ValidateForgedBlock(&conway.ConwayBlock{}, nil),
+				failure,
+			)
+			state.err = nil
+			require.NoError(
+				t,
+				validator.ValidateForgedBlock(&conway.ConwayBlock{}, nil),
+			)
+			if full {
+				require.Equal(t, 2, state.fullCalls)
+				require.Zero(
+					t,
+					state.aggregateCalls,
+					"full validation owns its aggregate check",
+				)
+			} else {
+				require.Equal(t, 2, state.aggregateCalls)
+				require.Zero(t, state.fullCalls, "default mode must not execute full validation")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enforce Conway and Dijkstra aggregate consumed reference-script limits before validated block application and default forging adoption. Full cryptographic self-validation remains optional.

For Conway protocol versions through 10, measure against the pre-block UTxO set and omit genuinely absent entries from aggregate accounting. Preserve storage/decode errors and ordinary transaction validation. Protocol version 11 and Dijkstra retain their existing accounting rules.

Select era-appropriate parameters for overlap blocks, reject typed-nil parameters before aggregate validation, and preserve the explicit Musashi prototype validation policy.

Fixes #4081.
