### PR TITLE
fix(node): preserve Midnight indexer reconstruction config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1198,6 +1198,13 @@ while components are still starting can therefore cancel startup without
 letting `Node.Stop` concurrently close a partially initialized component; the
 normal shutdown waits until rollback has finished.
 
+Midnight indexer startup and live reconstruction share their enablement gate
+and configuration builder. Both require indexing to be enabled in API storage
+mode, bound backfill using the current database's persisted ledger tip, and
+record the first fatal cause before cancelling the node. This is independent
+of Midnight server enablement; callbacks resolve replaced node components when
+invoked.
+
 The node creates one shutdown context from the configured `shutdownTimeout`
 and passes it through every phase. PeerGovernor shutdown cancels its internal
 run context, which interrupts ledger-peer DNS discovery and outbound work,

--- a/node.go
+++ b/node.go
@@ -817,68 +817,14 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 	// are required: the indexer depends on the api-mode indexes to function,
 	// and storage mode alone is no longer sufficient to start it (an api-mode
 	// deployment may not want Midnight indexing at all).
-	if n.config.midnight.Enabled && n.config.storageMode.IsAPI() {
+	if midnightIndexerActive(n.config.storageMode, n.config.midnight) {
 		if err := n.ledgerState.PrepareEpochCacheForStartup(); err != nil {
 			return fmt.Errorf(
 				"load epoch cache before Midnight indexer start: %w",
 				err,
 			)
 		}
-		midnightIdx, err := midnightindexer.New(midnightindexer.Config{
-			EventBus:                n.eventBus,
-			Metadata:                n.db.Metadata(),
-			SlotTimer:               n.ledgerState,
-			Logger:                  n.config.logger,
-			PromRegistry:            n.config.promRegistry,
-			CNightPolicyID:          n.config.midnight.CNightPolicyID,
-			CNightAssetName:         n.config.midnight.CNightAssetName,
-			MappingValidatorAddress: n.config.midnight.MappingValidatorAddress,
-			AuthTokenPolicyID:       n.config.midnight.AuthTokenPolicyID,
-			AuthTokenAssetName:      n.config.midnight.AuthTokenAssetName,
-			// Governance / Ariadne / candidate scanning
-			TechnicalCommitteeAddress:   n.config.midnight.TechnicalCommitteeAddress,
-			TechnicalCommitteePolicyID:  n.config.midnight.TechnicalCommitteePolicyID,
-			CouncilAddress:              n.config.midnight.CouncilAddress,
-			CouncilPolicyID:             n.config.midnight.CouncilPolicyID,
-			PermissionedCandidatePolicy: n.config.midnight.PermissionedCandidatePolicy,
-			CommitteeCandidateAddress:   n.config.midnight.CommitteeCandidateAddress,
-			SlotToEpoch: func(slot uint64) (uint64, error) {
-				epoch, err := n.ledgerState.SlotToEpoch(slot)
-				if err != nil {
-					return 0, err
-				}
-				return epoch.EpochId, nil
-			},
-			BlockIterator: func(startSlot, endSlot uint64, fn func(models.Block) error) error {
-				return database.ForEachBlockInRangeDB(
-					n.db,
-					startSlot,
-					endSlot,
-					fn,
-				)
-			},
-			// Read the applied ledger tip straight from metadata rather than
-			// from n.ledgerState.Tip(): LedgerState only loads its in-memory
-			// tip inside Start, which runs after this indexer has already
-			// backfilled, so Tip() would still be the zero value here. Blocks
-			// stored above this slot -- the whole post-snapshot suffix on a
-			// Mithril-bootstrapped node -- are replayed by LedgerState.Start
-			// and reach the indexer as live block events instead.
-			LedgerTipSlot: func() (uint64, error) {
-				tip, err := n.db.GetTip(nil)
-				if err != nil {
-					return 0, err
-				}
-				return tip.Point.Slot, nil
-			},
-			FatalErrorFunc: func(err error) {
-				n.config.logger.Error(
-					"fatal midnight indexer error, initiating shutdown",
-					"error", err,
-				)
-				n.cancel()
-			},
-		})
+		midnightIdx, err := midnightindexer.New(n.midnightIndexerConfig())
 		if err != nil {
 			return fmt.Errorf("creating midnight indexer: %w", err)
 		}

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -696,13 +696,13 @@ func (n *Node) reinitializeCoreStorage(ctx context.Context) error {
 	return nil
 }
 
-// reinitializeMidnightIndexer recreates the Midnight indexer (if API
-// storage mode) before n.ledgerState.Start, for the same race-avoidance
+// reinitializeMidnightIndexer recreates the enabled Midnight indexer in API
+// storage mode before n.ledgerState.Start, for the same race-avoidance
 // reason Run() creates it before starting the ledger: the synchronous
 // backfill must run while no new blocks can arrive, and the EventBus
 // subscription must exist before any BlockActionApply event can fire.
 func (n *Node) reinitializeMidnightIndexer() error {
-	if !n.config.storageMode.IsAPI() {
+	if !midnightIndexerActive(n.config.storageMode, n.config.midnight) {
 		return nil
 	}
 	if err := n.ledgerState.PrepareEpochCacheForStartup(); err != nil {
@@ -711,41 +711,7 @@ func (n *Node) reinitializeMidnightIndexer() error {
 			err,
 		)
 	}
-	midnightIdx, err := midnightindexer.New(midnightindexer.Config{
-		EventBus:                    n.eventBus,
-		Metadata:                    n.db.Metadata(),
-		SlotTimer:                   n.ledgerState,
-		Logger:                      n.config.logger,
-		PromRegistry:                n.config.promRegistry,
-		CNightPolicyID:              n.config.midnight.CNightPolicyID,
-		CNightAssetName:             n.config.midnight.CNightAssetName,
-		MappingValidatorAddress:     n.config.midnight.MappingValidatorAddress,
-		AuthTokenPolicyID:           n.config.midnight.AuthTokenPolicyID,
-		AuthTokenAssetName:          n.config.midnight.AuthTokenAssetName,
-		TechnicalCommitteeAddress:   n.config.midnight.TechnicalCommitteeAddress,
-		TechnicalCommitteePolicyID:  n.config.midnight.TechnicalCommitteePolicyID,
-		CouncilAddress:              n.config.midnight.CouncilAddress,
-		CouncilPolicyID:             n.config.midnight.CouncilPolicyID,
-		PermissionedCandidatePolicy: n.config.midnight.PermissionedCandidatePolicy,
-		CommitteeCandidateAddress:   n.config.midnight.CommitteeCandidateAddress,
-		SlotToEpoch: func(slot uint64) (uint64, error) {
-			epoch, err := n.ledgerState.SlotToEpoch(slot)
-			if err != nil {
-				return 0, err
-			}
-			return epoch.EpochId, nil
-		},
-		BlockIterator: func(startSlot, endSlot uint64, fn func(models.Block) error) error {
-			return database.ForEachBlockInRangeDB(n.db, startSlot, endSlot, fn)
-		},
-		FatalErrorFunc: func(err error) {
-			n.config.logger.Error(
-				"fatal midnight indexer error, initiating shutdown",
-				"error", err,
-			)
-			n.cancel()
-		},
-	})
+	midnightIdx, err := midnightindexer.New(n.midnightIndexerConfig())
 	if err != nil {
 		return fmt.Errorf("recreating midnight indexer: %w", err)
 	}

--- a/node_midnight_config.go
+++ b/node_midnight_config.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	midnightindexer "github.com/blinklabs-io/dingo/midnight/indexer"
+)
+
+// midnightIndexerActive is shared by initial startup and live reconstruction.
+// Indexer enablement is independent of the Midnight server's listener settings.
+func midnightIndexerActive(storageMode StorageMode, cfg MidnightConfig) bool {
+	return cfg.Enabled && storageMode.IsAPI()
+}
+
+// midnightIndexerConfig preserves startup configuration during reconstruction.
+// Callers must install the current database and ledger before building it;
+// callbacks resolve those components when invoked so they follow replacement.
+func (n *Node) midnightIndexerConfig() midnightindexer.Config {
+	return midnightindexer.Config{
+		EventBus:                n.eventBus,
+		Metadata:                n.db.Metadata(),
+		SlotTimer:               n.ledgerState,
+		Logger:                  n.config.logger,
+		PromRegistry:            n.config.promRegistry,
+		CNightPolicyID:          n.config.midnight.CNightPolicyID,
+		CNightAssetName:         n.config.midnight.CNightAssetName,
+		MappingValidatorAddress: n.config.midnight.MappingValidatorAddress,
+		AuthTokenPolicyID:       n.config.midnight.AuthTokenPolicyID,
+		AuthTokenAssetName:      n.config.midnight.AuthTokenAssetName,
+		// Governance / Ariadne / candidate scanning
+		TechnicalCommitteeAddress:   n.config.midnight.TechnicalCommitteeAddress,
+		TechnicalCommitteePolicyID:  n.config.midnight.TechnicalCommitteePolicyID,
+		CouncilAddress:              n.config.midnight.CouncilAddress,
+		CouncilPolicyID:             n.config.midnight.CouncilPolicyID,
+		PermissionedCandidatePolicy: n.config.midnight.PermissionedCandidatePolicy,
+		CommitteeCandidateAddress:   n.config.midnight.CommitteeCandidateAddress,
+		SlotToEpoch: func(slot uint64) (uint64, error) {
+			epoch, err := n.ledgerState.SlotToEpoch(slot)
+			if err != nil {
+				return 0, err
+			}
+			return epoch.EpochId, nil
+		},
+		BlockIterator: func(startSlot, endSlot uint64, fn func(models.Block) error) error {
+			return database.ForEachBlockInRangeDB(
+				n.db,
+				startSlot,
+				endSlot,
+				fn,
+			)
+		},
+		// Read the applied ledger tip straight from metadata rather than
+		// from n.ledgerState.Tip(): LedgerState only loads its in-memory
+		// tip inside Start, which runs after this indexer has already
+		// backfilled, so Tip() would still be the zero value here. Blocks
+		// stored above this slot -- the whole post-snapshot suffix on a
+		// Mithril-bootstrapped node -- are replayed by LedgerState.Start
+		// and reach the indexer as live block events instead.
+		LedgerTipSlot: func() (uint64, error) {
+			tip, err := n.db.GetTip(nil)
+			if err != nil {
+				return 0, err
+			}
+			return tip.Point.Slot, nil
+		},
+		FatalErrorFunc: func(err error) {
+			n.config.logger.Error(
+				"fatal midnight indexer error, initiating shutdown",
+				"error", err,
+			)
+			n.cancelForFatal(err)
+		},
+	}
+}

--- a/node_midnight_config_test.go
+++ b/node_midnight_config_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMidnightIndexerEnablement(t *testing.T) {
+	for _, mode := range []StorageMode{StorageModeAPI, StorageModeCore} {
+		for _, enabled := range []bool{false, true} {
+			cfg := MidnightConfig{Enabled: enabled}
+			want := enabled && mode.IsAPI()
+			require.Equal(t, want, midnightIndexerActive(mode, cfg))
+			if !want {
+				n := &Node{config: Config{storageMode: mode, midnight: cfg}}
+				require.NotPanics(t, func() {
+					require.NoError(t, n.reinitializeMidnightIndexer())
+				}, "inactive indexers must return before accessing ledger or storage")
+			}
+		}
+	}
+	// A separately enabled server must not enable indexing.
+	require.False(t, midnightIndexerActive(StorageModeAPI, MidnightConfig{
+		ServerEnabled: true, Port: 50051,
+	}))
+}
+
+func newMidnightConfigDatabase(t *testing.T, slot uint64) *database.Database {
+	t.Helper()
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dbtest.CloseDatabase(db)) })
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(slot, make([]byte, 32)),
+	}, nil))
+	return db
+}
+
+func TestMidnightIndexerConfigUsesCurrentPersistedTip(t *testing.T) {
+	n := &Node{db: newMidnightConfigDatabase(t, 123)}
+	cfg := n.midnightIndexerConfig()
+	require.NotNil(t, cfg.LedgerTipSlot)
+	slot, err := cfg.LedgerTipSlot()
+	require.NoError(t, err)
+	require.Equal(t, uint64(123), slot)
+	// The closure must follow a replaced database rather than pinning the old one.
+	n.db = newMidnightConfigDatabase(t, 456)
+	slot, err = cfg.LedgerTipSlot()
+	require.NoError(t, err)
+	require.Equal(t, uint64(456), slot)
+}
+
+func TestMidnightIndexerFatalCallbackPreservesCause(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n := &Node{
+		db:  newMidnightConfigDatabase(t, 123),
+		ctx: ctx, cancel: cancel,
+		config: Config{logger: slog.New(slog.NewTextHandler(io.Discard, nil))},
+	}
+	callback := n.midnightIndexerConfig().FatalErrorFunc
+	want := errors.New("midnight component failure")
+	callback(want)
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, n.waitForShutdown(), want)
+	require.ErrorIs(t, n.resolveRunError(context.Canceled), want)
+	callback(errors.New("later midnight failure"))
+	require.ErrorIs(t, n.waitForShutdown(), want)
+}


### PR DESCRIPTION
Share Midnight indexer enablement and configuration between startup and reconstruction, preserving the ledger-tip bound and fatal cause. Tests cover disabled reconstruction, current persisted-tip lookup, and first fatal cause retention.

Related to #3665 and #3666.
