### PR TITLE
fix(koiosparity): serialize cache writers to avoid SQLITE_BUSY

### DIFF
--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -294,6 +294,27 @@ func OpenCache(path string, logger *slog.Logger) (*Cache, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open cache db: %w", err)
 	}
+	// Every Cache write path opens its transaction with c.db.Begin(), which
+	// is DEFERRED: SQLite still treats the very first statement of a write
+	// transaction as write-intending even when it matches zero rows (e.g.
+	// SaveAccountFetchChunkProgress's opening DELETEs on a brand-new chunk),
+	// and grabs SQLite's single per-database WAL writer slot right there —
+	// for the rest of the transaction, not just its final COMMIT. Left
+	// unbounded, database/sql hands accountFetchConcurrency's concurrent
+	// chunk workers (fetch_accounts.go) distinct connections that genuinely
+	// contend for that one slot; busy_timeout=5000 only covers a wait
+	// shorter than 5s; five real chunk workers' large-chunk Prepare/Exec
+	// work can collectively outlast that and fail with SQLITE_BUSY /
+	// "database is locked" (dingo #4091). Restricting the pool to one
+	// connection makes database/sql itself queue every caller for that
+	// single connection with no fixed budget, so a writer already in
+	// progress is always waited out rather than timed out on. This also
+	// serializes the cache's own reads behind any in-flight write — the
+	// cache is a process-local comparison scratch file, not a
+	// high-throughput read service, so that tradeoff is preferred over a
+	// second unbounded connection. It has no effect on dingo_db.go's
+	// separate *sql.DB against Dingo's own node database.
+	db.SetMaxOpenConns(1)
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping cache db: %w", err)
@@ -303,8 +324,11 @@ func OpenCache(path string, logger *slog.Logger) (*Cache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("enable WAL: %w", err)
 	}
-	// Busy timeout prevents concurrent writers from failing immediately with
-	// "database is locked"; 5 s is sufficient for the parallel check workers.
+	// busy_timeout remains as a defensive backstop (e.g. a lingering
+	// external reader/writer against the same file), not the mechanism this
+	// package relies on for its own internal write concurrency — that is
+	// now SetMaxOpenConns(1) above, since a single-connection pool never
+	// gives SQLite two callers to contend with in the first place.
 	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("set busy timeout: %w", err)

