### PR TITLE
test: avoid restoring shared chainsync state

### DIFF
--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net"
 	"strings"
 	"sync"
@@ -325,12 +324,6 @@ func snapshotChainsyncNtNTimeouts() map[string]struct {
 
 func TestNewOuroborosDoesNotMutateChainsyncNtNTimeouts(t *testing.T) {
 	t.Parallel()
-
-	originalStateMap := ochainsync.StateMapNtN.Copy()
-	t.Cleanup(func() {
-		clear(ochainsync.StateMapNtN)
-		maps.Copy(ochainsync.StateMapNtN, originalStateMap)
-	})
 
 	before := snapshotChainsyncNtNTimeouts()
 


### PR DESCRIPTION
Remove the parallel timeout test’s unnecessary restoration of the shared chainsync state map. Preserve both assertions that constructing clients leaves the shared timeouts unchanged.