### PR TITLE
test(midnight): accept a rejected stream from reflection Send

### DIFF
--- a/midnight/server/server_test.go
+++ b/midnight/server/server_test.go
@@ -16,6 +16,7 @@ package server_test
 
 import (
 	"context"
+	"io"
 	"net"
 	"strconv"
 	"testing"
@@ -287,11 +288,23 @@ func TestReflectionDisabledByDefault(t *testing.T) {
 	defer cancel()
 	stream, err := client.ServerReflectionInfo(ctx)
 	require.NoError(t, err)
-	require.NoError(t, stream.Send(&reflectionpb.ServerReflectionRequest{
+	// With reflection unregistered the server terminates this stream as soon
+	// as it sees it, so Send races that rejection. grpc documents SendMsg as
+	// returning once "the stream is done" and directs callers to take the
+	// real status from RecvMsg rather than from Send, so io.EOF here is a
+	// valid outcome rather than a failure. Requiring NoError made the test
+	// fail whenever the rejection won, which the race detector's slower
+	// scheduling makes markedly more likely -- observed on the
+	// go-test (Linux, race) job while the same commit passed unraced.
+	if err := stream.Send(&reflectionpb.ServerReflectionRequest{
 		MessageRequest: &reflectionpb.ServerReflectionRequest_ListServices{
 			ListServices: "*",
 		},
-	}))
+	}); err != nil {
+		require.ErrorIs(t, err, io.EOF)
+	}
+	// The status is asserted here either way: this is the check that actually
+	// proves reflection is disabled.
 	_, err = stream.Recv()
 	require.Error(t, err)
 	require.Equal(t, codes.Unimplemented, status.Code(err))


### PR DESCRIPTION
`TestReflectionDisabledByDefault` required `stream.Send` to succeed. With reflection unregistered the server terminates the stream as soon as it sees it, so `Send` races that rejection.

grpc's contract is explicit that this is not something a caller may assert:

> SendMsg blocks until: there is sufficient flow control to schedule m with the transport, or **the stream is done**, or the stream breaks. […] To ensure delivery, users should ensure the RPC completed successfully using **RecvMsg**.

So `io.EOF` from `Send` is a valid outcome here, not a failure. The test now tolerates it and keeps asserting `codes.Unimplemented` on `Recv`, which is the check that actually proves reflection is disabled.

## Evidence

Observed on `go-test (Linux, race)` in run 34163137182, failing at `server_test.go:290` with `Received unexpected error: EOF`, while the same commit passed `go-test (Linux)` unraced and 87 other packages were green. Race instrumentation slows the client enough that the server's rejection usually wins the race.

A deterministic regression test is not practical for a scheduling race, so this is not accompanied by one; the justification is the documented contract plus the observed failure at exactly that line.

## Class audit

Three call sites share the `Send`-then-`NoError` shape:

| site | keeps stream open? | changed |
| --- | --- | --- |
| `midnight/server/server_test.go:290` (reflection disabled) | no — server rejects immediately | yes |
| `midnight/server/server_test.go:256` (`TestReflectionListsService`) | yes | no |
| `api/utxorpc/reflection_test.go:86` (`listServices`) | yes | no |

The latter two expect reflection to work, so the stream stays open and a `Send` failure there is a genuine defect. Their assertions are deliberately left alone.

## Validation

`go build ./...`, `go vet ./midnight/...`, `gofmt`, and `golangci-lint run ./midnight/server/` clean; `go test -race ./midnight/...` passes, including 50 consecutive runs of `-run TestReflection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QHXPb9hhgbvMgMxokmzWa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `TestReflectionDisabledByDefault` tolerate `io.EOF` from `Send` because, with reflection unregistered, the server terminates the stream immediately and `Send` races that rejection. Per grpc's contract, `EOF` is a valid outcome there; the test still asserts `codes.Unimplemented` on `Recv`, which is what actually proves reflection is disabled.

- `Send` now accepts `io.EOF` instead of requiring `NoError`.
- The other `Send`-then-`NoError` sites in `TestReflectionListsService` and `api/utxorpc` keep their stream open and remain unchanged.

<sup>Written for commit 88b657470a7030f4f0344176ba9172d902deeb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stream handling tests to correctly allow an end-of-stream response when reflection is disabled.
  * Continued verifying that reflection requests are rejected as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->