--- a/internal/koiosparity/cache.go
+++ b/internal/koiosparity/cache.go
@@ -1722,22 +1722,11 @@ func createCacheSchema(db *sql.DB) error {
 	}
 	// Older cache files may contain columns that the current structs no longer write.
 	for _, item := range [][2]string{{"koios_epoch_info", "pool_cnt"}, {"koios_epoch_info", "delegator_cnt"}, {"koios_totals", "deposits_d_rep"}} {
-		rows, err := db.Query(
-			"SELECT 1 FROM pragma_table_info(?) WHERE name = ?",
-			item[0],
-			item[1],
-		)
-		if err != nil {
+		present, err := columnExists(db, item[0], item[1])
+		if err != nil || !present {
 			continue
 		}
-		defer rows.Close()
-		present := rows.Next()
-		if err := rows.Err(); err != nil {
-			continue
-		}
-		if present {
-			_, _ = db.Exec("ALTER TABLE " + item[0] + " DROP COLUMN " + item[1])
-		}
+		_, _ = db.Exec("ALTER TABLE " + item[0] + " DROP COLUMN " + item[1])
 	}
 
 	// A cache written before koios_account_universe_state existed carries the
@@ -1816,17 +1805,8 @@ GROUP BY network`); err != nil {
 // against an older cache.db is idempotent and never errors on a column that
 // already exists.
 func addColumnIfMissing(db *sql.DB, table, column, columnDDL string) error {
-	rows, err := db.Query(
-		"SELECT 1 FROM pragma_table_info(?) WHERE name = ?",
-		table,
-		column,
-	)
+	present, err := columnExists(db, table, column)
 	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	present := rows.Next()
-	if err := rows.Err(); err != nil {
 		return err
 	}
 	if present {
@@ -1836,6 +1816,32 @@ func addColumnIfMissing(db *sql.DB, table, column, columnDDL string) error {
 		"ALTER TABLE " + table + " ADD COLUMN " + column + " " + columnDDL,
 	)
 	return err
+}
+
+// columnExists reports whether table already has a column named column.
+//
+// The pragma_table_info probe is confined to this function so its *sql.Rows is
+// always closed before the caller runs its next statement. OpenCache bounds the
+// pool to a single connection, and an open *sql.Rows holds that connection: a
+// caller that issued its ALTER TABLE while the probe was still open would wait
+// for a connection only it could release, hanging inside OpenCache with no
+// error and no timeout (the migration paths use the context-free Exec, so there
+// is nothing to cancel it either).
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(
+		"SELECT 1 FROM pragma_table_info(?) WHERE name = ?",
+		table,
+		column,
+	)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	present := rows.Next()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return present, nil
 }
 
 func scanPool(rows *sql.Rows, p *KoiosPoolEpoch) error {

--- a/internal/koiosparity/cache_concurrency_test.go
+++ b/internal/koiosparity/cache_concurrency_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package koiosparity
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// busyTimeoutMargin exceeds OpenCache's hardcoded 5s busy_timeout pragma,
+// so a connection that only frees the WAL writer slot after this long
+// forces any contending connection's own busy-retry loop to exhaust before
+// the slot is released — the specific condition dingo #4091 hits, as
+// opposed to ordinary contention a shorter hold resolves on its own well
+// within busy_timeout (verified separately: a 100ms hold never fails either
+// before or after the fix, because busy_timeout's retry genuinely covers
+// short waits — see the handoff for that finding).
+const busyTimeoutMargin = 5500 * time.Millisecond
+
+// TestSaveAccountFetchChunkProgressDeferredWriteAfterConcurrentCommit is
+// dingo #4091's minimal, deterministic reproduction.
+//
+// SaveAccountFetchChunkProgress's transaction (cache.go) always opens with
+// two DELETEs targeting a brand-new chunk_hash nothing has written before.
+// Both match zero rows on a fresh chunk, but SQLite still treats the
+// statements as write-intending (a DELETE always opens a write cursor, even
+// if it ultimately touches nothing) and, under c.db.Begin()'s default
+// DEFERRED mode, grabs SQLite's single per-database WAL writer slot right
+// there — and holds it for the rest of the transaction, not just its final
+// COMMIT. OpenCache never bounds the connection pool, so
+// accountFetchConcurrency's five chunk workers really do run on five
+// distinct connections that then contend for that one slot.
+//
+// This test drives exactly that: connection A opens a transaction and runs
+// SaveAccountFetchChunkProgress's own two opening DELETE statements
+// verbatim (there is no seam to pause mid-transaction inside the real
+// function, so this reproduces its exact SQL rather than calling it), which
+// already claims the writer slot, and holds it for busyTimeoutMargin —
+// standing in for five real chunk workers' large-chunk Prepare/Exec work
+// colllectively outlasting busy_timeout. While A holds it, a second
+// goroutine calls the real, unmodified SaveAccountFetchChunkProgress for a
+// different chunk of the same (network, epoch) — exactly fetch_accounts.go's
+// concurrent-worker shape.
+//
+// Pre-fix, B's connection retries against busy_timeout (5s), exhausts it
+// before A releases, and fails with SQLITE_BUSY / "database is locked" —
+// matching the issue's exact log line. Post-fix (a serialized connection
+// pool), B's Begin() instead blocks at the Go connection-pool level with no
+// fixed budget, so it simply waits for A to finish and then succeeds.
+func TestSaveAccountFetchChunkProgressDeferredWriteAfterConcurrentCommit(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	const network = "preview"
+	const epoch = uint64(4091)
+	now := time.Now().UTC()
+
+	// Connection A: open a deferred transaction and run
+	// SaveAccountFetchChunkProgress's own opening statements verbatim
+	// against a chunk hash nothing has ever written, claiming the WAL
+	// writer slot exactly as the real function would.
+	txA, err := cache.db.Begin()
+	require.NoError(t, err)
+	_, err = txA.Exec(
+		`DELETE FROM koios_account_fetch_staged_rows WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+		network, epoch, "chunk-A",
+	)
+	require.NoError(t, err)
+	_, err = txA.Exec(
+		`DELETE FROM koios_account_checked WHERE network = ? AND epoch = ? AND chunk_hash = ?`,
+		network, epoch, "chunk-A",
+	)
+	require.NoError(t, err)
+
+	// Connection B: a second, genuinely concurrent chunk worker — the real
+	// production entry point — races to complete its own chunk for the same
+	// (network, epoch) while A still holds the writer slot open.
+	bErr := make(chan error, 1)
+	go func() {
+		bErr <- cache.SaveAccountFetchChunkProgress(
+			network, epoch, "chunk-B",
+			[]KoiosAccountRewards{{StakeAddress: "addr-B", RewardType: "member", Earned: "1"}},
+			[]string{"addr-B"},
+			now,
+		)
+	}()
+
+	// Release A only after busyTimeoutMargin, so a pre-fix B has already
+	// exhausted its own busy_timeout wait by the time A lets go.
+	go func() {
+		time.Sleep(busyTimeoutMargin)
+		_ = txA.Commit()
+	}()
+
+	select {
+	case err := <-bErr:
+		if err != nil {
+			if strings.Contains(err.Error(), "locked") ||
+				strings.Contains(err.Error(), "SQLITE_BUSY") {
+				t.Fatalf(
+					"SaveAccountFetchChunkProgress for a concurrent chunk "+
+						"hit SQLITE_BUSY because another chunk worker held "+
+						"the WAL writer slot for %s, longer than "+
+						"busy_timeout: %v",
+					busyTimeoutMargin, err,
+				)
+			}
+			require.NoError(t, err)
+		}
+	case <-time.After(busyTimeoutMargin + 4*time.Second):
+		t.Fatalf(
+			"SaveAccountFetchChunkProgress for a concurrent chunk did not "+
+				"return within %s of a %s writer-slot hold — it is either "+
+				"stuck in SQLite's busy retry loop or deadlocked",
+			busyTimeoutMargin+4*time.Second, busyTimeoutMargin,
+		)
+	}
+}
+
+// TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy
+// drives fetch_accounts.go's actual dispatch shape — accountFetchConcurrency
+// (5) chunk workers calling SaveAccountFetchChunkProgress in parallel via
+// the unmodified public API, repeated over many rounds — and fails if any
+// call returns a SQLITE_BUSY-shaped error.
+//
+// This is a best-effort companion to the deterministic reproduction above,
+// not the primary regression guard: at the production concurrency of 5
+// workers this defect is timing-dependent and was not observed at all
+// within a unit test's timeframe (see the handoff for measured reproduction
+// rates — it took roughly 60 concurrent workers sustained for several
+// seconds to observe any SQLITE_BUSY at all, versus production's 5). It is
+// kept because it exercises the real dispatch width and the real public
+// API, and costs little to run even when it does not reproduce the
+// failure on its own.
+func TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy(
+	t *testing.T,
+) {
+	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
+	require.NoError(t, err)
+	defer cache.Close() //nolint:errcheck
+
+	const (
+		workers = accountFetchConcurrency // 5, matches fetch_accounts.go's dispatch width
+		rounds  = 40
+	)
+	network := "preview"
+	now := time.Now().UTC()
+
+	for round := 0; round < rounds; round++ {
+		epoch := uint64(round)
+		var wg sync.WaitGroup
+		errs := make([]error, workers)
+		start := make(chan struct{})
+		for w := 0; w < workers; w++ {
+			w := w
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				chunkHash := "chunk-" + strconv.Itoa(w)
+				addr := "addr-" + strconv.Itoa(w)
+				errs[w] = cache.SaveAccountFetchChunkProgress(
+					network,
+					epoch,
+					chunkHash,
+					[]KoiosAccountRewards{
+						{StakeAddress: addr, RewardType: "member", Earned: "1"},
+					},
+					[]string{addr},
+					now,
+				)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		for w, err := range errs {
+			if err == nil {
+				continue
+			}
+			if strings.Contains(err.Error(), "SQLITE_BUSY") ||
+				strings.Contains(err.Error(), "database is locked") {
+				t.Fatalf(
+					"round %d worker %d: SaveAccountFetchChunkProgress hit "+
+						"SQLITE_BUSY under its own designed concurrency: %v",
+					round, w, err,
+				)
+			}
+			require.NoError(t, err)
+		}
+	}
+}

--- a/internal/koiosparity/cache_concurrency_test.go
+++ b/internal/koiosparity/cache_concurrency_test.go
@@ -30,13 +30,12 @@ import (
 // forces any contending connection's own busy-retry loop to exhaust before
 // the slot is released — the specific condition dingo #4091 hits, as
 // opposed to ordinary contention a shorter hold resolves on its own well
-// within busy_timeout (verified separately: a 100ms hold never fails either
-// before or after the fix, because busy_timeout's retry genuinely covers
-// short waits — see the handoff for that finding).
+// within busy_timeout: a 100ms hold fails neither before nor after the fix,
+// because busy_timeout's retry genuinely covers short waits.
 const busyTimeoutMargin = 5500 * time.Millisecond
 
-// TestSaveAccountFetchChunkProgressDeferredWriteAfterConcurrentCommit is
-// dingo #4091's minimal, deterministic reproduction.
+// TestSaveAccountFetchChunkProgressWaitsOutSlowConcurrentWriter is dingo
+// #4091's minimal, deterministic reproduction.
 //
 // SaveAccountFetchChunkProgress's transaction (cache.go) always opens with
 // two DELETEs targeting a brand-new chunk_hash nothing has written before.
@@ -55,7 +54,7 @@ const busyTimeoutMargin = 5500 * time.Millisecond
 // function, so this reproduces its exact SQL rather than calling it), which
 // already claims the writer slot, and holds it for busyTimeoutMargin —
 // standing in for five real chunk workers' large-chunk Prepare/Exec work
-// colllectively outlasting busy_timeout. While A holds it, a second
+// collectively outlasting busy_timeout. While A holds it, a second
 // goroutine calls the real, unmodified SaveAccountFetchChunkProgress for a
 // different chunk of the same (network, epoch) — exactly fetch_accounts.go's
 // concurrent-worker shape.
@@ -65,7 +64,7 @@ const busyTimeoutMargin = 5500 * time.Millisecond
 // matching the issue's exact log line. Post-fix (a serialized connection
 // pool), B's Begin() instead blocks at the Go connection-pool level with no
 // fixed budget, so it simply waits for A to finish and then succeeds.
-func TestSaveAccountFetchChunkProgressDeferredWriteAfterConcurrentCommit(
+func TestSaveAccountFetchChunkProgressWaitsOutSlowConcurrentWriter(
 	t *testing.T,
 ) {
 	cache, err := OpenCache(filepath.Join(t.TempDir(), "cache.db"), nil)
@@ -147,12 +146,12 @@ func TestSaveAccountFetchChunkProgressDeferredWriteAfterConcurrentCommit(
 // This is a best-effort companion to the deterministic reproduction above,
 // not the primary regression guard: at the production concurrency of 5
 // workers this defect is timing-dependent and was not observed at all
-// within a unit test's timeframe (see the handoff for measured reproduction
-// rates — it took roughly 60 concurrent workers sustained for several
-// seconds to observe any SQLITE_BUSY at all, versus production's 5). It is
-// kept because it exercises the real dispatch width and the real public
-// API, and costs little to run even when it does not reproduce the
-// failure on its own.
+// within a unit test's timeframe: measured here, 5 workers produced no
+// SQLITE_BUSY across thousands of attempts, and it took roughly 60
+// concurrent workers sustained for several seconds to see any at all
+// (29 of 71,468 attempts). It is kept because it exercises the real
+// dispatch width and the real public API, and costs little to run even
+// when it does not reproduce the failure on its own.
 func TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy(
 	t *testing.T,
 ) {
@@ -167,13 +166,12 @@ func TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy(
 	network := "preview"
 	now := time.Now().UTC()
 
-	for round := 0; round < rounds; round++ {
+	for round := range rounds {
 		epoch := uint64(round)
 		var wg sync.WaitGroup
 		errs := make([]error, workers)
 		start := make(chan struct{})
-		for w := 0; w < workers; w++ {
-			w := w
+		for w := range workers {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -209,5 +207,81 @@ func TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy(
 			}
 			require.NoError(t, err)
 		}
+	}
+}
+
+// TestOpenCacheLegacyColumnMigrationDoesNotDeadlock covers the hazard the
+// single-connection pool above creates for the rest of the package: with
+// SetMaxOpenConns(1), any code path that asks for a second connection while
+// still holding the first blocks forever, because database/sql queues the
+// request on an unbuffered channel with no deadline (OpenCache's write paths
+// use the context-free Exec/Begin, so there is nothing to cancel it).
+//
+// createCacheSchema's legacy-column migration is exactly that shape: it holds
+// an open *sql.Rows from the pragma_table_info probe (closed only by a
+// deferred Close at function exit) and issues ALTER TABLE ... DROP COLUMN on
+// the same *sql.DB while the probe row is still unread. It only reaches that
+// Exec when the legacy column is actually present, i.e. against a cache.db
+// written by an older dingo, so a fresh-file test never exercises it — the
+// node would simply hang inside OpenCache with no error and no timeout.
+//
+// The sibling probe in addColumnIfMissing is safe by contrast: it Execs only
+// when rows.Next() returned false, and an exhausted *sql.Rows has already
+// released its connection.
+func TestOpenCacheLegacyColumnMigrationDoesNotDeadlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.db")
+	cache, err := OpenCache(path, nil)
+	require.NoError(t, err)
+
+	// Recreate an older cache file: the three columns createCacheSchema
+	// migrates away, as written by a dingo that still had them.
+	legacy := [][2]string{
+		{"koios_epoch_info", "pool_cnt"},
+		{"koios_epoch_info", "delegator_cnt"},
+		{"koios_totals", "deposits_d_rep"},
+	}
+	for _, col := range legacy {
+		_, err = cache.db.Exec(
+			"ALTER TABLE " + col[0] + " ADD COLUMN " + col[1] + " INTEGER",
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, cache.Close())
+
+	reopened := make(chan *Cache, 1)
+	reopenErr := make(chan error, 1)
+	go func() {
+		c, err := OpenCache(path, nil)
+		if err != nil {
+			reopenErr <- err
+			return
+		}
+		reopened <- c
+	}()
+
+	select {
+	case err := <-reopenErr:
+		require.NoError(t, err)
+	case c := <-reopened:
+		defer c.Close() //nolint:errcheck
+		for _, col := range legacy {
+			var n int
+			require.NoError(t, c.db.QueryRow(
+				"SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?",
+				col[0], col[1],
+			).Scan(&n))
+			require.Zerof(
+				t, n,
+				"%s.%s should have been dropped by the migration",
+				col[0], col[1],
+			)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal(
+			"OpenCache did not return within 30s against a cache.db carrying " +
+				"legacy columns: createCacheSchema's DROP COLUMN Exec is " +
+				"waiting for a second connection while its pragma_table_info " +
+				"rows still hold the only one",
+		)
 	}
 }

--- a/internal/koiosparity/cache_concurrency_test.go
+++ b/internal/koiosparity/cache_concurrency_test.go
@@ -44,9 +44,9 @@ const busyTimeoutMargin = 5500 * time.Millisecond
 // if it ultimately touches nothing) and, under c.db.Begin()'s default
 // DEFERRED mode, grabs SQLite's single per-database WAL writer slot right
 // there — and holds it for the rest of the transaction, not just its final
-// COMMIT. OpenCache never bounds the connection pool, so
-// accountFetchConcurrency's five chunk workers really do run on five
-// distinct connections that then contend for that one slot.
+// COMMIT. Before this fix OpenCache left the connection pool unbounded, so
+// accountFetchConcurrency's five chunk workers really did run on five
+// distinct connections that then contended for that one slot.
 //
 // This test drives exactly that: connection A opens a transaction and runs
 // SaveAccountFetchChunkProgress's own two opening DELETE statements
@@ -217,17 +217,19 @@ func TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy(
 // request on an unbuffered channel with no deadline (OpenCache's write paths
 // use the context-free Exec/Begin, so there is nothing to cancel it).
 //
-// createCacheSchema's legacy-column migration is exactly that shape: it holds
-// an open *sql.Rows from the pragma_table_info probe (closed only by a
-// deferred Close at function exit) and issues ALTER TABLE ... DROP COLUMN on
-// the same *sql.DB while the probe row is still unread. It only reaches that
-// Exec when the legacy column is actually present, i.e. against a cache.db
-// written by an older dingo, so a fresh-file test never exercises it — the
-// node would simply hang inside OpenCache with no error and no timeout.
+// createCacheSchema's legacy-column migration was exactly that shape: it held
+// an open *sql.Rows from its pragma_table_info probe — closed only by a
+// deferred Close at function exit — while issuing ALTER TABLE ... DROP COLUMN
+// on the same *sql.DB. It reaches that Exec only when the legacy column is
+// actually present, i.e. against a cache.db written by an older dingo, so a
+// fresh-file test never exercised it and the node would simply hang inside
+// OpenCache with no error and no timeout. The probe now lives in
+// columnExists, whose rows are closed before it returns.
 //
-// The sibling probe in addColumnIfMissing is safe by contrast: it Execs only
+// The sibling probe in addColumnIfMissing was safe by contrast: it Execs only
 // when rows.Next() returned false, and an exhausted *sql.Rows has already
-// released its connection.
+// released its connection. It shares columnExists so the invariant holds in
+// one place rather than by accident in two.
 func TestOpenCacheLegacyColumnMigrationDoesNotDeadlock(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "cache.db")
 	cache, err := OpenCache(path, nil)


### PR DESCRIPTION
## Defect

`SaveAccountFetchChunkProgress` fails with `database is locked (5) (SQLITE_BUSY)`
under koiosparity's own designed concurrency. `fetch_accounts.go` dispatches
`accountFetchConcurrency` (5) chunk workers and `OpenCache` never bounded the
connection pool, so those workers run on distinct SQLite connections contending
for the single per-database WAL writer slot. Each chunk transaction's first
statement is a `DELETE`, which claims that slot immediately even when it matches
zero rows, and holds it for the whole transaction. Five workers' large-chunk
writes can collectively outlast `busy_timeout=5000`; the epoch is then abandoned
after 5 attempts, silently under `--koios-parity-strict=false`.

The issue attributed this to a DEFERRED-transaction snapshot upgrade bypassing
`busy_timeout`. That variant is real in this driver but is not what this path
hits: `_txlock=immediate` was tried against the reproduction and does not fix it,
because the transaction's first statement is already write-intending.

## Change

- `OpenCache` sets `SetMaxOpenConns(1)`. `database/sql` then queues callers for
  the single connection with no deadline, so an in-progress writer is waited out
  rather than timed out on. The `busy_timeout` comment, which claimed it
  prevented this failure, is corrected. This also serializes the cache's own
  reads; it is a process-local comparison scratch file, and `dingo_db.go`'s
  separate `*sql.DB` is unaffected.
- `createCacheSchema`'s legacy-column migration held an open `*sql.Rows` from its
  `pragma_table_info` probe while issuing `ALTER TABLE ... DROP COLUMN` on the
  same pool. Under a one-connection pool that `Exec` waits for the connection the
  probe still holds, with no deadline, so `OpenCache` hangs with no error against
  any older `cache.db` still carrying `pool_cnt`, `delegator_cnt` or
  `deposits_d_rep`. The probe is extracted into `columnExists`, which closes its
  rows before returning; `addColumnIfMissing` shared the shape and now uses the
  same helper.

## Tests

- `TestSaveAccountFetchChunkProgressWaitsOutSlowConcurrentWriter` — deterministic
  reproduction: one connection holds the writer slot for 5.5s (past
  `busy_timeout`) while a second goroutine calls the real
  `SaveAccountFetchChunkProgress`. Fail-before verified by reverting only
  `cache.go` in place: FAIL in 5.09s with the issue's exact
  `database is locked (5) (SQLITE_BUSY)` line, PASS with the change.
- `TestOpenCacheLegacyColumnMigrationDoesNotDeadlock` — adds the three legacy
  columns, reopens under a timeout guard, asserts the migration still drops them.
  Fail-before verified against the pool-bound commit without `columnExists`: it
  hangs and fails after 30s.
- `TestSaveAccountFetchChunkProgressConcurrentWritersDoNotHitSQLiteBusy` — drives
  the real 5-worker dispatch width through the public API. It passes before the
  fix too and is documented as a guard, not as fail-before evidence.

## Checks

`go build -tags dingo_extra_plugins ./...`,
`go vet -tags dingo_extra_plugins ./internal/...`, `gofmt -s -l`,
`golangci-lint run ./internal/koiosparity/...` (0 issues),
`go test -race -count=1 ./internal/koiosparity/`,
`go test ./internal/architecture ./internal/docsparity` — all pass.

Skipped: the live Preview from-genesis parity replay against a Koios host (no
live Cardano infrastructure available in this environment), Antithesis and
conformance suites (not applicable and not available), `nilaway` and `modernize`
(not installed here; CI's lint job runs golangci-lint only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY3D9bzbTUF6A9Y2KDUrLi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQLITE_BUSY failures in koiosparity's concurrent chunk workers by limiting the cache to one SQLite connection, so writers queue instead of exhausting `busy_timeout`.

- `OpenCache` now calls `SetMaxOpenConns(1)`; the cache is a process-local scratch file, so serialized reads are acceptable.
- Extracts the column probe into `columnExists` so its rows close before the migration's `ALTER TABLE`, preventing an `OpenCache` hang against older cache files.
- Adds tests for a slow concurrent writer held past `busy_timeout`, the real 5-worker dispatch, and the legacy column migration.

<sup>Written for commit 81ba6ba16dd1b145be72735dbab5b2227e60bb72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache reliability during concurrent operations, reducing SQLite busy and timeout errors.
  - Prevented potential hangs while upgrading older cache databases.
  - Ensured database schema updates complete safely under concurrent activity.

- **Tests**
  - Added regression coverage for concurrent cache writes, parallel chunk processing, and legacy database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->