### PR TITLE
fix(ouroboros): honor Acquire's requested point in LocalStateQuery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3191,9 +3191,15 @@ connection-closed fan-out deliberately excludes NtC from) clear it, so a
 disconnecting client can't leak a map entry) and threads it into every
 `LedgerState.Query` call as `at`. `QueryPoint.pinned()` treats only the
 all-zero value as unpinned -- a slot-0 point with a nonempty hash is a real
-chain point, not the origin sentinel, and still goes through validation.
-Both slot and hash are recorded, not slot alone, because a fork switch can
-leave a different block at the same slot than the one the caller acquired.
+chain point, not the origin sentinel, and still goes through validation
+*and* dispatch: every point-aware handler takes the whole `QueryPoint` and
+checks `at.pinned()`, not a bare `asOfSlot uint64` compared against zero --
+an earlier version derived `asOfSlot` from `at.Slot` before dispatching,
+which correctly validated a slot-0 pin but then had every handler treat
+that same zero as "live," silently discarding the pin one layer down from
+where it was checked. Both slot and hash are recorded, not slot alone,
+because a fork switch can leave a different block at the same slot than the
+one the caller acquired.
 `Query` opens one read transaction whenever `at` is pinned and reuses it for
 both `verifyPointOnChain` and whichever handler below honors `at`, so the
 validated point and the historical read it guards describe the same

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3177,6 +3177,41 @@ and go stake are all zero are omitted; without a pool filter, the result
 contains the union of pools present in those snapshots and the corresponding
 totals.
 
