### PR TITLE
fix(ouroboros): preserve transaction rejection era width

### DIFF
--- a/ouroboros/localtxsubmission.go
+++ b/ouroboros/localtxsubmission.go
@@ -95,7 +95,7 @@ type cborRejectReason interface {
 }
 
 type hardForkApplyTxError struct {
-	era uint8
+	era uint16
 	err error
 }
 
@@ -107,7 +107,7 @@ func newLocalTxSubmissionRejectReason(
 		return err
 	}
 	return &hardForkApplyTxError{
-		era: uint8(eraId), //nolint:gosec // Cardano era IDs fit in uint8
+		era: eraId,
 		err: err,
 	}
 }

--- a/ouroboros/localtxsubmission_test.go
+++ b/ouroboros/localtxsubmission_test.go
@@ -121,3 +121,34 @@ func TestLocalTxSubmissionRejectReason_PreservesTypedReason(t *testing.T) {
 	assert.Equal(t, typed.OtherEra, eraMismatch.OtherEra)
 	assert.Equal(t, typed.LedgerEra, eraMismatch.LedgerEra)
 }
+
+// Exercise the protocol callback and real mempool decode rejection so the
+// response preserves the original wire era, including unsupported values.
+func TestLocalTxSubmissionServerSubmitTx_PreservesRejectEra(t *testing.T) {
+	for _, era := range []uint16{255, 256, 257, 65535} {
+		t.Run(fmt.Sprint(era), func(t *testing.T) {
+			o, connID := newTxSubmissionTestOuroboros(t)
+			err := o.localtxsubmissionServerSubmitTx(
+				olocaltxsubmission.CallbackContext{ConnectionId: connID},
+				olocaltxsubmission.NewMsgSubmitTx(era, []byte{0x80}).Transaction,
+			)
+			require.ErrorContains(t, err, "decode transaction")
+			var reason cborRejectReason
+			require.ErrorAs(t, err, &reason)
+			encoded, err := reason.MarshalCBOR()
+			require.NoError(t, err)
+			var envelope []cbor.RawMessage
+			_, err = cbor.Decode(encoded, &envelope)
+			require.NoError(t, err)
+			require.Len(t, envelope, 1)
+			var failure []cbor.RawMessage
+			_, err = cbor.Decode(envelope[0], &failure)
+			require.NoError(t, err)
+			require.Len(t, failure, 2)
+			var rejectedEra uint16
+			_, err = cbor.Decode(failure[0], &rejectedEra)
+			require.NoError(t, err)
+			assert.Equal(t, era, rejectedEra, "reject envelope must preserve submitted era")
+		})
+	}
+}


### PR DESCRIPTION
Preserve the full uint16 era in local transaction submission rejection reasons. Add callback regression coverage for era boundaries.

Fixes #3404.
