### PR TITLE
fix(chainsync): update tracked client state on rollback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -468,6 +468,12 @@ sequenceDiagram
     LS->>EB: publish TransactionEvent(rollback: true) per tx
 ```
 
+An admitted ChainSync rollback atomically refreshes the tracked client's
+cursor, advertised tip, activity, and syncing status before chain selection
+observes it and before the ledger apply gate runs. This bookkeeping does not
+count a rollback as a delivered header or record it in the header deduplication
+cache. A callback for a removed client does not recreate its tracked state.
+
 `ledger.tx` is published with `PublishOrdered`, not `PublishAsync`, so a
 subscriber deriving state from it sees a block's transactions in index order
 and sees a rollback's undo events (`Rollback: true`) before any transaction

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -795,6 +795,29 @@ func (s *State) UpdateClientTipWithoutDedup(
 	return s.updateTrackedClientTip(connId, point, tip)
 }
 
+// UpdateClientRollback updates an existing client's cursor, advertised tip,
+// activity, and syncing status atomically. Rollbacks do not count as delivered
+// headers or enter the header deduplication cache.
+func (s *State) UpdateClientRollback(
+	connId ouroboros.ConnectionId,
+	point ocommon.Point,
+	tip ochainsync.Tip,
+) bool {
+	s.clientConnIdMutex.Lock()
+	defer s.clientConnIdMutex.Unlock()
+	tc, exists := s.trackedClients[connId]
+	if !exists {
+		return false
+	}
+	point.Hash = cloneBytes(point.Hash)
+	tip.Point.Hash = cloneBytes(tip.Point.Hash)
+	tc.Cursor = point
+	tc.Tip = tip
+	tc.LastActivity = time.Now()
+	tc.Status = ClientStatusSyncing
+	return true
+}
+
 // RecordHeaderForDedup records a tracked header in the shared cross-peer
 // deduplication and fork-detection cache. Callers that update the tracked tip
 // before a synchronous selection decision use this after the apply gate, so a

--- a/chainsync/rollback_test.go
+++ b/chainsync/rollback_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateClientRollbackRefreshesActivityAndOwnsHashes(t *testing.T) {
+	connID := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 3001},
+	}
+	oldActivity := time.Unix(1, 0)
+	state := NewState(nil, nil)
+	state.trackedClients[connID] = &TrackedClient{
+		ConnId:       connID,
+		LastActivity: oldActivity,
+		Status:       ClientStatusStalled,
+	}
+	point := ocommon.NewPoint(90, []byte("rollback"))
+	tip := ochainsync.Tip{Point: ocommon.NewPoint(110, []byte("tip"))}
+	require.True(t, state.UpdateClientRollback(connID, point, tip))
+	current := state.GetTrackedClient(connID)
+	require.True(t, current.LastActivity.After(oldActivity))
+	require.Equal(t, ClientStatusSyncing, current.Status)
+	point.Hash[0] = 'X'
+	tip.Point.Hash[0] = 'X'
+	current = state.GetTrackedClient(connID)
+	require.Equal(t, []byte("rollback"), current.Cursor.Hash)
+	require.Equal(t, []byte("tip"), current.Tip.Point.Hash)
+}

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -909,6 +909,11 @@ func (o *Ouroboros) chainsyncClientRollBackward(
 	) {
 		return nil
 	}
+	if o.chainsyncState != nil && !o.chainsyncState.UpdateClientRollback(
+		ctx.ConnectionId, point, tip,
+	) {
+		return nil
+	}
 	// Observe the rollback for chain selection FIRST — it trims the peer's
 	// observed frontier (ApplyRollback), which can change its corroboration
 	// status, so the apply gate below must reflect it. If the hook handles it

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -2322,3 +2322,54 @@ func TestChainsyncResyncMithrilReasonsDenyPeerAndRequireFreshConnection(
 		}
 	}
 }
+
+func TestChainsyncClientRollBackwardUpdatesTrackedClient(t *testing.T) {
+	for _, origin := range []bool{false, true} {
+		t.Run(fmt.Sprint(origin), func(t *testing.T) {
+			bus := event.NewEventBus(nil, nil)
+			defer bus.Close()
+			state := dchainsync.NewState(bus, nil)
+			connID := newTestConnId("127.0.0.1:6000", "10.0.0.1:3001")
+			require.True(t, state.AddClientConnId(connID))
+			previous := ocommon.NewPoint(100, []byte("previous"))
+			state.UpdateClientTip(connID, previous, ochainsync.Tip{Point: previous})
+			state.MarkClientSynced(connID)
+			before := state.GetTrackedClient(connID)
+			point := ocommon.NewPoint(90, []byte("rollback"))
+			if origin {
+				point = ocommon.NewPointOrigin()
+			}
+			tip := ochainsync.Tip{Point: ocommon.NewPoint(110, []byte("tip")), BlockNumber: 10}
+			observed := false
+			o := newOuroboros(OuroborosConfig{
+				ChainsyncIngressEligible: func(ouroboros.ConnectionId) bool { return true },
+				ChainsyncApplyEligible:   func(ouroboros.ConnectionId) bool { return false },
+				ChainsyncObservePeerRollback: func(chainselection.PeerRollbackEvent) bool {
+					observed = true
+					current := state.GetTrackedClient(connID)
+					require.Equal(t, point, current.Cursor)
+					require.Equal(t, tip, current.Tip)
+					require.Equal(t, dchainsync.ClientStatusSyncing, current.Status)
+					require.False(t, current.LastActivity.Before(before.LastActivity))
+					require.Equal(t, before.HeadersRecv, current.HeadersRecv)
+					return true
+				},
+			})
+			o.chainsyncState = state
+			o.eventBus = bus
+			require.NoError(t, o.chainsyncClientRollBackward(
+				ochainsync.CallbackContext{ConnectionId: connID}, point, tip,
+			))
+			require.True(t, observed)
+			// Rollback points are not headers and must not enter the dedup cache.
+			require.True(t, state.RecordHeaderForDedup(connID, point))
+			state.RemoveClientConnId(connID)
+			observed = false
+			require.NoError(t, o.chainsyncClientRollBackward(
+				ochainsync.CallbackContext{ConnectionId: connID}, point, tip,
+			))
+			require.False(t, observed)
+			require.Nil(t, state.GetTrackedClient(connID))
+		})
+	}
+}


### PR DESCRIPTION
Update tracked client cursor, tip, activity, and status atomically on admitted rollbacks without changing header counts or deduplication. Add rollback sequencing, disconnected-client, timestamp, and hash-ownership coverage.

Fixes #3423.
