### PR TITLE
fix(config): preserve redaction value boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8765,7 +8765,13 @@ port, path, and non-credential parameters and loses only its userinfo
 password and the value of every credential-named parameter, because "which
 host and database was this node pointed at" is most of the reason the
 configuration is logged at all; the same handling covers both URL-form and
-keyword-form database DSNs. A provider-config field (`plugins.*.config`, a
+keyword-form database DSNs. Quotes delimit keyword-form DSN values but are
+literal data in URI query values, whose boundaries remain query separators.
+Inputs beginning with a keyword assignment are sanitized as keyword DSNs
+before scanning any remaining query, so a question mark inside a password
+cannot leave its prefix exposed. Remaining queries are still scanned because
+a relative URI can also begin with an assignment-shaped path.
+A provider-config field (`plugins.*.config`, a
 free-form `map[string]any` whose keys belong to the selected provider, not
 to `Config`) is walked recursively and classified per key name, so a
 secret nested at any depth under a provider section is still redacted;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8771,6 +8771,11 @@ Inputs beginning with a keyword assignment are sanitized as keyword DSNs
 before scanning any remaining query, so a question mark inside a password
 cannot leave its prefix exposed. Remaining queries are still scanned because
 a relative URI can also begin with an assignment-shaped path.
+When that assignment is credential-named, the input is indistinguishable from
+an unquoted keyword DSN: `password=secret?network=preview` can have the entire
+`secret?network=preview` as its password. The whole value is therefore redacted,
+including its query-looking suffix. A question mark does not end a DSN value;
+preserving an apparent benign URL parameter here could disclose a password.
 A provider-config field (`plugins.*.config`, a
 free-form `map[string]any` whose keys belong to the selected provider, not
 to `Config`) is walked recursively and classified per key name, so a

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -642,6 +642,15 @@ func redactCredentialParams(s string) string {
 	// If the assignment itself is credential-named, its entire DSN value
 	// stays secret; a '?' suffix cannot safely be assumed to be a URL query.
 	if startsParam(s, skipParamSpace(s, 0), keywordDSNSyntax) {
+		// A relative URL can begin with an assignment-shaped path. When its
+		// suffix has URI separators and no whitespace, keep that suffix as a
+		// query instead of treating it as part of the DSN value.
+		if query := strings.IndexByte(s, '?'); query > 0 &&
+			strings.Contains(s[query+1:], "&") &&
+			!strings.ContainsAny(s[query+1:], " \t\r\n") {
+			return redactParams(s[:query], keywordDSNSyntax) +
+				"?" + redactParams(s[query+1:], uriQuerySyntax)
+		}
 		s = redactParams(s, keywordDSNSyntax)
 	}
 	if start, end, ok := uriQuerySpan(s); ok {

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -615,6 +615,8 @@ func sortedStringKeys(v reflect.Value) []string {
 // operational value of knowing which host and database the node was
 // pointed at, which is most of the reason the configuration is logged at
 // all.
+// Ambiguous assignment-shaped inputs follow DSN value boundaries: a query-like
+// suffix inside a credential value is redacted too, since it may be secret.
 func redactURICredentials(s string) string {
 	if s == "" {
 		return s
@@ -637,6 +639,8 @@ func redactCredentialParams(s string) string {
 	// values first so a '?' inside a password cannot hide its prefix.
 	// Still scan any remaining query: a relative URI can also start with
 	// "name=value", so that shape alone must not disable query redaction.
+	// If the assignment itself is credential-named, its entire DSN value
+	// stays secret; a '?' suffix cannot safely be assumed to be a URL query.
 	if startsParam(s, skipParamSpace(s, 0), keywordDSNSyntax) {
 		s = redactParams(s, keywordDSNSyntax)
 	}

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -633,6 +633,13 @@ func redactURICredentials(s string) string {
 // has no query string: its pairs are whitespace separated, whitespace
 // around '=' is optional, and a value containing whitespace is quoted.
 func redactCredentialParams(s string) string {
+	// net/url also accepts keyword DSNs as relative URLs. Sanitize their
+	// values first so a '?' inside a password cannot hide its prefix.
+	// Still scan any remaining query: a relative URI can also start with
+	// "name=value", so that shape alone must not disable query redaction.
+	if startsParam(s, skipParamSpace(s, 0), keywordDSNSyntax) {
+		s = redactParams(s, keywordDSNSyntax)
+	}
 	if start, end, ok := uriQuerySpan(s); ok {
 		return s[:start] +
 			redactParams(s[start:end], uriQuerySyntax) +
@@ -652,6 +659,8 @@ type paramSyntax struct {
 	// without them "api%5Fkey" scans as the two fragments "api" and
 	// "5Fkey", and neither of those reads as a credential.
 	encoded bool
+	// quoted reports whether quotes delimit values rather than being data.
+	quoted bool
 }
 
 var (
@@ -661,7 +670,7 @@ var (
 	// keywordDSNSyntax is the keyword-form database DSN: whitespace
 	// separates the pairs and the keywords are literal, because no DSN
 	// parser percent-decodes them.
-	keywordDSNSyntax = paramSyntax{delims: " \t\r\n"}
+	keywordDSNSyntax = paramSyntax{delims: " \t\r\n", quoted: true}
 )
 
 // isNameByte reports whether b belongs to a parameter name written in this
@@ -674,8 +683,8 @@ func (syntax paramSyntax) isNameByte(b byte) bool {
 }
 
 // uriQuerySpan returns the bounds of s's URI query string, if it has one.
-// net/url does the parsing, so a keyword DSN -- which is not a URI -- does
-// not get its whitespace-separated keywords treated as query parameters.
+// net/url does the parsing after any leading keyword-DSN form has been
+// sanitized, since net/url also accepts that form as a relative URI.
 // The span is verified against RawQuery before it is used, so a URI whose
 // '?' net/url located differently is left to the keyword scanner instead
 // of being spliced at the wrong offset.
@@ -762,9 +771,10 @@ func paramValueStart(s string, nameEnd int, syntax paramSyntax) (int, bool) {
 // paramValueEnd returns the index one past the value beginning at i. A
 // quoted value ends at its closing quote, so a keyword DSN password
 // containing whitespace is redacted whole rather than up to its first
-// space; an unquoted value ends at the first byte in delims.
+// space; URI query quotes are literal data. Other values end at the first
+// byte in delims.
 func paramValueEnd(s string, i int, syntax paramSyntax) int {
-	if i < len(s) && (s[i] == '\'' || s[i] == '"') {
+	if syntax.quoted && i < len(s) && (s[i] == '\'' || s[i] == '"') {
 		quote := s[i]
 		for j := i + 1; j < len(s); {
 			switch s[j] {

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -642,15 +642,6 @@ func redactCredentialParams(s string) string {
 	// If the assignment itself is credential-named, its entire DSN value
 	// stays secret; a '?' suffix cannot safely be assumed to be a URL query.
 	if startsParam(s, skipParamSpace(s, 0), keywordDSNSyntax) {
-		// A relative URL can begin with an assignment-shaped path. When its
-		// suffix has URI separators and no whitespace, keep that suffix as a
-		// query instead of treating it as part of the DSN value.
-		if query := strings.IndexByte(s, '?'); query > 0 &&
-			strings.Contains(s[query+1:], "&") &&
-			!strings.ContainsAny(s[query+1:], " \t\r\n") {
-			return redactParams(s[:query], keywordDSNSyntax) +
-				"?" + redactParams(s[query+1:], uriQuerySyntax)
-		}
 		s = redactParams(s, keywordDSNSyntax)
 	}
 	if start, end, ok := uriQuerySpan(s); ok {

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -378,7 +378,8 @@ func TestRedactURICredentials(t *testing.T) {
 		{
 			name: "ambiguous unquoted dsn keeps query-shaped suffix secret",
 			in:   "password=secret?network=preview&apiKey=key",
-			want: "password=" + redactedPlaceholder,
+			want: "password=" + redactedPlaceholder +
+				"?network=preview&apiKey=" + redactedPlaceholder,
 		},
 		{
 			name: "unquoted dsn retains whitespace-delimited database",

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"bytes"
 	"log/slog"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/blinklabs-io/dingo/internal/apiconfig"
 	hostplugin "github.com/blinklabs-io/dingo/plugin"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
 )
 
 // configLeafFieldPaths returns the dotted Go field path of every exported
@@ -378,8 +381,7 @@ func TestRedactURICredentials(t *testing.T) {
 		{
 			name: "ambiguous unquoted dsn keeps query-shaped suffix secret",
 			in:   "password=secret?network=preview&apiKey=key",
-			want: "password=" + redactedPlaceholder +
-				"?network=preview&apiKey=" + redactedPlaceholder,
+			want: "password=" + redactedPlaceholder,
 		},
 		{
 			name: "unquoted dsn retains whitespace-delimited database",
@@ -543,6 +545,35 @@ func TestRedactURICredentials(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRedactKeywordDSNMatchesPgxValueBoundary(t *testing.T) {
+	const dsn = "host=localhost user=dingo dbname=dingo sslmode=disable " +
+		"connect_timeout=5 password=secret?network=preview&apiKey=key"
+
+	for _, name := range []string{
+		"PGSERVICE", "PGSERVICEFILE", "PGPASSFILE", "PGTARGETSESSIONATTRS",
+		"PGSSLMODE", "PGHOST", "PGPORT", "PGUSER", "PGDATABASE", "PGOPTIONS",
+		"PGCONNECT_TIMEOUT",
+	} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("PGSERVICEFILE", os.DevNull)
+	t.Setenv("PGPASSFILE", os.DevNull)
+	parsed, err := pgconn.ParseConfig(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "secret?network=preview&apiKey=key", parsed.Password)
+	require.Equal(
+		t,
+		"host=localhost user=dingo dbname=dingo sslmode=disable "+
+			"connect_timeout=5 password="+redactedPlaceholder,
+		redactURICredentials(dsn),
+	)
+	require.Equal(
+		t,
+		"path=value?network=preview&apiKey="+redactedPlaceholder,
+		redactURICredentials("path=value?network=preview&apiKey=key"),
+	)
 }
 
 // TestProviderConfigUnknownKeyIsRedacted pins the fail-safe default for a

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -376,6 +376,16 @@ func TestRedactURICredentials(t *testing.T) {
 			want: "path?apiKey=" + redactedPlaceholder + "&page=2",
 		},
 		{
+			name: "ambiguous unquoted dsn keeps query-shaped suffix secret",
+			in:   "password=secret?network=preview&apiKey=key",
+			want: "password=" + redactedPlaceholder,
+		},
+		{
+			name: "unquoted dsn retains whitespace-delimited database",
+			in:   "password=secret?network=preview dbname=dingo",
+			want: "password=" + redactedPlaceholder + " dbname=dingo",
+		},
+		{
 			name: "ambiguous relative query still redacts credentials",
 			in:   "path=value?apiKey=secret&page=2",
 			want: "path=value?apiKey=" + redactedPlaceholder + "&page=2",

--- a/internal/config/redact_test.go
+++ b/internal/config/redact_test.go
@@ -163,11 +163,12 @@ func sentinelSecretConfig() *Config {
 		},
 		Mithril: MithrilConfig{
 			AggregatorURL: "https://aggregator.example/aggregator" +
-				"?apiKey=SENTINEL-MITHRIL-KEY&network=preview",
+				"?apiKey='prefix'SENTINEL-MITHRIL-KEY&network=preview",
 		},
 		TokenRegistry: TokenRegistryConfig{
 			SourceURL: "https://reg:SENTINEL-TOKEN-REGISTRY-PASSWORD" +
-				"@registry.example/registry.tar.gz",
+				"@registry.example/registry.tar.gz" +
+				"?apiKey='prefix'SENTINEL-TOKEN-REGISTRY-PASSWORD",
 		},
 		OffchainMetadata: OffchainMetadataConfig{
 			IPFSGatewayURL: "https://ipfs:SENTINEL-IPFS-PASSWORD" +
@@ -194,8 +195,9 @@ func sentinelSecretConfig() *Config {
 						"database": "dingo",
 						"sslMode":  "require",
 						"password": "SENTINEL-PG-PASSWORD",
-						"dsn": "postgres://dingo:SENTINEL-DSN-PASSWORD" +
-							"@db.example:5432/dingo?sslmode=require",
+						"dsn": "host=db.example port=5432 dbname=dingo " +
+							"password='SENTINEL-DSN-PASSWORD?part' " +
+							"sslmode=require",
 						"futureKey": "SENTINEL-UNKNOWN-PROVIDER-KEY",
 					},
 				},
@@ -358,10 +360,50 @@ func TestRedactURICredentials(t *testing.T) {
 				redactedPlaceholder + " dbname=dingo",
 		},
 		{
+			name: "keyword dsn question mark in password",
+			in:   "host=db.example password='secret?part' dbname=dingo",
+			want: "host=db.example password=" + redactedPlaceholder +
+				" dbname=dingo",
+		},
+		{
+			name: "keyword dsn leading whitespace and query-shaped password",
+			in:   "  password = 'prefix?apiKey=secret' dbname=dingo",
+			want: "  password = " + redactedPlaceholder + " dbname=dingo",
+		},
+		{
+			name: "relative query retains credential boundary",
+			in:   "path?apiKey=secret&page=2",
+			want: "path?apiKey=" + redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "ambiguous relative query still redacts credentials",
+			in:   "path=value?apiKey=secret&page=2",
+			want: "path=value?apiKey=" + redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "mysql query and userinfo",
+			in:   "dingo:secret@tcp(db.example:3306)/db?apiKey=key&parseTime=true",
+			want: "dingo:" + redactedPlaceholder +
+				"@tcp(db.example:3306)/db?apiKey=" +
+				redactedPlaceholder + "&parseTime=true",
+		},
+		{
 			name: "credential query parameter",
 			in:   "https://aggregator.example/x?apiKey=abc123&network=preview",
 			want: "https://aggregator.example/x?apiKey=" +
 				redactedPlaceholder + "&network=preview",
+		},
+		{
+			name: "query quotes are literal",
+			in:   "https://api.example/v1?apiKey='prefix'credential&page=2",
+			want: "https://api.example/v1?apiKey=" +
+				redactedPlaceholder + "&page=2",
+		},
+		{
+			name: "query quotes do not hide following parameter",
+			in:   "https://api.example/v1?apiKey='credential&page=2",
+			want: "https://api.example/v1?apiKey=" +
+				redactedPlaceholder + "&page=2",
 		},
 		{
 			name: "quoted keyword dsn password containing whitespace",


### PR DESCRIPTION
Configuration logging treated quotes in URI query values as keyword-DSN
delimiters, leaving a credential suffix visible or consuming the next query
parameter. A question mark inside a keyword-DSN password could also select
query parsing and leave the password visible.

- Make quote handling explicit per parameter syntax: literal in URI queries,
  delimited in keyword DSNs.
- Sanitize assignment-shaped inputs as keyword DSNs before scanning remaining
  query parameters, retaining redaction for ambiguous relative URLs.
- Keep the whole credential value secret when its suffix could be either a
  relative-URL query or part of an unquoted DSN password. Preserving apparent
  benign parameters in that ambiguous suffix could expose password content.
- Cover quoted and unquoted values, benign parameter boundaries, and text/JSON
  configuration output; document the syntax precedence.

Related to #3667; this does not add a non-URL registry authentication mechanism.
