### PR TITLE
test(ledger): assert scheduler/slot-clock ticks, not real-time windows

### DIFF
--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -426,14 +426,12 @@ func TestSlotClockReceivesTicks(t *testing.T) {
 	clock.Start(ctx)
 	defer clock.Stop()
 
-	// Wait for a tick
-	select {
-	case tick := <-ch:
-		assert.GreaterOrEqual(t, tick.Slot, uint64(0))
-		assert.False(t, tick.SlotStart.IsZero())
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("timeout waiting for slot tick")
-	}
+	// Wait for a tick. The bound is a deadlock guard, not a latency
+	// budget: 200ms is four nominal slot periods, so a slot-clock
+	// goroutine delayed by CI scheduling load misses it with no retry.
+	tick := testutil.RequireReceive(t, ch, 10*time.Second, "slot tick")
+	assert.GreaterOrEqual(t, tick.Slot, uint64(0))
+	assert.False(t, tick.SlotStart.IsZero())
 }
 
 func TestSlotClockEpochBoundary(t *testing.T) {
@@ -451,14 +449,16 @@ func TestSlotClockEpochBoundary(t *testing.T) {
 	clock.Start(ctx)
 	defer clock.Stop()
 
-	// Collect ticks until we see an epoch boundary. Bound the wait by the
-	// test binary's own -timeout deadline (with headroom to still fail
-	// cleanly) rather than an arbitrary real-time window shorter than
-	// that deadline -- a delayed slot-clock goroutine under CI scheduling
-	// load can otherwise miss a fixed short window with no retry.
+	// Collect ticks until we see an epoch boundary. The bound is a
+	// deadlock guard, not a latency budget: the boundary is ~20ms away
+	// and recurs every 10 slots, so 10s admits 50 boundaries and a
+	// slot-clock goroutine delayed by CI scheduling load still passes,
+	// while a clock that stops ticking still fails promptly. Clamp to the
+	// test binary's own -timeout deadline when that is nearer, so the
+	// failure is this t.Fatal rather than a binary-wide timeout panic.
 	waitFor := 10 * time.Second
 	if deadline, ok := t.Deadline(); ok {
-		if remaining := time.Until(deadline) - time.Second; remaining > 0 {
+		if remaining := time.Until(deadline) - time.Second; remaining < waitFor {
 			waitFor = remaining
 		}
 	}

--- a/ledger/slot_clock_test.go
+++ b/ledger/slot_clock_test.go
@@ -451,9 +451,20 @@ func TestSlotClockEpochBoundary(t *testing.T) {
 	clock.Start(ctx)
 	defer clock.Stop()
 
-	// Collect ticks until we see an epoch boundary
+	// Collect ticks until we see an epoch boundary. Bound the wait by the
+	// test binary's own -timeout deadline (with headroom to still fail
+	// cleanly) rather than an arbitrary real-time window shorter than
+	// that deadline -- a delayed slot-clock goroutine under CI scheduling
+	// load can otherwise miss a fixed short window with no retry.
+	waitFor := 10 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline) - time.Second; remaining > 0 {
+			waitFor = remaining
+		}
+	}
+	timeout := time.After(waitFor)
+
 	var sawEpochStart bool
-	timeout := time.After(500 * time.Millisecond)
 	for !sawEpochStart {
 		select {
 		case tick := <-ch:

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -69,8 +69,6 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 	}, 2*time.Second, 5*time.Millisecond,
 		"expected at least 2 executions before interval change",
 	)
-	beforeChange := counter.Load()
-
 	// updateIntervalChan is unbuffered and ChangeInterval's send is
 	// non-blocking (select/default; see
 	// TestScheduler_StopDoesNotRaceChangeInterval) -- run() can be mid-tick
@@ -115,7 +113,13 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 		"timer did not respect interval change: ran too frequently",
 	)
 
-	require.Greater(t, counter.Load(), beforeChange,
+	// Anchor the lower bound at the post-change reading. Comparing
+	// against a pre-change reading is satisfied by ticks the old interval
+	// delivered while the change was being confirmed, so it passes even
+	// when ticking stopped outright at the change.
+	require.Eventually(t, func() bool {
+		return counter.Load() > afterChangeReq
+	}, 10*time.Second, 10*time.Millisecond,
 		"expected ticking to continue after interval change",
 	)
 }

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -113,12 +113,24 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 		"timer did not respect interval change: ran too frequently",
 	)
 
