### PR TITLE
fix(ledger): bound hardfork summary durations

### DIFF
--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -16,10 +16,33 @@ package ledger
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 )
+
+const maxHardForkSlotLengthMilliseconds = uint64(1<<63-1) / uint64(time.Millisecond)
+
+func hardForkCachedEraParams(
+	lengthInSlots uint,
+	slotLengthMilliseconds uint,
+) (hardfork.EraParams, error) {
+	if uint64(slotLengthMilliseconds) > maxHardForkSlotLengthMilliseconds {
+		return hardfork.EraParams{}, fmt.Errorf(
+			"slot length %dms overflows time.Duration",
+			slotLengthMilliseconds,
+		)
+	}
+	params := hardfork.EraParams{
+		EpochSize:  uint64(lengthInSlots),
+		SlotLength: time.Duration(slotLengthMilliseconds) * time.Millisecond,
+	}
+	if err := params.Validate(); err != nil {
+		return hardfork.EraParams{}, err
+	}
+	return params, nil
+}
 
 // HardForkSummary constructs a hardfork.Summary describing the chain's era
 // history from the LedgerState's current epoch cache, tip, current era, and
@@ -87,10 +110,20 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 		eraID := first.EraId
 		// Per-epoch params within an era are expected to be constant; we use
 		// the first epoch's values as the era-level params.
