### PR TITLE
fix(mesh): report applied ledger sync status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6053,6 +6053,12 @@ TLS and token authentication are configured through
 
 Implements the Mesh (formerly Rosetta) API specification for wallet integration and chain analysis. Provides endpoints for network status, account balances, block queries, transaction construction, and mempool access.
 
+Mesh `network/status` reports `synced` only when the optional ledger sync
+progress capability reports 1: the applied ledger has caught up with its known
+upstream target. Missing or unknown progress reports false. This is not a
+peer-freshness or node-readiness check; the response retains its current block
+identifier independently of the applied-ledger progress.
+
 Request bodies are bounded in two dimensions, because either bound alone
 leaves a handler goroutine reachable indefinitely. `maxRequestBody` (1 MiB)
 caps how many bytes a client may send; `defaultRequestBodyTimeout` (30s),

--- a/api/mesh/network.go
+++ b/api/mesh/network.go
@@ -84,7 +84,10 @@ func (s *Server) handleNetworkStatus(
 
 	tip := s.config.Chain.Tip()
 	tipTimestamp := s.slotToTimestamp(tip.Point.Slot)
-	synced := true
+	synced := false
+	if progress, ok := s.config.LedgerState.(MeshSyncProgress); ok {
+		synced = progress.SyncProgress() == 1
+	}
 
 	resp := &NetworkStatusResponse{
 		CurrentBlockIdentifier: s.tipBlockID(tip),

--- a/api/mesh/network_sync_test.go
+++ b/api/mesh/network_sync_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mesh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type syncProgressLedger struct {
+	MeshLedgerState
+	progress float64
+}
+
+func (l syncProgressLedger) SyncProgress() float64 { return l.progress }
+
+func TestNetworkStatusUsesLedgerSyncProgress(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider bool
+		progress float64
+		synced   bool
+	}{
+		{name: "no provider"},
+		{name: "unknown target", provider: true},
+		{name: "behind target", provider: true, progress: 0.99},
+		{name: "caught up", provider: true, progress: 1, synced: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := newTestDeps()
+			h := newTestHandler(t, deps, func(cfg *ServerConfig) {
+				if tc.provider {
+					cfg.LedgerState = syncProgressLedger{
+						MeshLedgerState: deps.ledger,
+						progress:        tc.progress,
+					}
+				}
+			})
+			rec := postJSON(t, h, "/network/status", NetworkRequest{
+				networkIdentifierField: networkIdentifierField{
+					NetworkIdentifier: testNetworkID(),
+				},
+			})
+			resp := decodeResponse[NetworkStatusResponse](t, rec)
+			require.NotNil(t, resp.SyncStatus)
+			require.NotNil(t, resp.SyncStatus.Synced)
+			require.Equal(t, tc.synced, *resp.SyncStatus.Synced)
+		})
+	}
+}

--- a/api/mesh/network_test.go
+++ b/api/mesh/network_test.go
@@ -144,7 +144,8 @@ func TestNetworkStatus(t *testing.T) {
 	)
 	require.NotNil(t, resp.SyncStatus)
 	require.NotNil(t, resp.SyncStatus.Synced)
-	require.True(t, *resp.SyncStatus.Synced)
+	// This ledger double does not expose sync progress.
+	require.False(t, *resp.SyncStatus.Synced)
 	require.NotNil(t, resp.Peers)
 	require.Empty(t, resp.Peers)
 }

--- a/api/mesh/node_interface.go
+++ b/api/mesh/node_interface.go
@@ -56,6 +56,14 @@ type MeshLedgerState interface {
 	) ([]models.Utxo, error)
 }
 
+// MeshSyncProgress is an optional ledger capability for network/status.
+// Progress is between 0 (unknown) and 1 (applied ledger caught up with the
+// known upstream target), matching ledger.LedgerState.SyncProgress.
+// It does not establish peer freshness or node readiness.
+type MeshSyncProgress interface {
+	SyncProgress() float64
+}
+
 // MeshMempool is the subset of mempool.Mempool needed by the Mesh server.
 type MeshMempool interface {
 	AddTransaction(txType uint, txBytes []byte) error


### PR DESCRIPTION
Derive network sync status from applied ledger progress and report unsynced when no progress provider is available.

Regression coverage includes missing providers, unknown targets, incomplete progress, and a caught-up ledger.