+**Acquiring a specific historical point (blinklabs-io/dingo#382).** A real
+NtC client can `Acquire` LocalStateQuery at a specific past point, not just
+the live tip -- `ouroboros/localstatequery.go`'s server-side `Acquire`
+callback previously ignored this entirely and always answered every query
+at the live tip regardless of what was requested. It now records the
+acquired point per connection (`ledger.QueryPoint{Slot, Hash}`, keyed by
+connection ID; cleared on `Release` or on re-`Acquire`ing the live/immutable
+tip instead of a specific point) and threads it into every
+`LedgerState.Query` call as `at`. Both slot and hash are recorded, not slot
+alone, because a fork switch can leave a different block at the same slot
+than the one the caller acquired; `Query` calls `verifyPointOnChain` first
+whenever `at` is pinned, rejecting with `ErrPointNotOnChain` if this node's
+current chain no longer has `at.Hash` at `at.Slot` (the block was rolled
+back after acquisition, or was never on this node's view of the chain in
+the first place) before dispatching to any handler -- one fork-safety check
+shared by every point-sensitive query type rather than one per handler.
+
+Only some query types honor a pinned point today: `GetStakeDistribution`/
+`GetPoolDistr2` (`PoolStakeDistribution`, resolving the pinned slot to the
+epoch that governed it and reading that epoch's already-persisted mark
+snapshot -- rejecting a point outside the pool-snapshot retention window or
+ahead of the live epoch with `ErrHistoricalStateUnavailable`),
+`GetCurrentProtocolParams` (safe only when the pinned point's epoch matches
+the live tip's, since protocol parameters have no persisted
+historical-by-epoch record -- a pin spanning an epoch boundary fails
+clearly rather than silently answering with the wrong epoch's value), and
+`GetEpochNo` (unconditionally safe: epoch records are never pruned and
+carry no other coupled state). `ledger/queries.go`'s `queryShelleyLeaf`
+carries a full audit of every remaining query type, classified as
+intentionally live-only, or a real gap left for a caller that needs it.
+`GetUTxOWhole` is not yet one of the honoring types -- pinning only matters
+for a query slow enough that the live tip could move underneath it before
+finishing, and a paginated form built to actually need that is tracked
+separately as blinklabs-io/dingo#4082.
+
 Credential filters are bounded by `ledger.MaxLocalStateQueryItems` (currently
 1000) for `GetDRepState`, `GetStakeDelegDeposits`,
 `GetFilteredDelegationsAndRewardAccounts`, and `GetFilteredVoteDelegatees`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3183,34 +3183,61 @@ the live tip -- `ouroboros/localstatequery.go`'s server-side `Acquire`
 callback previously ignored this entirely and always answered every query
 at the live tip regardless of what was requested. It now records the
 acquired point per connection (`ledger.QueryPoint{Slot, Hash}`, keyed by
-connection ID; cleared on `Release` or on re-`Acquire`ing the live/immutable
-tip instead of a specific point) and threads it into every
-`LedgerState.Query` call as `at`. Both slot and hash are recorded, not slot
-alone, because a fork switch can leave a different block at the same slot
-than the one the caller acquired; `Query` calls `verifyPointOnChain` first
-whenever `at` is pinned, rejecting with `ErrPointNotOnChain` if this node's
-current chain no longer has `at.Hash` at `at.Slot` (the block was rolled
-back after acquisition, or was never on this node's view of the chain in
-the first place) before dispatching to any handler -- one fork-safety check
-shared by every point-sensitive query type rather than one per handler.
+connection ID; cleared on `Release`, on re-`Acquire`ing the live/immutable
+tip instead of a specific point, and on the connection closing without a
+clean `Release` -- both the NtN path (`Ouroboros.HandleConnClosedEvent`) and
+the NtC-only path (`Node.handleConnManagerClosed`, which the EventBus's
+connection-closed fan-out deliberately excludes NtC from) clear it, so a
+disconnecting client can't leak a map entry) and threads it into every
+`LedgerState.Query` call as `at`. `QueryPoint.pinned()` treats only the
+all-zero value as unpinned -- a slot-0 point with a nonempty hash is a real
+chain point, not the origin sentinel, and still goes through validation.
+Both slot and hash are recorded, not slot alone, because a fork switch can
+leave a different block at the same slot than the one the caller acquired.
+`Query` opens one read transaction whenever `at` is pinned and reuses it for
+both `verifyPointOnChain` and whichever handler below honors `at`, so the
+validated point and the historical read it guards describe the same
+snapshot -- a rollback committing between the two cannot make the handler
+answer for a point that already left the canonical chain. `verifyPointOnChain`
+rejects with `ErrPointNotOnChain` when `at.Slot` is ahead of that
+transaction's own tip (a block can be retained in the blob store at a slot
+beyond what has actually been applied -- e.g. a header-ahead-of-ledger
+buffer entry -- and a purely slot-keyed lookup has no notion of "applied"
+at all) or when the chain's block at `at.Slot` doesn't have hash `at.Hash`
+(rolled back after acquisition, or never on this node's chain at all).
 
-Only some query types honor a pinned point today: `GetStakeDistribution`/
-`GetPoolDistr2` (`PoolStakeDistribution`, resolving the pinned slot to the
-epoch that governed it and reading that epoch's already-persisted mark
-snapshot -- rejecting a point outside the pool-snapshot retention window or
-ahead of the live epoch with `ErrHistoricalStateUnavailable`),
-`GetCurrentProtocolParams` (safe only when the pinned point's epoch matches
-the live tip's, since protocol parameters have no persisted
-historical-by-epoch record -- a pin spanning an epoch boundary fails
-clearly rather than silently answering with the wrong epoch's value), and
-`GetEpochNo` (unconditionally safe: epoch records are never pruned and
-carry no other coupled state). `ledger/queries.go`'s `queryShelleyLeaf`
-carries a full audit of every remaining query type, classified as
-intentionally live-only, or a real gap left for a caller that needs it.
-`GetUTxOWhole` is not yet one of the honoring types -- pinning only matters
-for a query slow enough that the live tip could move underneath it before
+Only some query types honor a pinned point today: `GetPoolDistr2`
+(`PoolStakeDistribution`, resolving the pinned slot to the epoch that
+governed it and reading that epoch's already-persisted mark snapshot --
+rejecting a point outside the pool-snapshot retention window, ahead of the
+live epoch, or ahead of the live tip's own slot with
+`ErrHistoricalStateUnavailable`; the retention check compares the *derived
+mark-snapshot epoch* (`praos.StakeSnapshotEpoch(targetEpoch)`, one epoch
+further back than `targetEpoch` itself) against the cleanup floor, not
+`targetEpoch` directly -- comparing `targetEpoch` itself is off by that same
+one-epoch shift), `GetCurrentProtocolParams` (safe only when the pinned
+point's epoch matches the live tip's, since protocol parameters have no
+persisted historical-by-epoch record -- both the live-epoch comparison and
+the returned parameters come from one `loadConsensusSnapshot()` call, not
+two separate reads, so an epoch-boundary commit landing between them can't
+make the comparison pass against one epoch while returning another's
+parameters), and `GetEpochNo` (unconditionally safe: epoch records are
+never pruned and carry no other coupled state). `GetStakeDistribution`
+shares `PoolStakeDistribution` with `GetPoolDistr2` but rejects any pinned
+point outright with `ErrHistoricalStateUnavailable`: unlike `GetPoolDistr2`
+(whose denominator, `TotalActiveStake`, is itself a historical per-epoch
+snapshot total), `GetStakeDistribution`'s denominator is
+`TotalCirculatingSupply`, computed from `GetNetworkState`'s reserves row --
+and `GetNetworkState` only ever returns the latest row, with no
+historical-by-slot lookup yet, so honoring a pin here would silently mix a
+correct historical numerator with the current live reserves. `GetUTxOWhole`
+is not yet one of the honoring types either -- pinning only matters for a
+query slow enough that the live tip could move underneath it before
 finishing, and a paginated form built to actually need that is tracked
-separately as blinklabs-io/dingo#4082.
+separately as blinklabs-io/dingo#4082. `ledger/queries.go`'s
+`queryShelleyLeaf` carries a full audit of every remaining query type,
+classified as intentionally live-only, or a real gap left for a caller that
+needs it.
 
 Credential filters are bounded by `ledger.MaxLocalStateQueryItems` (currently
 1000) for `GetDRepState`, `GetStakeDelegDeposits`,

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -57,11 +57,12 @@ type UtxorpcLedgerState interface {
 	) (lcommon.ProtocolParameters, error)
 	// PoolStakeDistribution reports the active stake distribution across
 	// block-producing pools. A nil filter asks for every pool; see the method
-	// on ledger.LedgerState for why an empty non-nil filter differs. txn is
-	// nil here -- this RPC handler always answers live, never pinned.
+	// on ledger.LedgerState for why an empty non-nil filter differs. at is
+	// the zero value and txn is nil here -- this RPC handler always answers
+	// live, never pinned.
 	PoolStakeDistribution(
 		poolFilter []lcommon.PoolKeyHash,
-		asOfSlot uint64,
+		at ledger.QueryPoint,
 		txn *database.Txn,
 	) (*ledger.PoolStakeDistribution, error)
 	SlotToTime(slot uint64) (time.Time, error)

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -59,6 +59,7 @@ type UtxorpcLedgerState interface {
 	// on ledger.LedgerState for why an empty non-nil filter differs.
 	PoolStakeDistribution(
 		poolFilter []lcommon.PoolKeyHash,
+		asOfSlot uint64,
 	) (*ledger.PoolStakeDistribution, error)
 	SlotToTime(slot uint64) (time.Time, error)
 	SystemStart() (time.Time, error)

--- a/api/utxorpc/node_interface.go
+++ b/api/utxorpc/node_interface.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/chain"
 	"github.com/blinklabs-io/dingo/config/cardano"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/event"
 	"github.com/blinklabs-io/dingo/ledger"
@@ -56,10 +57,12 @@ type UtxorpcLedgerState interface {
 	) (lcommon.ProtocolParameters, error)
 	// PoolStakeDistribution reports the active stake distribution across
 	// block-producing pools. A nil filter asks for every pool; see the method
-	// on ledger.LedgerState for why an empty non-nil filter differs.
+	// on ledger.LedgerState for why an empty non-nil filter differs. txn is
+	// nil here -- this RPC handler always answers live, never pinned.
 	PoolStakeDistribution(
 		poolFilter []lcommon.PoolKeyHash,
 		asOfSlot uint64,
+		txn *database.Txn,
 	) (*ledger.PoolStakeDistribution, error)
 	SlotToTime(slot uint64) (time.Time, error)
 	SystemStart() (time.Time, error)

--- a/api/utxorpc/readstate.go
+++ b/api/utxorpc/readstate.go
@@ -128,7 +128,7 @@ func (s *betaQueryServiceServer) readStakePoolDistribution(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	dist, err := s.utxorpc.config.LedgerState.PoolStakeDistribution(poolFilter)
+	dist, err := s.utxorpc.config.LedgerState.PoolStakeDistribution(poolFilter, 0)
 	if err != nil {
 		return nil, connect.NewError(
 			connect.CodeInternal,

--- a/api/utxorpc/readstate.go
+++ b/api/utxorpc/readstate.go
@@ -128,7 +128,11 @@ func (s *betaQueryServiceServer) readStakePoolDistribution(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	dist, err := s.utxorpc.config.LedgerState.PoolStakeDistribution(poolFilter, 0)
+	dist, err := s.utxorpc.config.LedgerState.PoolStakeDistribution(
+		poolFilter,
+		0,
+		nil,
+	)
 	if err != nil {
 		return nil, connect.NewError(
 			connect.CodeInternal,

--- a/api/utxorpc/readstate.go
+++ b/api/utxorpc/readstate.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	betacardano "github.com/utxorpc/go-codegen/utxorpc/v1beta/cardano"
@@ -130,7 +131,7 @@ func (s *betaQueryServiceServer) readStakePoolDistribution(
 
 	dist, err := s.utxorpc.config.LedgerState.PoolStakeDistribution(
 		poolFilter,
-		0,
+		ledger.QueryPoint{},
 		nil,
 	)
 	if err != nil {

--- a/api/utxorpc/readstate_test.go
+++ b/api/utxorpc/readstate_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -75,6 +76,7 @@ func (s *readStateLedgerStub) GetBlock(ocommon.Point) (models.Block, error) {
 func (s *readStateLedgerStub) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
 	_ uint64,
+	_ *database.Txn,
 ) (*ledger.PoolStakeDistribution, error) {
 	s.calls++
 	s.gotFilter = poolFilter

--- a/api/utxorpc/readstate_test.go
+++ b/api/utxorpc/readstate_test.go
@@ -74,6 +74,7 @@ func (s *readStateLedgerStub) GetBlock(ocommon.Point) (models.Block, error) {
 
 func (s *readStateLedgerStub) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
+	_ uint64,
 ) (*ledger.PoolStakeDistribution, error) {
 	s.calls++
 	s.gotFilter = poolFilter

--- a/api/utxorpc/readstate_test.go
+++ b/api/utxorpc/readstate_test.go
@@ -75,7 +75,7 @@ func (s *readStateLedgerStub) GetBlock(ocommon.Point) (models.Block, error) {
 
 func (s *readStateLedgerStub) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
-	_ uint64,
+	_ ledger.QueryPoint,
 	_ *database.Txn,
 ) (*ledger.PoolStakeDistribution, error) {
 	s.calls++

--- a/ledger/peer_snapshot_query_test.go
+++ b/ledger/peer_snapshot_query_test.go
@@ -89,7 +89,7 @@ func TestQueryLedgerPeerSnapshotDispatch(t *testing.T) {
 		},
 	}
 
-	result, err := ls.Query(query)
+	result, err := ls.Query(query, QueryPoint{})
 	require.NoError(t, err)
 
 	snapshot, ok := result.(olocalstatequery.LedgerPeerSnapshotResult)

--- a/ledger/pool_stake_distribution.go
+++ b/ledger/pool_stake_distribution.go
@@ -151,15 +151,15 @@ type PoolStakeDistribution struct {
 // key. Its stake stays in TotalActiveStake, so every reported pool's own
 // fraction is unaffected by the omission.
 //
-// asOfSlot pins the distribution to the historical point instead of
-// live-right-now (blinklabs-io/dingo#382): 0 means live (the existing
-// default). A non-zero asOfSlot resolves to the epoch that governed that
+// at pins the distribution to the historical point instead of
+// live-right-now (blinklabs-io/dingo#382): unpinned means live (the
+// existing default). A pinned at resolves to the epoch that governed that
 // slot and uses that epoch's mark snapshot instead of the live tip's --
 // this is a real historical reconstruction, not an approximation, because
 // the mark snapshot is already persisted per-epoch for leader election.
 // checkAsOfEpochRecency rejects a historical epoch already outside the
 // mark-snapshot retention window (ledger/snapshot's pool-snapshot pruning),
-// since those rows are physically gone. asOfSlot ahead of the transaction
+// since those rows are physically gone. at.Slot ahead of the transaction
 // tip is rejected directly (not just by epoch): GetEpochBySlot can resolve
 // a future slot within the live epoch to that same live epoch, which would
 // otherwise let a future-slot pin silently pass as "live epoch, therefore
@@ -172,7 +172,7 @@ type PoolStakeDistribution struct {
 // direct, unpinned RPC handler) with no such transaction of its own.
 func (ls *LedgerState) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
-	asOfSlot uint64,
+	at QueryPoint,
 	txn *database.Txn,
 ) (*PoolStakeDistribution, error) {
 	// The per-pool stakes, their total, and the epoch naming the snapshot they
@@ -192,20 +192,20 @@ func (ls *LedgerState) PoolStakeDistribution(
 	if err != nil {
 		return nil, err
 	}
-	if asOfSlot != 0 && asOfSlot > tip.Point.Slot {
+	if at.pinned() && at.Slot > tip.Point.Slot {
 		return nil, fmt.Errorf(
 			"%w: as-of slot %d is ahead of the current tip (slot %d)",
 			ErrHistoricalStateUnavailable,
-			asOfSlot,
+			at.Slot,
 			tip.Point.Slot,
 		)
 	}
-	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	epoch, err := ls.resolveAsOfEpoch(txn, at)
 	if err != nil {
 		return nil, err
 	}
-	if asOfSlot != 0 {
-		liveEpoch, err := ls.resolveAsOfEpoch(txn, 0)
+	if at.pinned() {
+		liveEpoch, err := ls.resolveAsOfEpoch(txn, QueryPoint{})
 		if err != nil {
 			return nil, err
 		}

--- a/ledger/pool_stake_distribution.go
+++ b/ledger/pool_stake_distribution.go
@@ -17,6 +17,7 @@ package ledger
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"slices"
 
@@ -27,6 +28,41 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 )
+
+// stakeSnapshotRetentionEpochs mirrors ledger/snapshot/rotation.go's pool
+// mark-snapshot pruning window (cleanupOldSnapshots' currentEpoch-3 default
+// window): rows older than that are physically deleted, so a historical
+// stake-distribution query pinned further back than this cannot be
+// reconstructed. Not shared as an exported constant from ledger/snapshot
+// because that package does not itself export it; kept in sync by comment
+// reference rather than by import to avoid coupling this query path to
+// snapshot rotation internals.
+const stakeSnapshotRetentionEpochs = 3
+
+// checkAsOfEpochRecency rejects a historical epoch already outside the pool
+// mark-snapshot retention window, or ahead of the live epoch
+// (blinklabs-io/dingo#382).
+func checkAsOfEpochRecency(targetEpoch, liveEpoch uint64) error {
+	if targetEpoch > liveEpoch {
+		return fmt.Errorf(
+			"%w: as-of epoch %d is ahead of the live epoch (%d)",
+			ErrHistoricalStateUnavailable,
+			targetEpoch,
+			liveEpoch,
+		)
+	}
+	if liveEpoch-targetEpoch > stakeSnapshotRetentionEpochs {
+		return fmt.Errorf(
+			"%w: as-of epoch %d is outside the %d-epoch pool-snapshot "+
+				"retention window behind the live epoch (%d)",
+			ErrHistoricalStateUnavailable,
+			targetEpoch,
+			stakeSnapshotRetentionEpochs,
+			liveEpoch,
+		)
+	}
+	return nil
+}
 
 // PoolStakeShare is one pool's entry in the active stake distribution.
 type PoolStakeShare struct {
@@ -94,8 +130,19 @@ type PoolStakeDistribution struct {
 // rather than reported with a zero VRF key hash, which would read as a real
 // key. Its stake stays in TotalActiveStake, so every reported pool's own
 // fraction is unaffected by the omission.
+//
+// asOfSlot pins the distribution to the historical point instead of
+// live-right-now (blinklabs-io/dingo#382): 0 means live (the existing
+// default). A non-zero asOfSlot resolves to the epoch that governed that
+// slot and uses that epoch's mark snapshot instead of the live tip's --
+// this is a real historical reconstruction, not an approximation, because
+// the mark snapshot is already persisted per-epoch for leader election.
+// checkAsOfEpochRecency rejects a historical epoch already outside the
+// mark-snapshot retention window (ledger/snapshot's pool-snapshot pruning),
+// since those rows are physically gone.
 func (ls *LedgerState) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
+	asOfSlot uint64,
 ) (*PoolStakeDistribution, error) {
 	// The per-pool stakes, their total, and the epoch naming the snapshot they
 	// come from all have to come from one view: read separately, an epoch
@@ -106,17 +153,24 @@ func (ls *LedgerState) PoolStakeDistribution(
 	defer txn.Release()
 	metaTxn := txn.Metadata()
 
-	// The epoch comes from the tip inside this transaction rather than from the
-	// in-memory consensus snapshot; see epochAtTip for why. A chain that has
-	// applied no blocks has no epoch record covering its tip, and epoch zero is
-	// the right answer there.
-	tip, current, err := ls.epochAtTip(txn)
+	// The tip comes from this transaction rather than the in-memory
+	// consensus snapshot; see epochAtTip for why.
+	tip, err := ls.db.GetTip(txn)
 	if err != nil {
 		return nil, err
 	}
-	var epoch uint64
-	if current != nil {
-		epoch = current.EpochId
+	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	if err != nil {
+		return nil, err
+	}
+	if asOfSlot != 0 {
+		liveEpoch, err := ls.resolveAsOfEpoch(txn, 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := checkAsOfEpochRecency(epoch, liveEpoch); err != nil {
+			return nil, err
+		}
 	}
 	snapshotEpoch := praos.StakeSnapshotEpoch(epoch)
 

--- a/ledger/pool_stake_distribution.go
+++ b/ledger/pool_stake_distribution.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/blinklabs-io/dingo/consensus/praos"
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/types"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -42,6 +43,16 @@ const stakeSnapshotRetentionEpochs = 3
 // checkAsOfEpochRecency rejects a historical epoch already outside the pool
 // mark-snapshot retention window, or ahead of the live epoch
 // (blinklabs-io/dingo#382).
+//
+// The window is checked on the derived mark-snapshot epoch
+// (praos.StakeSnapshotEpoch(targetEpoch), i.e. targetEpoch-1), not on
+// targetEpoch itself: cleanupOldSnapshots' default retention floor
+// (liveEpoch-stakeSnapshotRetentionEpochs) is a floor on snapshot epochs,
+// and the snapshot a query at targetEpoch needs is one epoch further back
+// than targetEpoch. Comparing targetEpoch directly against that floor is
+// off by the same one-epoch shift: at liveEpoch 6, targetEpoch 3 resolves
+// to snapshot epoch 2, which the floor (6-3=3) has already pruned, but
+// 6-3=3 is not > 3 so the un-shifted comparison wrongly accepted it.
 func checkAsOfEpochRecency(targetEpoch, liveEpoch uint64) error {
 	if targetEpoch > liveEpoch {
 		return fmt.Errorf(
@@ -51,13 +62,22 @@ func checkAsOfEpochRecency(targetEpoch, liveEpoch uint64) error {
 			liveEpoch,
 		)
 	}
-	if liveEpoch-targetEpoch > stakeSnapshotRetentionEpochs {
+	if liveEpoch < stakeSnapshotRetentionEpochs {
+		// cleanupOldSnapshots itself does nothing below this floor (its own
+		// currentEpoch < 3 guard) -- nothing has ever been pruned yet.
+		return nil
+	}
+	deleteBeforeEpoch := liveEpoch - stakeSnapshotRetentionEpochs
+	snapshotEpoch := praos.StakeSnapshotEpoch(targetEpoch)
+	if snapshotEpoch < deleteBeforeEpoch {
 		return fmt.Errorf(
-			"%w: as-of epoch %d is outside the %d-epoch pool-snapshot "+
-				"retention window behind the live epoch (%d)",
+			"%w: as-of epoch %d (mark snapshot epoch %d) is outside the "+
+				"retained pool-snapshot window (rows below epoch %d have "+
+				"been pruned) behind the live epoch (%d)",
 			ErrHistoricalStateUnavailable,
 			targetEpoch,
-			stakeSnapshotRetentionEpochs,
+			snapshotEpoch,
+			deleteBeforeEpoch,
 			liveEpoch,
 		)
 	}
@@ -139,18 +159,31 @@ type PoolStakeDistribution struct {
 // the mark snapshot is already persisted per-epoch for leader election.
 // checkAsOfEpochRecency rejects a historical epoch already outside the
 // mark-snapshot retention window (ledger/snapshot's pool-snapshot pruning),
-// since those rows are physically gone.
+// since those rows are physically gone. asOfSlot ahead of the transaction
+// tip is rejected directly (not just by epoch): GetEpochBySlot can resolve
+// a future slot within the live epoch to that same live epoch, which would
+// otherwise let a future-slot pin silently pass as "live epoch, therefore
+// fine" despite naming a point that has not happened yet.
+//
+// txn reuses an already-open transaction (Query's point-validation
+// transaction, when called through it) rather than opening a fresh one, so
+// a pinned call's point-validation and this read share one consistent
+// snapshot -- nil opens and releases one internally, for a caller (a
+// direct, unpinned RPC handler) with no such transaction of its own.
 func (ls *LedgerState) PoolStakeDistribution(
 	poolFilter []lcommon.PoolKeyHash,
 	asOfSlot uint64,
+	txn *database.Txn,
 ) (*PoolStakeDistribution, error) {
 	// The per-pool stakes, their total, and the epoch naming the snapshot they
 	// come from all have to come from one view: read separately, an epoch
 	// boundary landing in between would produce fractions that do not sum to
 	// one, or a distribution belonging to an epoch other than the one this
 	// query resolved.
-	txn := ls.db.Transaction(false)
-	defer txn.Release()
+	if txn == nil {
+		txn = ls.db.Transaction(false)
+		defer txn.Release()
+	}
 	metaTxn := txn.Metadata()
 
 	// The tip comes from this transaction rather than the in-memory
@@ -158,6 +191,14 @@ func (ls *LedgerState) PoolStakeDistribution(
 	tip, err := ls.db.GetTip(txn)
 	if err != nil {
 		return nil, err
+	}
+	if asOfSlot != 0 && asOfSlot > tip.Point.Slot {
+		return nil, fmt.Errorf(
+			"%w: as-of slot %d is ahead of the current tip (slot %d)",
+			ErrHistoricalStateUnavailable,
+			asOfSlot,
+			tip.Point.Slot,
+		)
 	}
 	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
 	if err != nil {

--- a/ledger/pool_stake_distribution_test.go
+++ b/ledger/pool_stake_distribution_test.go
@@ -98,7 +98,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0)
+	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	require.Len(t, dist.Pools, 3)
@@ -115,7 +115,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	// Repeating the read must produce the same order. A single call cannot
 	// distinguish a real sort from a map that happened to range in order.
-	again, err := ls.PoolStakeDistribution(nil, 0)
+	again, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.Equal(t, dist.Pools, again.Pools)
 }
@@ -142,7 +142,7 @@ func TestPoolStakeDistribution_ReportsStakeFractionAndVrf(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0)
+	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 2)
 
@@ -197,7 +197,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(first, nil))
 
-	dist, err := ls.PoolStakeDistribution(nil, 0)
+	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Equal(t, first.Point.Slot, dist.Tip.Point.Slot)
@@ -210,7 +210,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(second, nil))
 
-	again, err := ls.PoolStakeDistribution(nil, 0)
+	again, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, again)
 	assert.Equal(t, second.Point.Slot, again.Tip.Point.Slot)
@@ -243,7 +243,7 @@ func TestPoolStakeDistribution_FilterReportsOnlyRequestedPools(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA}, 0)
+	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA}, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1)
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -277,7 +277,7 @@ func TestPoolStakeDistribution_OmitsPoolWithoutRegistration(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0)
+	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1, "the unregistered pool is omitted")
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -294,7 +294,7 @@ func TestPoolStakeDistribution_EmptySnapshotDoesNotDivide(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0)
+	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Empty(t, dist.Pools)

--- a/ledger/pool_stake_distribution_test.go
+++ b/ledger/pool_stake_distribution_test.go
@@ -98,7 +98,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil)
+	dist, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	require.Len(t, dist.Pools, 3)
@@ -115,7 +115,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	// Repeating the read must produce the same order. A single call cannot
 	// distinguish a real sort from a map that happened to range in order.
-	again, err := ls.PoolStakeDistribution(nil)
+	again, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, dist.Pools, again.Pools)
 }
@@ -142,7 +142,7 @@ func TestPoolStakeDistribution_ReportsStakeFractionAndVrf(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil)
+	dist, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 2)
 
@@ -197,7 +197,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(first, nil))
 
-	dist, err := ls.PoolStakeDistribution(nil)
+	dist, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Equal(t, first.Point.Slot, dist.Tip.Point.Slot)
@@ -210,7 +210,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(second, nil))
 
-	again, err := ls.PoolStakeDistribution(nil)
+	again, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.NotNil(t, again)
 	assert.Equal(t, second.Point.Slot, again.Tip.Point.Slot)
@@ -243,7 +243,7 @@ func TestPoolStakeDistribution_FilterReportsOnlyRequestedPools(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA})
+	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA}, 0)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1)
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -277,7 +277,7 @@ func TestPoolStakeDistribution_OmitsPoolWithoutRegistration(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil)
+	dist, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1, "the unregistered pool is omitted")
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -294,7 +294,7 @@ func TestPoolStakeDistribution_EmptySnapshotDoesNotDivide(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil)
+	dist, err := ls.PoolStakeDistribution(nil, 0)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Empty(t, dist.Pools)

--- a/ledger/pool_stake_distribution_test.go
+++ b/ledger/pool_stake_distribution_test.go
@@ -98,7 +98,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
+	dist, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	require.Len(t, dist.Pools, 3)
@@ -115,7 +115,7 @@ func TestPoolStakeDistribution_OrdersPoolsByKeyHash(t *testing.T) {
 
 	// Repeating the read must produce the same order. A single call cannot
 	// distinguish a real sort from a map that happened to range in order.
-	again, err := ls.PoolStakeDistribution(nil, 0, nil)
+	again, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, dist.Pools, again.Pools)
 }
@@ -142,7 +142,7 @@ func TestPoolStakeDistribution_ReportsStakeFractionAndVrf(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
+	dist, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 2)
 
@@ -197,7 +197,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(first, nil))
 
-	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
+	dist, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Equal(t, first.Point.Slot, dist.Tip.Point.Slot)
@@ -210,7 +210,7 @@ func TestPoolStakeDistribution_CarriesTheTipItWasReadAt(t *testing.T) {
 	}
 	require.NoError(t, db.SetTip(second, nil))
 
-	again, err := ls.PoolStakeDistribution(nil, 0, nil)
+	again, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, again)
 	assert.Equal(t, second.Point.Slot, again.Tip.Point.Slot)
@@ -243,7 +243,7 @@ func TestPoolStakeDistribution_FilterReportsOnlyRequestedPools(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA}, 0, nil)
+	dist, err := ls.PoolStakeDistribution([]lcommon.PoolKeyHash{pkhA}, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1)
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -277,7 +277,7 @@ func TestPoolStakeDistribution_OmitsPoolWithoutRegistration(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
+	dist, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.Len(t, dist.Pools, 1, "the unregistered pool is omitted")
 	assert.Equal(t, pkhA, dist.Pools[0].PoolKeyHash)
@@ -294,7 +294,7 @@ func TestPoolStakeDistribution_EmptySnapshotDoesNotDivide(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	dist, err := ls.PoolStakeDistribution(nil, 0, nil)
+	dist, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dist)
 	assert.Empty(t, dist.Pools)

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -99,8 +99,11 @@ type QueryPoint struct {
 }
 
 // pinned reports whether p names a historical point rather than "live."
+// Only the origin sentinel (Slot 0, empty Hash) is unpinned -- a slot-0
+// point with a nonempty Hash is a real chain point, not the origin, and
+// must still be validated rather than silently treated as "live."
 func (p QueryPoint) pinned() bool {
-	return p.Slot != 0
+	return p.Slot != 0 || len(p.Hash) != 0
 }
 
 // ErrHistoricalStateUnavailable indicates a caller pinned a Query to a point
@@ -127,8 +130,33 @@ var ErrPointNotOnChain = errors.New("acquired point is not on the current chain"
 // block at at.Slot whose hash is at.Hash, so a pinned query can't silently
 // reconstruct against a fork the caller never acquired
 // (blinklabs-io/dingo#382). Only called when at.pinned().
-func (ls *LedgerState) verifyPointOnChain(at QueryPoint) error {
-	block, err := database.BlockBySlot(ls.db, at.Slot)
+//
+// txn bounds both the tip read and the block lookup to one transaction, so
+// the two describe the same moment: database.BlockBySlot on its own has no
+// notion of "applied tip" at all -- it scans the blob store's slot-keyed
+// block index directly, which can retain a block slotted ahead of what has
+// actually been applied to ledger state (e.g. a header-ahead-of-ledger
+// buffer entry). Without the tip bound, such a block could satisfy both the
+// slot and hash check here while the ledger state this query is about to
+// read from has not incorporated it at all. Rejecting at.Slot above the
+// transaction-consistent tip closes that gap.
+func (ls *LedgerState) verifyPointOnChain(
+	txn *database.Txn,
+	at QueryPoint,
+) error {
+	tip, err := ls.db.GetTip(txn)
+	if err != nil {
+		return err
+	}
+	if at.Slot > tip.Point.Slot {
+		return fmt.Errorf(
+			"%w: point at slot %d is ahead of the current tip (slot %d)",
+			ErrPointNotOnChain,
+			at.Slot,
+			tip.Point.Slot,
+		)
+	}
+	block, err := database.BlockBySlotTxn(txn, at.Slot)
 	if err != nil {
 		if errors.Is(err, models.ErrBlockNotFound) {
 			return fmt.Errorf(
@@ -190,12 +218,23 @@ func (ls *LedgerState) resolveAsOfEpoch(
 // point, unlike stake distribution or protocol parameters: epoch records
 // are never pruned and carry no other coupled state, so resolving which
 // epoch covered a historical slot has no retention window to violate.
-func (ls *LedgerState) queryShelleyEpochNo(asOfSlot uint64) (any, error) {
+//
+// txn is Query's point-validation transaction, non-nil whenever asOfSlot is
+// non-zero -- reusing it rather than opening a fresh one keeps this read
+// inside the same snapshot verifyPointOnChain already validated at.Slot
+// against, so a rollback landing between validation and this read cannot
+// make the two disagree about which chain they're describing.
+func (ls *LedgerState) queryShelleyEpochNo(
+	asOfSlot uint64,
+	txn *database.Txn,
+) (any, error) {
 	if asOfSlot == 0 {
 		return []any{ls.loadConsensusSnapshot().currentEpoch.EpochId}, nil
 	}
-	txn := ls.db.Transaction(false)
-	defer txn.Release()
+	if txn == nil {
+		txn = ls.db.Transaction(false)
+		defer txn.Release()
+	}
 	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
 	if err != nil {
 		return nil, err
@@ -222,14 +261,25 @@ func (ls *LedgerState) queryShelleyEpochNo(asOfSlot uint64) (any, error) {
 // full scope (every query pinnable at any historical point) remains out of
 // scope for what cross-node validation via node-parity actually needs.
 func (ls *LedgerState) Query(query any, at QueryPoint) (any, error) {
+	// txn is nil on the live (unpinned) path -- every handler below falls
+	// back to opening its own transaction in that case, unchanged from
+	// before this point-pinning existed. When pinned, this one transaction
+	// is reused for both verifyPointOnChain and whichever handler below
+	// honors at, so the validated point and the historical read it guards
+	// come from the same consistent snapshot: a rollback committing between
+	// the two cannot make the handler answer for a point that already left
+	// the canonical chain.
+	var txn *database.Txn
 	if at.pinned() {
-		if err := ls.verifyPointOnChain(at); err != nil {
+		txn = ls.db.Transaction(false)
+		defer txn.Release()
+		if err := ls.verifyPointOnChain(txn, at); err != nil {
 			return nil, err
 		}
 	}
 	switch q := query.(type) {
 	case *olocalstatequery.BlockQuery:
-		return ls.queryBlock(q, at)
+		return ls.queryBlock(q, at, txn)
 	case *olocalstatequery.SystemStartQuery:
 		return ls.querySystemStart()
 	case *olocalstatequery.ChainBlockNoQuery:
@@ -244,12 +294,13 @@ func (ls *LedgerState) Query(query any, at QueryPoint) (any, error) {
 func (ls *LedgerState) queryBlock(
 	query *olocalstatequery.BlockQuery,
 	at QueryPoint,
+	txn *database.Txn,
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.HardForkQuery:
 		return ls.queryHardFork(q)
 	case *olocalstatequery.ShelleyQuery:
-		return ls.queryShelley(q, at)
+		return ls.queryShelley(q, at, txn)
 	default:
 		return nil, fmt.Errorf("unsupported query type: %T", q)
 	}
@@ -279,6 +330,12 @@ func (ls *LedgerState) querySystemStart() (any, error) {
 	return ret, nil
 }
 
+// dispatch switch, which is what lets that switch return each case's
+// result directly; this handler happens to never fail, unlike its
+// siblings, but a special-cased signature here would break that
+// uniformity for no real benefit.
+//
+//nolint:unparam // (any, error) matches every other case in Query's
 func (ls *LedgerState) queryChainBlockNo() (any, error) {
 	tip := ls.loadTipSnapshot().currentTip
 	// WithOrigin BlockNo: [0] at genesis, [1, blockNo] once a block exists.
@@ -288,6 +345,7 @@ func (ls *LedgerState) queryChainBlockNo() (any, error) {
 	return []any{1, tip.BlockNumber}, nil
 }
 
+//nolint:unparam // see queryChainBlockNo's identical note just above.
 func (ls *LedgerState) queryChainPoint() (any, error) {
 	return cloneTip(ls.loadTipSnapshot().currentTip).Point, nil
 }
@@ -615,8 +673,9 @@ func picosecondsToDuration(p *big.Int) time.Duration {
 func (ls *LedgerState) queryShelley(
 	query *olocalstatequery.ShelleyQuery,
 	at QueryPoint,
+	txn *database.Txn,
 ) (any, error) {
-	return ls.queryShelleyLeaf(query.Query, at)
+	return ls.queryShelleyLeaf(query.Query, at, txn)
 }
 
 // queryShelleyLeaf dispatches a decoded Shelley block-query leaf and returns
@@ -680,14 +739,18 @@ func (ls *LedgerState) queryShelley(
 //
 // Not applicable: ShelleyCborQuery (a combinator, not a leaf query --
 // forwards at to whatever it wraps).
-func (ls *LedgerState) queryShelleyLeaf(query any, at QueryPoint) (any, error) {
+func (ls *LedgerState) queryShelleyLeaf(
+	query any,
+	at QueryPoint,
+	txn *database.Txn,
+) (any, error) {
 	switch q := query.(type) {
 	case *olocalstatequery.ShelleyCborQuery:
-		return ls.queryShelleyCbor(q, at)
+		return ls.queryShelleyCbor(q, at, txn)
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		return ls.queryShelleyEpochNo(at.Slot)
+		return ls.queryShelleyEpochNo(at.Slot, txn)
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
-		return ls.queryShelleyCurrentProtocolParams(at.Slot)
+		return ls.queryShelleyCurrentProtocolParams(at.Slot, txn)
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
 		return ls.queryShelleyGenesisConfig()
 	case *olocalstatequery.ShelleyUtxoByAddressQuery:
@@ -717,9 +780,9 @@ func (ls *LedgerState) queryShelleyLeaf(query any, at QueryPoint) (any, error) {
 	case *olocalstatequery.ShelleyDebugChainDepStateQuery:
 		return ls.queryShelleyDebugChainDepState()
 	case *olocalstatequery.ShelleyPoolDistr2Query:
-		return ls.queryShelleyPoolDistr2(q, at.Slot)
+		return ls.queryShelleyPoolDistr2(q, at.Slot, txn)
 	case *olocalstatequery.ShelleyStakeDistributionQuery:
-		return ls.queryShelleyStakeDistribution(at.Slot)
+		return ls.queryShelleyStakeDistribution(at.Slot, txn)
 	case *olocalstatequery.ShelleyUtxoWholeQuery:
 		// Always live: pinning a point only matters for a query slow enough
 		// that the live tip could move underneath it before it finishes
@@ -752,8 +815,9 @@ func (ls *LedgerState) queryShelleyLeaf(query any, at QueryPoint) (any, error) {
 func (ls *LedgerState) queryShelleyCbor(
 	q *olocalstatequery.ShelleyCborQuery,
 	at QueryPoint,
+	txn *database.Txn,
 ) (any, error) {
-	inner, err := ls.queryShelleyLeaf(q.Query, at)
+	inner, err := ls.queryShelleyLeaf(q.Query, at, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -179,20 +179,25 @@ func (ls *LedgerState) verifyPointOnChain(
 	return nil
 }
 
-// resolveAsOfEpoch resolves asOfSlot to the epoch that governed it -- 0
-// means live, resolving the live tip's own epoch instead (the same "0
-// accepts the live/published value" convention QueryPoint itself uses).
-// Shared by every query handler that reconstructs epoch-keyed historical
-// state (blinklabs-io/dingo#382) -- PoolStakeDistribution,
+// resolveAsOfEpoch resolves at to the epoch that governed it -- unpinned
+// (at.pinned() false) means live, resolving the live tip's own epoch
+// instead. Shared by every query handler that reconstructs epoch-keyed
+// historical state (blinklabs-io/dingo#382) -- PoolStakeDistribution,
 // queryShelleyCurrentProtocolParams, queryShelleyEpochNo -- so the
 // live-vs-pinned epoch lookup is written once rather than once per handler.
 // A slot with no covering epoch record (a chain that has applied no blocks
 // yet) resolves to epoch 0, matching epochAtTip's existing convention.
+//
+// Takes the whole QueryPoint, not a bare slot: a point pinned at slot 0
+// (a real, validated chain point -- see QueryPoint.pinned()'s own doc
+// comment on why slot 0 alone doesn't mean "live") must still resolve
+// against that slot rather than falling through to the live branch the
+// way comparing a bare uint64 against zero would.
 func (ls *LedgerState) resolveAsOfEpoch(
 	txn *database.Txn,
-	asOfSlot uint64,
+	at QueryPoint,
 ) (uint64, error) {
-	if asOfSlot == 0 {
+	if !at.pinned() {
 		_, current, err := ls.epochAtTip(txn)
 		if err != nil {
 			return 0, err
@@ -202,7 +207,7 @@ func (ls *LedgerState) resolveAsOfEpoch(
 		}
 		return current.EpochId, nil
 	}
-	epoch, err := ls.db.GetEpochBySlot(asOfSlot, txn)
+	epoch, err := ls.db.GetEpochBySlot(at.Slot, txn)
 	if err != nil {
 		return 0, err
 	}
@@ -212,30 +217,35 @@ func (ls *LedgerState) resolveAsOfEpoch(
 	return epoch.EpochId, nil
 }
 
-// queryShelleyEpochNo answers GetEpochNo: the epoch containing asOfSlot (0 =
-// live, using the fast in-memory consensus snapshot rather than paying for
-// a transaction on the common unpinned path). Safe to pin at any retained
-// point, unlike stake distribution or protocol parameters: epoch records
-// are never pruned and carry no other coupled state, so resolving which
-// epoch covered a historical slot has no retention window to violate.
+// queryShelleyEpochNo answers GetEpochNo: the epoch containing at (unpinned
+// = live, using the fast in-memory consensus snapshot rather than paying
+// for a transaction on the common unpinned path). Safe to pin at any
+// retained point, unlike stake distribution or protocol parameters: epoch
+// records are never pruned and carry no other coupled state, so resolving
+// which epoch covered a historical slot has no retention window to
+// violate.
 //
-// txn is Query's point-validation transaction, non-nil whenever asOfSlot is
-// non-zero -- reusing it rather than opening a fresh one keeps this read
-// inside the same snapshot verifyPointOnChain already validated at.Slot
+// Takes the whole QueryPoint, not a bare slot -- see resolveAsOfEpoch's
+// doc comment for why a bare uint64 would silently mistreat a real point
+// pinned at slot 0 as live.
+//
+// txn is Query's point-validation transaction, non-nil whenever at is
+// pinned -- reusing it rather than opening a fresh one keeps this read
+// inside the same snapshot verifyPointOnChain already validated at
 // against, so a rollback landing between validation and this read cannot
 // make the two disagree about which chain they're describing.
 func (ls *LedgerState) queryShelleyEpochNo(
-	asOfSlot uint64,
+	at QueryPoint,
 	txn *database.Txn,
 ) (any, error) {
-	if asOfSlot == 0 {
+	if !at.pinned() {
 		return []any{ls.loadConsensusSnapshot().currentEpoch.EpochId}, nil
 	}
 	if txn == nil {
 		txn = ls.db.Transaction(false)
 		defer txn.Release()
 	}
-	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	epoch, err := ls.resolveAsOfEpoch(txn, at)
 	if err != nil {
 		return nil, err
 	}
@@ -748,9 +758,9 @@ func (ls *LedgerState) queryShelleyLeaf(
 	case *olocalstatequery.ShelleyCborQuery:
 		return ls.queryShelleyCbor(q, at, txn)
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		return ls.queryShelleyEpochNo(at.Slot, txn)
+		return ls.queryShelleyEpochNo(at, txn)
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
-		return ls.queryShelleyCurrentProtocolParams(at.Slot, txn)
+		return ls.queryShelleyCurrentProtocolParams(at, txn)
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
 		return ls.queryShelleyGenesisConfig()
 	case *olocalstatequery.ShelleyUtxoByAddressQuery:
@@ -780,9 +790,9 @@ func (ls *LedgerState) queryShelleyLeaf(
 	case *olocalstatequery.ShelleyDebugChainDepStateQuery:
 		return ls.queryShelleyDebugChainDepState()
 	case *olocalstatequery.ShelleyPoolDistr2Query:
-		return ls.queryShelleyPoolDistr2(q, at.Slot, txn)
+		return ls.queryShelleyPoolDistr2(q, at, txn)
 	case *olocalstatequery.ShelleyStakeDistributionQuery:
-		return ls.queryShelleyStakeDistribution(at.Slot, txn)
+		return ls.queryShelleyStakeDistribution(at, txn)
 	case *olocalstatequery.ShelleyUtxoWholeQuery:
 		// Always live: pinning a point only matters for a query slow enough
 		// that the live tip could move underneath it before it finishes

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -81,10 +81,155 @@ func checkLocalStateQueryItemLimit(query string, items int) error {
 	}
 }
 
-func (ls *LedgerState) Query(query any) (any, error) {
+// QueryPoint pins a Query call to a specific historical block instead of
+// live-right-now (blinklabs-io/dingo#382). The zero value (Slot 0, no Hash)
+// means no pin -- the existing, default behavior of answering from whatever
+// is live right now -- matching the same "0 accepts the live/published
+// value" convention SlotToTimeWithHorizonFrom's horizonAnchorSlot already
+// uses elsewhere in this package.
+//
+// Hash is required whenever Slot is non-zero: identifying a historical
+// point by slot alone is ambiguous across a rollback (a fork switch can
+// leave a different block at the same slot than the one the caller
+// acquired), so Query verifies Hash against this node's current chain
+// before answering -- see verifyPointOnChain.
+type QueryPoint struct {
+	Slot uint64
+	Hash []byte
+}
+
+// pinned reports whether p names a historical point rather than "live."
+func (p QueryPoint) pinned() bool {
+	return p.Slot != 0
+}
+
+// ErrHistoricalStateUnavailable indicates a caller pinned a Query to a point
+// this node cannot answer historically -- either because retained history
+// (a stake snapshot, a spent-UTxO row) has already been pruned past it, or
+// because the requested field's historical reconstruction is not
+// implemented for a point that far from the live tip
+// (blinklabs-io/dingo#382). errors.Is distinguishes this from a generic
+// query failure or ErrPointNotOnChain.
+var ErrHistoricalStateUnavailable = errors.New(
+	"historical ledger state unavailable for the requested point",
+)
+
+// ErrPointNotOnChain indicates a pinned Query's QueryPoint does not match
+// what this node's current chain has at that slot: either the block was
+// rolled back after the caller acquired it, or the point never existed on
+// this node's view of the chain. Distinguished from
+// ErrHistoricalStateUnavailable because the fix is different -- a caller
+// seeing this should re-acquire a current point, not simply pick an older
+// one.
+var ErrPointNotOnChain = errors.New("acquired point is not on the current chain")
+
+// verifyPointOnChain confirms this node's current canonical chain has a
+// block at at.Slot whose hash is at.Hash, so a pinned query can't silently
+// reconstruct against a fork the caller never acquired
+// (blinklabs-io/dingo#382). Only called when at.pinned().
+func (ls *LedgerState) verifyPointOnChain(at QueryPoint) error {
+	block, err := database.BlockBySlot(ls.db, at.Slot)
+	if err != nil {
+		if errors.Is(err, models.ErrBlockNotFound) {
+			return fmt.Errorf(
+				"%w: no block at slot %d on the current chain",
+				ErrPointNotOnChain,
+				at.Slot,
+			)
+		}
+		return err
+	}
+	if !bytes.Equal(block.Hash, at.Hash) {
+		return fmt.Errorf(
+			"%w: block at slot %d has hash %x, acquired point named %x",
+			ErrPointNotOnChain,
+			at.Slot,
+			block.Hash,
+			at.Hash,
+		)
+	}
+	return nil
+}
+
+// resolveAsOfEpoch resolves asOfSlot to the epoch that governed it -- 0
+// means live, resolving the live tip's own epoch instead (the same "0
+// accepts the live/published value" convention QueryPoint itself uses).
+// Shared by every query handler that reconstructs epoch-keyed historical
+// state (blinklabs-io/dingo#382) -- PoolStakeDistribution,
+// queryShelleyCurrentProtocolParams, queryShelleyEpochNo -- so the
+// live-vs-pinned epoch lookup is written once rather than once per handler.
+// A slot with no covering epoch record (a chain that has applied no blocks
+// yet) resolves to epoch 0, matching epochAtTip's existing convention.
+func (ls *LedgerState) resolveAsOfEpoch(
+	txn *database.Txn,
+	asOfSlot uint64,
+) (uint64, error) {
+	if asOfSlot == 0 {
+		_, current, err := ls.epochAtTip(txn)
+		if err != nil {
+			return 0, err
+		}
+		if current == nil {
+			return 0, nil
+		}
+		return current.EpochId, nil
+	}
+	epoch, err := ls.db.GetEpochBySlot(asOfSlot, txn)
+	if err != nil {
+		return 0, err
+	}
+	if epoch == nil {
+		return 0, nil
+	}
+	return epoch.EpochId, nil
+}
+
+// queryShelleyEpochNo answers GetEpochNo: the epoch containing asOfSlot (0 =
+// live, using the fast in-memory consensus snapshot rather than paying for
+// a transaction on the common unpinned path). Safe to pin at any retained
+// point, unlike stake distribution or protocol parameters: epoch records
+// are never pruned and carry no other coupled state, so resolving which
+// epoch covered a historical slot has no retention window to violate.
+func (ls *LedgerState) queryShelleyEpochNo(asOfSlot uint64) (any, error) {
+	if asOfSlot == 0 {
+		return []any{ls.loadConsensusSnapshot().currentEpoch.EpochId}, nil
+	}
+	txn := ls.db.Transaction(false)
+	defer txn.Release()
+	epoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	if err != nil {
+		return nil, err
+	}
+	return []any{epoch}, nil
+}
+
+// Query answers a decoded LocalStateQuery message against Dingo's live
+// ledger state, or against the historical point at named by QueryPoint.
+//
+// When at is pinned, Query first verifies at against this node's current
+// chain (verifyPointOnChain) before dispatching, so every point-sensitive
+// query type below shares one fork-safety check rather than repeating it.
+// at is threaded through only as far as the query types that actually honor
+// it today: stake distribution (queryShelleyStakeDistribution/
+// queryShelleyPoolDistr2, via PoolStakeDistribution's epoch-snapshot
+// lookup), current protocol parameters (queryShelleyCurrentProtocolParams,
+// which only pinned answers when the pinned point's epoch matches the live
+// tip's -- protocol parameters have no persisted historical-by-epoch
+// record, so a pin spanning an epoch boundary returns
+// ErrHistoricalStateUnavailable rather than a silently wrong live value),
+// and epoch number (queryShelleyEpochNo, unconditionally safe). Every other
+// query type ignores at and continues answering from live state; #382's
+// full scope (every query pinnable at any historical point) remains out of
+// scope for what cross-node validation via node-parity actually needs.
+func (ls *LedgerState) Query(query any, at QueryPoint) (any, error) {
+	if at.pinned() {
+		if err := ls.verifyPointOnChain(at); err != nil {
+			return nil, err
+		}
+	}
 	switch q := query.(type) {
 	case *olocalstatequery.BlockQuery:
-		return ls.queryBlock(q)
+		return ls.queryBlock(q, at)
 	case *olocalstatequery.SystemStartQuery:
 		return ls.querySystemStart()
 	case *olocalstatequery.ChainBlockNoQuery:
@@ -98,12 +243,13 @@ func (ls *LedgerState) Query(query any) (any, error) {
 
 func (ls *LedgerState) queryBlock(
 	query *olocalstatequery.BlockQuery,
+	at QueryPoint,
 ) (any, error) {
 	switch q := query.Query.(type) {
 	case *olocalstatequery.HardForkQuery:
 		return ls.queryHardFork(q)
 	case *olocalstatequery.ShelleyQuery:
-		return ls.queryShelley(q)
+		return ls.queryShelley(q, at)
 	default:
 		return nil, fmt.Errorf("unsupported query type: %T", q)
 	}
@@ -468,22 +614,80 @@ func picosecondsToDuration(p *big.Int) time.Duration {
 
 func (ls *LedgerState) queryShelley(
 	query *olocalstatequery.ShelleyQuery,
+	at QueryPoint,
 ) (any, error) {
-	return ls.queryShelleyLeaf(query.Query)
+	return ls.queryShelleyLeaf(query.Query, at)
 }
 
 // queryShelleyLeaf dispatches a decoded Shelley block-query leaf and returns
 // its result in the single-element MsgResult wire form (`[]any{value}`). It
 // is shared by queryShelley and by the GetCBOR combinator handler, which
-// re-runs the wrapped inner query through it.
-func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
+// re-runs the wrapped inner query through it. at is Query's pinned point
+// (Slot 0 = live).
+//
+// #382 point-pinning coverage audit (every case below, classified):
+//
+// Honors at today: ShelleyStakeDistributionQuery and ShelleyPoolDistr2Query
+// (both via PoolStakeDistribution, resolving at to its epoch and reading
+// that epoch's persisted mark snapshot), ShelleyCurrentProtocolParamsQuery
+// (queryShelleyCurrentProtocolParams, safe only when at's epoch matches the
+// live tip's -- see its doc comment), and ShelleyEpochNoQuery
+// (queryShelleyEpochNo, unconditionally safe: epoch records are never
+// pruned and carry no other coupled state).
+//
+// Intentionally live-only, not a gap: ShelleyUtxoWholeQuery (see its case
+// below -- a paginated form honoring at is a natural extension, tracked
+// separately as blinklabs-io/dingo#4082), ShelleyGenesisConfigQuery
+// (genesis is an immutable chain-wide constant with no historical variant),
+// ShelleyGetLedgerPeerSnapshotQuery (peer/networking bootstrap data, not
+// ledger state at all).
+//
+// Not point-aware, real gap, out of scope for this pass: every remaining
+// case answers unconditionally from live state regardless of at, because
+// making it historically correct needs storage or reconstruction logic
+// that does not exist yet --
+//   - ShelleyUtxoByAddressQuery, ShelleyUtxoByTxinQuery: same underlying
+//     utxo table as the whole-set query, so a historical, added/deleted-
+//     slot-bounded predicate could extend here, filtered instead of
+//     cursor-paginated -- no current caller needs it (only the whole-set
+//     query is used for cross-node comparison), so not built.
+//   - ShelleyFilteredDelegationAndRewardAccountsQuery,
+//     ShelleyStakeDelegDepositsQuery, ShelleyDRepStateQuery,
+//     ShelleyFilteredVoteDelegateesQuery, ShelleyStakePoolsQuery,
+//     ShelleyGetProposalsQuery: each reads live per-credential/per-pool/
+//     per-proposal state with no historical-by-point record; would need new
+//     historical tracking analogous to GetUtxoRefsAsOfAfter's added/deleted
+//     slot columns, not attempted.
+//   - ShelleyAccountStateQuery: chain-wide treasury/reserves totals, same
+//     class of gap as protocol parameters (no historical-by-epoch record).
+//   - ShelleyStakeSnapshotsQuery: its per-epoch mark/set/go reads are
+//     structurally identical to PoolStakeDistribution's and could resolve
+//     at the same way, but its zero-pool-omission rule
+//     (omitZeroPools, protocol-version-gated) reads
+//     GetProtocolVersion(consensus.currentPParams) -- the *live* protocol
+//     version. Pinning the snapshot epoch without also resolving the
+//     protocol version that was active at that epoch would answer with
+//     the right stake but a version-dependent inclusion rule from the
+//     wrong point, so this has the same missing-historical-storage
+//     dependency as ShelleyCurrentProtocolParamsQuery and was left alone
+//     for the same reason.
+//   - ShelleyDebugChainDepStateQuery: consensus nonce/opcert state.
+//     computeCandidateNonceAsOf already takes an arbitrary end-slot
+//     internally (a possible future entry point), but OpCertCounters
+//     reads live per-pool operational-certificate counters with no
+//     historical tracking, so the reply as a whole cannot be pinned
+//     without that piece too.
+//
+// Not applicable: ShelleyCborQuery (a combinator, not a leaf query --
+// forwards at to whatever it wraps).
+func (ls *LedgerState) queryShelleyLeaf(query any, at QueryPoint) (any, error) {
 	switch q := query.(type) {
 	case *olocalstatequery.ShelleyCborQuery:
-		return ls.queryShelleyCbor(q)
+		return ls.queryShelleyCbor(q, at)
 	case *olocalstatequery.ShelleyEpochNoQuery:
-		return []any{ls.loadConsensusSnapshot().currentEpoch.EpochId}, nil
+		return ls.queryShelleyEpochNo(at.Slot)
 	case *olocalstatequery.ShelleyCurrentProtocolParamsQuery:
-		return []any{ls.GetCurrentPParamsForReporting()}, nil
+		return ls.queryShelleyCurrentProtocolParams(at.Slot)
 	case *olocalstatequery.ShelleyGenesisConfigQuery:
 		return ls.queryShelleyGenesisConfig()
 	case *olocalstatequery.ShelleyUtxoByAddressQuery:
@@ -513,10 +717,14 @@ func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
 	case *olocalstatequery.ShelleyDebugChainDepStateQuery:
 		return ls.queryShelleyDebugChainDepState()
 	case *olocalstatequery.ShelleyPoolDistr2Query:
-		return ls.queryShelleyPoolDistr2(q)
+		return ls.queryShelleyPoolDistr2(q, at.Slot)
 	case *olocalstatequery.ShelleyStakeDistributionQuery:
-		return ls.queryShelleyStakeDistribution()
+		return ls.queryShelleyStakeDistribution(at.Slot)
 	case *olocalstatequery.ShelleyUtxoWholeQuery:
+		// Always live: pinning a point only matters for a query slow enough
+		// that the live tip could move underneath it before it finishes
+		// (blinklabs-io/dingo#382) -- a paginated form honoring at is
+		// tracked separately as blinklabs-io/dingo#4082.
 		return ls.queryShelleyUtxoWhole()
 	// TODO (#394)
 	/*
@@ -543,8 +751,9 @@ func (ls *LedgerState) queryShelleyLeaf(query any) (any, error) {
 // GetCBOR-wrapped queries flows through here. See issue #2917.
 func (ls *LedgerState) queryShelleyCbor(
 	q *olocalstatequery.ShelleyCborQuery,
+	at QueryPoint,
 ) (any, error) {
-	inner, err := ls.queryShelleyLeaf(q.Query)
+	inner, err := ls.queryShelleyLeaf(q.Query, at)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_asofslot_test.go
+++ b/ledger/queries_asofslot_test.go
@@ -63,9 +63,15 @@ func TestPoolStakeDistribution_AsOfSlot_ReadsHistoricalEpochSnapshot(t *testing.
 		nil,
 	))
 
-	// Epoch 3's mark snapshot (praos.StakeSnapshotEpoch(3) == 2).
+	// Epoch 4's mark snapshot (praos.StakeSnapshotEpoch(4) == 3) -- exactly
+	// the retained-boundary case: at live epoch 6, cleanupOldSnapshots'
+	// default window deletes snapshot epochs below 6-3=3, so epoch 3 is the
+	// oldest surviving row. Epoch 3, one epoch older still (its own
+	// snapshot would be epoch 2), is already pruned -- see
+	// TestPoolStakeDistribution_AsOfSlot_TooOldRejected's sibling case
+	// below and checkAsOfEpochRecency's doc comment for the exact shift.
 	require.NoError(t, db.Metadata().SavePoolStakeSnapshot(&models.PoolStakeSnapshot{
-		Epoch: 2, SnapshotType: snapshotTypeMark,
+		Epoch: 3, SnapshotType: snapshotTypeMark,
 		PoolKeyHash: pkh.Bytes(), TotalStake: dbtypes.Uint64(1_000_000),
 		CapturedSlot: 1,
 	}, nil))
@@ -76,19 +82,21 @@ func TestPoolStakeDistribution_AsOfSlot_ReadsHistoricalEpochSnapshot(t *testing.
 		CapturedSlot: 1,
 	}, nil))
 
-	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 400: 4, 600: 6})
+	ls.currentEpoch = models.Epoch{EpochId: 6}
+	ls.publishSnapshotsLocked()
 	require.NoError(t, db.SetTip(ochainsync.Tip{
 		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	// asOfSlot 350 falls inside epoch 3's range: exactly 3 epochs behind the
-	// live epoch (6), the edge of the retention window (still allowed).
-	hist, err := ls.PoolStakeDistribution(nil, 350)
+	// asOfSlot 450 falls inside epoch 4's range: exactly the
+	// retained-boundary case (see the snapshot comment above).
+	hist, err := ls.PoolStakeDistribution(nil, 450, nil)
 	require.NoError(t, err)
 	require.Len(t, hist.Pools, 1)
 	assert.Equal(t, uint64(1_000_000), hist.Pools[0].Stake)
 
-	live, err := ls.PoolStakeDistribution(nil, 0)
+	live, err := ls.PoolStakeDistribution(nil, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, live.Pools, 1)
 	assert.Equal(t, uint64(9_000_000), live.Pools[0].Stake)
@@ -112,7 +120,7 @@ func TestPoolStakeDistribution_AsOfSlot_TooOldRejected(t *testing.T) {
 
 	// Epoch 3 is 7 epochs behind the live epoch (10) -- outside the 3-epoch
 	// retention window.
-	_, err := ls.PoolStakeDistribution(nil, 350)
+	_, err := ls.PoolStakeDistribution(nil, 350, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -133,7 +141,7 @@ func TestPoolStakeDistribution_AsOfSlot_AheadOfLiveRejected(t *testing.T) {
 	}, nil))
 
 	// asOfSlot 650 resolves to epoch 6, ahead of the live tip's epoch 3.
-	_, err := ls.PoolStakeDistribution(nil, 650)
+	_, err := ls.PoolStakeDistribution(nil, 650, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -150,6 +158,12 @@ func TestQueryShelleyCurrentProtocolParams_SameEpochAsLive_Succeeds(t *testing.T
 	ls := newPoolDistr2Ledger(t, db)
 	ls.currentEra = eras.ConwayEraDesc
 	ls.currentPParams = conwayPParamsWithCostModels(map[uint][]int64{0: {1, 1, 1}})
+	// The live epoch this handler compares against comes from the published
+	// consensus snapshot (loadConsensusSnapshot), not from a database read
+	// -- see queryShelleyCurrentProtocolParams' doc comment for why. So the
+	// in-memory epoch has to match the database epoch record seeded below,
+	// the same way production code keeps both in step on every transition.
+	ls.currentEpoch = models.Epoch{EpochId: 3}
 	ls.publishSnapshotsLocked()
 
 	seedEpochs(t, ls, map[uint64]uint64{300: 3})
@@ -157,7 +171,7 @@ func TestQueryShelleyCurrentProtocolParams_SameEpochAsLive_Succeeds(t *testing.T
 		Point: ocommon.NewPoint(350, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	result, err := ls.queryShelleyCurrentProtocolParams(320)
+	result, err := ls.queryShelleyCurrentProtocolParams(320, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
@@ -176,6 +190,12 @@ func TestQueryShelleyCurrentProtocolParams_DifferentEpochFromLive_Rejected(
 	ls := newPoolDistr2Ledger(t, db)
 	ls.currentEra = eras.ConwayEraDesc
 	ls.currentPParams = conwayPParamsWithCostModels(map[uint][]int64{0: {1, 1, 1}})
+	// See the same-epoch test's comment: the live epoch this handler
+	// compares against comes from the published consensus snapshot, so it
+	// has to match the database epoch record seeded below for this test to
+	// exercise a real epoch 3 vs. epoch 6 mismatch rather than an
+	// incidental one against an unset in-memory epoch.
+	ls.currentEpoch = models.Epoch{EpochId: 6}
 	ls.publishSnapshotsLocked()
 
 	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
@@ -183,7 +203,7 @@ func TestQueryShelleyCurrentProtocolParams_DifferentEpochFromLive_Rejected(
 		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	_, err := ls.queryShelleyCurrentProtocolParams(350)
+	_, err := ls.queryShelleyCurrentProtocolParams(350, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -207,14 +227,14 @@ func TestQueryShelleyEpochNo_AsOfSlot_ReadsHistoricalEpoch(t *testing.T) {
 		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	hist, err := ls.queryShelleyEpochNo(350)
+	hist, err := ls.queryShelleyEpochNo(350, nil)
 	require.NoError(t, err)
 	arr, ok := hist.([]any)
 	require.True(t, ok)
 	require.Len(t, arr, 1)
 	assert.Equal(t, uint64(3), arr[0])
 
-	live, err := ls.queryShelleyEpochNo(0)
+	live, err := ls.queryShelleyEpochNo(0, nil)
 	require.NoError(t, err)
 	arr, ok = live.([]any)
 	require.True(t, ok)

--- a/ledger/queries_asofslot_test.go
+++ b/ledger/queries_asofslot_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtypes "github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedEpochs writes an epoch record starting at each given slot, so
+// database.GetEpochBySlot can resolve which epoch covers an arbitrary slot
+// in between two consecutive entries.
+func seedEpochs(t *testing.T, ls *LedgerState, startSlotByEpoch map[uint64]uint64) {
+	t.Helper()
+	for startSlot, epoch := range startSlotByEpoch {
+		require.NoError(t, ls.db.SetEpoch(
+			startSlot, epoch, nil, nil, nil, nil, 0, 1, 100, nil,
+		))
+	}
+}
+
+// TestPoolStakeDistribution_AsOfSlot_ReadsHistoricalEpochSnapshot covers the
+// core #382 stake-distribution fix: a pinned point in an older epoch must
+// read that epoch's own mark snapshot, not the live tip's -- the two are
+// seeded with deliberately different stake for the same pool so a test that
+// silently fell back to live data would be caught.
+func TestPoolStakeDistribution_AsOfSlot_ReadsHistoricalEpochSnapshot(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	pkh := lcommon.PoolKeyHash(lcommon.NewBlake2b224(repeatedBytes(28, 0x11)))
+	require.NoError(t, db.Metadata().ImportPool(
+		&models.Pool{PoolKeyHash: pkh.Bytes(), VrfKeyHash: repeatedBytes(32, 0xAA)},
+		&models.PoolRegistration{
+			PoolKeyHash: pkh.Bytes(),
+			VrfKeyHash:  repeatedBytes(32, 0xAA),
+			AddedSlot:   1,
+			Pledge:      dbtypes.Uint64(1),
+			Cost:        dbtypes.Uint64(1),
+		},
+		nil,
+	))
+
+	// Epoch 3's mark snapshot (praos.StakeSnapshotEpoch(3) == 2).
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshot(&models.PoolStakeSnapshot{
+		Epoch: 2, SnapshotType: snapshotTypeMark,
+		PoolKeyHash: pkh.Bytes(), TotalStake: dbtypes.Uint64(1_000_000),
+		CapturedSlot: 1,
+	}, nil))
+	// Epoch 6's mark snapshot (praos.StakeSnapshotEpoch(6) == 5) -- live.
+	require.NoError(t, db.Metadata().SavePoolStakeSnapshot(&models.PoolStakeSnapshot{
+		Epoch: 5, SnapshotType: snapshotTypeMark,
+		PoolKeyHash: pkh.Bytes(), TotalStake: dbtypes.Uint64(9_000_000),
+		CapturedSlot: 1,
+	}, nil))
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	// asOfSlot 350 falls inside epoch 3's range: exactly 3 epochs behind the
+	// live epoch (6), the edge of the retention window (still allowed).
+	hist, err := ls.PoolStakeDistribution(nil, 350)
+	require.NoError(t, err)
+	require.Len(t, hist.Pools, 1)
+	assert.Equal(t, uint64(1_000_000), hist.Pools[0].Stake)
+
+	live, err := ls.PoolStakeDistribution(nil, 0)
+	require.NoError(t, err)
+	require.Len(t, live.Pools, 1)
+	assert.Equal(t, uint64(9_000_000), live.Pools[0].Stake)
+}
+
+// TestPoolStakeDistribution_AsOfSlot_TooOldRejected covers the retention
+// boundary: an asOfSlot resolving to an epoch further behind the live epoch
+// than the pool mark-snapshot retention window (ledger/snapshot's
+// cleanupOldSnapshots currentEpoch-3 default) must fail rather than
+// silently return an empty or wrong distribution for rows already pruned.
+func TestPoolStakeDistribution_AsOfSlot_TooOldRejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 1000: 10})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(1050, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	// Epoch 3 is 7 epochs behind the live epoch (10) -- outside the 3-epoch
+	// retention window.
+	_, err := ls.PoolStakeDistribution(nil, 350)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
+}
+
+// TestPoolStakeDistribution_AsOfSlot_AheadOfLiveRejected covers a caller
+// naming a point ahead of the live tip -- nonsensical (there is no future
+// state to reconstruct) and must fail clearly rather than answering with
+// whatever the live snapshot happens to be.
+func TestPoolStakeDistribution_AsOfSlot_AheadOfLiveRejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(350, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	// asOfSlot 650 resolves to epoch 6, ahead of the live tip's epoch 3.
+	_, err := ls.PoolStakeDistribution(nil, 650)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
+}
+
+// TestQueryShelleyCurrentProtocolParams_SameEpochAsLive_Succeeds covers the
+// safe case for #382's protocol-parameters gap: a pinned point in the same
+// epoch as the live tip is answerable, since protocol parameters only
+// change at epoch boundaries -- "as of asOfSlot" and "live right now" are
+// necessarily the same value within one epoch.
+func TestQueryShelleyCurrentProtocolParams_SameEpochAsLive_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+	ls.currentEra = eras.ConwayEraDesc
+	ls.currentPParams = conwayPParamsWithCostModels(map[uint][]int64{0: {1, 1, 1}})
+	ls.publishSnapshotsLocked()
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(350, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	result, err := ls.queryShelleyCurrentProtocolParams(320)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+// TestQueryShelleyCurrentProtocolParams_DifferentEpochFromLive_Rejected
+// covers the actual gap this session's review identified: protocol
+// parameters have no persisted historical-by-epoch record, so a pin naming
+// a slot in an epoch other than the live tip's must fail rather than
+// silently answer with the live (possibly different) value.
+func TestQueryShelleyCurrentProtocolParams_DifferentEpochFromLive_Rejected(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+	ls.currentEra = eras.ConwayEraDesc
+	ls.currentPParams = conwayPParamsWithCostModels(map[uint][]int64{0: {1, 1, 1}})
+	ls.publishSnapshotsLocked()
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	_, err := ls.queryShelleyCurrentProtocolParams(350)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
+}
+
+// TestQueryShelleyEpochNo_AsOfSlot_ReadsHistoricalEpoch covers GetEpochNo
+// pinned to a historical point: unlike stake distribution or protocol
+// parameters, epoch records carry no retention window or other coupled
+// state, so resolving a historical epoch has nothing to reject -- it just
+// answers whichever epoch actually covered the pinned slot, live tip
+// notwithstanding.
+func TestQueryShelleyEpochNo_AsOfSlot_ReadsHistoricalEpoch(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+	ls.currentEpoch = models.Epoch{EpochId: 6}
+	ls.publishSnapshotsLocked()
+
+	seedEpochs(t, ls, map[uint64]uint64{300: 3, 600: 6})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	hist, err := ls.queryShelleyEpochNo(350)
+	require.NoError(t, err)
+	arr, ok := hist.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(t, uint64(3), arr[0])
+
+	live, err := ls.queryShelleyEpochNo(0)
+	require.NoError(t, err)
+	arr, ok = live.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(t, uint64(6), arr[0])
+}

--- a/ledger/queries_asofslot_test.go
+++ b/ledger/queries_asofslot_test.go
@@ -91,12 +91,12 @@ func TestPoolStakeDistribution_AsOfSlot_ReadsHistoricalEpochSnapshot(t *testing.
 
 	// asOfSlot 450 falls inside epoch 4's range: exactly the
 	// retained-boundary case (see the snapshot comment above).
-	hist, err := ls.PoolStakeDistribution(nil, 450, nil)
+	hist, err := ls.PoolStakeDistribution(nil, QueryPoint{Slot: 450}, nil)
 	require.NoError(t, err)
 	require.Len(t, hist.Pools, 1)
 	assert.Equal(t, uint64(1_000_000), hist.Pools[0].Stake)
 
-	live, err := ls.PoolStakeDistribution(nil, 0, nil)
+	live, err := ls.PoolStakeDistribution(nil, QueryPoint{}, nil)
 	require.NoError(t, err)
 	require.Len(t, live.Pools, 1)
 	assert.Equal(t, uint64(9_000_000), live.Pools[0].Stake)
@@ -120,7 +120,7 @@ func TestPoolStakeDistribution_AsOfSlot_TooOldRejected(t *testing.T) {
 
 	// Epoch 3 is 7 epochs behind the live epoch (10) -- outside the 3-epoch
 	// retention window.
-	_, err := ls.PoolStakeDistribution(nil, 350, nil)
+	_, err := ls.PoolStakeDistribution(nil, QueryPoint{Slot: 350}, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -141,7 +141,7 @@ func TestPoolStakeDistribution_AsOfSlot_AheadOfLiveRejected(t *testing.T) {
 	}, nil))
 
 	// asOfSlot 650 resolves to epoch 6, ahead of the live tip's epoch 3.
-	_, err := ls.PoolStakeDistribution(nil, 650, nil)
+	_, err := ls.PoolStakeDistribution(nil, QueryPoint{Slot: 650}, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -171,7 +171,7 @@ func TestQueryShelleyCurrentProtocolParams_SameEpochAsLive_Succeeds(t *testing.T
 		Point: ocommon.NewPoint(350, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	result, err := ls.queryShelleyCurrentProtocolParams(320, nil)
+	result, err := ls.queryShelleyCurrentProtocolParams(QueryPoint{Slot: 320}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
@@ -203,7 +203,7 @@ func TestQueryShelleyCurrentProtocolParams_DifferentEpochFromLive_Rejected(
 		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	_, err := ls.queryShelleyCurrentProtocolParams(350, nil)
+	_, err := ls.queryShelleyCurrentProtocolParams(QueryPoint{Slot: 350}, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrHistoricalStateUnavailable)
 }
@@ -227,14 +227,14 @@ func TestQueryShelleyEpochNo_AsOfSlot_ReadsHistoricalEpoch(t *testing.T) {
 		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
 	}, nil))
 
-	hist, err := ls.queryShelleyEpochNo(350, nil)
+	hist, err := ls.queryShelleyEpochNo(QueryPoint{Slot: 350}, nil)
 	require.NoError(t, err)
 	arr, ok := hist.([]any)
 	require.True(t, ok)
 	require.Len(t, arr, 1)
 	assert.Equal(t, uint64(3), arr[0])
 
-	live, err := ls.queryShelleyEpochNo(0, nil)
+	live, err := ls.queryShelleyEpochNo(QueryPoint{}, nil)
 	require.NoError(t, err)
 	arr, ok = live.([]any)
 	require.True(t, ok)

--- a/ledger/queries_chaindepstate_test.go
+++ b/ledger/queries_chaindepstate_test.go
@@ -81,7 +81,7 @@ func TestQueryShelleyDebugChainDepState_Dispatches(t *testing.T) {
 	db := newTestDB(t)
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err,
 		"the query must be handled rather than aborting the protocol")
 	require.NotNil(t, result)
@@ -142,7 +142,7 @@ func TestQueryShelleyDebugChainDepState_DecodesAsPraosState(t *testing.T) {
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 
 	// Results travel wrapped in the single-element MsgResult array.
@@ -277,7 +277,7 @@ func TestQueryShelleyDebugChainDepState_TPraosEraUsesTPraosLayout(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)
@@ -352,7 +352,7 @@ func TestQueryShelleyDebugChainDepState_LayoutFollowsConsensusMode(
 
 			ls := newChainDepStateLedger(t, db)
 
-			result, err := ls.Query(chainDepStateQuery())
+			result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 			require.NoError(t, err)
 			arr, ok := result.([]any)
 			require.True(t, ok)
@@ -466,7 +466,7 @@ func TestQueryShelleyDebugChainDepState_NoncesTrackTipNotEpochCheckpoint(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)
@@ -596,7 +596,7 @@ func TestQueryShelleyDebugChainDepState_NoncesStopAtTipNotAtStoredBlocks(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)
@@ -697,7 +697,7 @@ func TestQueryShelleyDebugChainDepState_LabNonceTracksTipParent(t *testing.T) {
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, ok := result.([]any)
 	require.True(t, ok)
@@ -783,7 +783,7 @@ func TestQueryShelleyDebugChainDepState_LabNonceWithoutHashIndex(t *testing.T) {
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)
@@ -818,7 +818,7 @@ func TestQueryShelleyDebugChainDepState_LabNonceCarriesWithoutBlocks(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)
@@ -863,7 +863,7 @@ func TestQueryShelleyDebugChainDepState_LabNonceTipBlockUnavailable(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err,
 		"an unreadable tip block must not abort the protocol")
 	arr, _ := result.([]any)
@@ -937,7 +937,7 @@ func TestQueryShelleyDebugChainDepState_ReportsPreviousEpochNonce(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, ok := result.([]any)
 	require.True(t, ok)
@@ -1017,7 +1017,7 @@ func TestQueryShelleyDebugChainDepState_ReportsOpCertCounters(t *testing.T) {
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, ok := result.([]any)
 	require.True(t, ok)
@@ -1070,7 +1070,7 @@ func TestQueryShelleyDebugChainDepState_CountersOutliveRegistration(
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, ok := result.([]any)
 	require.True(t, ok)
@@ -1118,7 +1118,7 @@ func TestQueryShelleyDebugChainDepState_HighestCounterPerPool(t *testing.T) {
 
 	ls := newChainDepStateLedger(t, db)
 
-	result, err := ls.Query(chainDepStateQuery())
+	result, err := ls.Query(chainDepStateQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, _ := result.([]any)
 	require.Len(t, arr, 1)

--- a/ledger/queries_currentprotocolparams.go
+++ b/ledger/queries_currentprotocolparams.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import "fmt"
+
+// queryShelleyCurrentProtocolParams answers GetCurrentPParams.
+//
+// asOfSlot is Query's pinned point (0 = live). Unlike stake distribution,
+// there is no persisted historical record of protocol parameters by
+// epoch -- currentPParams is a single in-memory value, overwritten in place
+// on every governance/epoch transition. So a pinned point can only be
+// answered safely when it names a slot in the same epoch the live tip is
+// currently in: protocol parameters only change at epoch boundaries, so
+// within one epoch "as of asOfSlot" and "live right now" are the same
+// value. A pin spanning an epoch boundary since asOfSlot returns
+// ErrHistoricalStateUnavailable rather than silently answering with a live
+// value that may no longer match what was true at asOfSlot
+// (blinklabs-io/dingo#382). Building real historical-by-epoch pparams
+// storage (or replaying governance enactments) to lift this restriction is
+// a materially larger, not-yet-attempted piece of work.
+func (ls *LedgerState) queryShelleyCurrentProtocolParams(
+	asOfSlot uint64,
+) (any, error) {
+	if asOfSlot == 0 {
+		return []any{ls.GetCurrentPParamsForReporting()}, nil
+	}
+	txn := ls.db.Transaction(false)
+	defer txn.Release()
+	liveEpoch, err := ls.resolveAsOfEpoch(txn, 0)
+	if err != nil {
+		return nil, err
+	}
+	targetEpoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	if err != nil {
+		return nil, err
+	}
+	if targetEpoch != liveEpoch {
+		return nil, fmt.Errorf(
+			"%w: protocol parameters at slot %d (epoch %d) cannot be "+
+				"reconstructed while the live tip is in epoch %d -- "+
+				"historical protocol-parameter values across an epoch "+
+				"boundary are not yet supported",
+			ErrHistoricalStateUnavailable,
+			asOfSlot,
+			targetEpoch,
+			liveEpoch,
+		)
+	}
+	return []any{ls.GetCurrentPParamsForReporting()}, nil
+}

--- a/ledger/queries_currentprotocolparams.go
+++ b/ledger/queries_currentprotocolparams.go
@@ -22,19 +22,23 @@ import (
 
 // queryShelleyCurrentProtocolParams answers GetCurrentPParams.
 //
-// asOfSlot is Query's pinned point (0 = live). Unlike stake distribution,
+// at is Query's pinned point (unpinned = live). Unlike stake distribution,
 // there is no persisted historical record of protocol parameters by
 // epoch -- currentPParams is a single in-memory value, overwritten in place
 // on every governance/epoch transition. So a pinned point can only be
 // answered safely when it names a slot in the same epoch the live tip is
 // currently in: protocol parameters only change at epoch boundaries, so
-// within one epoch "as of asOfSlot" and "live right now" are the same
-// value. A pin spanning an epoch boundary since asOfSlot returns
-// ErrHistoricalStateUnavailable rather than silently answering with a live
-// value that may no longer match what was true at asOfSlot
-// (blinklabs-io/dingo#382). Building real historical-by-epoch pparams
-// storage (or replaying governance enactments) to lift this restriction is
-// a materially larger, not-yet-attempted piece of work.
+// within one epoch "as of at" and "live right now" are the same value. A
+// pin spanning an epoch boundary since at returns ErrHistoricalStateUnavailable
+// rather than silently answering with a live value that may no longer
+// match what was true at that point (blinklabs-io/dingo#382). Building
+// real historical-by-epoch pparams storage (or replaying governance
+// enactments) to lift this restriction is a materially larger,
+// not-yet-attempted piece of work.
+//
+// Takes the whole QueryPoint, not a bare slot -- see resolveAsOfEpoch's
+// doc comment for why a bare uint64 would silently mistreat a real point
+// pinned at slot 0 as live.
 //
 // The live epoch and the returned parameters both come from one
 // loadConsensusSnapshot() call, not two separate reads: an earlier version
@@ -45,11 +49,11 @@ import (
 // while returning the parameters of the epoch that had already replaced it.
 // Deriving both from the same snapshot value closes that window.
 func (ls *LedgerState) queryShelleyCurrentProtocolParams(
-	asOfSlot uint64,
+	at QueryPoint,
 	txn *database.Txn,
 ) (any, error) {
 	snapshot := ls.loadConsensusSnapshot()
-	if asOfSlot == 0 {
+	if !at.pinned() {
 		return []any{withoutSyntheticV2CostModel(
 			snapshot.currentPParams,
 			snapshot.syntheticV2CostModelInEffect,
@@ -60,7 +64,7 @@ func (ls *LedgerState) queryShelleyCurrentProtocolParams(
 		txn = ls.db.Transaction(false)
 		defer txn.Release()
 	}
-	targetEpoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
+	targetEpoch, err := ls.resolveAsOfEpoch(txn, at)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +76,7 @@ func (ls *LedgerState) queryShelleyCurrentProtocolParams(
 				"historical protocol-parameter values across an epoch "+
 				"boundary are not yet supported",
 			ErrHistoricalStateUnavailable,
-			asOfSlot,
+			at.Slot,
 			targetEpoch,
 			liveEpoch,
 		)

--- a/ledger/queries_currentprotocolparams.go
+++ b/ledger/queries_currentprotocolparams.go
@@ -14,7 +14,11 @@
 
 package ledger
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/dingo/database"
+)
 
 // queryShelleyCurrentProtocolParams answers GetCurrentPParams.
 //
@@ -31,22 +35,36 @@ import "fmt"
 // (blinklabs-io/dingo#382). Building real historical-by-epoch pparams
 // storage (or replaying governance enactments) to lift this restriction is
 // a materially larger, not-yet-attempted piece of work.
+//
+// The live epoch and the returned parameters both come from one
+// loadConsensusSnapshot() call, not two separate reads: an earlier version
+// compared the live epoch (from txn's database transaction) against
+// targetEpoch, then separately called GetCurrentPParamsForReporting (which
+// loads its own, possibly later, published snapshot). An epoch-boundary
+// commit landing between those two reads could pass targetEpoch == liveEpoch
+// while returning the parameters of the epoch that had already replaced it.
+// Deriving both from the same snapshot value closes that window.
 func (ls *LedgerState) queryShelleyCurrentProtocolParams(
 	asOfSlot uint64,
+	txn *database.Txn,
 ) (any, error) {
+	snapshot := ls.loadConsensusSnapshot()
 	if asOfSlot == 0 {
-		return []any{ls.GetCurrentPParamsForReporting()}, nil
+		return []any{withoutSyntheticV2CostModel(
+			snapshot.currentPParams,
+			snapshot.syntheticV2CostModelInEffect,
+			ls.config.Logger,
+		)}, nil
 	}
-	txn := ls.db.Transaction(false)
-	defer txn.Release()
-	liveEpoch, err := ls.resolveAsOfEpoch(txn, 0)
-	if err != nil {
-		return nil, err
+	if txn == nil {
+		txn = ls.db.Transaction(false)
+		defer txn.Release()
 	}
 	targetEpoch, err := ls.resolveAsOfEpoch(txn, asOfSlot)
 	if err != nil {
 		return nil, err
 	}
+	liveEpoch := snapshot.currentEpoch.EpochId
 	if targetEpoch != liveEpoch {
 		return nil, fmt.Errorf(
 			"%w: protocol parameters at slot %d (epoch %d) cannot be "+
@@ -59,5 +77,9 @@ func (ls *LedgerState) queryShelleyCurrentProtocolParams(
 			liveEpoch,
 		)
 	}
-	return []any{ls.GetCurrentPParamsForReporting()}, nil
+	return []any{withoutSyntheticV2CostModel(
+		snapshot.currentPParams,
+		snapshot.syntheticV2CostModelInEffect,
+		ls.config.Logger,
+	)}, nil
 }

--- a/ledger/queries_pointvalidation_test.go
+++ b/ledger/queries_pointvalidation_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +49,9 @@ func TestQuery_PinnedPointOnChain_Succeeds(t *testing.T) {
 
 	hash := bytes.Repeat([]byte{0xAB}, 32)
 	seedBlockAtSlot(t, ls, 100, hash)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(100, hash),
+	}, nil))
 
 	_, err := ls.Query(utxoWholeQuery(), QueryPoint{Slot: 100, Hash: hash})
 	require.NoError(t, err)
@@ -58,6 +63,9 @@ func TestQuery_PinnedPointOnChain_Succeeds(t *testing.T) {
 // rollback happened between Acquire and Query. Before verifyPointOnChain
 // existed, a purely slot-keyed reconstruction would have silently answered
 // against the new fork's data; it must instead fail with ErrPointNotOnChain.
+// The tip is set at slot 100 (not left at origin) so this exercises the
+// hash-mismatch rejection specifically, not the separate above-the-tip
+// rejection TestQuery_PinnedPointAboveTip_Rejected covers.
 func TestQuery_PinnedPointWrongHash_Rejected(t *testing.T) {
 	t.Parallel()
 
@@ -67,6 +75,9 @@ func TestQuery_PinnedPointWrongHash_Rejected(t *testing.T) {
 	actualHash := bytes.Repeat([]byte{0xAB}, 32)
 	acquiredHash := bytes.Repeat([]byte{0xCD}, 32)
 	seedBlockAtSlot(t, ls, 100, actualHash)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(100, actualHash),
+	}, nil))
 
 	_, err := ls.Query(
 		utxoWholeQuery(),
@@ -79,12 +90,20 @@ func TestQuery_PinnedPointWrongHash_Rejected(t *testing.T) {
 // TestQuery_PinnedPointNoBlockAtSlot_Rejected covers a point naming a slot
 // this node has no block for at all (never seen it, or it was never a real
 // chain point) -- must fail with ErrPointNotOnChain rather than silently
-// treating "no block" as equivalent to "empty state as of that slot".
+// treating "no block" as equivalent to "empty state as of that slot". The
+// tip is set past slot 999 (via a block at a later slot) so this exercises
+// the no-block-found rejection specifically, not the above-the-tip one.
 func TestQuery_PinnedPointNoBlockAtSlot_Rejected(t *testing.T) {
 	t.Parallel()
 
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
+
+	laterHash := bytes.Repeat([]byte{0xAB}, 32)
+	seedBlockAtSlot(t, ls, 1000, laterHash)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(1000, laterHash),
+	}, nil))
 
 	_, err := ls.Query(
 		utxoWholeQuery(),
@@ -92,6 +111,58 @@ func TestQuery_PinnedPointNoBlockAtSlot_Rejected(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrPointNotOnChain))
+}
+
+// TestQuery_PinnedPointAboveTip_Rejected covers the gap a purely
+// slot-keyed lookup left open: database.BlockBySlot has no notion of
+// "applied tip" at all, so a block retained in the blob store at a slot
+// ahead of what has actually been applied to ledger state (e.g. a
+// header-ahead-of-ledger buffer entry) could satisfy both the slot and
+// hash check even though the ledger state a query is about to read from
+// has not incorporated it. A point naming that block must be rejected
+// as not on the (applied) chain, regardless of whether the block itself
+// is retained.
+func TestQuery_PinnedPointAboveTip_Rejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	tipHash := bytes.Repeat([]byte{0xAB}, 32)
+	aheadHash := bytes.Repeat([]byte{0xCD}, 32)
+	seedBlockAtSlot(t, ls, 100, tipHash)
+	seedBlockAtSlot(t, ls, 200, aheadHash)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(100, tipHash),
+	}, nil))
+
+	_, err := ls.Query(
+		utxoWholeQuery(),
+		QueryPoint{Slot: 200, Hash: aheadHash},
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPointNotOnChain)
+}
+
+// TestQuery_SlotZeroWithHashIsPinned_Rejected covers QueryPoint.pinned()'s
+// own predicate: a slot-0 point with a nonempty Hash is a real chain point
+// (a real Byron genesis-adjacent block could sit at slot 0), not the origin
+// sentinel (QueryPoint{}, both fields zero), and must still go through
+// verifyPointOnChain -- not be silently treated as unpinned and answered
+// from live state. This node has no such block, so it must be rejected the
+// same way any other non-existent point would be.
+func TestQuery_SlotZeroWithHashIsPinned_Rejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	_, err := ls.Query(
+		utxoWholeQuery(),
+		QueryPoint{Slot: 0, Hash: bytes.Repeat([]byte{0xEE}, 32)},
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPointNotOnChain)
 }
 
 // TestQuery_UnpinnedSkipsPointValidation covers the live path: a zero-value

--- a/ledger/queries_pointvalidation_test.go
+++ b/ledger/queries_pointvalidation_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/blinklabs-io/dingo/database/models"
 	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,6 +165,56 @@ func TestQuery_SlotZeroWithHashIsPinned_Rejected(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrPointNotOnChain)
+}
+
+// epochNoQuery wraps the leaf query the way the wire delivers GetEpochNo.
+func epochNoQuery() *olocalstatequery.BlockQuery {
+	return &olocalstatequery.BlockQuery{
+		Query: &olocalstatequery.ShelleyQuery{
+			Query: &olocalstatequery.ShelleyEpochNoQuery{},
+		},
+	}
+}
+
+// TestQuery_SlotZeroPinned_DispatchesHistorically goes one step past
+// TestQuery_SlotZeroWithHashIsPinned_Rejected: this node genuinely has a
+// block at slot 0 matching the acquired hash, so verifyPointOnChain accepts
+// it -- proving pinned-ness survives all the way through dispatch to the
+// handler is the real point of this test. Every point-aware handler was
+// passed a bare `asOfSlot uint64` derived from at.Slot, and every one of
+// them treated asOfSlot == 0 as "live" -- so a point genuinely pinned at
+// slot 0 passed validation only to have the handler silently ignore the
+// pin and answer with the live epoch (6) instead of slot 0's own epoch
+// (0). Handlers now take the whole QueryPoint and check at.pinned()
+// instead of comparing a bare slot against zero.
+func TestQuery_SlotZeroPinned_DispatchesHistorically(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+	ls.currentEpoch = models.Epoch{EpochId: 6}
+	ls.publishSnapshotsLocked()
+
+	genesisHash := bytes.Repeat([]byte{0xAB}, 32)
+	seedBlockAtSlot(t, ls, 0, genesisHash)
+	seedEpochs(t, ls, map[uint64]uint64{0: 0, 600: 6})
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(650, repeatedBytes(32, 0x0B)),
+	}, nil))
+
+	result, err := ls.Query(
+		epochNoQuery(),
+		QueryPoint{Slot: 0, Hash: genesisHash},
+	)
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 1)
+	assert.Equal(
+		t, uint64(0), arr[0],
+		"a point pinned at slot 0 must resolve slot 0's own epoch, not "+
+			"silently fall through to the live epoch",
+	)
 }
 
 // TestQuery_UnpinnedSkipsPointValidation covers the live path: a zero-value

--- a/ledger/queries_pointvalidation_test.go
+++ b/ledger/queries_pointvalidation_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/stretchr/testify/require"
+)
+
+// seedBlockAtSlot writes a minimal block index entry for slot/hash, enough
+// for database.BlockBySlot to find it -- Query's verifyPointOnChain doesn't
+// decode the block, only compares Hash, so no real CBOR content is needed.
+func seedBlockAtSlot(t *testing.T, ls *LedgerState, slot uint64, hash []byte) {
+	t.Helper()
+	require.NoError(t, ls.db.BlockCreate(models.Block{
+		ID:   slot,
+		Slot: slot,
+		Hash: hash,
+	}, nil))
+}
+
+// TestQuery_PinnedPointOnChain_Succeeds covers the common case: a pinned
+// point naming a block this node's current chain actually has at that slot
+// must be accepted, dispatching through to the query as normal
+// (blinklabs-io/dingo#382, #5 in the follow-up review).
+func TestQuery_PinnedPointOnChain_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	hash := bytes.Repeat([]byte{0xAB}, 32)
+	seedBlockAtSlot(t, ls, 100, hash)
+
+	_, err := ls.Query(utxoWholeQuery(), QueryPoint{Slot: 100, Hash: hash})
+	require.NoError(t, err)
+}
+
+// TestQuery_PinnedPointWrongHash_Rejected covers a rollback/fork scenario:
+// the caller acquired a point at slot 100 naming hash A, but this node's
+// current chain now has a different block (hash B) at slot 100 -- e.g. a
+// rollback happened between Acquire and Query. Before verifyPointOnChain
+// existed, a purely slot-keyed reconstruction would have silently answered
+// against the new fork's data; it must instead fail with ErrPointNotOnChain.
+func TestQuery_PinnedPointWrongHash_Rejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	actualHash := bytes.Repeat([]byte{0xAB}, 32)
+	acquiredHash := bytes.Repeat([]byte{0xCD}, 32)
+	seedBlockAtSlot(t, ls, 100, actualHash)
+
+	_, err := ls.Query(
+		utxoWholeQuery(),
+		QueryPoint{Slot: 100, Hash: acquiredHash},
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPointNotOnChain)
+}
+
+// TestQuery_PinnedPointNoBlockAtSlot_Rejected covers a point naming a slot
+// this node has no block for at all (never seen it, or it was never a real
+// chain point) -- must fail with ErrPointNotOnChain rather than silently
+// treating "no block" as equivalent to "empty state as of that slot".
+func TestQuery_PinnedPointNoBlockAtSlot_Rejected(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	_, err := ls.Query(
+		utxoWholeQuery(),
+		QueryPoint{Slot: 999, Hash: bytes.Repeat([]byte{0xEE}, 32)},
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPointNotOnChain))
+}
+
+// TestQuery_UnpinnedSkipsPointValidation covers the live path: a zero-value
+// QueryPoint must not trigger verifyPointOnChain at all (no block need
+// exist at slot 0), preserving every existing unpinned query's behavior.
+func TestQuery_UnpinnedSkipsPointValidation(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ls := newPoolDistr2Ledger(t, db)
+
+	_, err := ls.Query(utxoWholeQuery(), QueryPoint{})
+	require.NoError(t, err)
+}

--- a/ledger/queries_pooldistr2.go
+++ b/ledger/queries_pooldistr2.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -39,6 +40,7 @@ import (
 func (ls *LedgerState) queryShelleyPoolDistr2(
 	q *olocalstatequery.ShelleyPoolDistr2Query,
 	asOfSlot uint64,
+	txn *database.Txn,
 ) (any, error) {
 	// PoolFilter reports all=true with a nil pool list when the query's
 	// StrictMaybe was SNothing, and all=false otherwise -- including for an
@@ -55,7 +57,7 @@ func (ls *LedgerState) queryShelleyPoolDistr2(
 		}
 	}
 
-	dist, err := ls.PoolStakeDistribution(poolFilter, asOfSlot)
+	dist, err := ls.PoolStakeDistribution(poolFilter, asOfSlot, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_pooldistr2.go
+++ b/ledger/queries_pooldistr2.go
@@ -32,8 +32,13 @@ import (
 // into the node-to-client reply shape. Keeping the read in one place is what
 // stops the two surfaces reporting different VRF keys or different snapshots
 // for the same chain.
+//
+// asOfSlot is Query's pinned point (0 = live); PoolStakeDistribution resolves
+// it to the historical epoch whose mark snapshot governed that slot
+// (blinklabs-io/dingo#382).
 func (ls *LedgerState) queryShelleyPoolDistr2(
 	q *olocalstatequery.ShelleyPoolDistr2Query,
+	asOfSlot uint64,
 ) (any, error) {
 	// PoolFilter reports all=true with a nil pool list when the query's
 	// StrictMaybe was SNothing, and all=false otherwise -- including for an
@@ -50,7 +55,7 @@ func (ls *LedgerState) queryShelleyPoolDistr2(
 		}
 	}
 
-	dist, err := ls.PoolStakeDistribution(poolFilter)
+	dist, err := ls.PoolStakeDistribution(poolFilter, asOfSlot)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_pooldistr2.go
+++ b/ledger/queries_pooldistr2.go
@@ -34,12 +34,12 @@ import (
 // stops the two surfaces reporting different VRF keys or different snapshots
 // for the same chain.
 //
-// asOfSlot is Query's pinned point (0 = live); PoolStakeDistribution resolves
-// it to the historical epoch whose mark snapshot governed that slot
-// (blinklabs-io/dingo#382).
+// at is Query's pinned point (unpinned = live); PoolStakeDistribution
+// resolves it to the historical epoch whose mark snapshot governed that
+// slot (blinklabs-io/dingo#382).
 func (ls *LedgerState) queryShelleyPoolDistr2(
 	q *olocalstatequery.ShelleyPoolDistr2Query,
-	asOfSlot uint64,
+	at QueryPoint,
 	txn *database.Txn,
 ) (any, error) {
 	// PoolFilter reports all=true with a nil pool list when the query's
@@ -57,7 +57,7 @@ func (ls *LedgerState) queryShelleyPoolDistr2(
 		}
 	}
 
-	dist, err := ls.PoolStakeDistribution(poolFilter, asOfSlot, txn)
+	dist, err := ls.PoolStakeDistribution(poolFilter, at, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_pooldistr2_test.go
+++ b/ledger/queries_pooldistr2_test.go
@@ -157,7 +157,7 @@ func TestQueryShelleyPoolDistr2_ReportsStakeFractionAndVrf(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 
@@ -244,7 +244,7 @@ func TestQueryShelleyPoolDistr2_FilterReportsOnlyRequestedPools(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2QueryFor(pkhA))
+	result, err := ls.Query(poolDistr2QueryFor(pkhA), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 
@@ -301,7 +301,7 @@ func TestQueryShelleyPoolDistr2_FilterOmitsPoolAbsentFromSnapshot(
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2QueryFor(pkhA, unknownPkh))
+	result, err := ls.Query(poolDistr2QueryFor(pkhA, unknownPkh), QueryPoint{})
 	require.NoError(t, err,
 		"a pool the snapshot does not hold is omitted, not an error")
 	distr := decodePoolDistr2Result(t, result)
@@ -322,7 +322,7 @@ func TestQueryShelleyPoolDistr2_ZeroTotalStakeDoesNotDivide(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err,
 		"an empty snapshot reports an empty distribution, not an error")
 	distr := decodePoolDistr2Result(t, result)
@@ -387,7 +387,7 @@ func TestQueryShelleyPoolDistr2_OmitsPoolWithoutRegistrationRatherThanAborting(
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err,
 		"an unregistered pool must not abort the protocol and drop the "+
 			"client's connection")
@@ -466,7 +466,7 @@ func TestQueryShelleyPoolDistr2_PrefersRegistrationVrfKey(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 
@@ -556,7 +556,7 @@ func TestQueryShelleyPoolDistr2_VrfKeyMatchesHeaderValidation(t *testing.T) {
 		nil,
 	))
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 	entry, ok := distr.Pools[lcommon.PoolId(pkh)]
@@ -654,7 +654,7 @@ func TestQueryShelleyPoolDistr2_EpochComesFromTheTransactionNotTheSnapshot(
 	ls.currentEpoch = models.Epoch{EpochId: staleEpoch}
 	ls.publishSnapshotsLocked()
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 
@@ -736,7 +736,7 @@ func TestQueryShelleyPoolDistr2_TotalMatchesRowsWhenSummaryIsReady(
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2Query())
+	result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	distr := decodePoolDistr2Result(t, result)
 
@@ -803,7 +803,7 @@ func TestQueryShelleyPoolDistr2_ViaGetCBOR(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(poolDistr2CborQuery())
+	result, err := ls.Query(poolDistr2CborQuery(), QueryPoint{})
 	require.NoError(t, err, "GetCBOR-wrapped GetPoolDistr2 must not error")
 
 	arr, ok := result.([]any)

--- a/ledger/queries_stakedistribution.go
+++ b/ledger/queries_stakedistribution.go
@@ -52,10 +52,10 @@ type stakeDistributionEntry = struct {
 // -- see totalCirculatingSupply's doc comment (blinklabs-io/dingo#3824) for
 // the full story and why GetPoolDistr2 must not make the same change.
 //
-// asOfSlot is Query's pinned point (0 = live), but a pinned (non-zero)
-// asOfSlot is rejected here rather than answered: unlike GetPoolDistr2 (which
-// uses TotalActiveStake, itself a historical, per-epoch snapshot total),
-// this query's denominator is TotalCirculatingSupply, computed from
+// at is Query's pinned point (unpinned = live), but a pinned at is rejected
+// here rather than answered: unlike GetPoolDistr2 (which uses
+// TotalActiveStake, itself a historical, per-epoch snapshot total), this
+// query's denominator is TotalCirculatingSupply, computed from
 // GetNetworkState's reserves row -- and GetNetworkState only ever returns
 // the latest row, with no historical-by-epoch or historical-by-slot lookup
 // yet. Answering a pinned point here would silently mix a correct
@@ -66,19 +66,19 @@ type stakeDistributionEntry = struct {
 // historical NetworkState lookup exists is safer than a plausible-looking
 // wrong fraction (blinklabs-io/dingo#382).
 func (ls *LedgerState) queryShelleyStakeDistribution(
-	asOfSlot uint64,
+	at QueryPoint,
 	txn *database.Txn,
 ) (any, error) {
-	if asOfSlot != 0 {
+	if at.pinned() {
 		return nil, fmt.Errorf(
 			"%w: GetStakeDistribution pinned to slot %d is not yet "+
 				"supported -- its circulating-supply denominator has no "+
 				"historical-by-slot record",
 			ErrHistoricalStateUnavailable,
-			asOfSlot,
+			at.Slot,
 		)
 	}
-	dist, err := ls.PoolStakeDistribution(nil, asOfSlot, txn)
+	dist, err := ls.PoolStakeDistribution(nil, at, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_stakedistribution.go
+++ b/ledger/queries_stakedistribution.go
@@ -49,8 +49,12 @@ type stakeDistributionEntry = struct {
 // denominator instead, confirmed against real cardano-node's raw wire bytes
 // -- see totalCirculatingSupply's doc comment (blinklabs-io/dingo#3824) for
 // the full story and why GetPoolDistr2 must not make the same change.
-func (ls *LedgerState) queryShelleyStakeDistribution() (any, error) {
-	dist, err := ls.PoolStakeDistribution(nil)
+//
+// asOfSlot is Query's pinned point (0 = live); PoolStakeDistribution resolves
+// it to the historical epoch whose mark snapshot governed that slot
+// (blinklabs-io/dingo#382).
+func (ls *LedgerState) queryShelleyStakeDistribution(asOfSlot uint64) (any, error) {
+	dist, err := ls.PoolStakeDistribution(nil, asOfSlot)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_stakedistribution.go
+++ b/ledger/queries_stakedistribution.go
@@ -15,8 +15,10 @@
 package ledger
 
 import (
+	"fmt"
 	"math/big"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -50,11 +52,33 @@ type stakeDistributionEntry = struct {
 // -- see totalCirculatingSupply's doc comment (blinklabs-io/dingo#3824) for
 // the full story and why GetPoolDistr2 must not make the same change.
 //
-// asOfSlot is Query's pinned point (0 = live); PoolStakeDistribution resolves
-// it to the historical epoch whose mark snapshot governed that slot
-// (blinklabs-io/dingo#382).
-func (ls *LedgerState) queryShelleyStakeDistribution(asOfSlot uint64) (any, error) {
-	dist, err := ls.PoolStakeDistribution(nil, asOfSlot)
+// asOfSlot is Query's pinned point (0 = live), but a pinned (non-zero)
+// asOfSlot is rejected here rather than answered: unlike GetPoolDistr2 (which
+// uses TotalActiveStake, itself a historical, per-epoch snapshot total),
+// this query's denominator is TotalCirculatingSupply, computed from
+// GetNetworkState's reserves row -- and GetNetworkState only ever returns
+// the latest row, with no historical-by-epoch or historical-by-slot lookup
+// yet. Answering a pinned point here would silently mix a correct
+// historical numerator (the pinned epoch's pool stakes) with the current
+// live reserves as the denominator, which is wrong whenever reserves have
+// moved between the pinned point and now (MIR, treasury donations,
+// monetary expansion). Rejecting with ErrHistoricalStateUnavailable until a
+// historical NetworkState lookup exists is safer than a plausible-looking
+// wrong fraction (blinklabs-io/dingo#382).
+func (ls *LedgerState) queryShelleyStakeDistribution(
+	asOfSlot uint64,
+	txn *database.Txn,
+) (any, error) {
+	if asOfSlot != 0 {
+		return nil, fmt.Errorf(
+			"%w: GetStakeDistribution pinned to slot %d is not yet "+
+				"supported -- its circulating-supply denominator has no "+
+				"historical-by-slot record",
+			ErrHistoricalStateUnavailable,
+			asOfSlot,
+		)
+	}
+	dist, err := ls.PoolStakeDistribution(nil, asOfSlot, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/queries_stakedistribution_test.go
+++ b/ledger/queries_stakedistribution_test.go
@@ -267,7 +267,7 @@ func TestQueryShelleyStakeDistribution_EmptySnapshot(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.queryShelleyStakeDistribution(0)
+	result, err := ls.queryShelleyStakeDistribution(0, nil)
 	require.NoError(t, err)
 	dist := decodeStakeDistributionResult(t, result)
 	assert.Empty(t, dist.Results)

--- a/ledger/queries_stakedistribution_test.go
+++ b/ledger/queries_stakedistribution_test.go
@@ -267,7 +267,7 @@ func TestQueryShelleyStakeDistribution_EmptySnapshot(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.queryShelleyStakeDistribution(0, nil)
+	result, err := ls.queryShelleyStakeDistribution(QueryPoint{}, nil)
 	require.NoError(t, err)
 	dist := decodeStakeDistributionResult(t, result)
 	assert.Empty(t, dist.Results)

--- a/ledger/queries_stakedistribution_test.go
+++ b/ledger/queries_stakedistribution_test.go
@@ -95,7 +95,7 @@ func TestQueryShelleyStakeDistribution_ReportsFractionAndVrf(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(stakeDistributionQuery())
+	result, err := ls.Query(stakeDistributionQuery(), QueryPoint{})
 	require.NoError(t, err)
 	dist := decodeStakeDistributionResult(t, result)
 	require.Len(t, dist.Results, 2)
@@ -157,7 +157,7 @@ func TestQueryShelleyStakeDistribution_ViaGetCBOR(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(stakeDistributionCborQuery())
+	result, err := ls.Query(stakeDistributionCborQuery(), QueryPoint{})
 	require.NoError(t, err, "GetCBOR-wrapped GetStakeDistribution must not error")
 
 	arr, ok := result.([]any)
@@ -235,7 +235,7 @@ func TestQueryShelleyStakeDistribution_UsesCirculationNotGetPoolDistr2sTotal(
 
 	// GetPoolDistr2 must be unaffected: still sum-of-delegated (2_000_000),
 	// so each pool is 1/2.
-	poolDistr2Result, err := ls.Query(poolDistr2Query())
+	poolDistr2Result, err := ls.Query(poolDistr2Query(), QueryPoint{})
 	require.NoError(t, err)
 	poolDistr2 := decodePoolDistr2Result(t, poolDistr2Result)
 	entryA2, ok := poolDistr2.Pools[lcommon.PoolId(pkhA)]
@@ -246,7 +246,7 @@ func TestQueryShelleyStakeDistribution_UsesCirculationNotGetPoolDistr2sTotal(
 
 	// GetStakeDistribution must use circulation (4_000_000) instead, so each
 	// pool is 1/4 -- not 1/2.
-	stakeDistResult, err := ls.Query(stakeDistributionQuery())
+	stakeDistResult, err := ls.Query(stakeDistributionQuery(), QueryPoint{})
 	require.NoError(t, err)
 	stakeDist := decodeStakeDistributionResult(t, stakeDistResult)
 	entryA, ok := stakeDist.Results[lcommon.PoolId(pkhA)]
@@ -267,7 +267,7 @@ func TestQueryShelleyStakeDistribution_EmptySnapshot(t *testing.T) {
 	db := newTestDB(t)
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.queryShelleyStakeDistribution()
+	result, err := ls.queryShelleyStakeDistribution(0)
 	require.NoError(t, err)
 	dist := decodeStakeDistributionResult(t, result)
 	assert.Empty(t, dist.Results)

--- a/ledger/queries_utxowhole_test.go
+++ b/ledger/queries_utxowhole_test.go
@@ -100,7 +100,7 @@ func TestQueryShelleyUtxoWhole_ReturnsLiveUtxos(t *testing.T) {
 
 	ls := newPoolDistr2Ledger(t, db)
 
-	result, err := ls.Query(utxoWholeQuery())
+	result, err := ls.Query(utxoWholeQuery(), QueryPoint{})
 	require.NoError(t, err)
 	arr, ok := result.([]any)
 	require.True(t, ok, "expected the []any result wrapper")

--- a/ledger/stake_snapshot_query_test.go
+++ b/ledger/stake_snapshot_query_test.go
@@ -112,7 +112,7 @@ func epochSummary(epoch, total uint64) *models.EpochSummary {
 // GetCBOR result shape along the way.
 func serialisedInner(t *testing.T, ls *LedgerState, payloadHex string) []byte {
 	t.Helper()
-	result, err := ls.Query(blockQueryFromHex(t, payloadHex))
+	result, err := ls.Query(blockQueryFromHex(t, payloadHex), QueryPoint{})
 	require.NoError(t, err)
 	outer, ok := result.([]any)
 	require.True(t, ok, "expected []any MsgResult wire form")

--- a/ledger/synthetic_v2_cost_model_test.go
+++ b/ledger/synthetic_v2_cost_model_test.go
@@ -378,7 +378,7 @@ func TestQueryShelleyCurrentProtocolParams_OmitsSyntheticV2CostModel(
 	ls.syntheticV2CostModel = true
 	ls.publishSnapshotsLocked()
 
-	result, err := ls.Query(protocolParamsQuery())
+	result, err := ls.Query(protocolParamsQuery(), QueryPoint{})
 	require.NoError(t, err)
 
 	arr, ok := result.([]any)
@@ -436,7 +436,7 @@ func TestQueryShelleyCurrentProtocolParams_IncludesRealV2CostModel(
 	ls.syntheticV2CostModel = false
 	ls.publishSnapshotsLocked()
 
-	result, err := ls.Query(protocolParamsQuery())
+	result, err := ls.Query(protocolParamsQuery(), QueryPoint{})
 	require.NoError(t, err)
 
 	arr, ok := result.([]any)

--- a/node.go
+++ b/node.go
@@ -1826,12 +1826,16 @@ func (n *Node) handleConnManagerClosed(
 	if n.chainsyncState != nil {
 		n.chainsyncState.RemoveClient(connId)
 	}
-	// Wake any NtC chainsync server callback parked waiting for this
-	// connection's certified endorser closure. connmanager drives this
-	// callback from its own per-connection goroutine, so it runs even while
-	// that server callback still owns gouroboros's receive loop.
 	if o := n.ouroboros(); o != nil {
+		// Wake any NtC chainsync server callback parked waiting for this
+		// connection's certified endorser closure. connmanager drives this
+		// callback from its own per-connection goroutine, so it runs even
+		// while that server callback still owns gouroboros's receive loop.
 		o.ReleaseLeiosServeWaiters(connId)
+		// Clear any LocalStateQuery pinned point this connection acquired:
+		// a client that disconnects without a clean Release must not leak
+		// its map entry (blinklabs-io/dingo#382).
+		o.ReleaseLocalStateQueryAcquiredPoint(connId)
 	}
 }
 

--- a/node_ntc_conn_closed_test.go
+++ b/node_ntc_conn_closed_test.go
@@ -232,6 +232,83 @@ func TestHandleConnManagerClosed_NtC_ReleasesLeiosServeWaiters(t *testing.T) {
 	)
 }
 
+// TestHandleConnManagerClosed_NtC_ReleasesLocalStateQueryAcquiredPoint covers
+// the NtC-close half of blinklabs-io/dingo#382's point-pinning: a client
+// that pins a point and then disconnects without a clean Release must not
+// leak its map entry, since NtC closes never reach
+// Ouroboros.HandleConnClosedEvent (the EventBus's ConnectionClosedEventType
+// is intentionally NtN-only) and localstatequeryServerRelease is therefore
+// never invoked for it. Without ReleaseLocalStateQueryAcquiredPoint wired
+// into handleConnManagerClosed, this assertion fails: the entry
+// SetLocalStateQueryAcquiredPointForTesting seeded is still present after
+// the simulated close.
+func TestHandleConnManagerClosed_NtC_ReleasesLocalStateQueryAcquiredPoint(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	n := newHandleConnManagerClosedTestNode(t)
+	bus := event.NewEventBus(nil, logger)
+	t.Cleanup(bus.Stop)
+
+	db, err := dbtest.NewDatabase(t, &database.Config{DataDir: ""})
+	require.NoError(t, err)
+	t.Cleanup(func() { dbtest.CloseDatabase(db) })
+	chainManager, err := chain.NewManager(db, nil)
+	require.NoError(t, err)
+	ledgerState, err := ledger.NewLedgerState(ledger.LedgerStateConfig{
+		Database:     db,
+		ChainManager: chainManager,
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+	harnessMempool, err := mempool.NewMempool(mempool.MempoolConfig{
+		Logger:          logger,
+		PromRegistry:    prometheus.NewRegistry(),
+		Validator:       ledgerState,
+		MempoolCapacity: 1024 * 1024,
+	})
+	require.NoError(t, err)
+	connManager := connmanager.NewConnectionManager(
+		connmanager.ConnectionManagerConfig{Logger: logger},
+	)
+	o, err := ouroborosPkg.NewOuroboros(ouroborosPkg.OuroborosConfig{
+		Logger:         logger,
+		EventBus:       bus,
+		LedgerState:    ledgerState,
+		Mempool:        &mempool.FIFO{Mempool: harnessMempool},
+		ChainsyncState: chainsync.NewState(bus, ledgerState),
+		ConnManager:    connManager,
+		PeerGov: peergov.NewPeerGovernor(peergov.PeerGovernorConfig{
+			Logger:      logger,
+			EventBus:    bus,
+			ConnManager: connManager,
+		}),
+	})
+	require.NoError(t, err)
+	n.ouroborosRef.Store(o)
+
+	connId := newNtCTestConnId(6)
+	o.SetLocalStateQueryAcquiredPointForTesting(connId, ledger.QueryPoint{
+		Slot: 100,
+		Hash: []byte{0xAB},
+	})
+	require.True(
+		t,
+		o.HasLocalStateQueryAcquiredPointForTesting(connId),
+		"precondition: pinned point recorded",
+	)
+
+	n.handleConnManagerClosed(connId, true, nil)
+
+	require.False(
+		t,
+		o.HasLocalStateQueryAcquiredPointForTesting(connId),
+		"NtC close must release the pinned LocalStateQuery point",
+	)
+}
+
 // TestHandleConnManagerClosed_NilOuroboros guards the same restore window as
 // TestHandleConnManagerClosed_NilChainsyncState for the added ouroboros
 // dereference: n.ouroboros() is nil before Run wires it.

--- a/ouroboros/localstatequery.go
+++ b/ouroboros/localstatequery.go
@@ -17,6 +17,7 @@ package ouroboros
 import (
 	"time"
 
+	"github.com/blinklabs-io/dingo/ledger"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
@@ -74,12 +75,36 @@ func (o *Ouroboros) instrumentLocalstatequeryRelease(
 	}
 }
 
+// localstatequeryServerAcquire records the point the client asked to pin
+// this connection's LocalStateQuery session to (blinklabs-io/dingo#382).
+// AcquireSpecificPoint's slot AND hash are both recorded -- hash matters
+// because identifying a point by slot alone is ambiguous across a rollback
+// (a fork switch can leave a different block at the same slot than the one
+// the caller acquired); LedgerState.Query.verifyPointOnChain checks the
+// recorded hash against this node's current chain before answering any
+// pinned query. AcquireVolatileTip and AcquireImmutableTip both clear any
+// previous pin, since only a specific point makes sense to hold stable
+// across a slow query -- both tip kinds are, by construction, "whatever is
+// live/immutable right now", the same thing querying with no pin at all
+// (a zero-value ledger.QueryPoint) already means.
+//
+// Not every query type honors the recorded point yet -- see
+// ledger.LedgerState.Query's doc comment for which ones do.
 func (o *Ouroboros) localstatequeryServerAcquire(
 	ctx olocalstatequery.CallbackContext,
 	acquireTarget olocalstatequery.AcquireTarget,
 	reAcquire bool,
 ) error {
-	// TODO: create "view" from ledger state (#382)
+	o.localstatequeryAcquireMutex.Lock()
+	defer o.localstatequeryAcquireMutex.Unlock()
+	if specific, ok := acquireTarget.(olocalstatequery.AcquireSpecificPoint); ok {
+		o.localstatequeryAcquiredPoints[ctx.ConnectionId] = ledger.QueryPoint{
+			Slot: specific.Point.Slot,
+			Hash: specific.Point.Hash,
+		}
+	} else {
+		delete(o.localstatequeryAcquiredPoints, ctx.ConnectionId)
+	}
 	return nil
 }
 
@@ -87,12 +112,17 @@ func (o *Ouroboros) localstatequeryServerQuery(
 	ctx olocalstatequery.CallbackContext,
 	query olocalstatequery.QueryWrapper,
 ) (any, error) {
-	return o.ledgerState.Query(query.Query)
+	o.localstatequeryAcquireMutex.Lock()
+	at := o.localstatequeryAcquiredPoints[ctx.ConnectionId]
+	o.localstatequeryAcquireMutex.Unlock()
+	return o.ledgerState.Query(query.Query, at)
 }
 
 func (o *Ouroboros) localstatequeryServerRelease(
 	ctx olocalstatequery.CallbackContext,
 ) error {
-	// TODO: release "view" from ledger state (#382)
+	o.localstatequeryAcquireMutex.Lock()
+	delete(o.localstatequeryAcquiredPoints, ctx.ConnectionId)
+	o.localstatequeryAcquireMutex.Unlock()
 	return nil
 }

--- a/ouroboros/localstatequery.go
+++ b/ouroboros/localstatequery.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/dingo/ledger"
+	ouroboros "github.com/blinklabs-io/gouroboros"
 	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
@@ -125,4 +126,46 @@ func (o *Ouroboros) localstatequeryServerRelease(
 	delete(o.localstatequeryAcquiredPoints, ctx.ConnectionId)
 	o.localstatequeryAcquireMutex.Unlock()
 	return nil
+}
+
+// ReleaseLocalStateQueryAcquiredPoint clears connId's pinned point, the same
+// cleanup localstatequeryServerRelease performs for a clean client Release.
+// A NtC client that disconnects without ever calling Release skips that
+// callback entirely, so without this the map entry would otherwise persist
+// until this Ouroboros instance itself is discarded -- a one-entry-per-
+// pinned-client leak. Called from the node's NtC connection-closed callback
+// (handleConnManagerClosed), the NtC counterpart to HandleConnClosedEvent's
+// equivalent cleanup for NtN closes.
+func (o *Ouroboros) ReleaseLocalStateQueryAcquiredPoint(
+	connId ouroboros.ConnectionId,
+) {
+	o.localstatequeryAcquireMutex.Lock()
+	delete(o.localstatequeryAcquiredPoints, connId)
+	o.localstatequeryAcquireMutex.Unlock()
+}
+
+// SetLocalStateQueryAcquiredPointForTesting seeds connId's pinned point
+// directly, bypassing a real Acquire callback, so the root package can prove
+// its NtC connection-closed callback actually clears this map -- the same
+// two-package split RegisterLeiosServeWaiterForTesting exists for.
+func (o *Ouroboros) SetLocalStateQueryAcquiredPointForTesting(
+	connId ouroboros.ConnectionId,
+	point ledger.QueryPoint,
+) {
+	o.localstatequeryAcquireMutex.Lock()
+	o.localstatequeryAcquiredPoints[connId] = point
+	o.localstatequeryAcquireMutex.Unlock()
+}
+
+// HasLocalStateQueryAcquiredPointForTesting reports whether connId currently
+// has a map entry, regardless of whether the recorded point is the pinned
+// or the live/cleared zero value -- the presence of the entry itself is
+// what a leak looks like, so this checks membership, not QueryPoint.pinned().
+func (o *Ouroboros) HasLocalStateQueryAcquiredPointForTesting(
+	connId ouroboros.ConnectionId,
+) bool {
+	o.localstatequeryAcquireMutex.Lock()
+	defer o.localstatequeryAcquireMutex.Unlock()
+	_, ok := o.localstatequeryAcquiredPoints[connId]
+	return ok
 }

--- a/ouroboros/ouroboros.go
+++ b/ouroboros/ouroboros.go
@@ -112,12 +112,21 @@ type Ouroboros struct {
 	// multiple connections delivering byte-identical data (the common case
 	// when several peers relay the same block) decode once instead of once
 	// per connection. See #489 and decode_cache.go.
-	blockDecodeCache         *decodeCache[gledger.Block]
-	headerDecodeCache        *decodeCache[gledger.BlockHeader]
-	decodeCacheMetrics       *decodeCacheMetrics
-	blockFetchStarts         map[ouroboros.ConnectionId]time.Time
-	blockFetchMutex          sync.Mutex
-	blockfetchNoBlocksCounts map[ouroboros.ConnectionId]blockfetchNoBlocksState
+	blockDecodeCache   *decodeCache[gledger.Block]
+	headerDecodeCache  *decodeCache[gledger.BlockHeader]
+	decodeCacheMetrics *decodeCacheMetrics
+	blockFetchStarts   map[ouroboros.ConnectionId]time.Time
+	blockFetchMutex    sync.Mutex
+	// localstatequeryAcquiredPoints records the pinned point (zero value =
+	// no pin, answer from live state) an NtC client acquired on this
+	// connection's LocalStateQuery session, keyed by ConnectionId so
+	// multiple simultaneous NtC clients don't share state. Populated by
+	// localstatequeryServerAcquire when the client names a specific point
+	// (blinklabs-io/dingo#382), read by localstatequeryServerQuery, and
+	// cleared by localstatequeryServerRelease and on connection close.
+	localstatequeryAcquiredPoints map[ouroboros.ConnectionId]ledger.QueryPoint
+	localstatequeryAcquireMutex   sync.Mutex
+	blockfetchNoBlocksCounts      map[ouroboros.ConnectionId]blockfetchNoBlocksState
 	// ChainSync measurement tracking for peer scoring
 	chainsyncStats map[ouroboros.ConnectionId]*chainsyncPeerStats
 	chainsyncMutex sync.Mutex
@@ -451,6 +460,9 @@ func newOuroboros(cfg OuroborosConfig) *Ouroboros {
 		chainsyncState:          cfg.ChainsyncState,
 		peerGov:                 cfg.PeerGov,
 		blockFetchStarts:        make(map[ouroboros.ConnectionId]time.Time),
+		localstatequeryAcquiredPoints: make(
+			map[ouroboros.ConnectionId]ledger.QueryPoint,
+		),
 		blockfetchNoBlocksCounts: make(
 			map[ouroboros.ConnectionId]blockfetchNoBlocksState,
 		),
@@ -765,6 +777,11 @@ func (o *Ouroboros) HandleConnClosedEvent(evt event.Event) {
 	delete(o.blockFetchStarts, connId)
 	delete(o.blockfetchNoBlocksCounts, connId)
 	o.blockFetchMutex.Unlock()
+	// Clean up any LocalStateQuery acquired point: a client that disconnects
+	// without a clean Release must not leak its map entry.
+	o.localstatequeryAcquireMutex.Lock()
+	delete(o.localstatequeryAcquiredPoints, connId)
+	o.localstatequeryAcquireMutex.Unlock()
 	// Clean up chainsync stats
 	o.chainsyncMutex.Lock()
 	delete(o.chainsyncStats, connId)


### PR DESCRIPTION
## Summary

Addresses #382. `ouroboros/localstatequery.go`'s server-side `Acquire` always
answered every query at the live tip regardless of the requested point --
there was no way to pin "ledger state as of exactly block N" on Dingo's
side, unlike a real `cardano-node`'s working `Acquire(point)`.

## Change

- `Acquire` now records the acquired point per connection
  (`ledger.QueryPoint{Slot, Hash}`), threaded into `LedgerState.Query` as
  `at`. Both slot and hash are recorded -- identifying a point by slot alone
  is ambiguous across a rollback (a fork switch can leave a different block
  at the same slot than the one the caller acquired).
- `Query` calls `verifyPointOnChain` before dispatching whenever `at` is
  pinned, rejecting with `ErrPointNotOnChain` if this node's current chain
  no longer has that hash at that slot -- one fork-safety check shared by
  every point-sensitive query type rather than repeated per handler.
- Four query types now honor a pinned point: `GetStakeDistribution` /
  `GetPoolDistr2` (via `PoolStakeDistribution`, resolving to the epoch that
  governed the pinned slot and reading that epoch's already-persisted mark
  snapshot), `GetCurrentProtocolParams` (only when the pinned point's epoch
  matches the live tip's -- protocol parameters have no historical-by-epoch
  record, so a pin spanning an epoch boundary fails clearly with the new
  `ErrHistoricalStateUnavailable` rather than silently answering the wrong
  epoch's value), and `GetEpochNo` (unconditionally safe).
- Every other query type is unaffected and continues answering live --
  `queryShelleyLeaf`'s doc comment carries a full case-by-case audit
  (honors the point today / intentionally live-only / a real gap out of
  scope for this pass).
- `GetUTxOWhole` is deliberately not one of the honoring types here: pinning
  only matters for a query slow enough that the live tip could move
  underneath it, and a paginated form built to actually need that is
  tracked separately as #4082 (which will build on top of this).

## Testing

- `go build ./...`, `go vet ./...` clean (whole repo).
- `go test -race ./ledger/... ./ouroboros/... ./api/utxorpc/...` -- all pass.
- `golangci-lint run` (scoped), `nilaway`, `modernize`, `golines` -- 0 new
  findings against these changes (pre-existing, unrelated findings on
  `main` in untouched files were confirmed present regardless of this diff).
- `make docs-parity`, `make import-boundaries` -- clean.
- New tests: `queries_asofslot_test.go` (stake distribution / protocol
  params / epoch-no as-of-slot behavior, including the retention-window and
  epoch-mismatch rejection paths), `queries_pointvalidation_test.go`
  (`verifyPointOnChain` acceptance/rejection paths).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LocalStateQuery server so `Acquire`'s requested point is honored; previously every query answered at the live tip regardless of the requested point.

**Point pinning**
- `Acquire` records the acquired point (slot and hash) per connection; `Release`, tip acquisition, and disconnect (both NtN and NtC paths) clear it.
- A pinned query validates the point against the applied tip in one transaction, rejecting hashes not on the current chain (`ErrPointNotOnChain`), and reuses that transaction for the historical read so a rollback can't split the two.
- A slot-0 point with a nonempty hash counts as pinned, not live, and the pin survives dispatch instead of being silently dropped at a bare-slot zero check.

**Query coverage**
- `GetPoolDistr2`, `GetCurrentProtocolParams` (only within the live epoch), and `GetEpochNo` honor a pinned point; `GetStakeDistribution` rejects pins because its circulating-supply denominator is live-only.
- Pins beyond the 3-epoch snapshot retention window fail with `ErrHistoricalStateUnavailable`.
- All other query types, including `GetUTxOWhole`, still answer live; a paginated point-honoring `GetUTxOWhole` is tracked in #4082.

<sup>Written for commit dd08838efa0b0b0981c43d1303877ac4c0e3b7d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local state queries can now be pinned to a specific on-chain point for consistent historical results.
  - Historical epoch numbers, stake distributions, pool distributions, and compatible protocol-parameter queries are supported.
  - Pool stake distributions can be retrieved for a specified slot within the available snapshot history.
  - Queries validate that the requested point remains on the current chain.

- **Bug Fixes**
  - Invalid, rolled-back, unknown, or unavailable historical points now return clear errors instead of producing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->