### PR TITLE
fix(blockfrost): reject out-of-range list pagination

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5931,10 +5931,13 @@ transaction content/CBOR/metadata/UTxOs/certificates/redeemers/required
 signers, and account/delegation/registration/reward/UTxOs/withdrawals/
 transactions endpoints. It uses an adapter pattern to translate between
 Dingo's internal state and Blockfrost response types and supports
-Blockfrost-style pagination headers. The root document is served only at the
-literal `/` path (`GET /{$}`); any other unregistered path falls through to a
-catch-all `404` handler instead of the root document, matching real
-Blockfrost's behavior for unimplemented routes.
+Blockfrost-style pagination headers. Pool and account list routes reject
+out-of-range count and page values before calling the adapter, using the
+shared strict pagination parser (count 1–100, page 1–21474836).
+The root document is served only at the literal `/` path (`GET /{$}`); any
+other unregistered path falls through to a catch-all `404` handler instead
+of the root document, matching real Blockfrost's behavior for unimplemented
+routes.
 
 The account UTxOs, withdrawals, and transactions endpoints resolve everything
 by stake credential rather than a single address. Account UTxOs reuse the

--- a/api/blockfrost/handlers.go
+++ b/api/blockfrost/handlers.go
@@ -690,14 +690,8 @@ func (b *Blockfrost) handlePoolsExtended(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 
@@ -2192,14 +2186,8 @@ func (b *Blockfrost) handleAccountAssociatedAddresses(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountAssociatedAddresses(
@@ -2231,14 +2219,8 @@ func (b *Blockfrost) handleAccountDelegationHistory(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountDelegationHistory(
@@ -2270,14 +2252,8 @@ func (b *Blockfrost) handleAccountRegistrationHistory(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountRegistrationHistory(
@@ -2309,14 +2285,8 @@ func (b *Blockfrost) handleAccountRewardHistory(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountRewardHistory(

--- a/api/blockfrost/handlers_account_activity.go
+++ b/api/blockfrost/handlers_account_activity.go
@@ -31,14 +31,8 @@ func (b *Blockfrost) handleAccountUTXOs(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountUTXOs(
@@ -74,14 +68,8 @@ func (b *Blockfrost) handleAccountWithdrawals(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	params, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	params, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	items, total, err := b.node.AccountWithdrawals(
@@ -110,14 +98,8 @@ func (b *Blockfrost) handleAccountTransactions(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	pagination, err := ParsePagination(r)
-	if err != nil {
-		writeError(
-			w,
-			http.StatusBadRequest,
-			"Bad Request",
-			"Invalid pagination parameters.",
-		)
+	pagination, ok := parsePaginationOrWriteError(w, r)
+	if !ok {
 		return
 	}
 	params := AccountTransactionsParams{Pagination: pagination}

--- a/api/blockfrost/list_pagination_test.go
+++ b/api/blockfrost/list_pagination_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package blockfrost
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type listPaginationNode struct {
+	*mockNode
+	calls  int
+	params PaginationParams
+}
+
+func (n *listPaginationNode) PoolsExtended() ([]PoolExtendedInfo, error) {
+	n.calls++
+	return []PoolExtendedInfo{}, nil
+}
+
+func (n *listPaginationNode) AccountAssociatedAddresses(
+	_ string,
+	params PaginationParams,
+) ([]AccountAssociatedAddressInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountAssociatedAddressInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountDelegationHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountDelegationHistoryInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountDelegationHistoryInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountRegistrationHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountRegistrationHistoryInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountRegistrationHistoryInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountRewardHistory(
+	_ string,
+	params PaginationParams,
+) ([]AccountRewardHistoryInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountRewardHistoryInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountUTXOs(
+	_ string,
+	params PaginationParams,
+) ([]AccountUTXOInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountUTXOInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountWithdrawals(
+	_ string,
+	params PaginationParams,
+) ([]AccountWithdrawalInfo, int, error) {
+	n.calls++
+	n.params = params
+	return []AccountWithdrawalInfo{}, 0, nil
+}
+
+func (n *listPaginationNode) AccountTransactions(
+	_ string,
+	params AccountTransactionsParams,
+) ([]AccountTransactionInfo, int, error) {
+	n.calls++
+	n.params = params.Pagination
+	return []AccountTransactionInfo{}, 0, nil
+}
+
+func TestListRoutesRejectOutOfRangePagination(t *testing.T) {
+	routes := []string{
+		"/api/v0/pools/extended",
+		"/api/v0/accounts/stake_test1/addresses",
+		"/api/v0/accounts/stake_test1/delegations",
+		"/api/v0/accounts/stake_test1/registrations",
+		"/api/v0/accounts/stake_test1/rewards",
+		"/api/v0/accounts/stake_test1/utxos",
+		"/api/v0/accounts/stake_test1/withdrawals",
+		"/api/v0/accounts/stake_test1/transactions",
+	}
+	for _, route := range routes {
+		t.Run(route, func(t *testing.T) {
+			for _, query := range []string{
+				"count=0", "count=-1", "count=101", "count=abc",
+				"page=0", "page=-1", "page=21474837", "page=abc",
+				"order=sideways",
+			} {
+				t.Run(query, func(t *testing.T) {
+					node := &listPaginationNode{mockNode: &mockNode{}}
+					b := newTestBlockfrost(node)
+					recorder := httptest.NewRecorder()
+					request := httptest.NewRequest(
+						http.MethodGet, route+"?"+query, nil,
+					)
+					b.handler().ServeHTTP(recorder, request)
+					require.Zero(
+						t,
+						node.calls,
+						"invalid pagination must not reach the adapter",
+					)
+					require.Equal(t, http.StatusBadRequest, recorder.Code)
+					require.JSONEq(
+						t,
+						`{"status_code":400,"error":"Bad Request","message":"Invalid pagination parameters."}`,
+						recorder.Body.String(),
+					)
+				})
+			}
+			for _, tc := range []struct {
+				name  string
+				query string
+				want  PaginationParams
+			}{
+				{"defaults", "", PaginationParams{Count: 100, Page: 1, Order: "asc"}},
+				{"minimum", "count=1&page=1&order=asc", PaginationParams{Count: 1, Page: 1, Order: "asc"}},
+				{"maximum", "count=100&page=21474836&order=desc", PaginationParams{Count: 100, Page: 21474836, Order: "desc"}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					node := &listPaginationNode{mockNode: &mockNode{}}
+					b := newTestBlockfrost(node)
+					recorder := httptest.NewRecorder()
+					request := httptest.NewRequest(
+						http.MethodGet, route+"?"+tc.query, nil,
+					)
+					b.handler().ServeHTTP(recorder, request)
+					require.Equal(t, http.StatusOK, recorder.Code)
+					require.Equal(t, 1, node.calls)
+					if route != "/api/v0/pools/extended" {
+						require.Equal(t, tc.want, node.params)
+					}
+					require.JSONEq(t, `[]`, recorder.Body.String())
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Use the existing strict pagination helper for extended pools and seven account list routes.

Route regressions check rejection before adapter calls and acceptance of defaults and boundary values.

Fixes #3868.
