### PR TITLE
fix(ouroboros): bound LeiosFetch vote ID requests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2679,6 +2679,15 @@ The experimental N2N Leios protocols (`Config.experimentalLeiosNetworkingEnabled
 
 For the current respun prototype, the notify vote dialect is specifically the three-field `(announcing_rb_hash, voter_id, signature)` form. The selected-chain `chain.update` path records an announcement only after its ranking block is adopted; merely observing an eligible ChainSync header cannot make a local vote eligible. A bounded TTL queue holds votes that race ahead of adoption and retains a bounded set of alternate signatures per voter, so an invalid first candidate cannot suppress a later valid vote. Local votes use that same LeiosNotify stream; each outbound response reserves its log entry and commits the per-peer cursor only after gouroboros reports a successful send. Failed or aborted sends release the reservation into a counted retry set retained across reconnects; a reconnect advances through every pending retry on its stream rather than clearing only the first failed entry. The transitional offered-ID and four-field forms remain decode-compatible only.
 
+Configured LeiosFetch vote serving accepts at most 1,000 requested IDs per
+request, including duplicate and unknown IDs. Larger requests fail before
+dispatch to the vote manager, bounding lookup and response-cloning work under
+its shared lock. This is a local serving limit; clients must split larger
+queries into batches. An over-limit configured request produces a protocol
+error and terminates the requesting connection. If the optional vote manager
+is absent, requests still receive the empty `MsgVotes` response. The limit is
+per request, not a per-peer rate limit or a decoder allocation bound.
+
 Before header cryptography or body deltas run, the inbound consensus-envelope
 validator enforces the era's block body/header limits and, for Alonzo and later,
 the aggregate `MaxBlockExUnits` budget. The aggregate contains every declared

--- a/ouroboros/leios_vote_request_bound_test.go
+++ b/ouroboros/leios_vote_request_bound_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeiosFetchVoteRequestBound(t *testing.T) {
+	for _, count := range []int{0, 1, 1000, 1001} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			o := newOuroboros(OuroborosConfig{EnableLeios: true})
+			handler := &fakeLeiosVoteHandler{rawVotes: []cbor.RawMessage{mustCbor(t, "vote")}}
+			o.leiosVotes = handler
+			ids := make([]oleiosfetch.MsgVotesRequestVoteId, count)
+			msg, err := o.leiosfetchServerVotesRequest(oleiosfetch.CallbackContext{}, ids)
+			if count > 1000 {
+				require.ErrorContains(t, err, "vote ID request exceeds limit")
+				require.Nil(t, msg)
+				require.Empty(t, handler.requestedIds, "oversized request reached vote manager")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, handler.requestedIds, count)
+			require.Len(t, msg.(*oleiosfetch.MsgVotes).VotesRaw, 1)
+		})
+	}
+}
+
+func TestLeiosFetchVoteRequestBoundOnWire(t *testing.T) {
+	o := newOuroboros(OuroborosConfig{EnableLeios: true})
+	handler := &fakeLeiosVoteHandler{rawVotes: []cbor.RawMessage{mustCbor(t, "vote")}}
+	o.leiosVotes = handler
+	peer := newLeiosFetchServerPeer(t, o)
+	peer.send(
+		t,
+		oleiosfetch.ProtocolId,
+		oleiosfetch.NewMsgVotesRequest(make([]oleiosfetch.MsgVotesRequestVoteId, 1000)),
+	)
+	segment := peer.readResponse(t, 5*time.Second)
+	msg, err := oleiosfetch.NewMsgFromCbor(oleiosfetch.MessageTypeVotes, segment.Payload)
+	require.NoError(t, err)
+	require.Len(t, msg.(*oleiosfetch.MsgVotes).VotesRaw, 1)
+	peer.send(
+		t,
+		oleiosfetch.ProtocolId,
+		oleiosfetch.NewMsgVotesRequest(make([]oleiosfetch.MsgVotesRequestVoteId, 1001)),
+	)
+	err = testutil.RequireReceive(t, peer.errChan, 5*time.Second, "oversized vote request rejected")
+	require.ErrorContains(t, err, "vote ID request exceeds limit")
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	require.Len(t, handler.requestedIds, 1000, "only the accepted request reaches the manager")
+}
+
+func TestLeiosFetchLargeVoteRequestWithoutManager(t *testing.T) {
+	o := newOuroboros(OuroborosConfig{EnableLeios: true})
+	peer := newLeiosFetchServerPeer(t, o)
+	peer.send(
+		t,
+		oleiosfetch.ProtocolId,
+		oleiosfetch.NewMsgVotesRequest(make([]oleiosfetch.MsgVotesRequestVoteId, 1001)),
+	)
+	segment := peer.readResponse(t, 5*time.Second)
+	require.Equal(t, []byte{0x82, oleiosfetch.MessageTypeVotes, 0x80}, segment.Payload)
+	// A second request demonstrates that the unavailable-manager response
+	// returned protocol agency instead of closing or parking the bearer.
+	peer.send(t, oleiosfetch.ProtocolId, oleiosfetch.NewMsgVotesRequest(nil))
+	segment = peer.readResponse(t, 5*time.Second)
+	require.Equal(t, []byte{0x82, oleiosfetch.MessageTypeVotes, 0x80}, segment.Payload)
+}

--- a/ouroboros/leiosfetch.go
+++ b/ouroboros/leiosfetch.go
@@ -24,6 +24,11 @@ import (
 	oleiosfetch "github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 )
 
+// maxLeiosFetchVoteIDs bounds vote-manager lookup and response cloning per
+// request, matching the batch size supported by the standalone vote protocol.
+// This is a local serving policy, not a LeiosFetch wire-format restriction.
+const maxLeiosFetchVoteIDs = 1000
+
 func (o *Ouroboros) leiosfetchServerConnOpts() []oleiosfetch.LeiosFetchOptionFunc {
 	return []oleiosfetch.LeiosFetchOptionFunc{
 		oleiosfetch.WithBlockRequestFunc(
@@ -185,6 +190,13 @@ func (o *Ouroboros) leiosfetchServerVotesRequest(
 		// unavailable vote manager as an empty result instead of failing the
 		// shared bearer.
 		return oleiosfetch.NewMsgVotes(make([]cbor.RawMessage, 0)), nil
+	}
+	if len(voteIds) > maxLeiosFetchVoteIDs {
+		return nil, fmt.Errorf(
+			"leios-fetch vote ID request exceeds limit: %d > %d",
+			len(voteIds),
+			maxLeiosFetchVoteIDs,
+		)
 	}
 	// MsgVotesRequestVoteId aliases lcommon.LeiosVoteId; unknown ids
 	// are omitted from the response.


### PR DESCRIPTION
Bound configured LeiosFetch vote requests to 1,000 IDs before dispatch to the vote manager, preventing larger requests from extending its shared-lock lookup and cloning work. Oversized requests terminate the requesting connection; clients must batch larger queries. An absent vote manager retains the empty response.

Refs #3412.