-		// first.SlotLength is protocol-bounded (milliseconds per slot).
-		// #nosec G115
-		slotLen := time.Duration(first.SlotLength) * time.Millisecond
-		epochSize := uint64(first.LengthInSlots)
+		eraParams, err := hardForkCachedEraParams(
+			first.LengthInSlots,
+			first.SlotLength,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"ledger: cached epoch %d (era %d) params invalid: %w",
+				first.EpochId,
+				eraID,
+				err,
+			)
+		}
+		slotLen := eraParams.SlotLength
+		epochSize := eraParams.EpochSize
 
 		start := hardfork.Bound{
 			RelativeTime: relTime,
@@ -103,8 +136,17 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 		j := i
 		for j < len(cache) && cache[j].EraId == eraID {
 			ep := cache[j]
-			// LengthInSlots and SlotLength are protocol-bounded uints.
-			// #nosec G115
+			if _, err := hardForkCachedEraParams(
+				ep.LengthInSlots,
+				ep.SlotLength,
+			); err != nil {
+				return nil, fmt.Errorf(
+					"ledger: cached epoch %d (era %d) params invalid: %w",
+					ep.EpochId,
+					eraID,
+					err,
+				)
+			}
 			relTime += time.Duration(ep.LengthInSlots) *
 				time.Duration(ep.SlotLength) * time.Millisecond
 			j++

--- a/ledger/hardfork_summary.go
+++ b/ledger/hardfork_summary.go
@@ -22,7 +22,10 @@ import (
 	"github.com/blinklabs-io/dingo/ledger/hardfork"
 )
 
-const maxHardForkSlotLengthMilliseconds = uint64(1<<63-1) / uint64(time.Millisecond)
+const (
+	maxHardForkDurationNanoseconds    = uint64(1<<63 - 1)
+	maxHardForkSlotLengthMilliseconds = maxHardForkDurationNanoseconds / uint64(time.Millisecond)
+)
 
 func hardForkCachedEraParams(
 	lengthInSlots uint,
@@ -42,6 +45,30 @@ func hardForkCachedEraParams(
 		return hardfork.EraParams{}, err
 	}
 	return params, nil
+}
+
+func hardForkCachedEpochDuration(
+	lengthInSlots uint,
+	slotLengthMilliseconds uint,
+) (time.Duration, error) {
+	params, err := hardForkCachedEraParams(
+		lengthInSlots,
+		slotLengthMilliseconds,
+	)
+	if err != nil {
+		return 0, err
+	}
+	slotLengthNanoseconds := uint64(params.SlotLength)
+	if uint64(lengthInSlots) >
+		maxHardForkDurationNanoseconds/slotLengthNanoseconds {
+		return 0, fmt.Errorf(
+			"epoch duration overflows time.Duration: length=%d slots, slot length=%s",
+			lengthInSlots,
+			params.SlotLength,
+		)
+	}
+	// #nosec G115 -- the checked product is bounded by MaxInt64.
+	return time.Duration(uint64(lengthInSlots) * slotLengthNanoseconds), nil
 }
 
 // HardForkSummary constructs a hardfork.Summary describing the chain's era
@@ -136,10 +163,11 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 		j := i
 		for j < len(cache) && cache[j].EraId == eraID {
 			ep := cache[j]
-			if _, err := hardForkCachedEraParams(
+			epochDuration, err := hardForkCachedEpochDuration(
 				ep.LengthInSlots,
 				ep.SlotLength,
-			); err != nil {
+			)
+			if err != nil {
 				return nil, fmt.Errorf(
 					"ledger: cached epoch %d (era %d) params invalid: %w",
 					ep.EpochId,
@@ -147,8 +175,15 @@ func (ls *LedgerState) hardForkSummaryAnchoredAt(
 					err,
 				)
 			}
-			relTime += time.Duration(ep.LengthInSlots) *
-				time.Duration(ep.SlotLength) * time.Millisecond
+			if uint64(relTime) >
+				maxHardForkDurationNanoseconds-uint64(epochDuration) {
+				return nil, fmt.Errorf(
+					"ledger: cumulative cached epoch duration overflows time.Duration at epoch %d (era %d)",
+					ep.EpochId,
+					eraID,
+				)
+			}
+			relTime += epochDuration
 			j++
 		}
 

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -292,6 +292,91 @@ func TestHardForkSummary_ValidatesEveryCachedEpoch(t *testing.T) {
 	require.ErrorContains(t, err, "cached epoch 1")
 }
 
+func TestHardForkSummary_RejectsEpochDurationOverflow(t *testing.T) {
+	const slotLengthMilliseconds = uint64(1)
+	maxDurationMilliseconds := uint64(1<<63-1) / uint64(time.Millisecond)
+	if uint64(^uint(0)) < maxDurationMilliseconds+1 {
+		t.Skip("uint cannot represent the overflow boundary")
+	}
+
+	testCases := []struct {
+		name          string
+		lengthInSlots uint64
+		wantErr       bool
+	}{
+		{
+			name:          "maximum representable duration",
+			lengthInSlots: maxDurationMilliseconds,
+		},
+		{
+			name:          "multiplication overflow",
+			lengthInSlots: maxDurationMilliseconds + 1,
+			wantErr:       true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ls := &LedgerState{
+				epochCache: []models.Epoch{{
+					EpochId:       0,
+					StartSlot:     0,
+					SlotLength:    uint(slotLengthMilliseconds),
+					LengthInSlots: uint(testCase.lengthInSlots),
+					EraId:         1,
+				}},
+				currentTip: ochainsync.Tip{
+					Point: ocommon.NewPoint(0, []byte("tip")),
+				},
+			}
+			ls.publishSnapshotsLocked()
+
+			_, err := ls.HardForkSummary()
+			if testCase.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "duration")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHardForkSummary_RejectsCumulativeDurationOverflow(t *testing.T) {
+	maxDurationMilliseconds := uint64(1<<63-1) / uint64(time.Millisecond)
+	perEpochLength := maxDurationMilliseconds/2 + 1
+	if uint64(^uint(0)) < perEpochLength {
+		t.Skip("uint cannot represent the overflow boundary")
+	}
+
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				SlotLength:    1,
+				LengthInSlots: uint(perEpochLength),
+				EraId:         1,
+			},
+			{
+				EpochId:       1,
+				StartSlot:     perEpochLength,
+				SlotLength:    1,
+				LengthInSlots: uint(perEpochLength),
+				EraId:         1,
+			},
+		},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(0, []byte("tip")),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	_, err := ls.HardForkSummary()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duration")
+}
+
 // TestHardForkSummary_MissingShelleyGenesis tolerates a config without a
 // Shelley genesis: SystemStart stays at the
 // zero time. Callers that need wall-clock conversions must provide the

--- a/ledger/hardfork_summary_test.go
+++ b/ledger/hardfork_summary_test.go
@@ -188,6 +188,110 @@ func TestHardForkSummary_EmptyCache(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestHardForkSummary_ValidatesCachedEraParams(t *testing.T) {
+	testCases := []struct {
+		name          string
+		lengthInSlots uint
+		slotLength    uint
+		wantErr       bool
+	}{
+		{
+			name:          "minimum valid parameters",
+			lengthInSlots: 1,
+			slotLength:    1,
+		},
+		{
+			name:       "zero epoch size",
+			slotLength: 1_000,
+			wantErr:    true,
+		},
+		{
+			name:          "zero slot length",
+			lengthInSlots: 100,
+			wantErr:       true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ls := &LedgerState{
+				epochCache: []models.Epoch{
+					{
+						EpochId:       0,
+						StartSlot:     0,
+						SlotLength:    testCase.slotLength,
+						LengthInSlots: testCase.lengthInSlots,
+						EraId:         0,
+					},
+					{
+						EpochId:       1,
+						StartSlot:     100,
+						SlotLength:    1_000,
+						LengthInSlots: 100,
+						EraId:         1,
+					},
+				},
+				currentEra: eras.EraDesc{Id: 1, Name: "Shelley"},
+				currentTip: ochainsync.Tip{
+					Point: ocommon.NewPoint(150, []byte("tip")),
+				},
+				config: LedgerStateConfig{
+					CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+				},
+			}
+			ls.publishSnapshotsLocked()
+
+			_, err := ls.HardForkSummary()
+			if testCase.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "cached")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHardForkSummary_ValidatesEveryCachedEpoch(t *testing.T) {
+	ls := &LedgerState{
+		epochCache: []models.Epoch{
+			{
+				EpochId:       0,
+				StartSlot:     0,
+				SlotLength:    1_000,
+				LengthInSlots: 100,
+				EraId:         0,
+			},
+			{
+				EpochId:       1,
+				StartSlot:     100,
+				SlotLength:    0,
+				LengthInSlots: 100,
+				EraId:         0,
+			},
+			{
+				EpochId:       2,
+				StartSlot:     200,
+				SlotLength:    1_000,
+				LengthInSlots: 100,
+				EraId:         1,
+			},
+		},
+		currentEra: eras.EraDesc{Id: 1, Name: "Shelley"},
+		currentTip: ochainsync.Tip{
+			Point: ocommon.NewPoint(250, []byte("tip")),
+		},
+		config: LedgerStateConfig{
+			CardanoNodeConfig: minimalShelleyGenesisCfg(t),
+		},
+	}
+	ls.publishSnapshotsLocked()
+
+	_, err := ls.HardForkSummary()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cached epoch 1")
+}
+
 // TestHardForkSummary_MissingShelleyGenesis tolerates a config without a
 // Shelley genesis: SystemStart stays at the
 // zero time. Callers that need wall-clock conversions must provide the


### PR DESCRIPTION
## Summary
- validate cached hardfork epoch durations before conversion and accumulation
- reject malformed or overflowing cached values with boundary regression coverage

## Validation
- focused ledger and hardfork race tests
- caller-focused summary, slot, and header tests
- repeated summary tests
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds hardfork summary epoch durations so invalid cached values return errors with context instead of silently wrapping, while keeping unpopulated epoch rows (zero slot length/epoch size) accepted as before. Adds regression tests for zero-length epochs, slot-length overflow, and cumulative overflow.

<sup>Written for commit e860ce305cecb69e0d88bc661a6dfaa371d74775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