-	// Anchor the lower bound at the post-change reading. Comparing
-	// against a pre-change reading is satisfied by ticks the old interval
-	// delivered while the change was being confirmed, so it passes even
-	// when ticking stopped outright at the change.
+	// A lower bound on counter is not attributable to the new interval at
+	// any anchor. tick() enqueues onto taskQueue and the worker pool
+	// drains it asynchronously, so a closure enqueued by the last
+	// pre-change tick can increment counter after the reading above was
+	// taken -- satisfying "counter grew" on a scheduler that stopped
+	// ticking outright at the change.
+	//
+	// Register a second task instead. Register appends under the same
+	// mutex tick() holds, and run() stopped and discarded the old ticker
+	// before publishing st.interval, so no tick predating the confirmed
+	// change can reach this task: every execution of it is driven by a
+	// tick the new ticker delivered.
+	var postChange atomic.Int32
+	timer.Register(1, func() {
+		postChange.Add(1)
+	}, nil)
 	require.Eventually(t, func() bool {
-		return counter.Load() > afterChangeReq
+		return postChange.Load() > 0
 	}, 10*time.Second, 10*time.Millisecond,
 		"expected ticking to continue after interval change",
 	)

--- a/ledger/timer_test.go
+++ b/ledger/timer_test.go
@@ -51,12 +51,14 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 
 	var counter atomic.Int32
 
-	// Create a Scheduler with 50ms tick interval
-	timer := NewScheduler(50 * time.Millisecond)
+	// Create a Scheduler with a fast tick interval so the pre-change
+	// baseline is established quickly.
+	const fastInterval = 20 * time.Millisecond
+	timer := NewScheduler(fastInterval)
 	timer.Start()
 	defer timer.Stop()
 
-	// Registering task with 50ms tick interval to execute for every 1 tick
+	// Registering task to execute for every 1 tick
 	timer.Register(1, func() {
 		counter.Add(1)
 	}, nil)
@@ -64,34 +66,58 @@ func TestScheduler_ChangeInterval(t *testing.T) {
 	// Wait for at least 2 executions before changing interval
 	require.Eventually(t, func() bool {
 		return counter.Load() >= 2
-	}, 2*time.Second, 10*time.Millisecond,
+	}, 2*time.Second, 5*time.Millisecond,
 		"expected at least 2 executions before interval change",
 	)
 	beforeChange := counter.Load()
 
