### PR TITLE
fix(chainsync): close the transport when the post-AwaitReply server waiter gives up

### DIFF
--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -762,59 +762,79 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 	if conn == nil {
 		return fmt.Errorf("connection %s not found", ctx.ConnectionId.String())
 	}
-	go func() {
-		// Wait for next block in a separate goroutine so we can
-		// also monitor the connection for errors. This avoids
-		// leaking the monitor goroutine when Next returns first.
-		done := make(chan struct{})
-		var next *chain.ChainIteratorResult
-		var nextErr error
-		go func() {
-			defer close(done)
-			next, nextErr = clientState.ChainIter.Next(true)
-		}()
-		select {
-		case <-done:
-			// Iterator returned
-		case connErr := <-o.chainsyncServerConnErrorChan(conn):
-			// Abandoning the wait here leaves the peer parked in MustReply
-			// with the server holding agency, so the transport has to be
-			// dropped: an error-channel send alone does not unpark it. See
-			// closeChainsyncServerConn.
-			//
-			// conn.ErrorChan() is one buffered channel shared with blockfetch,
-			// tx-submission and the connection manager's own teardown watcher,
-			// so the error taken here may belong to another mini-protocol --
-			// in which case the manager never sees it and would not tear the
-			// connection down at all. Closing is correct either way: it is
-			// what the manager would have done with that error, and it wakes
-			// the manager's watcher through the closed error channel.
-			clientState.ChainIter.Cancel()
-			o.closeChainsyncServerConn(
-				conn,
-				ctx.ConnectionId.String(),
-				fmt.Errorf(
-					"connection error while peer awaited a reply: %w",
-					orErrConnectionClosed(connErr),
-				),
-			)
-			return
-		}
-		o.chainsyncServerServeAwaited(ctx, conn, next, nextErr)
-	}()
+	go o.chainsyncServerAwaitNext(ctx, conn, clientState)
 	return nil
 }
 
