### PR TITLE
fix(config): require authentication for remote APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5702,7 +5702,6 @@ loopback-only APIs may remain unauthenticated for local clients. An operator
 who intentionally exposes an API must configure token authentication (or put
 an authenticated reverse proxy in front and keep the Dingo listener on
 loopback).
-without one.
 
 - **Policy types (`internal/apiconfig`).** `TLSPolicy` (`mode`,
   `certFilePath`, `keyFilePath`) and `AuthPolicy` (`mode`, `token`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5819,10 +5819,11 @@ without one.
   upgrade for any deployment that had set them only for UTxO RPC, which
   they never protected. An operator opting Blockfrost/Mesh into TLS does so
   explicitly, through `api.tls` or their own `plugins.api.<name>.config.tls`.
-  `bindAddr`, `debugBindAddr`, and `corsAllowedOrigins` are unaffected by any
-  of this and stay at the `Config` root: `bindAddr` is not API-specific (the
-  relay/NtN and metrics listeners use it too), `debugBindAddr` controls the
-  separate pprof listener, and `corsAllowedOrigins`'s single shared value
+  `bindAddr`, `apiBindAddr`, `debugBindAddr`, and `corsAllowedOrigins` are
+  unaffected by any of this and stay at the `Config` root: `bindAddr` is not
+  API-specific (the relay/NtN and metrics listeners use it too), `apiBindAddr`
+  is the separate loopback-by-default bind for the three API listeners,
+  `debugBindAddr` controls the separate pprof listener, and `corsAllowedOrigins`'s single shared value
   already applies uniformly to all three API providers today. Duplicating
   these fields under `api:` would only add a second source of truth with no
   behavioral gain.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5693,7 +5693,15 @@ Blockfrost, Mesh, and UTxO RPC share one TLS/authentication contract
 (dingo#2996/#2998), rather than each exposing its own ad hoc surface. A
 reverse proxy or API gateway in front of these listeners remains fully
 supported — TLS/auth here is additive, not a replacement requirement — but
-an operator can now also secure any subset of the three in-process,
+an operator can now also secure any subset of the three in-process without
+one. Startup validation
+also refuses an enabled API on a non-loopback bind address
+when its effective authentication policy is disabled. This guard evaluates
+the shared `api.auth` policy after each provider override is merged, while
+loopback-only APIs may remain unauthenticated for local clients. An operator
+who intentionally exposes an API must configure token authentication (or put
+an authenticated reverse proxy in front and keep the Dingo listener on
+loopback).
 without one.
 
 - **Policy types (`internal/apiconfig`).** `TLSPolicy` (`mode`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5693,8 +5693,7 @@ Blockfrost, Mesh, and UTxO RPC share one TLS/authentication contract
 (dingo#2996/#2998), rather than each exposing its own ad hoc surface. A
 reverse proxy or API gateway in front of these listeners remains fully
 supported — TLS/auth here is additive, not a replacement requirement — but
-an operator can now also secure any subset of the three in-process without
-one. Startup validation
+an operator can now also secure any subset of the three in-process. Startup validation
 also refuses an enabled API on a non-loopback bind address
 when its effective authentication policy is disabled. This guard evaluates
 the shared `api.auth` policy after each provider override is merged, while

--- a/config.go
+++ b/config.go
@@ -206,6 +206,7 @@ type Config struct {
 	// canonical loaded configuration; these are refreshed by syncCompatFields.
 	dataDir                         string
 	bindAddr                        string
+	apiBindAddr                     string
 	pluginSelections                map[hostplugin.Capability]hostplugin.Selection
 	network                         string
 	tlsCertFilePath, tlsKeyFilePath string
@@ -513,6 +514,12 @@ func (n *Node) configValidate() error {
 			StorageModeAPI,
 		)
 	}
+	if err := internalconfig.ValidateAPIExposure(
+		n.config.cfg,
+		internalconfig.RunMode(n.config.cfg.RunMode),
+	); err != nil {
+		return fmt.Errorf("invalid API exposure: %w", err)
+	}
 	if !n.config.cfg.StartEra.Valid() {
 		return fmt.Errorf(
 			"invalid start era %q: must be empty or %q",
@@ -660,6 +667,7 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 	c := Config{
 		cfg: &internalconfig.Config{
 			BindAddr:           "0.0.0.0",
+			APIBindAddr:        internalconfig.DefaultAPIBindAddr,
 			StorageMode:        string(StorageModeCore),
 			RunMode:            internalconfig.RunModeServe,
 			Cache:              internalconfig.DefaultCacheConfig(),
@@ -721,6 +729,10 @@ func NewConfig(opts ...ConfigOptionFunc) Config {
 
 func (c *Config) syncCompatFields() {
 	c.dataDir, c.bindAddr = c.cfg.DatabasePath, c.cfg.BindAddr
+	c.apiBindAddr = c.cfg.APIBindAddr
+	if c.apiBindAddr == "" {
+		c.apiBindAddr = internalconfig.DefaultAPIBindAddr
+	}
 	c.network, c.networkMagic = c.cfg.Network, c.cfg.NetworkMagic
 	c.tlsCertFilePath, c.tlsKeyFilePath = c.cfg.TlsCertFilePath, c.cfg.TlsKeyFilePath
 	c.apiConfig = c.cfg.API
@@ -993,11 +1005,19 @@ func WithCardanoNodeConfig(
 	}
 }
 
-// WithBindAddr specifies the IP address used for API listeners
-// (Blockfrost, Mesh, UTxO RPC). The default is "0.0.0.0" (all interfaces).
+// WithBindAddr specifies the IP address used by relay and metrics listeners.
+// API listeners use WithAPIBindAddr.
 func WithBindAddr(addr string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.cfg.BindAddr = addr
+	}
+}
+
+// WithAPIBindAddr specifies the IP address used by the Blockfrost, Mesh, and
+// UTxO RPC listeners. It defaults to loopback; remote binds require API auth.
+func WithAPIBindAddr(addr string) ConfigOptionFunc {
+	return func(c *Config) {
+		c.cfg.APIBindAddr = addr
 	}
 }
 
@@ -1760,9 +1780,18 @@ func (c *Config) MetadataPlugin() string {
 	return c.cfg.Plugins.Storage.Metadata.Provider
 }
 
-// BindAddr returns the IP address for API listeners.
+// BindAddr returns the IP address for relay and metrics listeners.
 func (c *Config) BindAddr() string {
 	return c.cfg.BindAddr
+}
+
+// APIBindAddr returns the IP address for the Blockfrost, Mesh, and UTxO RPC
+// listeners.
+func (c *Config) APIBindAddr() string {
+	if c.cfg.APIBindAddr == "" {
+		return internalconfig.DefaultAPIBindAddr
+	}
+	return c.cfg.APIBindAddr
 }
 
 // PrivateBindAddr returns the IP address for the private NtC listener.

--- a/config_test.go
+++ b/config_test.go
@@ -107,6 +107,19 @@ func TestNewConfigMempoolCapacityDefaultsFromRunMode(t *testing.T) {
 	}
 }
 
+func TestNewConfigAPIBindAddressDefaultsToLoopback(t *testing.T) {
+	cfg := NewConfig(
+		WithRunMode(string(internalconfig.RunModeDev)),
+		WithBindAddr("0.0.0.0"),
+	)
+
+	assert.Equal(t, "0.0.0.0", cfg.BindAddr())
+	assert.Equal(t, internalconfig.DefaultAPIBindAddr, cfg.APIBindAddr())
+
+	cfg = NewConfig(WithAPIBindAddr("192.0.2.10"))
+	assert.Equal(t, "192.0.2.10", cfg.APIBindAddr())
+}
+
 func TestNewConfigPreservesExplicitMempoolCapacity(t *testing.T) {
 	const capacity = int64(42)
 	cfg := NewConfig(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ func FromContext(ctx context.Context) *Config {
 }
 
 const (
+	DefaultAPIBindAddr                 = "127.0.0.1"
 	DefaultBlobPlugin                  = "badger"
 	DefaultDebugBindAddr               = "127.0.0.1"
 	DefaultMetadataPlugin              = "sqlite"
@@ -518,24 +519,28 @@ type Config struct {
 	Plugins PluginsConfig `yaml:"plugins"`
 	// API holds shared TLS/auth policy defaults for every selected
 	// plugins.api.* provider. See APIConfig's own doc comment.
-	API                    APIConfig `yaml:"api"`
-	TlsKeyFilePath         string    `yaml:"tlsKeyFilePath"                      envconfig:"TLS_KEY_FILE_PATH"`
-	Topology               string    `yaml:"topology"`
-	CardanoConfig          string    `yaml:"cardanoConfig"                       envconfig:"config"`
-	DatabasePath           string    `yaml:"databasePath"                                                                                 split_words:"true"`
-	SocketPath             string    `yaml:"socketPath"                                                                                   split_words:"true"`
-	TlsCertFilePath        string    `yaml:"tlsCertFilePath"                     envconfig:"TLS_CERT_FILE_PATH"`
-	BindAddr               string    `yaml:"bindAddr"                                                                                     split_words:"true"`
-	PrivateBindAddr        string    `yaml:"privateBindAddr"                                                                              split_words:"true"`
-	ShutdownTimeout        string    `yaml:"shutdownTimeout"                                                                              split_words:"true"`
-	LedgerCatchupTimeout   string    `yaml:"ledgerCatchupTimeout"                envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
-	Network                string    `yaml:"network"`
-	NetworkMagic           uint32    `yaml:"networkMagic"                                                                                 split_words:"true"`
-	PrivatePort            uint      `yaml:"privatePort"                                                                                  split_words:"true"`
-	RelayPort              uint      `yaml:"relayPort"                           envconfig:"port"`
-	BarkBaseUrl            string    `yaml:"barkBaseUrl"                         envconfig:"DINGO_BARK_BASE_URL"`
-	BarkBlockDownloadHosts []string  `yaml:"barkBlockDownloadHosts"              envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
-	BarkPort               uint      `yaml:"barkPort"                            envconfig:"DINGO_BARK_PORT"`
+	API             APIConfig `yaml:"api"`
+	TlsKeyFilePath  string    `yaml:"tlsKeyFilePath"                      envconfig:"TLS_KEY_FILE_PATH"`
+	Topology        string    `yaml:"topology"`
+	CardanoConfig   string    `yaml:"cardanoConfig"                       envconfig:"config"`
+	DatabasePath    string    `yaml:"databasePath"                                                                                 split_words:"true"`
+	SocketPath      string    `yaml:"socketPath"                                                                                   split_words:"true"`
+	TlsCertFilePath string    `yaml:"tlsCertFilePath"                     envconfig:"TLS_CERT_FILE_PATH"`
+	BindAddr        string    `yaml:"bindAddr"                                                                                     split_words:"true"`
+	// APIBindAddr is the interface used by the Blockfrost, Mesh, and UTxO
+	// RPC listeners. It is separate from BindAddr because the latter also
+	// serves the relay and metrics listeners.
+	APIBindAddr            string   `yaml:"apiBindAddr"                       envconfig:"DINGO_API_BIND_ADDR"`
+	PrivateBindAddr        string   `yaml:"privateBindAddr"                                                                              split_words:"true"`
+	ShutdownTimeout        string   `yaml:"shutdownTimeout"                                                                              split_words:"true"`
+	LedgerCatchupTimeout   string   `yaml:"ledgerCatchupTimeout"                envconfig:"DINGO_LEDGER_CATCHUP_TIMEOUT"`
+	Network                string   `yaml:"network"`
+	NetworkMagic           uint32   `yaml:"networkMagic"                                                                                 split_words:"true"`
+	PrivatePort            uint     `yaml:"privatePort"                                                                                  split_words:"true"`
+	RelayPort              uint     `yaml:"relayPort"                           envconfig:"port"`
+	BarkBaseUrl            string   `yaml:"barkBaseUrl"                         envconfig:"DINGO_BARK_BASE_URL"`
+	BarkBlockDownloadHosts []string `yaml:"barkBlockDownloadHosts"              envconfig:"DINGO_BARK_BLOCK_DOWNLOAD_HOSTS"`
+	BarkPort               uint     `yaml:"barkPort"                            envconfig:"DINGO_BARK_PORT"`
 	// BarkHost is the interface Bark binds to. Left empty, node.go defaults
 	// it to loopback-only (127.0.0.1) whenever the database lifecycle
 	// service (Restore/Truncate and friends — gated on BarkClientCAFilePath,
@@ -772,9 +777,10 @@ type APIPluginsConfig struct {
 // internal/apiconfig for the merge/validation rules; composition (node.go)
 // performs the actual per-provider merge, not this package.
 //
-// bindAddr, debugBindAddr, and corsAllowedOrigins deliberately stay at the
-// Config root rather than moving under this section: bindAddr is not
-// API-specific (the relay/NtN and metrics listeners use it too),
+// bindAddr, apiBindAddr, debugBindAddr, and corsAllowedOrigins deliberately
+// stay at the Config root rather than moving under this section: bindAddr is
+// not API-specific (the relay/NtN and metrics listeners use it too),
+// apiBindAddr is the separate safe bind for the API listeners,
 // debugBindAddr controls the separate pprof listener, and corsAllowedOrigins
 // already applies uniformly to all three API providers
 // today with no override need identified by dingo#2996/#2998, so
@@ -1052,6 +1058,7 @@ var configMu sync.RWMutex
 var globalConfig = &Config{
 	Plugins:                             defaultPluginsConfig(),
 	BindAddr:                            "0.0.0.0",
+	APIBindAddr:                         DefaultAPIBindAddr,
 	CardanoConfig:                       "", // Will be set dynamically based on network
 	DatabasePath:                        ".dingo",
 	SocketPath:                          "dingo.socket",
@@ -1444,6 +1451,9 @@ func (c *Config) ApplyDefaults() {
 	// This also keeps manually constructed Config values fail-safe.
 	if c.DebugBindAddr == "" {
 		c.DebugBindAddr = DefaultDebugBindAddr
+	}
+	if c.APIBindAddr == "" {
+		c.APIBindAddr = DefaultAPIBindAddr
 	}
 	// Match the Midnight server's safe default before validation so an
 	// explicitly empty YAML or environment value does not look like a remote

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -282,6 +282,7 @@ func TestLoad_WithoutConfigFile_UsesDefaults(t *testing.T) {
 			return plugins
 		}(),
 		BindAddr:             "0.0.0.0",
+		APIBindAddr:          DefaultAPIBindAddr,
 		CardanoConfig:        "", // Resolved by consumers using cfg.Network
 		DatabasePath:         ".dingo",
 		SocketPath:           "dingo.socket",
@@ -852,7 +853,7 @@ func TestWatermarkDefaultingAndValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetGlobalConfig()
-			globalConfig.BindAddr = "127.0.0.1"
+			globalConfig.APIBindAddr = DefaultAPIBindAddr
 			globalConfig.Plugins.Mempool.Config["evictionWatermark"] = tt.eviction
 			globalConfig.Plugins.Mempool.Config["rejectionWatermark"] = tt.rejection
 			globalConfig.RunMode = RunModeDev

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -852,6 +852,7 @@ func TestWatermarkDefaultingAndValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetGlobalConfig()
+			globalConfig.BindAddr = "127.0.0.1"
 			globalConfig.Plugins.Mempool.Config["evictionWatermark"] = tt.eviction
 			globalConfig.Plugins.Mempool.Config["rejectionWatermark"] = tt.rejection
 			globalConfig.RunMode = RunModeDev

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -64,6 +64,7 @@ var flagSpecs = []flagSpec{
 		"data directory for all storage plugins (overrides CARDANO_DATABASE_PATH)",
 	),
 	stringFlag("BindAddr", "bind-addr", "", "public bind address"),
+	stringFlag("APIBindAddr", "api-bind-addr", "", "API bind address (remote exposure requires authentication)"),
 	stringFlag("SocketPath", "socket-path", "", "path to UNIX socket file"),
 	transformStringFlag(
 		"RunMode",

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -832,7 +832,7 @@ func TestPipeline_EmptyMidnightHostUsesLoopbackDefault(t *testing.T) {
 
 	cfg, err := loadConfigThroughPipeline(
 		t,
-		"storageMode: \"api\"\n",
+		"bindAddr: 127.0.0.1\nstorageMode: \"api\"\n",
 		nil,
 	)
 	if err != nil {

--- a/internal/config/flags_test.go
+++ b/internal/config/flags_test.go
@@ -134,6 +134,7 @@ func TestDebugBindAddressDefaultsToLoopback(t *testing.T) {
 	require.NoError(t, err)
 	cfg.ApplyDefaults()
 	require.Equal(t, "0.0.0.0", cfg.BindAddr)
+	require.Equal(t, DefaultAPIBindAddr, cfg.APIBindAddr)
 	require.Equal(t, DefaultDebugBindAddr, cfg.DebugBindAddr)
 	require.Equal(t, "127.0.0.1:0", cfg.DebugListenAddress())
 	require.Equal(
@@ -832,7 +833,7 @@ func TestPipeline_EmptyMidnightHostUsesLoopbackDefault(t *testing.T) {
 
 	cfg, err := loadConfigThroughPipeline(
 		t,
-		"bindAddr: 127.0.0.1\nstorageMode: \"api\"\n",
+		"apiBindAddr: 127.0.0.1\nstorageMode: \"api\"\n",
 		nil,
 	)
 	if err != nil {

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -107,6 +107,7 @@ var logPlainConfigFields = []string{
 	"API.Auth.TokenFilePath",
 	"API.TLS.CertFilePath",
 	"API.TLS.KeyFilePath",
+	"APIBindAddr",
 	"API.TLS.Mode",
 	"ActivePeersGossipQuota",
 	"ActivePeersLedgerQuota",

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -280,7 +280,9 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		(effectiveMode == RunModeDev || c.RunMode.IsDevMode() ||
 			c.StorageMode == storageModeAPI)
 	if apiListeners {
-		errs = append(errs, validateAPIExposure(c)...)
+		if err := ValidateAPIExposure(c, effectiveMode); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	midnightServer := apiListeners && c.Midnight.ServerEnabled
 	utxorpcPort := APIPluginPort(c.Plugins.API.Utxorpc)
@@ -304,14 +306,14 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		{"barkPort", c.BarkHost, c.BarkPort, serving, false},
 		{
 			"plugins.api.utxorpc.config.port",
-			c.BindAddr,
+			c.APIBindAddr,
 			utxorpcPort,
 			apiListeners,
 			false,
 		},
 		{
 			"plugins.api.blockfrost.config.port",
-			c.BindAddr,
+			c.APIBindAddr,
 			blockfrostPort,
 			apiListeners,
 			false,
@@ -810,12 +812,29 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	return errors.Join(errs...)
 }
 
-// validateAPIExposure prevents an enabled API from serving without
-// authentication on a non-loopback bind address. The API providers expose
-// mutating endpoints, so an operator must explicitly configure authentication
-// before making them reachable beyond the local host.
+// ValidateAPIExposure applies the API exposure policy to a fully merged
+// configuration. It is exported so the programmatic Node constructor can
+// enforce the same policy as the CLI path.
+// It prevents an enabled API from serving without authentication on a
+// non-loopback bind address. The API providers expose mutating endpoints, so
+// an operator must explicitly configure authentication before making them
+// reachable beyond the local host.
+func ValidateAPIExposure(c *Config, effectiveMode RunMode) error {
+	apiListeners := effectiveMode.RequiresListeners() &&
+		(effectiveMode == RunModeDev || c.RunMode.IsDevMode() ||
+			c.StorageMode == storageModeAPI)
+	if !apiListeners {
+		return nil
+	}
+	return errors.Join(validateAPIExposure(c)...)
+}
+
 func validateAPIExposure(c *Config) []error {
-	if isLoopbackAddr(c.BindAddr) {
+	bindAddr := c.APIBindAddr
+	if bindAddr == "" {
+		bindAddr = DefaultAPIBindAddr
+	}
+	if isLoopbackAddr(bindAddr) {
 		return nil
 	}
 	providers := []struct {
@@ -863,7 +882,7 @@ func validateAPIExposure(c *Config) []error {
 				"plugins.api.%s.config binds to non-loopback address %q "+
 					"without authentication: configure api.auth or a provider "+
 					"auth policy",
-				provider.name, c.BindAddr,
+				provider.name, bindAddr,
 			))
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -320,7 +320,7 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 		},
 		{
 			"plugins.api.mesh.config.port",
-			c.BindAddr,
+			c.APIBindAddr,
 			meshPort,
 			apiListeners,
 			false,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/internal/apiconfig"
+	hostplugin "github.com/blinklabs-io/dingo/plugin"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
 
@@ -278,6 +279,9 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	apiListeners := serving &&
 		(effectiveMode == RunModeDev || c.RunMode.IsDevMode() ||
 			c.StorageMode == storageModeAPI)
+	if apiListeners {
+		errs = append(errs, validateAPIExposure(c)...)
+	}
 	midnightServer := apiListeners && c.Midnight.ServerEnabled
 	utxorpcPort := APIPluginPort(c.Plugins.API.Utxorpc)
 	blockfrostPort := APIPluginPort(c.Plugins.API.Blockfrost)
@@ -804,6 +808,66 @@ func (c *Config) validate(effectiveMode RunMode, minBindable uint) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// validateAPIExposure prevents an enabled API from serving without
+// authentication on a non-loopback bind address. The API providers expose
+// mutating endpoints, so an operator must explicitly configure authentication
+// before making them reachable beyond the local host.
+func validateAPIExposure(c *Config) []error {
+	if isLoopbackAddr(c.BindAddr) {
+		return nil
+	}
+	providers := []struct {
+		name      string
+		selection hostplugin.Selection
+	}{
+		{"blockfrost", c.Plugins.API.Blockfrost},
+		{"mesh", c.Plugins.API.Mesh},
+		{"utxorpc", c.Plugins.API.Utxorpc},
+	}
+	var errs []error
+	for _, provider := range providers {
+		if APIPluginPort(provider.selection) == 0 {
+			continue
+		}
+		merged, err := apiconfig.MergeProviderConfig(
+			provider.selection.Config,
+			apiconfig.TLSPolicy{},
+			c.API.TLS,
+			c.API.Auth,
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"plugins.api.%s.config: validate security policy: %w",
+				provider.name, err,
+			))
+			continue
+		}
+		authPolicy, err := apiconfig.DecodeAuthPolicy(merged)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"plugins.api.%s.config.auth: %w", provider.name, err,
+			))
+			continue
+		}
+		auth, err := authPolicy.Resolve(
+			"plugins.api." + provider.name + ".config.auth",
+		)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !auth.Enabled {
+			errs = append(errs, fmt.Errorf(
+				"plugins.api.%s.config binds to non-loopback address %q "+
+					"without authentication: configure api.auth or a provider "+
+					"auth policy",
+				provider.name, c.BindAddr,
+			))
+		}
+	}
+	return errs
 }
 
 // validateAPIMode rejects a mode value that is neither unset (inherit/

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	hostplugin "github.com/blinklabs-io/dingo/plugin"
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,7 @@ func validTestConfig() *Config {
 		Chainsync:            DefaultChainsyncConfig(),
 		HistoryExpiry:        DefaultHistoryExpiryConfig(),
 		Midnight:             DefaultMidnightConfig(),
+		BindAddr:             "127.0.0.1",
 		Mithril: MithrilConfig{
 			Enabled: true,
 			Backend: "v2",
@@ -67,6 +69,55 @@ func setMempoolSetting(c *Config, name string, value any) {
 func TestValidateDefaultsPass(t *testing.T) {
 	cfg := validTestConfig()
 	assert.NoError(t, cfg.validate(cfg.RunMode, minUnprivilegedPort))
+}
+
+func TestValidateAPIExposureRequiresAuthOnRemoteBind(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
+	cfg.BindAddr = "0.0.0.0"
+
+	err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "without authentication")
+	assert.Contains(t, err.Error(), "blockfrost")
+}
+
+func TestValidateAPIExposureAllowsUnauthenticatedLoopback(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
+	cfg.BindAddr = "127.0.0.1"
+
+	require.NoError(t, cfg.validate(cfg.RunMode, minUnprivilegedPort))
+}
+
+func TestValidateAPIExposureAllowsAuthenticatedRemoteBind(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
+	cfg.BindAddr = "192.0.2.10"
+	mode := string(apiconfig.AuthModeToken)
+	tokenPath := "/run/secrets/api-token"
+	cfg.API.Auth.Mode = &mode
+	cfg.API.Auth.TokenFilePath = &tokenPath
+
+	require.NoError(t, cfg.validate(cfg.RunMode, minUnprivilegedPort))
+}
+
+func TestValidateAPIExposureHonorsProviderAuthOverride(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.StorageMode = storageModeAPI
+	cfg.BindAddr = "192.0.2.10"
+	mode := string(apiconfig.AuthModeToken)
+	tokenPath := "/run/secrets/api-token"
+	cfg.API.Auth.Mode = &mode
+	cfg.API.Auth.TokenFilePath = &tokenPath
+	cfg.Plugins.API.Mesh.Config["auth"] = map[string]any{
+		"mode": "disabled",
+	}
+
+	err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plugins.api.mesh.config")
+	assert.Contains(t, err.Error(), "without authentication")
 }
 
 func TestValidate(t *testing.T) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -48,7 +48,7 @@ func validTestConfig() *Config {
 		Chainsync:            DefaultChainsyncConfig(),
 		HistoryExpiry:        DefaultHistoryExpiryConfig(),
 		Midnight:             DefaultMidnightConfig(),
-		BindAddr:             "127.0.0.1",
+		APIBindAddr:          DefaultAPIBindAddr,
 		Mithril: MithrilConfig{
 			Enabled: true,
 			Backend: "v2",
@@ -74,7 +74,7 @@ func TestValidateDefaultsPass(t *testing.T) {
 func TestValidateAPIExposureRequiresAuthOnRemoteBind(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.StorageMode = storageModeAPI
-	cfg.BindAddr = "0.0.0.0"
+	cfg.APIBindAddr = "0.0.0.0"
 
 	err := cfg.validate(cfg.RunMode, minUnprivilegedPort)
 	require.Error(t, err)
@@ -85,7 +85,7 @@ func TestValidateAPIExposureRequiresAuthOnRemoteBind(t *testing.T) {
 func TestValidateAPIExposureAllowsUnauthenticatedLoopback(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.StorageMode = storageModeAPI
-	cfg.BindAddr = "127.0.0.1"
+	cfg.APIBindAddr = "127.0.0.1"
 
 	require.NoError(t, cfg.validate(cfg.RunMode, minUnprivilegedPort))
 }
@@ -93,7 +93,7 @@ func TestValidateAPIExposureAllowsUnauthenticatedLoopback(t *testing.T) {
 func TestValidateAPIExposureAllowsAuthenticatedRemoteBind(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.StorageMode = storageModeAPI
-	cfg.BindAddr = "192.0.2.10"
+	cfg.APIBindAddr = "192.0.2.10"
 	mode := string(apiconfig.AuthModeToken)
 	tokenPath := "/run/secrets/api-token"
 	cfg.API.Auth.Mode = &mode
@@ -105,7 +105,7 @@ func TestValidateAPIExposureAllowsAuthenticatedRemoteBind(t *testing.T) {
 func TestValidateAPIExposureHonorsProviderAuthOverride(t *testing.T) {
 	cfg := validTestConfig()
 	cfg.StorageMode = storageModeAPI
-	cfg.BindAddr = "192.0.2.10"
+	cfg.APIBindAddr = "192.0.2.10"
 	mode := string(apiconfig.AuthModeToken)
 	tokenPath := "/run/secrets/api-token"
 	cfg.API.Auth.Mode = &mode

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -272,6 +272,15 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "mesh uses API bind address for port collision checks",
+			modify: func(c *Config) {
+				c.StorageMode = storageModeAPI
+				c.BindAddr = "127.0.0.2"
+				c.APIBindAddr = "127.0.0.1"
+				c.MetricsPort = APIPluginPort(c.Plugins.API.Mesh)
+			},
+		},
+		{
 			name: "bark on distinct bind address may share a port",
 			modify: func(c *Config) {
 				c.BindAddr = "127.0.0.1"

--- a/node.go
+++ b/node.go
@@ -1441,7 +1441,7 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 			utxorpc.ProviderDependencies{
 				Logger: n.config.logger, EventBus: n.eventBus,
 				LedgerState: n.ledgerState, Mempool: n.mempool,
-				Host:               n.config.bindAddr,
+				Host:               n.config.apiBindAddr,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
 			},
 		)
@@ -1582,7 +1582,7 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 			n.ctx, n.pluginHost, plugin.CapabilityAPIBlockfrost,
 			blockfrostSelection.Provider, blockfrostSelection.Config,
 			blockfrost.ProviderDependencies{
-				Node: adapter, Logger: n.config.logger, Host: n.config.bindAddr,
+				Node: adapter, Logger: n.config.logger, Host: n.config.apiBindAddr,
 				CORSAllowedOrigins: n.config.corsAllowedOrigins,
 			},
 		)
@@ -1625,7 +1625,7 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 				Database:            mesh.NewMeshDatabase(n.db),
 				Chain:               n.ledgerState.Chain(),
 				Mempool:             n.mempool,
-				Host:                n.config.bindAddr,
+				Host:                n.config.apiBindAddr,
 				Network:             n.config.network,
 				NetworkMagic:        n.config.networkMagic,
 				GenesisHash:         genesisHash,

--- a/node_api_security_test.go
+++ b/node_api_security_test.go
@@ -250,3 +250,27 @@ func TestNewRejectsInvalidAPIAuthMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "config.auth")
 	assert.Contains(t, err.Error(), "invalid mode")
 }
+
+// TestNewRejectsUnauthenticatedRemoteAPI verifies the shared Node constructor
+// enforces the same API exposure policy as CLI configuration validation.
+func TestNewRejectsUnauthenticatedRemoteAPI(t *testing.T) {
+	cardanoCfg := newNodeTestCardanoNodeCfg(t)
+	_, err := New(NewConfig(
+		WithDatabasePath(t.TempDir()),
+		WithCardanoNodeConfig(cardanoCfg),
+		WithNetworkMagic(cardanoCfg.ShelleyGenesis().NetworkMagic),
+		WithPrometheusRegistry(prometheus.NewRegistry()),
+		WithStorageMode(StorageModeAPI),
+		WithAPIBindAddr("0.0.0.0"),
+		WithListeners(ListenerConfig{
+			ListenNetwork: "tcp",
+			ListenAddress: "127.0.0.1:0",
+		}),
+		WithMidnightConfig(MidnightConfig{Port: 0}),
+		WithShutdownTimeout(5*time.Second),
+	))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid API exposure")
+	assert.Contains(t, err.Error(), "without authentication")
+}


### PR DESCRIPTION
## Summary

- Require authentication when an enabled API binds beyond loopback.
- Enforce the same policy from both CLI validation and `dingo.New`.
- Give Blockfrost, Mesh, and UTxO RPC a separate loopback-by-default bind address.

## Validation

- `go test . ./internal/config ./internal/apiconfig ./api/blockfrost ./api/mesh ./api/utxorpc -count=1`
- Focused `-race` regressions for API exposure and configuration defaults
- Fail-before regression fails on the parent commit and passes with this change
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires authentication for API listeners that bind beyond loopback, and gives Blockfrost, Mesh, and UTxO RPC their own loopback-by-default bind address instead of reusing the relay/metrics bind. The same policy is enforced from CLI validation and `dingo.New`, and API port collision checks now use the API bind address.

**Migration**
- API listeners now default to `127.0.0.1` via new `apiBindAddr` config; set it explicitly to expose APIs.
- Non-loopback API binds require token auth via `api.auth` or provider auth policy.

<sup>Written for commit 065571518388fb4ad8587798715dd094f3ff2d30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

