### PR TITLE
test(chainselection): make the frontier-flap tests deterministic

### DIFF
--- a/chainselection/frontier_flap_test.go
+++ b/chainselection/frontier_flap_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // These tests pin the transport-frontier flapping reproduction from Preview
@@ -74,24 +75,66 @@ func itoa(v uint64) string {
 	return string(buf[i:])
 }
 
-// drainChainSwitchEvents collects every ChainSwitchEvent already delivered to
-// the subscriber channel. The selector publishes synchronously from
-// EvaluateAndSwitch, so anything it decided has already been buffered by the
-// time the driving update call returns.
-func drainChainSwitchEvents(
+// chainSwitchBarrierTimeout bounds the wait for the barrier below. It is a
+// deadlock bound, not a settling delay: the barrier is already queued behind
+// whatever the selector decided by the time the wait starts, so the normal
+// cost is one lane hand-off.
+const chainSwitchBarrierTimeout = 30 * time.Second
+
+// chainSwitchBarrier is a sentinel published through the chain-switch ordered
+// lane so a test can tell "no switch was decided" from "the switch has not
+// been delivered yet".
+//
+// ChainSelector.publishSelection routes chain switches through
+// EventBus.PublishOrdered (blinklabs-io/dingo#3550), so the call that drove
+// the decision returns before the lane worker has handed the event to any
+// subscriber. A lane is a FIFO drained by exactly one worker, so a sentinel
+// enqueued after those switches is delivered after them: receiving it back is
+// proof that every switch published earlier on this goroutine has already
+// reached the subscription. Its Data type is not ChainSwitchEvent, so it is
+// skipped rather than counted as a decision. Same construction as
+// switchBarrier in ouroboros/consensus_conformance_test.go.
+type chainSwitchBarrier struct{}
+
+// collectChainSwitchEvents returns every ChainSwitchEvent the selector has
+// published so far, bounded by the barrier above. A non-blocking drain is not
+// a bound: it reports a switch that has been published but not yet delivered
+// as no switch at all, which turns this file's assertions into a race against
+// the lane worker.
+func collectChainSwitchEvents(
 	t *testing.T,
+	bus *event.EventBus,
 	ch <-chan event.Event,
 ) []ChainSwitchEvent {
 	t.Helper()
+	require.True(
+		t,
+		bus.PublishOrdered(
+			ChainSwitchEventType,
+			event.NewEvent(ChainSwitchEventType, chainSwitchBarrier{}),
+		),
+		"event bus refused the chain-switch barrier",
+	)
 	var out []ChainSwitchEvent
 	for {
-		select {
-		case evt := <-ch:
-			switchEvent, ok := evt.Data.(ChainSwitchEvent)
-			require.True(t, ok, "unexpected event payload on switch channel")
-			out = append(out, switchEvent)
-		default:
+		evt := testutil.RequireReceive(
+			t,
+			ch,
+			chainSwitchBarrierTimeout,
+			"chain-switch barrier",
+		)
+		switch data := evt.Data.(type) {
+		case chainSwitchBarrier:
 			return out
+		case ChainSwitchEvent:
+			out = append(out, data)
+		default:
+			// Only the selector and the barrier above publish on this
+			// lane, so anything else is a bug in one of them. Skipping it
+			// would still terminate -- the barrier is behind it in the
+			// same FIFO -- but it would drop a switch decision the
+			// assertions below then read as "never switched".
+			t.Fatalf("unexpected %T on the chain_switch lane", evt.Data)
 		}
 	}
 }
@@ -249,7 +292,7 @@ func TestCanonicalPeersWithCrossingFrontiersDoNotFlap(t *testing.T) {
 		)
 	}
 
-	switchEvents := drainChainSwitchEvents(t, switchCh)
+	switchEvents := collectChainSwitchEvents(t, eventBus, switchCh)
 	require.Len(
 		t,
 		switchEvents,

--- a/ledger/chainsync_frontier_flap_test.go
+++ b/ledger/chainsync_frontier_flap_test.go
@@ -19,16 +19,39 @@ import (
 	"log/slog"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// chainSwitchBarrierTimeout bounds the wait for the barrier below. It is a
+// deadlock bound, not a settling delay: the barrier is already queued behind
+// whatever the selector decided by the time the wait starts, so the normal
+// cost is one lane hand-off.
+const chainSwitchBarrierTimeout = 30 * time.Second
+
+// chainSwitchBarrier is a sentinel published through the chain-switch ordered
+// lane so the test below can tell "no switch was decided" from "the switch has
+// not been delivered yet".
+//
+// ChainSelector.publishSelection routes chain switches through
+// EventBus.PublishOrdered (blinklabs-io/dingo#3550), so
+// HandlePeerTipUpdateEvent returns before the lane worker has handed the event
+// to any subscriber. A lane is a FIFO drained by exactly one worker, so a
+// sentinel enqueued after those switches is delivered after them: receiving it
+// back is proof that every switch published earlier on this goroutine has
+// already reached the subscription. Its Data type is not ChainSwitchEvent, so
+// it is skipped rather than counted as a decision. Same construction as
+// switchBarrier in ouroboros/consensus_conformance_test.go.
+type chainSwitchBarrier struct{}
 
 // TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip closes the loop
 // between chain selection and the ledger's fresh-cursor handling.
@@ -138,14 +161,33 @@ func TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip(
 		deliver(step.conn, step.block)
 	}
 
-	// The selector publishes synchronously from the update call, so everything
-	// it decided is already buffered on the subscriber channel.
+	// The selector publishes through an ordered lane, so a switch it decided
+	// during the deliveries above may not have reached switchCh yet. Enqueue a
+	// barrier behind those switches and read until it comes back: everything
+	// ahead of it in the lane's FIFO has been delivered by then.
+	require.True(
+		t,
+		selectorBus.PublishOrdered(
+			chainselection.ChainSwitchEventType,
+			event.NewEvent(
+				chainselection.ChainSwitchEventType,
+				chainSwitchBarrier{},
+			),
+		),
+		"event bus refused the chain-switch barrier",
+	)
 	var checked int
 	for drained := false; !drained; {
-		select {
-		case evt := <-switchCh:
-			switchEvent, ok := evt.Data.(chainselection.ChainSwitchEvent)
-			require.True(t, ok)
+		evt := testutil.RequireReceive(
+			t,
+			switchCh,
+			chainSwitchBarrierTimeout,
+			"chain-switch barrier",
+		)
+		switch switchEvent := evt.Data.(type) {
+		case chainSwitchBarrier:
+			drained = true
+		case chainselection.ChainSwitchEvent:
 			checked++
 			assert.False(
 				t,
@@ -158,7 +200,9 @@ func TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip(
 				switchEvent.NewObservedTip.BlockNumber,
 			)
 		default:
-			drained = true
+			// Only the selector and the barrier above publish on this
+			// lane, so anything else is a bug in one of them.
+			t.Fatalf("unexpected %T on the chain_switch lane", evt.Data)
 		}
 	}
 	require.Positive(


### PR DESCRIPTION
## What fails on main

`main` has been red on `go-test` since f3b7e55 (#4048). Two of the tests that
commit added fail on Linux, macOS and Windows, while `go-test (Linux, race)`
passes on the same commit:

- `chainselection.TestCanonicalPeersWithCrossingFrontiersDoNotFlap` —
  `chainselection/frontier_flap_test.go:253`, *"only the initial selection may
  publish a chain switch"*, `"[]" should have 1 item(s), but has 0`
- `ledger.TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip` —
  `ledger/chainsync_frontier_flap_test.go:164`, *"the scenario must publish at
  least the initial selection event"*, `"0" is not positive`

CI for f3b7e55:
[go-test (Linux)](https://github.com/blinklabs-io/dingo/actions/runs/34288463269/job/102269395677) failure ·
[go-test (macOS)](https://github.com/blinklabs-io/dingo/actions/runs/34288463269/job/102269395441) failure ·
[go-test (Windows)](https://github.com/blinklabs-io/dingo/actions/runs/34288463269/job/102269395790) failure ·
[go-test (Linux, race)](https://github.com/blinklabs-io/dingo/actions/runs/34288463269/job/102269395664) success

Every open PR inherits this, so nothing can go green against current `main`.

## Verdict: the tests assert a synchrony the code never promised

Not a production bug, and #4048's production change is not implicated: the
failure is *zero* switch events observed, i.e. the anti-flap logic is never
reached.

Both tests collect chain switches with a non-blocking `select` and treat an
empty channel as "the selector decided nothing":

```go
// drainChainSwitchEvents collects every ChainSwitchEvent already delivered to
// the subscriber channel. The selector publishes synchronously from
// EvaluateAndSwitch, so anything it decided has already been buffered by the
// time the driving update call returns.
```

That comment is not true. `ChainSelector.publishSelection` routes every chain
switch through `EventBus.PublishOrdered` (#3550, #2287), which enqueues onto a
per-event-type FIFO drained by a **separate worker goroutine**
(`event/ordered.go: orderedWorker`). The interleaving is:

1. test goroutine: `updatePeerTipObserved(rootA, …)` decides the initial
   selection under `cs.mutex`, releases it, calls `publishSelection`
2. test goroutine: `PublishOrderedContext` lazily creates the
   `chainselection.chain_switch` lane, `go e.orderedWorker(...)`, enqueues the
   event, returns — **delivery has not happened**
3. test goroutine: runs the eight remaining delivery steps and the final
   non-blocking drain, all CPU-bound with no channel op that yields
4. lane worker: only now gets scheduled and calls `Publish`, which hands the
   event to the subscriber channel — after the drain already returned empty

So the assertion is a race against the lane worker being scheduled, and the
same-goroutine assertions in the loop above it (`GetBestPeer()` reads shared
state directly) are unaffected, which is why only the event-count assertions
fail.

Evidence that it is scheduling and not chain-selection logic, on a 4-core
Linux box (`go1.26.7`), all on a clean checkout of f3b7e55:

| run | result |
|---|---|
| `go test ./chainselection/ -run TestCanonicalPeersWithCrossingFrontiersDoNotFlap -count=5` (GOMAXPROCS=4, default) | PASS |
| same, `GOMAXPROCS=1 -count=10` | FAIL |
| same, `GOMAXPROCS=2 -count=10` | FAIL |
| `go test ./chainselection/` (whole package, any GOMAXPROCS) | FAIL — the other tests' goroutines keep the Ps busy |
| `go test ./ledger/ -run TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip -count=10`, GOMAXPROCS 1 and 4 | FAIL at both |

The ledger test fails even standalone at `GOMAXPROCS=4` because it sets
`DisableEventSubscriptions: true` and calls `HandlePeerTipUpdateEvent`
directly, so there is no yield anywhere between the last delivery and the
drain. `go-test (Linux, race)` is green because the race detector's
instrumentation inserts the preemption points the drain depends on.

## Fix

Test files only; no production change. The repo already solved exactly this
for the consensus conformance harness — `switchBarrier` in
`ouroboros/consensus_conformance_test.go` — and both tests now use the same
construction:

- publish a sentinel (`chainSwitchBarrier`, a type that is *not*
  `ChainSwitchEvent`) onto the same ordered lane after the last delivery
- read until the sentinel comes back, recording every `ChainSwitchEvent` ahead
  of it

A lane is a FIFO drained by exactly one worker, so receiving the sentinel is
proof that every switch published earlier on the test goroutine has already
reached the subscription. No sleeps, no polling; the timeout is a deadlock
bound, not a settling delay. An unexpected payload on the lane fails loudly
rather than being skipped.

## Red -> green

| test | f3b7e55 (before) | this branch |
|---|---|---|
| `chainselection` target test, `-count=20`, GOMAXPROCS 1 / 2 / 4 | FAIL / FAIL / pass | pass / pass / pass |
| `ledger` target test, `-count=20`, GOMAXPROCS 1 / 2 / 4 | FAIL / FAIL / FAIL | pass / pass / pass |
| `chainselection` target test, `-race -count=20` | pass | pass |
| `ledger` target test, `-race -count=20` | pass | pass |
| `go test ./chainselection/` (full package) | FAIL | ok, 0.99s |
| `go test ./ledger/` (full package) | FAIL | ok, 32.2s |
| `go test -race ./chainselection/` | pass | ok, 2.96s |
| `go test -race ./ledger/` | pass | ok, 171.5s |
| `go build ./... && go vet ./...` | ok | ok |

The assertions are unchanged and still catch what #4048 fixed. Mutation check:
with `chainselection/selector.go` and `chainselection/peer_tip.go` reverted to
their pre-#4048 content (test files kept as on this branch), the chainselection
test collects **6** switch events instead of 1 and fails on the active peer
flapping, and the ledger test reports fresh-cursor closes at delivered blocks
28964 and 29274. So the barrier makes the regression coverage stronger, not
weaker — before this change the tests would have passed vacuously on any run
where the lane worker was late.

## Related

- #4048 — the commit that added these tests (f3b7e55); this does not revert or
  weaken any of its behaviour
- #3777 — the transport-frontier flapping issue #4048 closed
- #3550 — why chain switches go through `PublishOrdered` instead of an inline
  `Publish`
- #2287 — why the ordered lane exists (per-type FIFO, single worker)
- `ouroboros/consensus_conformance_test.go` — the pre-existing `switchBarrier`
  this reuses

No open or recently-closed issue/PR covers these test names, "chain-switch
barrier", or a `main`-red fix for f3b7e55.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky chain-selection tests that were racing against the event bus's ordered lane worker, keeping `main` red on `go-test`.

The tests drained the subscriber channel with a non-blocking `select`, assuming the selector published synchronously. But `PublishOrdered` enqueues onto a FIFO drained by a separate goroutine, so an empty channel meant "not delivered yet" rather than "no switch." The tests now publish a sentinel barrier onto the same lane after the last delivery and read until it returns, proving every switch published earlier has been delivered. This reuses the `switchBarrier` pattern from `ouroboros/consensus_conformance_test.go`.

- Test files only; no production behavior changes.
- The assertions are unchanged and still fail if the production fix from #4048 is reverted.

<sup>Written for commit 870abd31333f049ced0ef2aa16ba26ab908201aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage and reliability for chain synchronization scenarios involving rapidly changing chain frontiers.
  - Updated event handling in synchronization tests to wait for all ordered chain-switch notifications before evaluating results.
  - Added timeout and validation safeguards to detect incomplete or unexpected event delivery.
  - Reduced the risk of flaky test outcomes when chain-selection updates are delivered asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->