### PR TITLE
fix(database): reject DRep expiry arithmetic overflow

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -959,6 +959,10 @@ again.
 
 ### DReps, Governance, and Committee
 
+DRep activity updates reject epoch-plus-inactivity overflow before addition and
+reject activity or expiry values outside the signed SQL integer domain. Rejected
+updates preserve the previous activity and expiry epochs.
+
 | Table | Columns | Keys / indexes | Relationships and notes |
 |---|---|---|---|
 | `drep` | `id`, `credential_tag`, `credential`, `anchor_url`, `anchor_hash`, `added_slot`, `last_activity_epoch`, `expiry_epoch`, `active` | PK `id`; unique `(credential_tag, credential)`; indexes `added_slot`, `last_activity_epoch`, `expiry_epoch`, `active` | Current DRep state. `credential_tag`: 0 key-hash, 1 script-hash. The composite unique key distinguishes same-hash key and script DReps. The `active` index supports reconcile scans for live DReps. A DRep vote, registration, or update certificate sets `last_activity_epoch` to the containing epoch and `expiry_epoch` to that epoch plus the active Conway/Dijkstra `dRepInactivityPeriod`; certificate persistence and the activity refresh commit atomically. |

--- a/database/drep_activity_test.go
+++ b/database/drep_activity_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database_test
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateDRepActivityExpiryBounds(t *testing.T) {
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	for i, tc := range []struct {
+		name                 string
+		activity, inactivity uint64
+		valid                bool
+	}{
+		{"zero", 0, 0, true},
+		{"below_storage_maximum", math.MaxInt64 - 2, 1, true},
+		{"exact_storage_maximum", math.MaxInt64 - 1, 1, true},
+		{"maximum_activity", math.MaxInt64, 0, true},
+		{"one_past_storage_maximum", math.MaxInt64, 1, false},
+		{"inactivity_outside_storage", 0, math.MaxInt64 + 1, false},
+		{"exact_unsigned_maximum", 0, math.MaxUint64, false},
+		{"unsigned_wrap_to_zero", 1, math.MaxUint64, false},
+		{"unsigned_wrap_to_valid_epoch", math.MaxInt64, math.MaxUint64, false},
+		{"activity_outside_storage", math.MaxUint64, 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			credential := bytes.Repeat([]byte{byte(i + 1)}, 28)
+			require.NoError(t, db.CreateDrep(nil, &models.Drep{
+				CredentialTag: 1, Credential: credential, Active: true,
+				LastActivityEpoch: 10, ExpiryEpoch: 20,
+			}))
+			err := db.UpdateDRepActivity(1, credential, tc.activity, tc.inactivity, nil)
+			if tc.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err, "out-of-range DRep expiry was persisted")
+			}
+			got, err := db.GetDrepByCredential(1, credential, true, nil)
+			require.NoError(t, err)
+			if tc.valid {
+				require.Equal(t, tc.activity, got.LastActivityEpoch)
+				require.Equal(t, tc.activity+tc.inactivity, got.ExpiryEpoch)
+			} else {
+				require.Equal(t, uint64(10), got.LastActivityEpoch, "failed activity update mutated existing state")
+				require.Equal(t, uint64(20), got.ExpiryEpoch, "failed activity update mutated existing expiry")
+			}
+		})
+	}
+}

--- a/database/plugin/metadata/sqlstore/drep.go
+++ b/database/plugin/metadata/sqlstore/drep.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/blinklabs-io/dingo/database/models"
@@ -649,6 +650,13 @@ func (s *Store) UpdateDRepActivity(
 	activity, err := checkedInt64(activityEpoch)
 	if err != nil {
 		return err
+	}
+	if inactivityPeriod > math.MaxUint64-activityEpoch {
+		return fmt.Errorf(
+			"drep expiry epoch overflows uint64: %d + %d",
+			activityEpoch,
+			inactivityPeriod,
+		)
 	}
 	expiry, err := checkedInt64(activityEpoch + inactivityPeriod)
 	if err != nil {


### PR DESCRIPTION
Reject DRep expiry updates when the activity epoch plus inactivity period overflows uint64 before conversion to the database integer type. Rejected updates preserve the stored activity and expiry epochs.

Adds unsigned-overflow and signed-storage boundary coverage.

Fixes #3672.
