### PR TITLE
fix(storage): validate reverse-key spool frames

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1288,7 +1288,9 @@ uncapped, so an oversized blob can be both staged for deletion and committed —
 only reading its value back through `Get` hits the cap.
 Forward cloud iterators page keys directly; reverse iterators spool only their
 key records to a temporary file so bucket size does not determine iterator heap
-usage.
+usage. Reverse readers validate that each record fits the remaining spool and
+that its prefix and trailer lengths agree before allocating the key. Malformed
+spool records terminate iteration with an error instead of yielding a key.
 
 S3 has two prefix input forms with deliberately different compatibility contracts. `New` normalizes a non-empty prefix parsed from `s3://<bucket>/<prefix>` to end in `/`, so `s3://bucket/foo` produces object names such as `foo/<hex-key>`. `WithPrefix`, used by the `plugins.storage` config `prefix` field, preserves the configured value verbatim: `foo` produces `foo<hex-key>`, while `foo/` produces `foo/<hex-key>`. An empty prefix in either form adds nothing. Keeping the option form literal preserves the object-key layout of existing deployments.
 

--- a/database/plugin/blob/aws/database.go
+++ b/database/plugin/blob/aws/database.go
@@ -1234,12 +1234,27 @@ func (f *reverseKeyFile) nextReverse() (string, bool, error) {
 	if f.pos == 0 {
 		return "", false, nil
 	}
+	// Every record has a four-byte prefix and matching trailer. Validate
+	// the frame before trusting its declared allocation size.
+	if f.pos < 8 {
+		return "", false, errors.New("truncated reverse key record")
+	}
 	trailer := make([]byte, 4)
 	if _, err := f.file.ReadAt(trailer, f.pos-4); err != nil {
 		return "", false, err
 	}
 	length := int64(binary.BigEndian.Uint32(trailer))
-	start := f.pos - 4 - length - 4
+	if length > f.pos-8 || length > math.MaxInt {
+		return "", false, errors.New("invalid reverse key record length")
+	}
+	start := f.pos - 8 - length
+	prefix := make([]byte, 4)
+	if _, err := f.file.ReadAt(prefix, start); err != nil {
+		return "", false, err
+	}
+	if int64(binary.BigEndian.Uint32(prefix)) != length {
+		return "", false, errors.New("reverse key record lengths do not match")
+	}
 	key := make([]byte, length)
 	if _, err := f.file.ReadAt(key, start+4); err != nil {
 		return "", false, err

--- a/database/plugin/blob/aws/read_limit_test.go
+++ b/database/plugin/blob/aws/read_limit_test.go
@@ -11,6 +11,7 @@
 package aws
 
 import (
+	"encoding/binary"
 	"os"
 	"strings"
 	"testing"
@@ -81,4 +82,77 @@ func TestReverseKeyFile(t *testing.T) {
 		)
 	}
 	file.Close()
+}
+
+// Corrupt local spool framing must never yield a key to the cloud iterator.
+func TestReverseKeyFileRejectsMalformedRecords(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"short header", []byte{0, 0, 0}},
+		{"missing prefix", []byte{0, 0, 0, 4}},
+		{"truncated payload", []byte{0, 0, 0, 2, 'a', 0, 0, 0, 2}},
+		{"mismatched lengths", []byte{0, 0, 0, 2, 'a', 0, 0, 0, 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := os.CreateTemp(t.TempDir(), "reverse-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			if _, err := file.Write(tc.data); err != nil {
+				t.Fatal(err)
+			}
+			f := &reverseKeyFile{file: file}
+			key, valid, err := f.nextReverse()
+			if err == nil || valid || key != "" {
+				t.Fatalf("malformed spool yielded key %q, valid=%v, err=%v", key, valid, err)
+			}
+		})
+	}
+}
+
+func TestReverseKeyFileEmptyAndBinaryKeys(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "reverse-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	keys := []string{"", string(binary.BigEndian.AppendUint32(nil, 0xffffffff)), "last"}
+	for _, key := range keys {
+		if err := writeReverseKey(file, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f := &reverseKeyFile{file: file}
+	for i := len(keys) - 1; i >= 0; i-- {
+		key, valid, err := f.nextReverse()
+		if err != nil || !valid || key != keys[i] {
+			t.Fatalf("reverse key = %q, valid=%v, err=%v; want %q", key, valid, err, keys[i])
+		}
+	}
+	if _, valid, err := f.nextReverse(); err != nil || valid {
+		t.Fatalf("exhausted iterator: valid=%v err=%v", valid, err)
+	}
+}
+
+func TestReverseIteratorPropagatesSpoolCorruption(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "reverse-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := writeReverseKey(file, "a"); err != nil {
+		t.Fatal(err)
+	}
+	// The trailer still declares one byte, but the prefix declares two.
+	if _, err := file.WriteAt([]byte{0, 0, 0, 2}, 0); err != nil {
+		t.Fatal(err)
+	}
+	it := &s3ReverseIterator{keys: &reverseKeyFile{file: file}}
+	it.Rewind()
+	if it.Err() == nil || it.Valid() || it.Item() != nil {
+		t.Fatalf("corrupted spool iterator: valid=%v err=%v", it.Valid(), it.Err())
+	}
 }

--- a/database/plugin/blob/gcs/database.go
+++ b/database/plugin/blob/gcs/database.go
@@ -1248,12 +1248,27 @@ func (f *reverseKeyFile) nextReverse() (string, bool, error) {
 	if f.pos == 0 {
 		return "", false, nil
 	}
+	// Every record has a four-byte prefix and matching trailer. Validate
+	// the frame before trusting its declared allocation size.
+	if f.pos < 8 {
+		return "", false, errors.New("truncated reverse key record")
+	}
 	trailer := make([]byte, 4)
 	if _, err := f.file.ReadAt(trailer, f.pos-4); err != nil {
 		return "", false, err
 	}
 	length := int64(binary.BigEndian.Uint32(trailer))
-	start := f.pos - 4 - length - 4
+	if length > f.pos-8 || length > math.MaxInt {
+		return "", false, errors.New("invalid reverse key record length")
+	}
+	start := f.pos - 8 - length
+	prefix := make([]byte, 4)
+	if _, err := f.file.ReadAt(prefix, start); err != nil {
+		return "", false, err
+	}
+	if int64(binary.BigEndian.Uint32(prefix)) != length {
+		return "", false, errors.New("reverse key record lengths do not match")
+	}
 	key := make([]byte, length)
 	if _, err := f.file.ReadAt(key, start+4); err != nil {
 		return "", false, err

--- a/database/plugin/blob/gcs/read_limit_test.go
+++ b/database/plugin/blob/gcs/read_limit_test.go
@@ -11,6 +11,7 @@
 package gcs
 
 import (
+	"encoding/binary"
 	"os"
 	"strings"
 	"testing"
@@ -81,4 +82,77 @@ func TestReverseKeyFile(t *testing.T) {
 		)
 	}
 	file.Close()
+}
+
+// Corrupt local spool framing must never yield a key to the cloud iterator.
+func TestReverseKeyFileRejectsMalformedRecords(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"short header", []byte{0, 0, 0}},
+		{"missing prefix", []byte{0, 0, 0, 4}},
+		{"truncated payload", []byte{0, 0, 0, 2, 'a', 0, 0, 0, 2}},
+		{"mismatched lengths", []byte{0, 0, 0, 2, 'a', 0, 0, 0, 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := os.CreateTemp(t.TempDir(), "reverse-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			if _, err := file.Write(tc.data); err != nil {
+				t.Fatal(err)
+			}
+			f := &reverseKeyFile{file: file}
+			key, valid, err := f.nextReverse()
+			if err == nil || valid || key != "" {
+				t.Fatalf("malformed spool yielded key %q, valid=%v, err=%v", key, valid, err)
+			}
+		})
+	}
+}
+
+func TestReverseKeyFileEmptyAndBinaryKeys(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "reverse-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	keys := []string{"", string(binary.BigEndian.AppendUint32(nil, 0xffffffff)), "last"}
+	for _, key := range keys {
+		if err := writeReverseKey(file, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f := &reverseKeyFile{file: file}
+	for i := len(keys) - 1; i >= 0; i-- {
+		key, valid, err := f.nextReverse()
+		if err != nil || !valid || key != keys[i] {
+			t.Fatalf("reverse key = %q, valid=%v, err=%v; want %q", key, valid, err, keys[i])
+		}
+	}
+	if _, valid, err := f.nextReverse(); err != nil || valid {
+		t.Fatalf("exhausted iterator: valid=%v err=%v", valid, err)
+	}
+}
+
+func TestReverseIteratorPropagatesSpoolCorruption(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "reverse-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := writeReverseKey(file, "a"); err != nil {
+		t.Fatal(err)
+	}
+	// The trailer still declares one byte, but the prefix declares two.
+	if _, err := file.WriteAt([]byte{0, 0, 0, 2}, 0); err != nil {
+		t.Fatal(err)
+	}
+	it := &gcsReverseIterator{keys: &reverseKeyFile{file: file}}
+	it.Rewind()
+	if it.Err() == nil || it.Valid() || it.Item() != nil {
+		t.Fatalf("corrupted spool iterator: valid=%v err=%v", it.Valid(), it.Err())
+	}
 }


### PR DESCRIPTION
Validate AWS/GCS reverse-key spool frames before allocation, rejecting truncated or mismatched lengths. Tests cover malformed frames, valid keys, and iterator error propagation.

Related to #3387.
