### PR TITLE
fix(utxorpc): match signed mint and burn quantities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6095,6 +6095,11 @@ Two contracts follow from that boundary:
 
 ### UTxO RPC (`api/utxorpc/`)
 
+Transaction `MintsAsset` predicates inspect nonzero signed quantities in the
+transaction mint field, matching both minting and burning. A policy-only pattern
+matches any nonzero asset under that policy. Transfers alone do not satisfy this
+predicate; `MovesAsset` retains its output and resolved-input matching behavior.
+
 Each Connect message is bounded to `DefaultMaxRequestBody` (1 MiB) with
 Connect's `WithReadMaxBytes` option. The limit applies to both compressed wire
 bytes and decompressed message bytes before unary decoding reaches the

--- a/api/utxorpc/submit.go
+++ b/api/utxorpc/submit.go
@@ -530,7 +530,7 @@ func (u *Utxorpc) matchesTxPattern(
 		parts = append(parts, u.txPatternMatchHasAddress(tx, pattern))
 	}
 	if p := pattern.GetMintsAsset(); p != nil {
-		parts = append(parts, u.txPatternMatchAsset(tx, p))
+		parts = append(parts, txPatternMatchMint(tx, p))
 	}
 	if p := pattern.GetMovesAsset(); p != nil {
 		parts = append(parts, u.txPatternMatchAsset(tx, p))
@@ -798,6 +798,37 @@ func (u *Utxorpc) txPatternMatchHasAddress(
 	}
 	if sawUnevaluable {
 		return predUnevaluable
+	}
+	return predNoMatch
+}
+
+// txPatternMatchMint matches minting and burning from the signed mint field.
+// An omitted asset name matches any nonzero quantity under the policy.
+func txPatternMatchMint(
+	tx gledger.Transaction,
+	pattern *cardano.AssetPattern,
+) predOutcome {
+	if pattern == nil {
+		return predUnevaluable
+	}
+	mint := tx.AssetMint()
+	if mint == nil {
+		return predNoMatch
+	}
+	for _, policy := range mint.Policies() {
+		if !bytes.Equal(policy.Bytes(), pattern.GetPolicyId()) {
+			continue
+		}
+		for _, name := range mint.Assets(policy) {
+			if len(pattern.GetAssetName()) > 0 &&
+				!bytes.Equal(name, pattern.GetAssetName()) {
+				continue
+			}
+			quantity := mint.Asset(policy, name)
+			if quantity != nil && quantity.Sign() != 0 {
+				return predMatch
+			}
+		}
 	}
 	return predNoMatch
 }

--- a/api/utxorpc/submit_test.go
+++ b/api/utxorpc/submit_test.go
@@ -711,8 +711,11 @@ type txPatternTestTx struct {
 	consumed []common.TransactionInput
 	outs     []common.TransactionOutput
 	collRet  common.TransactionOutput
+	mint     *common.MultiAsset[common.MultiAssetTypeMint]
 	certs    []common.Certificate
 }
+
+func (t *txPatternTestTx) AssetMint() *common.MultiAsset[common.MultiAssetTypeMint] { return t.mint }
 
 func (t *txPatternTestTx) Certificates() []common.Certificate {
 	if t == nil {
@@ -1082,7 +1085,7 @@ func TestMatchesTxPattern_ConsumesOnly_LookupFailsWithoutLedger(t *testing.T) {
 	require.Equal(t, predUnevaluable, u.matchesTxPattern(tx, p))
 }
 
-func TestMatchesTxPattern_MintsAssetOnly(t *testing.T) {
+func TestMatchesTxPattern_TransferDoesNotMint(t *testing.T) {
 	t.Parallel()
 	addrA := txPatternMustAddr(t, txPatternAddrA)
 	u := txPatternTestUtxorpc(t)
@@ -1105,7 +1108,7 @@ func TestMatchesTxPattern_MintsAssetOnly(t *testing.T) {
 			AssetName: assetName,
 		},
 	}
-	require.Equal(t, predMatch, u.matchesTxPattern(tx, p))
+	require.Equal(t, predNoMatch, u.matchesTxPattern(tx, p))
 }
 
 func TestMatchesTxPattern_MovesAssetOnly(t *testing.T) {
@@ -1599,4 +1602,45 @@ func TestMatchesTxPattern_HasCertificateMalformedPatternUnevaluable(
 		HasCertificate: &cardano.CertificatePattern{},
 	}
 	require.Equal(t, predUnevaluable, u.matchesTxPattern(tx, p))
+}
+
+func TestMatchesTxPattern_SignedMint(t *testing.T) {
+	policy := common.Blake2b224{1}
+	name := []byte("asset")
+	for _, tc := range []struct {
+		name    string
+		amount  *big.Int
+		pattern *cardano.AssetPattern
+		want    predOutcome
+	}{
+		{"mint", big.NewInt(1), &cardano.AssetPattern{PolicyId: policy[:], AssetName: name}, predMatch},
+		{"burn", big.NewInt(-1), &cardano.AssetPattern{PolicyId: policy[:], AssetName: name}, predMatch},
+		{"large_mint", new(big.Int).Lsh(big.NewInt(1), 80), &cardano.AssetPattern{PolicyId: policy[:], AssetName: name}, predMatch},
+		{"large_burn", new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 80)), &cardano.AssetPattern{PolicyId: policy[:], AssetName: name}, predMatch},
+		{"policy_only_mint", big.NewInt(1), &cardano.AssetPattern{PolicyId: policy[:]}, predMatch},
+		{"policy_only_burn", big.NewInt(-1), &cardano.AssetPattern{PolicyId: policy[:]}, predMatch},
+		{"zero", big.NewInt(0), &cardano.AssetPattern{PolicyId: policy[:], AssetName: name}, predNoMatch},
+		{"nil_quantity", nil, &cardano.AssetPattern{PolicyId: policy[:]}, predNoMatch},
+		{"wrong_policy", big.NewInt(1), &cardano.AssetPattern{PolicyId: []byte{2}, AssetName: name}, predNoMatch},
+		{"wrong_name", big.NewInt(-1), &cardano.AssetPattern{PolicyId: policy[:], AssetName: []byte("other")}, predNoMatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mint := common.NewMultiAsset(
+				map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeMint{
+					policy: {cbor.NewByteString(name): tc.amount},
+				},
+			)
+			// No outputs or ledger lookup: only the signed mint field can match.
+			tx := &txPatternTestTx{mint: &mint}
+			u := txPatternTestUtxorpc(t)
+			require.Equal(
+				t,
+				tc.want,
+				u.matchesTxPattern(
+					tx,
+					&cardano.TxPattern{MintsAsset: tc.pattern},
+				),
+			)
+		})
+	}
 }


### PR DESCRIPTION
Match MintsAsset against nonzero signed mint quantities, including burns and policy-only patterns, while preserving MovesAsset. Tests cover transfers, mint/burn amounts, zero quantities, and policy/name mismatches.

Related to #3655.
