### PR TITLE
docs(event): state when a published event has been delivered

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1175,7 +1175,17 @@ func (e *EventBus) deliverWithTimeout(
 	}
 }
 
-// Publish allows a producer to send an event of a particular type to all subscribers
+// Publish allows a producer to send an event of a particular type to all
+// subscribers.
+//
+// Delivery is inline: Publish hands the event to every subscriber on the
+// caller's goroutine, returning once each has taken it or been unsubscribed
+// for failing to. A stopped or closed bus delivers nothing.
+//
+// PublishOrdered and PublishAsync are the opposite: they return once the event
+// is queued and deliver it from another goroutine afterwards. A caller that
+// reads a subscriber channel expecting the event to already be there can rely
+// on that only with the inline paths, Publish and PublishBlocking.
 func (e *EventBus) Publish(eventType EventType, evt Event) {
 	e.stopMu.RLock()
 	if e.stopped || e.closed {

--- a/event/ordered.go
+++ b/event/ordered.go
@@ -61,6 +61,27 @@ type orderedLane struct {
 // Each event type gets its own lane, so a slow subscriber delays only its own
 // event type instead of holding up every async event as it would on the shared
 // pool.
+//
+// It returns once the event is enqueued on the lane, not once it has been
+// delivered: the lane's worker calls Publish afterwards, on its own schedule.
+// A true return means the event was accepted for delivery, and says nothing
+// about whether the worker has delivered it yet. Publish, by contrast, hands
+// the event to every subscriber before it returns.
+//
+// A caller that must observe the result of a publish cannot do so by reading
+// the subscriber channel non-blockingly -- with a select/default, a len(ch)
+// check, or a drain loop that stops at the first empty read. Those report an
+// event that is enqueued but not yet delivered as no event at all, which in a
+// test turns an assertion into a race against the worker. Publish a barrier
+// event through the same lane and block until it comes back instead: the lane
+// is a FIFO drained by exactly one worker, so receiving the barrier proves
+// every event enqueued before it has already reached the subscriber. Every
+// subscriber on that lane receives the barrier too, so give it a Data type
+// they skip rather than act on.
+//
+// See switchBarrier in ouroboros/consensus_conformance_test.go for the
+// pattern, and blinklabs-io/dingo#4145 for the failures a non-blocking drain
+// produced.
 func (e *EventBus) PublishOrdered(eventType EventType, evt Event) bool {
 	return e.PublishOrderedContext(context.Background(), eventType, evt)
 }


### PR DESCRIPTION
`PublishOrdered` returns once the event is enqueued on its per-type lane; the
lane worker calls `Publish` afterwards, from its own goroutine. `Publish`
delivers inline, handing the event to every subscriber before it returns.
Neither method's doc comment said which side of that split it was on.

The distinction was recorded only in test helpers — `switchBarrier`
(`ouroboros/consensus_conformance_test.go`), `chainSwitchBarrier`
(`chainselection/frontier_flap_test.go`,
`ledger/chainsync_frontier_flap_test.go`) and `drainChainSwitchesUntilBest`
(`chainselection/selector_test.go`) — and in none of the API they describe.
The frontier-flap tests added in #4048 were written against the opposite
assumption, that the selector publishes synchronously, so a non-blocking drain
read an enqueued-but-undelivered event as no event; #4144 replaced both drains
with a barrier. Related to that work; closes nothing.

The comments now state:

- `PublishOrdered` returns once the event is on the lane. A true return means
  accepted for delivery, and says nothing about whether the worker has
  delivered it yet.
- `Publish` delivers on the caller's goroutine, returning once each subscriber
  has taken the event or been unsubscribed for failing to, and a stopped or
  closed bus delivers nothing. `PublishBlocking` is the other inline path.
- A non-blocking subscriber-channel read (`select`/`default`, `len(ch)`, a
  drain that stops at the first empty read) cannot observe an ordered publish.
  A barrier event through the same lane can, because the lane is a FIFO drained
  by exactly one worker. The barrier's `Data` type must be one every subscriber
  on that lane skips.

Doc comments only; no executable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ggZFQYmK8vLYepaQcssBP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the delivery semantics of `Publish` and `PublishOrdered` in their doc comments. `PublishOrdered` only enqueues the event; delivery happens later from a worker goroutine, while `Publish` delivers inline before returning. Also warns that non-blocking reads of subscriber channels can't observe an ordered publish and suggests the barrier pattern for tests that need to confirm delivery.

<sup>Written for commit b123065d99f243d1a43e4a74636e6016e4b59bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