-// chainsyncServerConnErrorChan returns the channel the post-AwaitReply waiter
-// watches for connection failures: conn.ErrorChan() unless a test has supplied
-// a single-consumer stand-in. See Ouroboros.chainsyncServerConnErrors.
-func (o *Ouroboros) chainsyncServerConnErrorChan(
-	conn *ouroboros.Connection,
-) <-chan error {
-	if o.chainsyncServerConnErrors != nil {
-		return o.chainsyncServerConnErrors(conn)
+// chainsyncServerConnection is the connection surface the post-AwaitReply
+// ChainSync server waiter needs: the error channel it watches while the peer is
+// parked in MustReply, and the Close that is the only thing that releases it.
+//
+// It is an interface for the same reason blockfetchConnection is: conn's error
+// channel is a single buffered channel shared with blockfetch, tx-submission
+// and the connection manager's teardown watcher, and delivery goes to whichever
+// consumer the runtime picks, so a test cannot address this waiter on the real
+// one. Taking the two methods the waiter actually uses keeps that seam in the
+// signature instead of in a production field only tests write.
+//
+// *ouroboros.Connection satisfies it, and the RequestNext callback above passes
+// exactly that.
+type chainsyncServerConnection interface {
+	ErrorChan() chan error
+	Close() error
+}
+
+// chainsyncServerAwaitNext is the post-AwaitReply waiter. It runs as its own
+// goroutine once the server has parked the peer in MustReply, and either serves
+// the block the iterator eventually yields or drops the transport.
+func (o *Ouroboros) chainsyncServerAwaitNext(
+	ctx ochainsync.CallbackContext,
+	conn chainsyncServerConnection,
+	clientState *chainsync.ChainsyncClientState,
+) {
+	// Wait for next block in a separate goroutine so we can
+	// also monitor the connection for errors. This avoids
+	// leaking the monitor goroutine when Next returns first.
+	done := make(chan struct{})
+	var next *chain.ChainIteratorResult
+	var nextErr error
+	go func() {
+		defer close(done)
+		next, nextErr = clientState.ChainIter.Next(true)
+	}()
+	select {
+	case <-done:
+		// Iterator returned
+	case connErr := <-conn.ErrorChan():
+		// Abandoning the wait here leaves the peer parked in MustReply
+		// with the server holding agency, so the transport has to be
+		// dropped: an error-channel send alone does not unpark it. See
+		// closeChainsyncServerConn.
+		//
+		// conn.ErrorChan() is one buffered channel shared with blockfetch,
+		// tx-submission and the connection manager's own teardown watcher,
+		// so the error taken here may belong to another mini-protocol --
+		// in which case the manager never sees it and would not tear the
+		// connection down at all. Closing is correct either way: it is
+		// what the manager would have done with that error, and it wakes
+		// the manager's watcher through the closed error channel.
+		//
+		// A closed channel delivers a nil error and is the ordinary way in:
+		// gouroboros' Connection.shutdown closes the channel it owns, so
+		// every consumer wakes at once. orErrConnectionClosed keeps the
+		// logged reason meaningful in that case.
+		clientState.ChainIter.Cancel()
+		o.closeChainsyncServerConn(
+			conn,
+			ctx.ConnectionId.String(),
+			fmt.Errorf(
+				"connection error while peer awaited a reply: %w",
+				orErrConnectionClosed(connErr),
+			),
+		)
+		return
 	}
-	return conn.ErrorChan()
+	o.chainsyncServerServeAwaited(ctx, conn, next, nextErr)
 }
 
 // errChainsyncAwaitConnectionClosed stands in for the nil value a closed
@@ -845,7 +865,7 @@ func orErrConnectionClosed(err error) error {
 // silently is not a third option.
 func (o *Ouroboros) chainsyncServerServeAwaited(
 	ctx ochainsync.CallbackContext,
-	conn *ouroboros.Connection,
+	conn chainsyncServerConnection,
 	next *chain.ChainIteratorResult,
 	nextErr error,
 ) {
@@ -930,7 +950,7 @@ func (o *Ouroboros) chainsyncServerServeAwaited(
 }
 
 func (o *Ouroboros) reportChainsyncServerAsyncError(
-	conn *ouroboros.Connection,
+	conn chainsyncServerConnection,
 	connectionID string,
 	operation string,
 	err error,
@@ -966,7 +986,7 @@ func (o *Ouroboros) reportChainsyncServerAsyncError(
 // point. It also closes the gouroboros-owned error channel, which wakes the
 // connmanager watcher without racing a Dingo send against channel closure.
 func (o *Ouroboros) closeChainsyncServerConn(
-	conn *ouroboros.Connection,
+	conn chainsyncServerConnection,
 	connectionID string,
 	err error,
 ) {

--- a/ouroboros/chainsync.go
+++ b/ouroboros/chainsync.go
@@ -776,71 +776,157 @@ func (o *Ouroboros) chainsyncServerRequestNext(
 		select {
 		case <-done:
 			// Iterator returned
-		case <-conn.ErrorChan():
+		case connErr := <-o.chainsyncServerConnErrorChan(conn):
+			// Abandoning the wait here leaves the peer parked in MustReply
+			// with the server holding agency, so the transport has to be
+			// dropped: an error-channel send alone does not unpark it. See
+			// closeChainsyncServerConn.
+			//
+			// conn.ErrorChan() is one buffered channel shared with blockfetch,
+			// tx-submission and the connection manager's own teardown watcher,
+			// so the error taken here may belong to another mini-protocol --
+			// in which case the manager never sees it and would not tear the
+			// connection down at all. Closing is correct either way: it is
+			// what the manager would have done with that error, and it wakes
+			// the manager's watcher through the closed error channel.
 			clientState.ChainIter.Cancel()
+			o.closeChainsyncServerConn(
+				conn,
+				ctx.ConnectionId.String(),
+				fmt.Errorf(
+					"connection error while peer awaited a reply: %w",
+					orErrConnectionClosed(connErr),
+				),
+			)
 			return
 		}
-		if nextErr != nil {
-			// Don't log context.Canceled errors as they're
-			// expected during connection closure.
-			if !errors.Is(nextErr, context.Canceled) {
-				o.config.Logger.Debug(
-					"failed to get next block from chain iterator",
-					"error", nextErr,
-				)
-			}
-			return
-		}
-		if next == nil {
+		o.chainsyncServerServeAwaited(ctx, conn, next, nextErr)
+	}()
+	return nil
+}
+
+// chainsyncServerConnErrorChan returns the channel the post-AwaitReply waiter
+// watches for connection failures: conn.ErrorChan() unless a test has supplied
+// a single-consumer stand-in. See Ouroboros.chainsyncServerConnErrors.
+func (o *Ouroboros) chainsyncServerConnErrorChan(
+	conn *ouroboros.Connection,
+) <-chan error {
+	if o.chainsyncServerConnErrors != nil {
+		return o.chainsyncServerConnErrors(conn)
+	}
+	return conn.ErrorChan()
+}
+
+// errChainsyncAwaitConnectionClosed stands in for the nil value a closed
+// conn.ErrorChan() yields, so the reason logged for the teardown is never an
+// empty error.
+var errChainsyncAwaitConnectionClosed = errors.New("connection closed")
+
+// orErrConnectionClosed substitutes a non-nil error for the nil a closed
+// error channel delivers.
+func orErrConnectionClosed(err error) error {
+	if err == nil {
+		return errChainsyncAwaitConnectionClosed
+	}
+	return err
+}
+
+// chainsyncServerServeAwaited delivers the chain iterator result that resolved
+// a post-AwaitReply wait, or drops the transport when there is nothing to
+// deliver.
+//
+// Once MsgAwaitReply is on the wire the server holds agency in MustReply. A
+// peer parked there cannot make progress and cannot detect abandonment except
+// through gouroboros' randomized MustReply timer (135-269s), after which it
+// tears the connection down, reconnects, re-intersects, receives one
+// MsgRollBackward and parks again -- a stable loop that keeps a node pinned
+// behind a healthy upstream with no ERROR logged on either side. So every path
+// out of here either sends a reply or closes the connection; returning
+// silently is not a third option.
+func (o *Ouroboros) chainsyncServerServeAwaited(
+	ctx ochainsync.CallbackContext,
+	conn *ouroboros.Connection,
+	next *chain.ChainIteratorResult,
+	nextErr error,
+) {
+	if nextErr != nil {
+		if errors.Is(nextErr, context.Canceled) {
+			// The only cancellations of a server client's iterator come from
+			// chainsync.State.RemoveClient (driven by connection-closed
+			// handling) and from the error-channel exit above, both of which
+			// have already dropped the transport. There is no parked peer left
+			// to unpark, so this stays a quiet, expected unwind.
 			o.config.Logger.Debug(
-				"chainsync server: goroutine got nil block",
+				"chainsync server: await unwound by connection teardown",
 				"connection_id", ctx.ConnectionId.String(),
 			)
 			return
 		}
-		tip := o.refreshTip(next)
-		if next.Rollback {
-			if err := ctx.Server.RollBackward(
-				next.Point,
-				tip,
-			); err != nil {
-				o.reportChainsyncServerAsyncError(
-					conn,
-					ctx.ConnectionId.String(),
-					"RollBackward",
-					err,
-				)
-			}
-		} else {
-			blockCbor, blockErr := o.chainsyncServerBlockCbor(ctx, next.Block)
-			if blockErr != nil {
-				// Do not RollForward an incomplete CertRB. This runs after the
-				// callback returned AwaitReply, so actively close the transport
-				// (an error-channel send alone does not) to unpark the client
-				// from AwaitReply so it reconnects and retries the point once
-				// the endorser closure is available.
-				o.closeChainsyncServerConn(
-					conn,
-					ctx.ConnectionId.String(),
-					blockErr,
-				)
-				return
-			}
-			if err := ctx.Server.RollForward(
-				next.Block.Type,
-				blockCbor,
-				tip,
-			); err != nil {
-				o.reportChainsyncServerAsyncError(
-					conn,
-					ctx.ConnectionId.String(),
-					"RollForward",
-					err,
-				)
-			}
+		o.closeChainsyncServerConn(
+			conn,
+			ctx.ConnectionId.String(),
+			fmt.Errorf(
+				"chain iterator failed while peer awaited a reply: %w",
+				nextErr,
+			),
+		)
+		return
+	}
+	if next == nil {
+		// Defensive: ChainIterator.Next maps an empty non-error result to
+		// ErrIteratorChainTip, so this is not reachable through the real
+		// iterator. Should it ever become reachable, dropping the transport is
+		// still the only way to release the parked peer.
+		o.closeChainsyncServerConn(
+			conn,
+			ctx.ConnectionId.String(),
+			errors.New(
+				"chain iterator returned no block while peer awaited a reply",
+			),
+		)
+		return
+	}
+	tip := o.refreshTip(next)
+	if next.Rollback {
+		if err := ctx.Server.RollBackward(
+			next.Point,
+			tip,
+		); err != nil {
+			o.reportChainsyncServerAsyncError(
+				conn,
+				ctx.ConnectionId.String(),
+				"RollBackward",
+				err,
+			)
 		}
-	}()
-	return nil
+		return
+	}
+	blockCbor, blockErr := o.chainsyncServerBlockCbor(ctx, next.Block)
+	if blockErr != nil {
+		// Do not RollForward an incomplete CertRB. This runs after the
+		// callback returned AwaitReply, so actively close the transport
+		// (an error-channel send alone does not) to unpark the client
+		// from AwaitReply so it reconnects and retries the point once
+		// the endorser closure is available.
+		o.closeChainsyncServerConn(
+			conn,
+			ctx.ConnectionId.String(),
+			blockErr,
+		)
+		return
+	}
+	if err := ctx.Server.RollForward(
+		next.Block.Type,
+		blockCbor,
+		tip,
+	); err != nil {
+		o.reportChainsyncServerAsyncError(
+			conn,
+			ctx.ConnectionId.String(),
+			"RollForward",
+			err,
+		)
+	}
 }
 
 func (o *Ouroboros) reportChainsyncServerAsyncError(

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -1075,34 +1075,29 @@ func newChainsyncServerFixtureLogging(
 	return f, logBuf
 }
 
-// TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient covers
-// the error-channel exit: the waiter gives up on the connection while the peer
-// is parked, so it must drop the transport rather than return silently. Neither
-// consumer of the error closes it otherwise -- the waiter returned silently and
+// TestChainsyncServerAwaitedWaiterClosesOnConnectionError covers the waiter's
+// error-channel exit: it gives up on the connection while the peer it parked is
+// still in MustReply, so it must drop the transport rather than return
+// silently. Nothing else closes it -- the waiter returned silently and
 // ConnectionManager.RemoveConnection only unregisters -- so before the fix the
-// peer stayed parked whichever consumer won.
+// peer stayed parked whichever consumer took the error.
 //
-// The peer is parked through the real protocol first, so this is the genuine
-// MustReply state; the waiter is then driven over a single-consumer stand-in
-// for the connection (see stubChainsyncServerConnection) whose Close is the
-// real one. What the waiter does with an error it has received is the same
-// either way, and that is what this asserts.
-func TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient(
+// The waiter is driven directly, over a single-consumer stand-in for the
+// connection whose Close is the real one, rather than through a peer parked by
+// the protocol. Parking arms the production waiter on the real error channel,
+// and a test cannot address one consumer of that shared channel, so the error
+// would still have to go to a second waiter -- which would then be a second
+// goroutine driving the same ChainIter. The end-to-end release of a genuinely
+// parked peer is covered by
+// TestChainsyncServerRequestNextIteratorErrorAfterAwaitReplyUnparksClient and
+// TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient, which
+// park through the protocol and drive the serve path on the real connection.
+func TestChainsyncServerAwaitedWaiterClosesOnConnectionError(
 	t *testing.T,
 ) {
 	const connErrText = "simulated protocol error for the parked waiter"
 	f, logBuf := newChainsyncServerFixtureLogging(t)
-	f.parkInAwaitReply(t)
-	observed, ok := f.observedConnId()
-	require.True(t, ok, "the server callbacks must have run")
-	require.Equal(t, f.conn.Id(), observed)
-	// AddClient returns the state the parked RequestNext registered rather
-	// than a second one, so the waiter below shares the peer's real iterator.
-	clientState, err := f.o.chainsyncState.AddClient(
-		f.conn.Id(),
-		ocommon.NewPointOrigin(),
-	)
-	require.NoError(t, err)
+	clientState := f.registerClientAtOrigin(t)
 
 	conn := newStubChainsyncServerConnection(f.conn.Close)
 	done := make(chan struct{})
@@ -1146,11 +1141,11 @@ func TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient(
 // either way, so what is distinct here is the reason -- the nil must not reach
 // the log as an empty or malformed error.
 //
-// Unlike the test above this one does not park the peer through the protocol,
-// deliberately: a parked peer arms the production waiter on the real error
-// channel, which the delegated Close would then wake with a closure of its own,
-// and its teardown reason is textually identical to the one under test. With no
-// second waiter the logged reason is attributable to this one.
+// Like its sibling it drives the waiter directly rather than through a parked
+// peer, which here is also what makes the reason attributable: a parked peer
+// arms the production waiter on the real error channel, and the delegated Close
+// would wake that waiter with a closure of its own whose teardown reason is
+// textually identical to the one under test.
 func TestChainsyncServerAwaitedWaiterClosesOnErrorChannelClosure(
 	t *testing.T,
 ) {

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -16,6 +16,7 @@ package ouroboros
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -152,10 +153,14 @@ func newChainsyncServerFixture(
 // closes over the o variable rather than a value because the manager has to
 // exist before newOuroboros can be given it; it can only fire after
 // AddConnection below, by which point o is assigned.
+// tweaks are applied to the Ouroboros instance after it is constructed and
+// before the harness exists, so a test can adjust an internal seam without
+// racing the protocol goroutine that will read it.
 func newChainsyncServerFixtureWithConfig(
 	t *testing.T,
 	mode csmock.Mode,
 	cfg OuroborosConfig,
+	tweaks ...func(*Ouroboros),
 ) *chainsyncServerFixture {
 	t.Helper()
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
@@ -194,6 +199,9 @@ func newChainsyncServerFixtureWithConfig(
 	o = newOuroboros(cfg)
 	o.ledgerState = ledgerState
 	o.chainsyncState = dchainsync.NewState(bus, ledgerState)
+	for _, tweak := range tweaks {
+		tweak(o)
+	}
 
 	f := &chainsyncServerFixture{o: o}
 
@@ -326,6 +334,34 @@ func (f *chainsyncServerFixture) requireConnectionClosed(
 		"close must be published as a graceful lifecycle event, not an "+
 			"error pushed onto the connection's error channel",
 	)
+}
+
+// requireClientUnparked asserts the server dropped the transport, which is the
+// only thing that releases a peer the server has parked in MustReply short of
+// gouroboros' randomized 135-269s MustReply timer. The harness surfaces the
+// drop by closing its observed-message stream, so Observe returns
+// csmock.ErrClosed; a server that abandons the wait silently instead leaves
+// Observe blocking until the deadline.
+func (f *chainsyncServerFixture) requireClientUnparked(
+	t *testing.T,
+	msg string,
+) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := f.h.Observe(ctx)
+	require.ErrorIs(t, err, csmock.ErrClosed, msg)
+}
+
+// parkInAwaitReply drives the fixture to the state this file's abandonment
+// tests all start from: the downstream client has intersected at origin, taken
+// its initial rollback, and asked for a block the server does not have yet, so
+// the server has sent AwaitReply and armed the asynchronous waiter.
+func (f *chainsyncServerFixture) parkInAwaitReply(t *testing.T) {
+	t.Helper()
+	f.drainInitialRollback(t, csmock.OriginPoint())
+	require.NoError(t, f.h.RequestNext())
+	require.True(t, f.observe(t).IsAwaitReply(), "expected AwaitReply")
 }
 
 // drainInitialRollback performs the intersect-then-rollback handshake every
@@ -908,4 +944,147 @@ func TestChainsyncServerRequestNextMissingConnectionAfterAwaitReply(
 	err := f.o.chainsyncServerRequestNext(f.callbackContext())
 
 	require.ErrorContains(t, err, "not found")
+}
+
+// =============================================================================
+// RequestNext: abandoning the peer after AwaitReply
+//
+// Once AwaitReply is on the wire the server holds agency in MustReply, so a
+// waiter that gives up without a reply must drop the transport. Every test
+// below asserts the client was released rather than left to gouroboros'
+// randomized 135-269s MustReply timeout, which is what produced the observed
+// reconnect-and-park loop.
+// =============================================================================
+
+// TestChainsyncServerRequestNextIteratorErrorAfterAwaitReplyUnparksClient
+// covers the exit taken when the blocking chain iterator fails after the peer
+// has been parked. Before the fix the goroutine logged at Debug and returned,
+// leaving the peer parked with the server still holding agency.
+func TestChainsyncServerRequestNextIteratorErrorAfterAwaitReplyUnparksClient(
+	t *testing.T,
+) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+	f.parkInAwaitReply(t)
+
+	// Break the backing store, then wake the parked iterator so its next
+	// lookup fails for real rather than returning the chain-tip sentinel.
+	require.NoError(t, dbtest.CloseDatabase(f.o.ledgerState.Database()))
+	f.o.ledgerState.Chain().NotifyIterators()
+
+	f.requireClientUnparked(
+		t,
+		"an iterator failure after AwaitReply must drop the transport, not "+
+			"leave the peer parked in MustReply",
+	)
+}
+
+// TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient covers the
+// nil-result exit. ChainIterator.Next maps an empty non-error result to
+// ErrIteratorChainTip, so the real iterator cannot produce it and the handler
+// is invoked directly against the fixture's real connection and server.
+func TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient(
+	t *testing.T,
+) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+	f.parkInAwaitReply(t)
+
+	f.o.chainsyncServerServeAwaited(f.callbackContext(), f.conn, nil, nil)
+
+	f.requireClientUnparked(
+		t,
+		"a nil iterator result after AwaitReply must drop the transport, not "+
+			"leave the peer parked in MustReply",
+	)
+}
+
+// TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient covers
+// the error-channel exit: the waiter gives up on the connection while the peer
+// is parked, so it must drop the transport rather than return silently. Neither
+// consumer of the error closes it otherwise -- the waiter returned silently and
+// ConnectionManager.RemoveConnection only unregisters -- so before the fix the
+// peer stayed parked whichever consumer won.
+//
+// The waiter is given a single-consumer stand-in for conn.ErrorChan(). The real
+// channel is shared with the connection manager's teardown watcher (and, in
+// production, blockfetch and tx-submission) and delivery goes to whichever
+// consumer the runtime picks, so a test cannot address this waiter on it.
+// Publishing an extra error to cover the other consumers is not an option
+// either: the consumer that wins closes the connection, and gouroboros'
+// Connection.shutdown closes the error channel it owns, so the extra send would
+// race that closure. What the waiter does with an error it has received is the
+// same either way, and that is what this asserts.
+func TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient(
+	t *testing.T,
+) {
+	connErrs := make(chan error, 1)
+	f := newChainsyncServerFixtureWithConfig(
+		t,
+		csmock.ModeNtC,
+		OuroborosConfig{},
+		func(o *Ouroboros) {
+			o.chainsyncServerConnErrors = func(
+				*ouroboros.Connection,
+			) <-chan error {
+				return connErrs
+			}
+		},
+	)
+	f.parkInAwaitReply(t)
+
+	connErrs <- errors.New("simulated protocol error for the parked waiter")
+
+	f.requireClientUnparked(
+		t,
+		"a connection error consumed by the parked waiter must drop the "+
+			"transport, not leave the peer parked in MustReply",
+	)
+}
+
+// TestChainsyncServerConnErrorChanDefaultsToTheConnection pins the production
+// wiring of that seam, so the test above cannot pass against a waiter that
+// never watches the real connection.
+func TestChainsyncServerConnErrorChanDefaultsToTheConnection(t *testing.T) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+
+	require.Nil(
+		t,
+		f.o.chainsyncServerConnErrors,
+		"production must not install a stand-in error channel",
+	)
+	got := f.o.chainsyncServerConnErrorChan(f.conn)
+	require.NotNil(t, got)
+
+	// Comparing the channels directly is the assertion: a waiter given any
+	// other channel would never see the connection's errors.
+	var want <-chan error = f.conn.ErrorChan()
+	require.Equal(t, want, got, "the waiter must watch conn.ErrorChan()")
+}
+
+// TestChainsyncServerServeAwaitedCancelledDoesNotCloseConnection pins the one
+// exit that must stay silent: a context.Canceled iterator result. The server
+// client's iterator is only cancelled from chainsync.State.RemoveClient, which
+// connection-closed handling drives, so the transport is already gone and
+// there is no parked peer to release. This is the invariant
+// TestChainsyncServerRequestNextIteratorCancelDoesNotCloseConnection asserts
+// end to end, restated at the handler so the abandonment fix cannot turn every
+// ordinary disconnect into a connection-recycling warning.
+func TestChainsyncServerServeAwaitedCancelledDoesNotCloseConnection(
+	t *testing.T,
+) {
+	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+	f.parkInAwaitReply(t)
+
+	f.o.chainsyncServerServeAwaited(
+		f.callbackContext(),
+		f.conn,
+		nil,
+		context.Canceled,
+	)
+
+	testutil.RequireNoReceive(
+		t,
+		f.closedCh,
+		100*time.Millisecond,
+		"a cancelled iterator is ordinary teardown and must not recycle the connection",
+	)
 }

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -997,6 +997,84 @@ func TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient(
 	)
 }
 
+// The post-AwaitReply waiter takes a chainsyncServerConnection, and the only
+// production caller hands it the *ouroboros.Connection the connection manager
+// resolved. Restating that here keeps the stand-in below from drifting away
+// from the type production actually passes.
+var _ chainsyncServerConnection = (*ouroboros.Connection)(nil)
+
+// stubChainsyncServerConnection is a single-consumer stand-in for the
+// connection the post-AwaitReply waiter watches, mirroring
+// stubBlockfetchConnection (blockfetch_test.go), which exists for the same
+// reason.
+//
+// The real conn.ErrorChan() is one buffered channel shared with the connection
+// manager's teardown watcher (and, in production, blockfetch and
+// tx-submission), and delivery goes to whichever consumer the runtime picks, so
+// a test cannot address this waiter on it. Publishing an extra error to cover
+// the other consumers is not an option either: the consumer that wins closes
+// the connection, and gouroboros' Connection.shutdown closes the error channel
+// it owns, so the extra send would race that closure.
+//
+// closeFn delegates to the real connection, so closing the stand-in still drops
+// the actual transport and the harness can observe the parked peer being
+// released.
+type stubChainsyncServerConnection struct {
+	errChan chan error
+	closeFn func() error
+
+	mu         sync.Mutex
+	closeCalls int
+}
+
+func newStubChainsyncServerConnection(
+	closeFn func() error,
+) *stubChainsyncServerConnection {
+	return &stubChainsyncServerConnection{
+		errChan: make(chan error, 1),
+		closeFn: closeFn,
+	}
+}
+
+func (c *stubChainsyncServerConnection) ErrorChan() chan error {
+	return c.errChan
+}
+
+func (c *stubChainsyncServerConnection) Close() error {
+	c.mu.Lock()
+	c.closeCalls++
+	c.mu.Unlock()
+	if c.closeFn != nil {
+		return c.closeFn()
+	}
+	return nil
+}
+
+func (c *stubChainsyncServerConnection) closeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closeCalls
+}
+
+// newChainsyncServerFixtureLogging is newChainsyncServerFixture with the
+// Ouroboros logger redirected into a buffer, for the two tests whose assertion
+// includes the reason the waiter logged for a teardown.
+func newChainsyncServerFixtureLogging(
+	t *testing.T,
+) (*chainsyncServerFixture, *lockedBuffer) {
+	t.Helper()
+	logBuf := &lockedBuffer{}
+	f := newChainsyncServerFixtureWithConfig(
+		t,
+		csmock.ModeNtC,
+		OuroborosConfig{},
+		func(o *Ouroboros) {
+			o.config.Logger = slog.New(slog.NewJSONHandler(logBuf, nil))
+		},
+	)
+	return f, logBuf
+}
+
 // TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient covers
 // the error-channel exit: the waiter gives up on the connection while the peer
 // is parked, so it must drop the transport rather than return silently. Neither
@@ -1004,60 +1082,120 @@ func TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient(
 // ConnectionManager.RemoveConnection only unregisters -- so before the fix the
 // peer stayed parked whichever consumer won.
 //
-// The waiter is given a single-consumer stand-in for conn.ErrorChan(). The real
-// channel is shared with the connection manager's teardown watcher (and, in
-// production, blockfetch and tx-submission) and delivery goes to whichever
-// consumer the runtime picks, so a test cannot address this waiter on it.
-// Publishing an extra error to cover the other consumers is not an option
-// either: the consumer that wins closes the connection, and gouroboros'
-// Connection.shutdown closes the error channel it owns, so the extra send would
-// race that closure. What the waiter does with an error it has received is the
-// same either way, and that is what this asserts.
+// The peer is parked through the real protocol first, so this is the genuine
+// MustReply state; the waiter is then driven over a single-consumer stand-in
+// for the connection (see stubChainsyncServerConnection) whose Close is the
+// real one. What the waiter does with an error it has received is the same
+// either way, and that is what this asserts.
 func TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient(
 	t *testing.T,
 ) {
-	connErrs := make(chan error, 1)
-	f := newChainsyncServerFixtureWithConfig(
-		t,
-		csmock.ModeNtC,
-		OuroborosConfig{},
-		func(o *Ouroboros) {
-			o.chainsyncServerConnErrors = func(
-				*ouroboros.Connection,
-			) <-chan error {
-				return connErrs
-			}
-		},
-	)
+	const connErrText = "simulated protocol error for the parked waiter"
+	f, logBuf := newChainsyncServerFixtureLogging(t)
 	f.parkInAwaitReply(t)
+	observed, ok := f.observedConnId()
+	require.True(t, ok, "the server callbacks must have run")
+	require.Equal(t, f.conn.Id(), observed)
+	// AddClient returns the state the parked RequestNext registered rather
+	// than a second one, so the waiter below shares the peer's real iterator.
+	clientState, err := f.o.chainsyncState.AddClient(
+		f.conn.Id(),
+		ocommon.NewPointOrigin(),
+	)
+	require.NoError(t, err)
 
-	connErrs <- errors.New("simulated protocol error for the parked waiter")
+	conn := newStubChainsyncServerConnection(f.conn.Close)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.o.chainsyncServerAwaitNext(f.callbackContext(), conn, clientState)
+	}()
 
+	conn.ErrorChan() <- errors.New(connErrText)
+
+	testutil.RequireReceive(
+		t,
+		done,
+		10*time.Second,
+		"the waiter must return once it has consumed a connection error",
+	)
 	f.requireClientUnparked(
 		t,
 		"a connection error consumed by the parked waiter must drop the "+
 			"transport, not leave the peer parked in MustReply",
 	)
+	require.Equal(
+		t,
+		1,
+		conn.closeCount(),
+		"the waiter itself must close the connection",
+	)
+	require.Contains(
+		t,
+		logBuf.String(),
+		connErrText,
+		"the teardown must be logged with the error that caused it",
+	)
 }
 
-// TestChainsyncServerConnErrorChanDefaultsToTheConnection pins the production
-// wiring of that seam, so the test above cannot pass against a waiter that
-// never watches the real connection.
-func TestChainsyncServerConnErrorChanDefaultsToTheConnection(t *testing.T) {
-	f := newChainsyncServerFixture(t, csmock.ModeNtC)
+// TestChainsyncServerAwaitedWaiterClosesOnErrorChannelClosure is the sibling of
+// the test above for the err == nil branch, which is the shape that fires most
+// often in production: gouroboros' Connection.shutdown closes the error channel
+// it owns, and every consumer then receives the zero value, whereas a live
+// error delivered to THIS consumer is the rarer race. Behavior is a Close()
+// either way, so what is distinct here is the reason -- the nil must not reach
+// the log as an empty or malformed error.
+//
+// Unlike the test above this one does not park the peer through the protocol,
+// deliberately: a parked peer arms the production waiter on the real error
+// channel, which the delegated Close would then wake with a closure of its own,
+// and its teardown reason is textually identical to the one under test. With no
+// second waiter the logged reason is attributable to this one.
+func TestChainsyncServerAwaitedWaiterClosesOnErrorChannelClosure(
+	t *testing.T,
+) {
+	f, logBuf := newChainsyncServerFixtureLogging(t)
+	clientState := f.registerClientAtOrigin(t)
 
-	require.Nil(
+	conn := newStubChainsyncServerConnection(f.conn.Close)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.o.chainsyncServerAwaitNext(f.callbackContext(), conn, clientState)
+	}()
+
+	close(conn.ErrorChan())
+
+	testutil.RequireReceive(
 		t,
-		f.o.chainsyncServerConnErrors,
-		"production must not install a stand-in error channel",
+		done,
+		10*time.Second,
+		"the waiter must return once its error channel is closed",
 	)
-	got := f.o.chainsyncServerConnErrorChan(f.conn)
-	require.NotNil(t, got)
-
-	// Comparing the channels directly is the assertion: a waiter given any
-	// other channel would never see the connection's errors.
-	var want <-chan error = f.conn.ErrorChan()
-	require.Equal(t, want, got, "the waiter must watch conn.ErrorChan()")
+	f.requireClientUnparked(
+		t,
+		"a closed error channel must drop the transport, not leave the "+
+			"waiter's peer able to park indefinitely",
+	)
+	require.Equal(
+		t,
+		1,
+		conn.closeCount(),
+		"the waiter itself must close the connection",
+	)
+	logged := logBuf.String()
+	require.Contains(
+		t,
+		logged,
+		errChainsyncAwaitConnectionClosed.Error(),
+		"a closed error channel must be reported as a closed connection",
+	)
+	require.NotContains(
+		t,
+		logged,
+		"%!w(<nil>)",
+		"the nil a closed channel yields must never reach the log verbatim",
+	)
 }
 
 // TestChainsyncServerServeAwaitedCancelledDoesNotCloseConnection pins the one

--- a/ouroboros/chainsync_server_fixture_test.go
+++ b/ouroboros/chainsync_server_fixture_test.go
@@ -1076,22 +1076,24 @@ func newChainsyncServerFixtureLogging(
 }
 
 // TestChainsyncServerAwaitedWaiterClosesOnConnectionError covers the waiter's
-// error-channel exit: it gives up on the connection while the peer it parked is
-// still in MustReply, so it must drop the transport rather than return
-// silently. Nothing else closes it -- the waiter returned silently and
-// ConnectionManager.RemoveConnection only unregisters -- so before the fix the
-// peer stayed parked whichever consumer took the error.
+// error-channel exit: it consumes an error for the connection it is serving and
+// must close the transport rather than return silently. Closing is the whole
+// point of the exit -- once MsgAwaitReply is on the wire the server holds
+// agency in MustReply and nothing else releases the peer: an error-channel send
+// does not, a silent return does not, and ConnectionManager.RemoveConnection
+// only unregisters.
 //
-// The waiter is driven directly, over a single-consumer stand-in for the
-// connection whose Close is the real one, rather than through a peer parked by
-// the protocol. Parking arms the production waiter on the real error channel,
-// and a test cannot address one consumer of that shared channel, so the error
-// would still have to go to a second waiter -- which would then be a second
-// goroutine driving the same ChainIter. The end-to-end release of a genuinely
-// parked peer is covered by
+// The waiter is driven directly here, over a single-consumer stand-in for the
+// connection whose Close is the real one; the test does not park a peer through
+// the protocol. Parking would arm the production waiter on the real error
+// channel, and since a test cannot address one consumer of that shared channel
+// the error would still have to be delivered to a second waiter -- a second
+// goroutine driving the same ChainIter. So the assertion here is the waiter's
+// own behavior on an error it has received, plus the transport actually going
+// away. A peer parked by the protocol is covered by
 // TestChainsyncServerRequestNextIteratorErrorAfterAwaitReplyUnparksClient and
 // TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient, which
-// park through the protocol and drive the serve path on the real connection.
+// park for real and drive the serve path on the real connection.
 func TestChainsyncServerAwaitedWaiterClosesOnConnectionError(
 	t *testing.T,
 ) {
@@ -1116,8 +1118,9 @@ func TestChainsyncServerAwaitedWaiterClosesOnConnectionError(
 	)
 	f.requireClientUnparked(
 		t,
-		"a connection error consumed by the parked waiter must drop the "+
-			"transport, not leave the peer parked in MustReply",
+		"a connection error consumed by the waiter must drop the transport, "+
+			"which is the only thing that releases a peer the server has "+
+			"parked in MustReply",
 	)
 	require.Equal(
 		t,
@@ -1141,11 +1144,11 @@ func TestChainsyncServerAwaitedWaiterClosesOnConnectionError(
 // either way, so what is distinct here is the reason -- the nil must not reach
 // the log as an empty or malformed error.
 //
-// Like its sibling it drives the waiter directly rather than through a parked
-// peer, which here is also what makes the reason attributable: a parked peer
-// arms the production waiter on the real error channel, and the delegated Close
-// would wake that waiter with a closure of its own whose teardown reason is
-// textually identical to the one under test.
+// Like its sibling it drives the waiter directly rather than through a peer
+// parked by the protocol, which here is also what makes the reason
+// attributable: a parked peer arms the production waiter on the real error
+// channel, and the delegated Close would wake that waiter with a closure of its
+// own whose teardown reason is textually identical to the one under test.
 func TestChainsyncServerAwaitedWaiterClosesOnErrorChannelClosure(
 	t *testing.T,
 ) {
@@ -1169,8 +1172,8 @@ func TestChainsyncServerAwaitedWaiterClosesOnErrorChannelClosure(
 	)
 	f.requireClientUnparked(
 		t,
-		"a closed error channel must drop the transport, not leave the "+
-			"waiter's peer able to park indefinitely",
+		"a closed error channel must drop the transport, which is the only "+
+			"thing that releases a peer the server has parked in MustReply",
 	)
 	require.Equal(
 		t,

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -151,6 +151,18 @@ type Ouroboros struct {
 	txSubmissionRateLimiter *txSubmissionRateLimiter
 	// Per-peer work-budget limiter for ChainSync FindIntersect
 	chainsyncFindIntersectLimiter *chainsyncFindIntersectRateLimiter
+	// Source of the connection-error channel the post-AwaitReply ChainSync
+	// server waiter watches. Nil means conn.ErrorChan(), which is what
+	// production uses.
+	//
+	// It is overridable because conn.ErrorChan() is a single buffered channel
+	// shared with blockfetch, tx-submission and the connection manager's
+	// teardown watcher, and delivery goes to whichever consumer the runtime
+	// picks. A test cannot address this waiter on it, and cannot publish an
+	// extra error to cover the other consumers either: the consumer that wins
+	// closes the connection, and gouroboros' Connection.shutdown closes the
+	// error channel it owns, so the extra send races that closure.
+	chainsyncServerConnErrors func(*ouroboros.Connection) <-chan error
 	// Cached Leios EB material fetched from peers. This lets NtC
 	// ChainSync serve merged RB+EB blocks without coupling the chain
 	// package to Leios prototype protocols.

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -151,18 +151,6 @@ type Ouroboros struct {
 	txSubmissionRateLimiter *txSubmissionRateLimiter
 	// Per-peer work-budget limiter for ChainSync FindIntersect
 	chainsyncFindIntersectLimiter *chainsyncFindIntersectRateLimiter
-	// Source of the connection-error channel the post-AwaitReply ChainSync
-	// server waiter watches. Nil means conn.ErrorChan(), which is what
-	// production uses.
-	//
-	// It is overridable because conn.ErrorChan() is a single buffered channel
-	// shared with blockfetch, tx-submission and the connection manager's
-	// teardown watcher, and delivery goes to whichever consumer the runtime
-	// picks. A test cannot address this waiter on it, and cannot publish an
-	// extra error to cover the other consumers either: the consumer that wins
-	// closes the connection, and gouroboros' Connection.shutdown closes the
-	// error channel it owns, so the extra send races that closure.
-	chainsyncServerConnErrors func(*ouroboros.Connection) <-chan error
 	// Cached Leios EB material fetched from peers. This lets NtC
 	// ChainSync serve merged RB+EB blocks without coupling the chain
 	// package to Leios prototype protocols.


### PR DESCRIPTION
Fixes #4137

## The bug

`chainsyncServerRequestNext` sends `MsgAwaitReply` and hands the follower to a
goroutine that waits on the client's chain iterator. Three of that goroutine's
exits returned without sending `MsgRollForward`/`MsgRollBackward` **and** without
closing the transport:

1. the `conn.ErrorChan()` case of the `select`,
2. a non-cancellation chain-iterator error (logged at `Debug`),
3. a nil iterator result (logged at `Debug`).

Once `MsgAwaitReply` is on the wire the server holds agency in `MustReply`. A
peer parked there cannot make progress and cannot detect the abandonment except
through gouroboros' randomized `MustReply` timer (135-269 s). It then tears the
connection down with `chain-sync: timeout waiting on transition from protocol
state MustReply`, reconnects, negotiates a fresh intersection, receives exactly
one `MsgRollBackward` — and lands in the same trap. The loop is stable and
silent: a node sits ~1000 slots behind a healthy upstream indefinitely with no
ERROR on either side, and its own plateau watchdog re-enters the trap every time
it fires. Five consecutive session lifetimes measured on a devnet were 198.1 s,
182.3 s, 188.6 s, 165.7 s and 166.1 s — every one inside
`[MustReplyTimeoutMin, MustReplyTimeoutMax]` and matching no other timer in
either process. Full evidence in #4137.

The `CertRB` branch of the same function already documents the correct behaviour
and calls `closeChainsyncServerConn`:

> Do not RollForward an incomplete CertRB. This runs after the callback returned
> AwaitReply, so actively close the transport (an error-channel send alone does
> not) to unpark the client from AwaitReply so it reconnects and retries...

That reasoning applies verbatim to the three earlier exits. This is the residual
gap in #2259, which routed the async *send* failures into connection lifecycle
handling but left the pre-send exits untouched.

## The change

Route all three exits through `closeChainsyncServerConn`, each with a reason
naming the exit, so the teardown is a warning rather than a debug line.

`context.Canceled` deliberately stays quiet and does **not** close. A server
client's iterator is only cancelled from `chainsync.State.RemoveClient` — which
connection-closed handling drives — and from the error-channel exit above; in
both cases the transport is already gone, so there is no parked peer to release
and closing would turn every ordinary disconnect into a connection-recycling
warning. `TestChainsyncServerServeAwaitedCancelledDoesNotCloseConnection` pins
that, alongside the pre-existing
`TestChainsyncServerRequestNextIteratorCancelDoesNotCloseConnection`.

On the shared error channel: `conn.ErrorChan()` is a single buffered `chan error`
with several consumers (this waiter, blockfetch, tx-submission, and the
connection manager's own teardown watcher), so the error this waiter consumes may
belong to another mini-protocol — and the manager then never sees it and does not
tear the connection down at all. Closing is correct either way: it is what the
manager would have done with that error, and it wakes the manager's watcher
through the closed error channel. **Reshaping that channel is deliberately out of
scope here**; this PR only stops the exits from leaking a live follower.

The post-wait handling moves into `chainsyncServerServeAwaited` so exit (3) is
reachable from a test: `ChainIterator.Next` maps an empty non-error result to
`ErrIteratorChainTip`, so the real iterator cannot produce one.

The channel the waiter watches is read through `chainsyncServerConnErrorChan`,
which returns `conn.ErrorChan()` unless a test supplies a single-consumer
stand-in. A test cannot drive exit (1) on the real channel: delivery goes to
whichever consumer the runtime picks, and publishing an extra error to cover the
other consumers races the channel's own closure — the consumer that wins closes
the connection, and gouroboros' `Connection.shutdown` closes the error channel it
owns, so the extra send can panic with `send on closed channel`. The default is
asserted separately so the seam cannot mask a waiter wired to the wrong channel.

## Tests

New, in `ouroboros/chainsync_server_fixture_test.go`, on the existing
ouroboros-mock server fixture. Each drives a real follower into `AwaitReply` over
a real protocol connection and asserts the client was *released* — the harness's
observed-message stream closes — rather than left blocking to the deadline:

| test | exit |
|---|---|
| `TestChainsyncServerRequestNextIteratorErrorAfterAwaitReplyUnparksClient` | (2) real iterator failure, driven by closing the backing store and waking the parked iterator |
| `TestChainsyncServerRequestNextNilBlockAfterAwaitReplyUnparksClient` | (3) nil result |
| `TestChainsyncServerRequestNextConnErrorAfterAwaitReplyUnparksClient` | (1) error-channel |
| `TestChainsyncServerConnErrorChanDefaultsToTheConnection` | the seam's production default |
| `TestChainsyncServerServeAwaitedCancelledDoesNotCloseConnection` | the exit that must stay silent |

Each was verified red by reverting only the branch it covers: the three
abandonment tests fail with `context deadline exceeded` instead of the expected
close, which is the production symptom exactly. The cancel test fails if the
`context.Canceled` branch is removed, and so does the pre-existing
`TestChainsyncServerRequestNextIteratorCancelDoesNotCloseConnection`. The seam
test fails if `chainsyncServerConnErrorChan` stops returning `conn.ErrorChan()`.

Note that on `main` neither consumer of a connection error closes the transport —
`ConnectionManager.RemoveConnection` only unregisters — so the peer stayed parked
whichever consumer won.

Full package green, including `-race`, on the current `main` base:

```
go test ./ouroboros/ -run TestChainsyncServer -count=5        ok  10.9s
go test -race ./ouroboros/ ./chainsync/ ./connmanager/        ok  44.2s / 1.5s / 4.9s
go build ./... && go vet ./ouroboros/                         clean
```

## Related

- #4137 — the report this fixes.
- #2259 — fixed the async *send* half; the pre-send exits were not touched.
- #2250, #2150, #2177 (closed) — the same observable from the client's side
  (`MustReply` timeout / local tip plateau / tip pinned at S on a single-peer
  BP), none of which reached this server-side exit.
- #4132 — chainsync protocol-state violations during re-sync: different failure,
  same re-sync path.
- #3987 — post-recycle peer selectability; adjacent but about selection, not
  about the server never speaking.
- #3808 / #3886 — the plateau watchdog's threshold and its catch-up behaviour.
  The watchdog's inability to re-arm at all is a separate PR against
  `internal/chainsyncrecycler`.



## CI status

Rebased onto `main` at `aa088149` (2026-09-09), which now includes #4144's fix
for the `chainselection`/`ledger` frontier-flap flakes noted below previously.
All 4 commits on this branch carried through the rebase byte-identical
(`git range-diff`, no conflicts).

Re-verified on the rebased head: `go build ./...`, `go vet ./ouroboros/...`,
and `go test ./ouroboros/...` all clean/green (this PR only touches
`ouroboros/chainsync.go` and its test fixture).

The one red check on this head, `go-test (Windows) (1.26.x)`, is an ambient
runner-infra flake ("the hosted runner lost communication with the server"),
not a test failure — `main`'s own CI at `aa088149` fails the identical
Windows job the same way. Not this branch; no action needed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ChainSync sessions that could remain stuck while awaiting a reply after a connection error.
  * Connections now close cleanly when awaiting operations encounter iterator failures, missing results, or connection errors.
  * Preserved graceful handling of canceled operations without unnecessarily closing the connection.

* **Tests**
  * Added coverage for error and cancellation scenarios to help ensure peers are consistently released from stalled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
