### PR TITLE
fix(mesh): validate construction elements and input indexes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6048,6 +6048,11 @@ above. CIP-68 datum metadata is not yet sourced and returns `null`.
 
 ### Mesh API (`api/mesh/`)
 
+Construction requests reject null operation, public-key, and signature elements
+before dereferencing them. Input indices must fit both the constructor's native
+integer and the serialized uint32 field; invalid inputs return the existing
+request error instead of panicking inside the handler.
+
 TLS and token authentication are configured through
 `plugins.api.mesh.config.tls`/`config.auth`; see "API security" above.
 

--- a/api/mesh/construction.go
+++ b/api/mesh/construction.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -272,6 +273,10 @@ func (s *Server) handleConstructionPreprocess(
 	var inputRefs []string
 	var requiredKeys []*AccountIdentifier
 	for _, op := range req.Operations {
+		if op == nil {
+			writeError(w, ErrInvalidRequest)
+			return
+		}
 		if op.Type != OpInput {
 			continue
 		}
@@ -409,6 +414,10 @@ func (s *Server) handleConstructionPayloads(
 	var maxOutputIdx int
 
 	for _, op := range req.Operations {
+		if op == nil {
+			writeError(w, ErrInvalidRequest)
+			return
+		}
 		switch op.Type {
 		case OpInput:
 			if op.CoinChange == nil ||
@@ -463,7 +472,7 @@ func (s *Server) handleConstructionPayloads(
 				return
 			}
 			idx, err := strconv.Atoi(parts[1])
-			if err != nil || idx < 0 {
+			if err != nil || idx < 0 || uint64(idx) > math.MaxUint32 {
 				writeError(w, wrapErr(
 					ErrInvalidRequest,
 					fmt.Errorf(
@@ -690,6 +699,10 @@ func (s *Server) handleConstructionPayloads(
 	if len(req.PublicKeys) > 0 {
 		seen := make(map[string]struct{})
 		for _, pk := range req.PublicKeys {
+			if pk == nil {
+				writeError(w, ErrInvalidPublicKey)
+				return
+			}
 			if _, dup := seen[pk.HexBytes]; dup {
 				continue
 			}
@@ -784,6 +797,10 @@ func (s *Server) handleConstructionCombine(
 		[]lcommon.VkeyWitness, 0, len(req.Signatures),
 	)
 	for _, sig := range req.Signatures {
+		if sig == nil {
+			writeError(w, ErrInvalidRequest)
+			return
+		}
 		if sig.PublicKey == nil {
 			writeError(w, wrapErr(
 				ErrInvalidPublicKey,

--- a/api/mesh/construction_test.go
+++ b/api/mesh/construction_test.go
@@ -17,8 +17,11 @@ package mesh
 import (
 	"encoding/hex"
 	"errors"
+	"math"
 	"math/big"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1405,4 +1408,62 @@ func TestConstructionMetadataConversionFailure(t *testing.T) {
 	requireMeshError(
 		t, rec, ErrInternal, http.StatusInternalServerError,
 	)
+}
+
+func TestConstructionRejectsNullElements(t *testing.T) {
+	addr := testAddress(t, lcommon.AddressTypeKeyNone, testKeyHash(0x32), nil)
+	for _, tc := range []struct {
+		name, path string
+		request    any
+		want       *Error
+	}{
+		{"preprocess_operation", "/construction/preprocess", ConstructionPreprocessRequest{
+			networkIdentifierField: networkIdentifierField{NetworkIdentifier: testNetworkID()},
+			Operations:             []*Operation{nil},
+		}, ErrInvalidRequest},
+		{"payload_operation", "/construction/payloads", payloadsRequest([]*Operation{nil}, nil, nil), ErrInvalidRequest},
+		{"payload_public_key", "/construction/payloads", payloadsRequest(payloadOps(t, addr), map[string]any{"fee": "170000"}, []*PublicKey{nil}), ErrInvalidPublicKey},
+		{"combine_signature", "/construction/combine", combineRequest("a0", []*Signature{nil}), ErrInvalidRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+			var rec *httptest.ResponseRecorder
+			// postJSON serializes nil pointers as JSON null and drives the route's
+			// actual decoder before the construction handler sees the elements.
+			require.NotPanics(t, func() { rec = postJSON(t, h, tc.path, tc.request) })
+			requireMeshError(t, rec, tc.want, http.StatusBadRequest)
+		})
+	}
+}
+
+func TestConstructionInputIndexBounds(t *testing.T) {
+	addr := testAddress(t, lcommon.AddressTypeKeyNone, testKeyHash(0x33), nil)
+	for _, index := range []int64{-1, 0, math.MaxUint32 - 1, math.MaxUint32, math.MaxUint32 + 1} {
+		t.Run(strconv.FormatInt(index, 10), func(t *testing.T) {
+			h := newTestHandler(t, newTestDeps())
+			coin := hexString(testHash(0xb2)) + ":" + strconv.FormatInt(index, 10)
+			var rec *httptest.ResponseRecorder
+			require.NotPanics(t, func() {
+				rec = postJSON(t, h, "/construction/payloads", payloadsRequest(
+					payloadOpsFor(addr, coin), map[string]any{"fee": "170000"}, nil,
+				))
+			})
+			// The library constructor takes int, so 32-bit hosts cannot represent
+			// the upper uint32 half even though its serialized index is uint32.
+			maxIndex := int64(math.MaxUint32)
+			if strconv.IntSize == 32 {
+				maxIndex = math.MaxInt32
+			}
+			if index < 0 || index > maxIndex {
+				requireMeshError(t, rec, ErrInvalidRequest, http.StatusBadRequest)
+				return
+			}
+			response := decodeResponse[ConstructionPayloadsResponse](t, rec)
+			var body conway.ConwayTransactionBody
+			_, err := cbor.Decode(mustDecodeHex(t, response.UnsignedTransaction), &body)
+			require.NoError(t, err)
+			require.Len(t, body.Inputs(), 1)
+			require.Equal(t, uint32(index), body.Inputs()[0].Index())
+		})
+	}
 }


### PR DESCRIPTION
Reject null construction operations, public keys, and signatures, and reject input indexes outside uint32 before conversion.

Regression coverage exercises decoded null elements and the maximum supported serialized input index.

Related to #3663.
