### PR TITLE
fix(ledger): resolve pool VRF key from live registration below Mithril anchor

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2809,6 +2809,41 @@ the *earliest* lookup at or before the capture slot. Earliest rather than
 latest, because a pool that also re-registered within that same epoch had the
 re-registration deferred, so the snapshot still carries the first one.
 
+A Mithril snapshot import writes a pool's registration (`ImportPool`) stamped
+at the import slot, because the snapshot carries only the pool's current
+parameters, not the certificate history that produced them. Both lookups
+above filter `added_slot <= slot`, so for any cutoff or capture slot before
+that import slot -- which the very first post-bootstrap epoch boundary's
+cutoff and capture necessarily are, since that boundary's electing snapshot
+was captured no later than the anchor the node just bootstrapped from --
+neither query finds a row for a pool that has in fact been continuously
+registered the whole time, and `electingVrfKeyHashWithCache`
+(`ledger/verify_header.go`) raised `errVrfKeyRegistrationHistoryUnavailable`
+unconditionally (issue #4047; the deferred-retry path in
+`verifyBlockHeaderStateWithCache` only covers a ledger tip still catching up,
+not this permanent gap).
+
+The fix lives in `electingVrfKeyHashWithCache`, not in these two queries or in
+`ImportPool`: when both lookups miss, and this is a Mithril-bootstrapped node
+(`ls.mithrilLedgerSlot != 0`) whose stake-snapshot capture slot is at or below
+that boundary, the gap is known to be exactly this bootstrap shape rather than
+a genuine missing-registration bug, so the caller falls back to the pool's
+current live registration (`GetPool(includeInactive=true)`) the same way it
+already does when `electingPoolParamsCutoffSlotWithCache` reports no snapshot
+at all (`ok == false`). An earlier version of this fix instead seeded a second,
+`added_slot = 0` "floor" registration row at import time so the existing
+queries would resolve on their own; that synthetic row also satisfied
+`GetPoolRegistrationsEffectiveForEpoch`'s in-epoch registration window
+whenever a processed epoch's start slot was small, letting it outrank the
+pool's real, owner-populated registration under that query's ascending
+"earliest first-in-epoch" ordering and zeroing out the pool's owner stake in
+reward-input seeding -- caught by
+`TestHandleEpochTransitionCapturesSelfDelegatedOwnerStake` and its
+neighboring `ledger/snapshot` tests. Resolving the gap only where the
+consensus-critical question is actually asked, using the boundary the node
+already persists for exactly this purpose, avoids adding a row that other
+`added_slot`-scoped readers have to reason about.
+
 ### `GetPoolsRetiringAtEpoch`
 
 Pools whose effective retirement takes effect at a given epoch, with the reward

--- a/ledger/verify_header.go
+++ b/ledger/verify_header.go
@@ -1618,6 +1618,37 @@ func (ls *LedgerState) electingVrfKeyHashWithCache(
 			copy(hash[:], vrfKeyHash)
 			return hash, true, nil
 		}