-	// Change interval to 200ms
-	err := timer.ChangeInterval(200 * time.Millisecond)
-	require.NoError(t, err)
-
-	// Wait for at least 1 execution after interval change
+	// updateIntervalChan is unbuffered and ChangeInterval's send is
+	// non-blocking (select/default; see
+	// TestScheduler_StopDoesNotRaceChangeInterval) -- run() can be mid-tick
+	// and miss the send entirely, so a single call is not guaranteed to
+	// take effect. Retry until the scheduler's own interval field
+	// confirms the change, reading it under the same mutex run() uses to
+	// update it, rather than assuming one call succeeded.
+	// require.Eventually runs its condition func on a separate goroutine
+	// per poll, where require's t.FailNow is unsafe to call -- so check
+	// the (always-nil, since slowInterval is a positive constant) error
+	// directly rather than through require.NoError.
+	const slowInterval = 300 * time.Millisecond
 	require.Eventually(t, func() bool {
-		return counter.Load()-beforeChange >= 1
-	}, 2*time.Second, 10*time.Millisecond,
-		"expected at least 1 execution after interval change",
+		if err := timer.ChangeInterval(slowInterval); err != nil {
+			t.Logf("ChangeInterval: %v", err)
+			return false
+		}
+		timer.mutex.Lock()
+		applied := timer.interval == slowInterval
+		timer.mutex.Unlock()
+		return applied
+	}, 5*time.Second, 5*time.Millisecond,
+		"expected interval change to be applied",
+	)
+	afterChangeReq := counter.Load()
+
+	// Assert the observable property -- the tick rate slowed down --
+	// instead of a hard real-time window. Even after the change is
+	// confirmed applied, one leftover tick from the pre-change ticker can
+	// still land, and CI scheduling delays can bunch ticks. Rather than
+	// counting ticks in a narrow fixed window, require that the count
+	// never reaches a threshold that is reachable only if the scheduler
+	// kept running at the old (fast) interval: over this window the new
+	// interval nominally delivers ~4 ticks (plus at most one leftover),
+	// while the old interval would reach the threshold in well under a
+	// fifth of the window.
+	const window = 1200 * time.Millisecond
+	const tooManyTicks = 10
+	require.Never(t, func() bool {
+		return counter.Load()-afterChangeReq >= tooManyTicks
+	}, window, 10*time.Millisecond,
+		"timer did not respect interval change: ran too frequently",
 	)
 
-	// Allow enough time for potential additional ticks
-	time.Sleep(500 * time.Millisecond)
-
-	secondCount := counter.Load()
-	afterChange := secondCount - beforeChange
-
-	if afterChange < 1 || afterChange > 3 {
-		t.Errorf(
-			"timer did not respect interval change, ran too frequently: %d more ticks",
-			afterChange,
-		)
-	}
+	require.Greater(t, counter.Load(), beforeChange,
+		"expected ticking to continue after interval change",
+	)
 }
 
 func TestSchedulerRunFailFunc(t *testing.T) {


### PR DESCRIPTION
Two `ledger` tests gated their assertions on wall-clock windows short relative to CI scheduling, so they failed intermittently under full-package load.

- **`TestScheduler_ChangeInterval`** counted ticks in a fixed 500ms sleep window and required the count to land in `[1, 3]` — 2.5 nominal ticks admitted against a bound of 3. It also assumed a single `ChangeInterval` call takes effect: `updateIntervalChan` is unbuffered and the send is non-blocking, so `run()` can be mid-tick and drop it silently. The test now retries until the scheduler's own `interval` field confirms the change, asserts the tick count never reaches a threshold reachable only at the old interval, and proves ticking continues by registering a second task after the change.
- **`TestSlotClockEpochBoundary`** required the boundary tick inside a fixed 500ms deadline with no retry. The wait is now a deadlock guard rather than a latency budget: 10s admits 50 epoch boundaries at this test's 20ms slot length and 10-slot epoch, clamped to the test binary's own `-timeout` deadline when that is nearer, so a clock that stops ticking fails as a `t.Fatal` rather than consuming the package's timeout budget (#3032).
- **`TestSlotClockReceivesTicks`** is the same fixed-window class in the same file — a 200ms deadline is four nominal slot periods — and now uses the file's existing bounded-receive helper at 10s.

The replacements are not weaker assertions: restoring each previous form and driving it under `GOMAXPROCS=1` contention reproduces the original failures with the messages the issue names.

The scheduler's closing guard cannot be anchored on the first task's counter at any reading. `tick()` enqueues onto `taskQueue` and the worker pool drains it asynchronously, so a closure enqueued by the last pre-change tick can increment that counter after the reading is taken, satisfying a bare lower bound on a scheduler that stopped ticking outright at the change. The guard registers a second task once the change is confirmed instead: `Register` appends under the same mutex `tick()` holds, and `run()` discards the old ticker before publishing `st.interval`, so every execution of that task is driven by a tick the new ticker delivered.

Test files only; no production change.

Closes #4146

Related to #2265, which tracks the same class across the mempool and ledger tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ggZFQYmK8vLYepaQcssBP
