### PR TITLE
fix(leios): share announcement election budgets across sources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4817,6 +4817,16 @@ requires the same validated interval; `PoolCredentials.KESSign` remains the
 lower-level cryptographic primitive used by credential tooling and tests that
 may not have Shelley genesis context.
 
+### Leios Announcement Admission (`ouroboros/`)
+
+After header validation, at most two distinct ranking-block announcements are
+retained for each slot/issuer election within the announcement retention window.
+The election budget is shared across relay sources and reconnects; a connection
+identifier does not create a new election. An already-recorded header remains
+an idempotent duplicate even after the budget is full. Another slot or issuer
+has an independent budget. Rejected third headers are neither retained nor added
+to the relay log.
+
 ### Leios Voting (`ledger/leios/`)
 
 Experimental CIP-0164 stake-truncated committee voting, active only under the Dijkstra/Leios gate. `VoteManager` collects, validates, serves, and emits Leios votes:

--- a/ouroboros/leios_election_bound_test.go
+++ b/ouroboros/leios_election_bound_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func electionAnnouncement(t *testing.T, slot, blockNo uint64, issuer byte) []byte {
+	t.Helper()
+	raw := testDijkstraAnnouncementHeaderRawFor(t, slot, lcommon.Blake2b256{0xaa}, 1234)
+	var top, body []cbor.RawMessage
+	_, err := cbor.Decode(raw, &top)
+	require.NoError(t, err)
+	if len(top) == 0 {
+		t.Fatal("missing announcement header body")
+		return nil
+	}
+	_, err = cbor.Decode(top[0], &body)
+	require.NoError(t, err)
+	if len(body) < 4 {
+		t.Fatal("incomplete announcement header body")
+		return nil
+	}
+	body[0] = mustCbor(t, blockNo)
+	body[3] = mustCbor(t, bytes.Repeat([]byte{issuer}, 32))
+	top[0] = mustCbor(t, body)
+	return mustCbor(t, top)
+}
+
+func TestLeiosAnnouncementElectionBoundAcrossSources(t *testing.T) {
+	// Header cryptography is supplied by the existing ledger fixture; this
+	// exercises the real decode, time-window, pruning, recording and relay path.
+	ledger := &fakeLeiosAnnouncementLedger{currentSlot: 11, slotTime: time.Now().Add(-time.Minute)}
+	o := newOuroboros(OuroborosConfig{EnableLeios: true, LeiosAnnouncementLedger: ledger})
+	o.leiosEBLog.registerConn("observer")
+	first := electionAnnouncement(t, 10, 1, 1)
+	require.NoError(t, o.acceptLeiosAnnouncement(first, "connection-a"))
+	require.NoError(t, o.acceptLeiosAnnouncement(electionAnnouncement(t, 10, 2, 1), "connection-b"))
+	// Relaying an already-known header from a new source must not consume
+	// another slot or fail after the election's two distinct headers are seen.
+	require.NoError(t, o.acceptLeiosAnnouncement(first, "connection-c"))
+	err := o.acceptLeiosAnnouncement(electionAnnouncement(t, 10, 3, 1), "connection-c")
+	require.ErrorContains(t, err, "third distinct")
+	require.Len(t, o.leiosAnnouncements, 2)
+	require.Len(t, o.leiosEBLog.items, 2, "rejected announcement must not be relayed")
+
+	// Both parts of election identity matter: another issuer at the same
+	// slot and the same issuer at another slot each get their own budget.
+	for _, election := range []struct {
+		slot   uint64
+		issuer byte
+	}{{10, 2}, {11, 1}} {
+		require.NoError(
+			t,
+			o.acceptLeiosAnnouncement(
+				electionAnnouncement(t, election.slot, 1, election.issuer),
+				"connection-c",
+			),
+		)
+		require.NoError(
+			t,
+			o.acceptLeiosAnnouncement(
+				electionAnnouncement(t, election.slot, 2, election.issuer),
+				"connection-c",
+			),
+		)
+	}
+	require.Len(t, o.leiosAnnouncements, 6)
+}

--- a/ouroboros/leiosnotify.go
+++ b/ouroboros/leiosnotify.go
@@ -1742,7 +1742,7 @@ func (o *Ouroboros) recordLeiosAnnouncementLocked(
 	ebHash lcommon.Blake2b256,
 	ebSize uint64,
 	header *gdijkstra.DijkstraBlockHeader,
-	source string,
+	_ string,
 	relay bool,
 ) error {
 	key := string(header.Hash().Bytes())
@@ -1785,7 +1785,9 @@ func (o *Ouroboros) recordLeiosAnnouncementLocked(
 		return nil
 	}
 	issuer := header.IssuerVkey()
-	electionKey := fmt.Sprintf("%s:%d:%x", source, slot, issuer)
+	// An election belongs to its slot and issuer, not the relaying peer.
+	// Changing connections must not reset its distinct-announcement budget.
+	electionKey := fmt.Sprintf("%d:%x", slot, issuer)
 	electionAnnouncements := o.leiosAnnouncementElections[electionKey]
 	if electionAnnouncements == nil {
 		electionAnnouncements = make(map[string]struct{})

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -219,9 +219,8 @@ type Ouroboros struct {
 	// review).
 	leiosAnnouncementSlots map[string]map[uint64]struct{}
 	// LeiosNotify permits at most two distinct announcements for one election
-	// (slot plus issuer) from each peer. Keep that bound per source so one
-	// equivocating peer cannot inject an unbounded stream without suppressing
-	// independent observations from other peers.
+	// (slot plus issuer), shared across all sources so relays and reconnects
+	// cannot reset the distinct-announcement budget.
 	leiosAnnouncementElections map[string]map[string]struct{}
 
 	// Asynchronous best-effort persistence of fetched endorser blocks to the


### PR DESCRIPTION
Key the existing two-announcement election budget by slot and issuer so relays and reconnects cannot create fresh budgets. Repeated copies of a known header remain idempotent; different slots and issuers remain independent.

Refs #3412.