+		// Both lookups missed. That is ordinarily the unanswerable gap the
+		// error below reports, but it is also exactly what a Mithril
+		// bootstrap produces for the epoch boundary the node crosses right
+		// after import: the snapshot import writes only the pool's live
+		// registration, stamped at the import slot, and never replays the
+		// certificate history that produced it. So a pool that has in fact
+		// been continuously registered the whole time has no row at or
+		// before a cutoff/capture slot that predates the import (issue
+		// #4047).
+		//
+		// mithrilLedgerSlot pins that import slot for the life of the
+		// process (set once at startup, like the other reads of this field
+		// in this file), so a capture at or below it is diagnostic: the
+		// snapshot that elected this pool was captured no later than the
+		// bootstrap boundary, which only a bootstrap-created gap explains.
+		// Falling back to the live registration here is the same trust
+		// electingVrfKeyHashWithCache already extends when ok is false --
+		// no snapshot at all -- applied to the narrower case of a snapshot
+		// whose registration history the import could not carry. It is not
+		// the general "no history found" fallback #3842 removed: outside
+		// this bootstrap-anchor window, a genuine gap still hard-rejects
+		// rather than resolving the pool's current (possibly rotated) key.
+		if ls.mithrilLedgerSlot != 0 && capturedSlot <= ls.mithrilLedgerSlot {
+			pool, poolErr := ls.db.GetPool(poolKeyHash, true, nil)
+			if poolErr != nil && !errors.Is(poolErr, models.ErrPoolNotFound) {
+				return lcommon.Blake2b256{}, false, poolErr
+			}
+			if hash, ok := registeredPoolVrfKeyHash(pool); ok {
+				return hash, true, nil
+			}
+		}
 		return lcommon.Blake2b256{}, false, fmt.Errorf(
 			"%w at cutoff slot %d or capture slot %d for pool %x",
 			errVrfKeyRegistrationHistoryUnavailable,

--- a/ledger/verify_header_vrf_params_lag_test.go
+++ b/ledger/verify_header_vrf_params_lag_test.go
@@ -2,6 +2,7 @@ package ledger
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -329,4 +330,143 @@ func TestLeaderEligibilityStakeSkipDecisionUsesTheSuppliedEpochCache(
 	assert.Equal(t, uint64(1_000), poolStake)
 	assert.Equal(t, uint64(10_000), totalStake,
 		"not skipping means the threshold's denominator is actually read")
+}
+
+// TestElectingVrfKeyHashResolvesBelowMithrilBootstrapAnchor is the dingo #4047
+// regression: a Mithril-bootstrapped node wedges at its first epoch boundary
+// because the pool's only registration row is stamped at the bootstrap
+// anchor slot, which is later than the parameter cutoff and stake-snapshot
+// capture slots the electing snapshot resolves against.
+//
+// A Mithril snapshot import writes the pool's live-at-anchor registration
+// (ImportPool) -- it never replays the certificate history that produced it
+// -- so seedPoolRegistrationAtSlot here models exactly one such bootstrap
+// row, at anchor slot 3_200_000: after mark(37)'s capture (3_196_799) and
+// cutoff (3_110_399), which elect epoch 38. ls.mithrilLedgerSlot is set to
+// the same anchor, the way LedgerState restores it from the persisted
+// mithril_ledger_slot sync-state key at startup.
+//
+// Before the fix, both GetPoolVrfKeyHashAtSlot(cutoff) and
+// GetPoolEarliestVrfKeyHashAtSlot(capture) miss -- the only row about this
+// pool is time-stamped after both slots -- and electingVrfKeyHash returns
+// errVrfKeyRegistrationHistoryUnavailable. That is what wedges the node: the
+// error is unconditional once the ledger tip has caught up to the checked
+// slot, which is exactly the epoch-boundary case being validated live. The
+// fix recognizes capturedSlot <= mithrilLedgerSlot as diagnostic of that
+// bootstrap gap and falls back to the pool's live registration instead.
+func TestElectingVrfKeyHashResolvesBelowMithrilBootstrapAnchor(t *testing.T) {
+	nonce := bytes.Repeat([]byte{0x07}, 32)
+	tb := createTestBlock(t, [32]byte{56}, 56, tamperNone)
+	ls, db := newEligibilityTestLedger(t, nonce)
+	ls.epochCache = previewEpochs(35, 39, nonce)
+
+	pool := lcommon.PoolKeyHash(bytes.Repeat([]byte{0x11}, 28))
+	vrfKey := bytes.Repeat([]byte{0xB5}, 32)
+
+	// The bootstrap's only registration row for this pool: no history below
+	// it, matching a Mithril import that never saw the pool's real,
+	// pre-anchor registration certificate.
+	const anchorSlot = 3_200_000
+	seedPoolRegistrationAtSlot(t, db, pool[:], vrfKey, anchorSlot)
+	ls.mithrilLedgerSlot = anchorSlot
+	ls.publishSnapshotsLocked()
+
+	// mark(37) elects epoch 38. Its capture (3_196_799) and the resulting
+	// parameter cutoff (3_110_399, the last slot of epoch 36) both precede
+	// the anchor, reproducing the reported gap.
+	seedPoolStakeSnapshotOfTypeAtSlot(t, db, 37,
+		models.PoolStakeSnapshotTypeMark, pool[:], 1_000, 10_000, 3_196_799)
+
+	cutoff, captured, ok, err := ls.electingPoolParamsCutoffSlot(
+		tb.block, 38, pool,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Less(t, cutoff, uint64(anchorSlot),
+		"the fixture must reproduce the reported gap: cutoff below the anchor")
+	require.Less(t, captured, uint64(anchorSlot),
+		"the fixture must reproduce the reported gap: capture below the anchor")
+
+	gotKey, ok, err := ls.electingVrfKeyHash(tb.block, 38, pool)
+	require.NoError(t, err,
+		"a bootstrap-only registration below the anchor must not raise "+
+			"errVrfKeyRegistrationHistoryUnavailable for a pool that has, "+
+			"in fact, always been registered")
+	require.True(t, ok)
+	assert.Equal(t, vrfKey, gotKey.Bytes())
+}
+
+// TestElectingVrfKeyHashStillRejectsAPoolWithNoRegistrationAtAll pins the
+// boundary the #4047 fix must not erase: on a Mithril-bootstrapped node, a
+// pool with no registration row at all still raises
+// errVrfKeyRegistrationHistoryUnavailable rather than silently resolving.
+// The fallback reads the pool's live registration; a pool nothing was ever
+// imported or registered for has none, so GetPool finds nothing and the
+// fallback yields ok == false, falling through to the same error as before
+// the fix.
+func TestElectingVrfKeyHashStillRejectsAPoolWithNoRegistrationAtAll(
+	t *testing.T,
+) {
+	nonce := bytes.Repeat([]byte{0x07}, 32)
+	tb := createTestBlock(t, [32]byte{57}, 57, tamperNone)
+	ls, db := newEligibilityTestLedger(t, nonce)
+	ls.epochCache = previewEpochs(35, 39, nonce)
+	ls.mithrilLedgerSlot = 3_200_000
+	ls.publishSnapshotsLocked()
+
+	pool := lcommon.PoolKeyHash(bytes.Repeat([]byte{0x11}, 28))
+	// No seedPoolRegistrationAtSlot call: this pool has no registration row
+	// anywhere in the database.
+
+	seedPoolStakeSnapshotOfTypeAtSlot(t, db, 37,
+		models.PoolStakeSnapshotTypeMark, pool[:], 1_000, 10_000, 3_196_799)
+
+	_, _, err := ls.electingVrfKeyHash(tb.block, 38, pool)
+	require.Error(t, err)
+	assert.True(t,
+		errors.Is(err, errVrfKeyRegistrationHistoryUnavailable),
+		"a pool with no registration history at all must still be rejected: "+
+			"got %v",
+		err,
+	)
+}
+
+// TestElectingVrfKeyHashDoesNotFallBackWithoutAMithrilBoundary pins the other
+// half of the boundary: on a node with no Mithril bootstrap
+// (mithrilLedgerSlot == 0, e.g. a genesis sync), a missing-history gap must
+// still hard-reject even though the pool has a resolvable live registration.
+// This is the #3842 guarantee the fix must not erase: falling back to the
+// live registration whenever history merely looks incomplete reintroduces
+// the VRF-rotation wedge that issue fixed. The fallback here fires only when
+// mithrilLedgerSlot pins a bootstrap boundary that explains the gap.
+func TestElectingVrfKeyHashDoesNotFallBackWithoutAMithrilBoundary(
+	t *testing.T,
+) {
+	nonce := bytes.Repeat([]byte{0x07}, 32)
+	tb := createTestBlock(t, [32]byte{58}, 58, tamperNone)
+	ls, db := newEligibilityTestLedger(t, nonce)
+	ls.epochCache = previewEpochs(35, 39, nonce)
+	// mithrilLedgerSlot left at its zero value: no Mithril bootstrap.
+	ls.publishSnapshotsLocked()
+
+	pool := lcommon.PoolKeyHash(bytes.Repeat([]byte{0x11}, 28))
+	vrfKey := bytes.Repeat([]byte{0xB5}, 32)
+
+	// A live, resolvable registration exists, but only after both the
+	// cutoff and the capture -- the same "both lookups miss" shape as the
+	// bootstrap gap, reached here by a certificate genuinely arriving late
+	// rather than by an import never seeing one at all.
+	seedPoolRegistrationAtSlot(t, db, pool[:], vrfKey, 3_300_000)
+
+	seedPoolStakeSnapshotOfTypeAtSlot(t, db, 37,
+		models.PoolStakeSnapshotTypeMark, pool[:], 1_000, 10_000, 3_196_799)
+
+	_, _, err := ls.electingVrfKeyHash(tb.block, 38, pool)
+	require.Error(t, err,
+		"without a Mithril boundary, a history gap must hard-reject rather "+
+			"than fall back to the pool's live (later) registration")
+	assert.True(t,
+		errors.Is(err, errVrfKeyRegistrationHistoryUnavailable),
+		"got %v", err,
+	)
 }


### PR DESCRIPTION
## Summary

- `electingVrfKeyHashWithCache` (`ledger/verify_header.go`) raised
  `errVrfKeyRegistrationHistoryUnavailable` whenever both
  `GetPoolVrfKeyHashAtSlot` and `GetPoolEarliestVrfKeyHashAtSlot` missed for a
  pool. A Mithril snapshot import writes only a pool's live registration,
  stamped at the import slot, never the certificate history that produced it,
  so any stake-snapshot capture or parameter cutoff slot before that import
  slot has no answerable row. The very first post-bootstrap epoch boundary's
  cutoff and capture are always before the anchor, so this fires
  deterministically at every epoch boundary after a Mithril bootstrap. The
  error is unconditional once the ledger tip has caught up to the checked
  slot (the deferred-retry path only covers a tip still catching up), so the
  node rewinds, cannot re-follow past security parameter k, and wedges.
- Fix: when both lookups miss and the stake-snapshot capture slot is at or
  below the persisted Mithril boundary (`mithrilLedgerSlot`), fall back to
  the pool's live registration. That combination is diagnostic of the
  bootstrap gap specifically, not a general missing-registration case, so it
  does not reintroduce the VRF-rotation wedge #3842 removed: a pool with no
  registration at all still hard-rejects, and a node with no Mithril boundary
  (`mithrilLedgerSlot == 0`, e.g. genesis-synced) still hard-rejects an
  equivalent-looking gap.
- An earlier version of this fix instead seeded a second, `added_slot = 0`
  "floor" registration row at Mithril import time (`ImportPool`). That also
  satisfied `GetPoolRegistrationsEffectiveForEpoch`'s in-epoch registration
  window whenever a processed epoch's start slot was small, letting the floor
  row outrank a pool's real, owner-populated registration under that query's
  ascending "earliest first-in-epoch" ordering and zero out the pool's owner
  stake in reward-input seeding. Caught by
  `TestHandleEpochTransitionCapturesSelfDelegatedOwnerStake` and two
  neighboring `ledger/snapshot` tests failing under `-race`. Resolving the
  gap only at the one call site that has the consensus-critical question,
  using the boundary the node already persists for exactly this purpose,
  avoids that collateral damage entirely.

Fixes #4047

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./ledger/... ./database/... ./ledgerstate/... -race` — all
      packages pass, including `ledger/snapshot` (which failed under the
      abandoned floor-row approach)
- [x] `golangci-lint run ./ledger/... ./database/...` — 0 issues
- [x] `modernize ./...` — no new findings in changed files (repo-wide
      pre-existing findings unrelated to this change untouched)
- [x] `make docs-parity`
- [x] New regression tests added to
      `ledger/verify_header_vrf_params_lag_test.go`:
      `TestElectingVrfKeyHashResolvesBelowMithrilBootstrapAnchor` (the #4047
      repro; verified it fails with the fix reverted, reproducing the exact
      reported error message), `TestElectingVrfKeyHashStillRejectsAPoolWithNoRegistrationAtAll`,
      `TestElectingVrfKeyHashDoesNotFallBackWithoutAMithrilBoundary` (the
      #3842 boundary the fix must not erase)
- [x] `DATABASE.md` updated (the `GetPoolVrfKeyHashAtSlot`/`GetPoolEarliestVrfKeyHashAtSlot`
      section); `ARCHITECTURE.md` not affected (no component/plugin/lifecycle
      change)
- [ ] Not verified: no live Preview node available in this environment, so
      this was not reproduced/confirmed fixed against live Preview infra;
      DevNet/conformance suites were not run (this change is header-only VRF
      key resolution logic, not consensus rule/wire-format changes, so `make
      lint`'s `nilaway`/full-module run plus the targeted `-race` suite above
      were used as the available substitute)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wedge where a Mithril-bootstrapped node gets stuck at its first epoch boundary after import. A Mithril snapshot import records only a pool's live registration stamped at the import slot, so when the electing snapshot's cutoff and capture slots precede that anchor — which the first post-bootstrap boundary always does — VRF key resolution found no row and raised `errVrfKeyRegistrationHistoryUnavailable`, rewinding the node past security parameter k.

**Fix**
- Falls back to the pool's live registration when both lookups miss and the capture slot is at or below the persisted Mithril boundary (`mithrilLedgerSlot`).
- Keeps the #3842 guarantee: pools with no registration at all still hard-reject, and nodes without a Mithril boundary do not fall back for an equivalent-looking gap.
- Avoids seeding a synthetic registration row at import time, which outranked real registrations in reward-input seeding.
- Adds three regression tests covering the reported gap, the no-registration case, and the non-bootstrapped case, plus documents the lookup behavior in `DATABASE.md`.

<sup>Written for commit 465b01908832572b75e9724b99412f5cb9766344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed epoch-boundary processing on Mithril-bootstrapped nodes when VRF registration history is unavailable.
  - The system now uses a pool’s current registered VRF key for eligible bootstrap-era lookups.
  - Genuine registration gaps and pools without a registered VRF key continue to return an error.

- **Documentation**
  - Documented the bootstrap-era VRF lookup behavior and the rejected alternative approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->