### PR TITLE
test(chainselection,ledger): fix frontier-flap event race

### DIFF
--- a/chainselection/frontier_flap_test.go
+++ b/chainselection/frontier_flap_test.go
@@ -91,8 +91,8 @@ var chainSwitchDrainSentinelConnId = newTestConnectionId(50000)
 // subscriber channel immediately after the driving calls return can therefore
 // observe zero events even though the selector already decided to publish
 // one: nothing has forced the delivery goroutine to run yet. That assumption
-// -- reading the channel is exactly what made this scenario's regression test
-// flake under full-package parallelism, where CPU contention widens the gap
+// is exactly what made this scenario's regression test flake under
+// full-package parallelism, where CPU contention widens the gap
 // between "enqueued" and "delivered" (blinklabs-io/dingo#4145).
 //
 // The fix is a handshake, not a wait: publish a sentinel ChainSwitchEvent

--- a/chainselection/frontier_flap_test.go
+++ b/chainselection/frontier_flap_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 )
 
 // These tests pin the transport-frontier flapping reproduction from Preview
@@ -74,25 +75,65 @@ func itoa(v uint64) string {
 	return string(buf[i:])
 }
 
-// drainChainSwitchEvents collects every ChainSwitchEvent already delivered to
-// the subscriber channel. The selector publishes synchronously from
-// EvaluateAndSwitch, so anything it decided has already been buffered by the
-// time the driving update call returns.
-func drainChainSwitchEvents(
+// chainSwitchDrainSentinelConnId names a connection no scenario in this file
+// uses. drainChainSwitchEventsSynced publishes a ChainSwitchEvent carrying it
+// through the same ordered lane the selector publishes on, to detect (by
+// receiving it) that every event enqueued earlier has already been delivered.
+var chainSwitchDrainSentinelConnId = newTestConnectionId(50000)
+
+// drainChainSwitchEventsSynced collects every ChainSwitchEvent the scenario
+// published so far, blocking until it is certain none remain in flight.
+//
+// The selector publishes ChainSwitchEvent through EventBus.PublishOrdered,
+// which only enqueues onto the event type's lane before returning -- a
+// dedicated goroutine (event.orderedWorker) delivers to subscribers later, on
+// its own schedule (see event/ordered.go). A non-blocking read of the
+// subscriber channel immediately after the driving calls return can therefore
+// observe zero events even though the selector already decided to publish
+// one: nothing has forced the delivery goroutine to run yet. That assumption
+// -- reading the channel is exactly what made this scenario's regression test
+// flake under full-package parallelism, where CPU contention widens the gap
+// between "enqueued" and "delivered" (blinklabs-io/dingo#4145).
+//
+// The fix is a handshake, not a wait: publish a sentinel ChainSwitchEvent
+// through the same ordered lane after the driving calls return. The lane has
+// exactly one worker draining it in FIFO order (event.orderedWorker), so the
+// sentinel cannot be delivered ahead of any real event already enqueued
+// before it. Receiving the sentinel is therefore proof, not a guess, that
+// every earlier event has already reached the subscriber channel.
+func drainChainSwitchEventsSynced(
 	t *testing.T,
+	eventBus *event.EventBus,
 	ch <-chan event.Event,
 ) []ChainSwitchEvent {
 	t.Helper()
+	require.True(
+		t,
+		eventBus.PublishOrdered(
+			ChainSwitchEventType,
+			event.NewEvent(
+				ChainSwitchEventType,
+				ChainSwitchEvent{
+					NewConnectionId: chainSwitchDrainSentinelConnId,
+				},
+			),
+		),
+		"sentinel publish must be accepted",
+	)
 	var out []ChainSwitchEvent
 	for {
-		select {
-		case evt := <-ch:
-			switchEvent, ok := evt.Data.(ChainSwitchEvent)
-			require.True(t, ok, "unexpected event payload on switch channel")
-			out = append(out, switchEvent)
-		default:
+		evt := testutil.RequireReceive(
+			t,
+			ch,
+			event.RemoteDeliverTimeout,
+			"chain switch event drain",
+		)
+		switchEvent, ok := evt.Data.(ChainSwitchEvent)
+		require.True(t, ok, "unexpected event payload on switch channel")
+		if switchEvent.NewConnectionId == chainSwitchDrainSentinelConnId {
 			return out
 		}
+		out = append(out, switchEvent)
 	}
 }
 
@@ -249,7 +290,7 @@ func TestCanonicalPeersWithCrossingFrontiersDoNotFlap(t *testing.T) {
 		)
 	}
 
-	switchEvents := drainChainSwitchEvents(t, switchCh)
+	switchEvents := drainChainSwitchEventsSynced(t, eventBus, switchCh)
 	require.Len(
 		t,
 		switchEvents,

--- a/ledger/chainsync_frontier_flap_test.go
+++ b/ledger/chainsync_frontier_flap_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/chainselection"
 	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -138,28 +139,56 @@ func TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip(
 		deliver(step.conn, step.block)
 	}
 
-	// The selector publishes synchronously from the update call, so everything
-	// it decided is already buffered on the subscriber channel.
+	// The selector publishes ChainSwitchEvent through EventBus.PublishOrdered,
+	// which only enqueues onto the event type's lane before returning; a
+	// dedicated goroutine delivers to subscribers later, on its own schedule
+	// (see event/ordered.go). A non-blocking read of switchCh right after the
+	// deliver() calls return can therefore observe zero events even though the
+	// selector already decided to publish one, because nothing has forced the
+	// delivery goroutine to run yet -- that assumption is exactly what made
+	// this test flake under full-package parallelism, where CPU contention
+	// widens the gap between "enqueued" and "delivered"
+	// (blinklabs-io/dingo#4145).
+	//
+	// The fix is a handshake, not a wait: publish a sentinel ChainSwitchEvent
+	// through the same ordered lane after the deliver() calls return. The lane
+	// has exactly one worker draining it in FIFO order, so the sentinel cannot
+	// be delivered ahead of any real event already enqueued before it;
+	// receiving the sentinel is proof, not a guess, that every earlier event
+	// has already reached switchCh.
+	sentinelConnId := testChainsyncConnId(6000, 9999)
+	require.True(t, selectorBus.PublishOrdered(
+		chainselection.ChainSwitchEventType,
+		event.NewEvent(
+			chainselection.ChainSwitchEventType,
+			chainselection.ChainSwitchEvent{NewConnectionId: sentinelConnId},
+		),
+	), "sentinel publish must be accepted")
+
 	var checked int
-	for drained := false; !drained; {
-		select {
-		case evt := <-switchCh:
-			switchEvent, ok := evt.Data.(chainselection.ChainSwitchEvent)
-			require.True(t, ok)
-			checked++
-			assert.False(
-				t,
-				ls.chainSwitchNeedsFreshCursorLocked(
-					switchEvent,
-					switchEvent.NewConnectionId,
-				),
-				"a delivered-frontier crossing between peers on the same advertised chain must not close the selected connection (switch to %s at delivered block %d)",
-				switchEvent.NewConnectionId.String(),
-				switchEvent.NewObservedTip.BlockNumber,
-			)
-		default:
-			drained = true
+	for {
+		evt := testutil.RequireReceive(
+			t,
+			switchCh,
+			event.RemoteDeliverTimeout,
+			"chain switch event drain",
+		)
+		switchEvent, ok := evt.Data.(chainselection.ChainSwitchEvent)
+		require.True(t, ok)
+		if switchEvent.NewConnectionId == sentinelConnId {
+			break
 		}
+		checked++
+		assert.False(
+			t,
+			ls.chainSwitchNeedsFreshCursorLocked(
+				switchEvent,
+				switchEvent.NewConnectionId,
+			),
+			"a delivered-frontier crossing between peers on the same advertised chain must not close the selected connection (switch to %s at delivered block %d)",
+			switchEvent.NewConnectionId.String(),
+			switchEvent.NewObservedTip.BlockNumber,
+		)
 	}
 	require.Positive(
 		t,


### PR DESCRIPTION
`go-test` on `main` has been red since #4048 added two frontier-flap
regression tests. Both fail with zero events observed:

| Test | Package | Failure |
| --- | --- | --- |
| `TestCanonicalPeersWithCrossingFrontiersDoNotFlap` | `chainselection` | `"[]" should have 1 item(s), but has 0` |
| `TestCanonicalFrontierCrossingDoesNotCloseAPeerAheadOfLocalTip` | `ledger` | `"0" is not positive` |

## Defect

Both tests drained their `EventBus` subscriber channel with a non-blocking
`select`/`default` immediately after the driving calls returned, documented as
"the selector publishes synchronously". It does not.
`ChainSelector.publishSelection` (`chainselection/selector.go:1527`) publishes
through `EventBus.PublishOrdered`, which only enqueues onto the event type's
lane before returning (`event/ordered.go:103`); `event.orderedWorker` delivers
to subscribers later on its own schedule. The non-blocking read raced that
goroutine and saw nothing whenever it lost. #4131's package-level parallelism
widened the gap between "enqueued" and "delivered" enough to make losing the
common case.

## Change

Test-only, confined to the two test files. After the driving calls, publish a
sentinel `ChainSwitchEvent` through the same ordered lane, then block-receive
until it arrives, bounded by `event.RemoteDeliverTimeout`. Everything received
before the sentinel is the scenario's real output.

Receiving the sentinel is proof rather than a wait because the lane is strictly
serial:

- `event/ordered.go:136` — a lane is created once per event type under
  `orderedMu` and starts exactly one `orderedWorker` goroutine.
- `event/ordered.go:158` — that worker dequeues serially and calls
  `EventBus.Publish` inline.
- `event/event.go:1179` — `Publish` hands the event to every subscriber before
  returning.

An event enqueued before the sentinel therefore reaches the subscriber channel
before it. No `t.Parallel()` is removed, and there is no sleep, retry, skip or
timeout increase.

## #4048's production logic is not at fault

Forcing `sameCanonicalChain` to return `false` reverts both of #4048's
behavior changes, since it is the sole gate on each (`isPeerSelectableLocked`
and `pinIncumbentDuringCatchUpLocked`). Against that reverted selector the
updated tests fail on their selection assertions — `active peer must not flap
on delivered-frontier lead` in `chainselection`, and `must not close the
selected connection` for five separate switch events in `ledger`. The
handshake synchronises the tests without making them vacuous.

The observed pre-fix failures are only ever the event-count assertions. The
per-step selection assertions read selector state synchronously in the test
goroutine and cannot be affected by delivery timing.

## Measured pass rates

Runs that passed, at `-cpu=1` to make the race deterministic:

| Scope | Pre-fix | Post-fix |
| --- | --- | --- |
| `chainselection`, target test, 20 runs | 0/20 | 20/20 |
| `ledger`, target test, 20 runs | 0/20 | 20/20 |
| `chainselection` full package, `-race`, two sweeps of 20 | 6/20, 5/20 | 20/20 |
| `ledger` full package, `-race`, 13 runs | 0/3 | 13/13 |

`ledger` keeps two unrelated real-time-window flakes, `TestScheduler_ChangeInterval`
and `TestSlotClockEpochBoundary`, tracked in #4146. They fire under a
`-cpu=1 -race` full-package run and are the reason the `ledger` column above is
scoped to the target test.

Closes #4145.

Red `go-test` from this failure alone: #3855, #3853, #3938, #3982, #3838, #3929.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the `chainselection` and `ledger` frontier-flap regression tests that has kept `go-test` red since #4048 (closes #4145). The tests drained the `EventBus` subscriber channel with non-blocking reads, but `ChainSelector` publishes through `PublishOrdered`, which only enqueues and delivers asynchronously, so the tests could observe zero events even though the selector had decided to publish one.

Replaces the non-blocking drain with a handshake: after the driving calls return, publish a sentinel `ChainSwitchEvent` through the same ordered lane and block until it arrives. Because the lane has a single FIFO worker, receiving the sentinel proves every earlier event has been delivered. The change is test-only; production logic and `t.Parallel()` remain untouched, and the target tests now pass 20/20 at `-cpu=1`.

<sup>Written for commit 10bdec6499cd79efe7aa95bed1184d33d0269d52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved chain-switch event test reliability by synchronizing event delivery before validation.
  - Replaced non-blocking event draining with timeout-based receives and ordered sentinel checks.
  - Reduced flaky failures during parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->