### PR TITLE
fix(node): preserve ledger fatal shutdown cause

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1198,6 +1198,11 @@ while components are still starting can therefore cancel startup without
 letting `Node.Stop` concurrently close a partially initialized component; the
 normal shutdown waits until rollback has finished.
 
+The ledger fatal-error callback records its cause before cancelling the node.
+`Node.Run` returns that cause on normal shutdown and cancellation-shaped startup
+exits, preserving the first fatal cause across repeated callbacks. This wiring
+is shared by initial ledger construction and live ledger reconstruction.
+
 The node creates one shutdown context from the configured `shutdownTimeout`
 and passes it through every phase. PeerGovernor shutdown cancels its internal
 run context, which interrupts ledger-peer DNS discovery and outbound work,

--- a/node_fatal_error_test.go
+++ b/node_fatal_error_test.go
@@ -17,8 +17,11 @@ package dingo
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
+	internalconfig "github.com/blinklabs-io/dingo/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,4 +52,26 @@ func TestFatalDuringStartupOverridesCancellationError(t *testing.T) {
 	n.cancelForFatal(want)
 
 	require.ErrorIs(t, n.resolveRunError(context.Canceled), want)
+}
+
+func TestLedgerFatalCallbackPreservesShutdownCause(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n := &Node{
+		ctx:    ctx,
+		cancel: cancel,
+		config: Config{
+			cfg:    &internalconfig.Config{},
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+	}
+	callback := n.ledgerStateConfig().FatalErrorFunc
+	want := errors.New("ledger component failure")
+	callback(want)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, n.waitForShutdown(), want)
+	require.ErrorIs(t, n.resolveRunError(context.Canceled), want)
+
+	callback(errors.New("later ledger failure"))
+	require.ErrorIs(t, n.waitForShutdown(), want)
 }

--- a/node_ledger_config.go
+++ b/node_ledger_config.go
@@ -293,7 +293,7 @@ func (n *Node) ledgerStateConfig() ledger.LedgerStateConfig {
 				"fatal ledger error, initiating shutdown",
 				"error", err,
 			)
-			n.cancel()
+			n.cancelForFatal(err)
 		},
 	}
 }


### PR DESCRIPTION
Route the ledger fatal callback through cause-preserving cancellation so node shutdown retains the original failure. Regression coverage exercises the configured callback and first-cause preservation.

Related to #3665.
