### PR TITLE
fix(ouroboros): initialize hashes before sharing decoded headers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -412,6 +412,15 @@ graph LR
 
 How blocks flow from the network through validation and into storage.
 
+The Ouroboros block-fetch and chain-sync decoders initialize the decoded
+block/header hash before returning to the shared decode cache. This includes
+Musashi dispatch and the legacy full-Byron-EBB header fallback. The cache's
+mutex and waiter channels publish the initialized hash before another peer
+can use the same object; computing it in the receiving handler is too late.
+Consumers must treat cached decoded objects as immutable. Hash initialization
+remains inside the cache's panic-recovery boundary, and failed decodes retain
+their existing error, TTL, and eviction behavior.
+
 ```mermaid
 sequenceDiagram
     participant Peer

--- a/ouroboros/blockfetch.go
+++ b/ouroboros/blockfetch.go
@@ -126,7 +126,12 @@ func (o *Ouroboros) blockfetchClientConnOpts() []blockfetch.BlockFetchOptionFunc
 func (o *Ouroboros) decodeBlockfetchBlock(
 	blockType uint,
 	raw []byte,
-) (gledger.Block, error) {
+) (block gledger.Block, err error) {
+	defer func() {
+		if err == nil && block != nil {
+			block.Hash()
+		}
+	}()
 	if o.config.NetworkMagic == ouroboros.NetworkCardanoMusashi.NetworkMagic &&
 		blockType == gledger.BlockTypeConway {
 		return models.DecodeConwayBlock(raw)

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -1796,12 +1796,17 @@ func (o *Ouroboros) instrumentChainsyncRollBackward(
 func (o *Ouroboros) decodeChainsyncHeader(
 	blockType uint,
 	raw []byte,
-) (gledger.BlockHeader, error) {
+) (header gledger.BlockHeader, err error) {
+	defer func() {
+		if err == nil && header != nil {
+			header.Hash()
+		}
+	}()
 	if o.config.NetworkMagic == ouroboros.NetworkCardanoMusashi.NetworkMagic &&
 		blockType == gledger.BlockTypeConway {
 		return gdijkstra.NewDijkstraBlockHeaderFromCbor(raw)
 	}
-	header, err := gledger.NewBlockHeaderFromCbor(blockType, raw)
+	header, err = gledger.NewBlockHeaderFromCbor(blockType, raw)
 	if err == nil || blockType != gledger.BlockTypeByronEbb {
 		return header, err
 	}

--- a/ouroboros/decode_cache_hash_test.go
+++ b/ouroboros/decode_cache_hash_test.go
@@ -1,0 +1,160 @@
+package ouroboros
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeCacheConcurrentHash(t *testing.T) {
+	generators := map[string]func(
+		uint64, common.Blake2b256, uint64, uint64, int,
+	) ([]gledger.Block, error){
+		"shelley":  fixtures.GenerateShelleyChain,
+		"allegra":  fixtures.GenerateAllegraChain,
+		"mary":     fixtures.GenerateMaryChain,
+		"alonzo":   fixtures.GenerateAlonzoChain,
+		"babbage":  fixtures.GenerateBabbageChain,
+		"conway":   fixtures.GenerateConwayChain,
+		"dijkstra": fixtures.GenerateDijkstraChain,
+	}
+	for name, generate := range generators {
+		t.Run(name, func(t *testing.T) {
+			blocks, err := generate(1, common.Blake2b256{}, 2, 20, 1)
+			require.NoError(t, err)
+			require.Len(t, blocks, 1)
+			block := blocks[0]
+			testDecodedHashPublication(t, 0, uint(block.Type()),
+				block.Cbor(), block.Header().Cbor(), block.Hash())
+		})
+	}
+	t.Run("byron_ebb", func(t *testing.T) {
+		raw := byronEbbFixtureCbor(t)
+		block, err := gledger.NewBlockFromCbor(gledger.BlockTypeByronEbb, raw)
+		require.NoError(t, err)
+		testDecodedHashPublication(t, 0, gledger.BlockTypeByronEbb,
+			raw, block.Header().Cbor(), block.Hash())
+		t.Run("full_block_header_fallback", func(t *testing.T) {
+			testDecodedHashPublication(t, 0, gledger.BlockTypeByronEbb,
+				raw, raw, block.Hash())
+		})
+	})
+	t.Run("musashi", func(t *testing.T) {
+		raw := readHexFixture(t, musashiType7BlockFixture)
+		headerRaw := readHexFixture(t, musashiType7HeaderFixture)
+		oracle := testOuroborosForDecodeCache(t)
+		oracle.config.NetworkMagic = musashiNetworkMagic
+		block, err := oracle.decodeBlockfetchBlock(gledger.BlockTypeConway, raw)
+		require.NoError(t, err)
+		testDecodedHashPublication(t, musashiNetworkMagic,
+			gledger.BlockTypeConway, raw, headerRaw, block.Hash())
+	})
+}
+
+func testDecodedHashPublication(
+	t *testing.T,
+	networkMagic uint32,
+	blockType uint,
+	blockRaw, headerRaw []byte,
+	expected common.Blake2b256,
+) {
+	t.Helper()
+	t.Run("header", func(t *testing.T) {
+		ob := testOuroborosForDecodeCache(t)
+		ob.config.NetworkMagic = networkMagic
+		testConcurrentCachedHash(t, ob.headerDecodeCache,
+			hashDecodeInput(blockType, headerRaw),
+			func() (gledger.BlockHeader, error) {
+				return ob.decodeChainsyncHeader(blockType, headerRaw)
+			}, expected)
+	})
+	t.Run("block", func(t *testing.T) {
+		ob := testOuroborosForDecodeCache(t)
+		ob.config.NetworkMagic = networkMagic
+		testConcurrentCachedHash(t, ob.blockDecodeCache,
+			hashDecodeInput(blockType, blockRaw),
+			func() (gledger.Block, error) {
+				return ob.decodeBlockfetchBlock(blockType, blockRaw)
+			}, expected)
+	})
+}
+
+func testConcurrentCachedHash[T gledger.BlockHeader](
+	t *testing.T,
+	cache *decodeCache[T],
+	key decodeCacheKey,
+	decode func() (T, error),
+	expected common.Blake2b256,
+) {
+	t.Helper()
+	const readers = 8
+	decodeStarted := make(chan struct{})
+	releaseDecode := make(chan struct{})
+	startHash := make(chan struct{})
+	ready := make(chan struct{}, readers)
+	done := make(chan struct{}, readers)
+	finishDecode := sync.OnceFunc(func() { close(releaseDecode) })
+	beginHash := sync.OnceFunc(func() { close(startHash) })
+	defer finishDecode()
+	defer beginHash()
+	var decodeCalls atomic.Int64
+	values := make([]T, readers)
+	errors := make([]error, readers)
+	hashes := make([]common.Blake2b256, readers)
+	for reader := range readers {
+		go func() {
+			values[reader], errors[reader], _ = cache.getOrDecode(
+				key, func() (T, error) {
+					if decodeCalls.Add(1) == 1 {
+						close(decodeStarted)
+					}
+					<-releaseDecode
+					return decode()
+				})
+			ready <- struct{}{}
+			<-startHash
+			if errors[reader] == nil {
+				hashes[reader] = values[reader].Hash()
+			}
+			done <- struct{}{}
+		}()
+	}
+	testutil.RequireReceive(t, decodeStarted, 5*time.Second, "decode leader")
+	require.Eventually(t, func() bool {
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+		return len(cache.inFlight[key]) == readers-1
+	}, 5*time.Second, time.Millisecond, "all followers must wait for decode")
+	finishDecode()
+	for range readers {
+		testutil.RequireReceive(t, ready, 5*time.Second, "cache result")
+	}
+	beginHash()
+	for range readers {
+		testutil.RequireReceive(t, done, 5*time.Second, "concurrent hash")
+	}
+	for reader := range readers {
+		require.NoError(t, errors[reader])
+		require.Same(t, values[0], values[reader])
+		require.Equal(t, expected, hashes[reader])
+		if block, ok := any(values[reader]).(gledger.Block); ok {
+			require.Equal(t, expected, block.Header().Hash())
+		}
+	}
+	cached, err, decoded := cache.getOrDecode(key, decode)
+	require.NoError(t, err)
+	require.False(t, decoded)
+	require.Same(t, values[0], cached)
+	require.Equal(t, expected, cached.Hash())
+	require.EqualValues(t, 1, decodeCalls.Load())
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	require.Empty(t, cache.inFlight)
+}


### PR DESCRIPTION
Shared block/header decode caches publish decoded objects to multiple peer handlers. gouroboros header `Hash()` methods lazily populate an unsynchronized pointer, so concurrent first use of a cached object can race.

This change initializes block and header hashes in the Ouroboros decode functions before cache publication, including Musashi dispatch and the full-Byron-EBB fallback. It adds concurrent regression coverage across supported eras and cache paths.

Validation: focused race regression, scoped Ouroboros/chainsync/chainselection race tests, SQLite conformance, build, vet, golangci-lint, nilaway, modernize, import-boundary, and docs-parity checks pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data race in the shared decode cache: `Hash()` lazily populates an unsynchronized pointer, so concurrent first use of a cached block/header could race. The Ouroboros block-fetch and chain-sync decoders now compute the hash before the object is published, covering Musashi dispatch and the full-Byron-EBB fallback. Adds concurrent regression tests across supported eras and both cache paths. Consumers must treat cached decoded objects as immutable; failed decodes keep their existing error, TTL, and eviction behavior.

<sup>Written for commit 2509bf603cce969f637af224603f9d770e064f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block and header decoding reliability by ensuring hashes are initialized before decoded data is shared with concurrent readers.
  * Preserved existing handling for supported eras, Byron EBB headers, and Musashi-era blocks.
  * Maintained existing error handling, expiration, and cache eviction behavior for failed decodes.

* **Tests**
  * Added coverage for concurrent cache access, hash consistency, and reuse of previously decoded values across supported block types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->