### PR TITLE
fix: preserve metadata labels with unavailable JSON

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,15 @@ repeatable-read snapshots. All three return `*sqlstore.Store`; metadata
 business behavior is implemented once in `sqlstore` and dialect translation is
 limited to SQL mechanics.
 
+## Metadata JSON/CBOR boundary
+
+Metadata indexing treats raw CBOR as the lossless storage and API JSON as an
+optional representation. A label whose map keys collide after JSON
+stringification keeps its label and CBOR row but has no JSON representation;
+readers handle that condition per record rather than aborting indexing or
+dropping pagination rows. Duplicate top-level labels remain rejected because
+the relational label key is unique and no deterministic row selection exists.
+
 The public compatibility interface is decomposing into narrow capabilities so
 components need not inherit the full historical metadata surface. Three are
 cross-cutting -- `LifecycleStore`, `SettingsStore`, and `TxnStore` (which

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,8 +79,6 @@ repeatable-read snapshots. All three return `*sqlstore.Store`; metadata
 business behavior is implemented once in `sqlstore` and dialect translation is
 limited to SQL mechanics.
 
-## Metadata JSON/CBOR boundary
-
 Metadata indexing treats raw CBOR as the lossless storage and API JSON as an
 optional representation. A label whose map keys collide after JSON
 stringification keeps its label and CBOR row but has no JSON representation;

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -2224,6 +2224,14 @@ ORDER BY t.slot DESC, t.block_index DESC, t.id DESC
 LIMIT 100;
 ```
 
+### Transaction metadata JSON representation
+
+API-mode ingestion stores each unique metadata label with its raw CBOR value.
+If distinct ledger map keys cannot be represented uniquely as JSON object keys,
+the label remains indexed and `json_value` is NULL; this does not reject an
+otherwise valid transaction. The label-transaction JSON endpoint emits
+`json_metadata: null`, while CBOR endpoints continue to serve the raw value.
+
 ### `GetAccount`
 
 Latest delegation state for an account:

--- a/api/blockfrost/adapter.go
+++ b/api/blockfrost/adapter.go
@@ -3654,13 +3654,16 @@ func (a *NodeAdapter) MetadataTransactions(
 	ret := make([]MetadataTransactionJSONInfo, 0, len(txs))
 	for _, tx := range txs {
 		jsonValue, _, err := labelcodec.RawValues(tx.Metadata, label)
-		if err != nil {
+		if err != nil && !errors.Is(err, labelcodec.ErrJSONUnavailable) {
 			return nil, 0, fmt.Errorf(
 				"extract json metadata label %d from tx %x: %w",
 				label,
 				tx.Hash,
 				err,
 			)
+		}
+		if errors.Is(err, labelcodec.ErrJSONUnavailable) {
+			jsonValue = nil
 		}
 		ret = append(ret, MetadataTransactionJSONInfo{
 			TxHash:       hex.EncodeToString(tx.Hash),
@@ -3704,7 +3707,7 @@ func (a *NodeAdapter) MetadataTransactionsCBOR(
 
 	ret := make([]MetadataTransactionCBORInfo, 0, len(txs))
 	for _, tx := range txs {
-		_, cborValue, err := labelcodec.RawValues(tx.Metadata, label)
+		cborValue, err := labelcodec.RawValue(tx.Metadata, label)
 		if err != nil {
 			return nil, 0, fmt.Errorf(
 				"extract cbor metadata label %d from tx %x: %w",
@@ -3996,9 +3999,13 @@ func (a *NodeAdapter) TransactionMetadata(
 	}
 	ret := make([]TransactionMetadataInfo, 0, len(entries))
 	for _, entry := range entries {
+		var jsonMetadata json.RawMessage
+		if entry.JSONError == nil {
+			jsonMetadata = json.RawMessage(entry.JsonValue)
+		}
 		ret = append(ret, TransactionMetadataInfo{
 			Label:        strconv.FormatUint(entry.Label, 10),
-			JSONMetadata: json.RawMessage(entry.JsonValue),
+			JSONMetadata: jsonMetadata,
 		})
 	}
 	return ret, nil

--- a/api/blockfrost/blockfrost_test.go
+++ b/api/blockfrost/blockfrost_test.go
@@ -56,6 +56,54 @@ func TestRedeemerExecutionFee(t *testing.T) {
 	assert.Equal(t, uint64(21647), fee)
 }
 
+func TestMetadataJSONUnavailableSerializesAsNull(t *testing.T) {
+	payload, err := json.Marshal(MetadataTransactionJSONResponse{
+		TxHash:       "deadbeef",
+		JSONMetadata: nil,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"tx_hash":"deadbeef","json_metadata":null}`, string(payload))
+}
+
+func TestMetadataTransactionsCollisionKeepsLabelAndRawCBOR(t *testing.T) {
+	t.Parallel()
+	adapter, raw, _ := newDBBackedAdapter(t)
+	validHash := bytes.Repeat([]byte{0x41}, 32)
+	ambiguousHash := bytes.Repeat([]byte{0x42}, 32)
+	validMetadata, err := hex.DecodeString("a11902d1626f6b")
+	require.NoError(t, err)
+	ambiguousMetadata, err := hex.DecodeString("a11902d1a20163696e7461316474657874")
+	require.NoError(t, err)
+	validTx := &models.Transaction{Hash: validHash, Metadata: validMetadata}
+	ambiguousTx := &models.Transaction{Hash: ambiguousHash, Metadata: ambiguousMetadata}
+	insertAdapterTransaction(t, raw, validTx)
+	insertAdapterTransaction(t, raw, ambiguousTx)
+	ambiguousLabelCBOR, err := hex.DecodeString("a20163696e7461316474657874")
+	require.NoError(t, err)
+	_, err = raw.Exec(`INSERT INTO transaction_metadata_label (transaction_id, label, slot, cbor_value, json_value) VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+		validTx.ID, "721", 1, []byte{0x62, 0x6f, 0x6b}, `"ok"`,
+		ambiguousTx.ID, "721", 2, ambiguousLabelCBOR, nil)
+	require.NoError(t, err)
+	jsonRows, total, err := adapter.MetadataTransactions(721, PaginationParams{Count: 2, Page: 1, Order: PaginationOrderAsc})
+	require.NoError(t, err)
+	require.Equal(t, 2, total)
+	require.Len(t, jsonRows, 2)
+	require.Equal(t, `"ok"`, string(jsonRows[0].JSONMetadata))
+	require.Nil(t, jsonRows[1].JSONMetadata)
+	cborRows, _, err := adapter.MetadataTransactionsCBOR(721, PaginationParams{Count: 2, Page: 1, Order: PaginationOrderAsc})
+	require.NoError(t, err)
+	require.Len(t, cborRows, 2)
+	require.Equal(t, "a20163696e7461316474657874", cborRows[1].Metadata)
+	transactionJSON, err := adapter.TransactionMetadata(ambiguousHash)
+	require.NoError(t, err)
+	require.Len(t, transactionJSON, 1)
+	require.Equal(t, "", string(transactionJSON[0].JSONMetadata))
+	transactionCBOR, err := adapter.TransactionMetadataCBOR(ambiguousHash)
+	require.NoError(t, err)
+	require.Len(t, transactionCBOR, 1)
+	require.Equal(t, "a20163696e7461316474657874", transactionCBOR[0].CBORMetadata)
+}
+
 // mockNode implements BlockfrostNode for testing.
 type mockNode struct {
 	chainTip                      ChainTipInfo
@@ -3770,6 +3818,23 @@ func TestHandleMetadataTransactions(t *testing.T) {
 	require.Len(t, resp, 1)
 	assert.Equal(t, "txhash1", resp[0].TxHash)
 	assert.JSONEq(t, `{"name":"nft-one"}`, string(resp[0].JSONMetadata))
+}
+
+func TestHandleMetadataTransactionsKeepsUnavailableJSONAsNull(t *testing.T) {
+	t.Parallel()
+	mock := &mockNode{metadataJSONTotal: 1, metadataJSON: []MetadataTransactionJSONInfo{{
+		TxHash: "txhash-ambiguous", JSONMetadata: nil,
+	}}}
+	b := newTestBlockfrost(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/metadata/txs/labels/721", nil)
+	req.SetPathValue("label", "721")
+	w := httptest.NewRecorder()
+	b.handleMetadataTransactions(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp []MetadataTransactionJSONResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "null", string(resp[0].JSONMetadata))
 }
 
 func TestHandleMetadataTransactionsCBOR(t *testing.T) {

--- a/database/plugin/metadata/labelcodec/labelcodec.go
+++ b/database/plugin/metadata/labelcodec/labelcodec.go
@@ -30,7 +30,13 @@ type Entry struct {
 	Label     uint64
 	CborValue []byte
 	JsonValue string
+	JSONError error
 }
+
+// ErrJSONUnavailable indicates that a metadata value cannot be represented in
+// the Blockfrost JSON shape without losing information. Its raw CBOR remains
+// available to callers.
+var ErrJSONUnavailable = errors.New("metadata JSON representation unavailable")
 
 // Returns full metadata CBOR and per-label entries
 func EncodeAndExtract(
@@ -76,7 +82,7 @@ func RawValues(
 	}
 
 	jsonValue, err := metadatumRawToJSON(rawValue)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrJSONUnavailable) {
 		return nil, nil, fmt.Errorf(
 			"decode metadata label %d JSON: %w",
 			label,
@@ -84,7 +90,23 @@ func RawValues(
 		)
 	}
 
-	return json.RawMessage(jsonValue), append([]byte(nil), rawValue...), nil
+	return json.RawMessage(jsonValue), append([]byte(nil), rawValue...), err
+}
+
+// RawValue returns one label's CBOR without requiring JSON conversion.
+func RawValue(metadataCbor []byte, label uint64) ([]byte, error) {
+	if len(metadataCbor) == 0 {
+		return nil, errors.New("transaction has no metadata")
+	}
+	rawByLabel, err := decodeMetadataLabelMap(metadataCbor)
+	if err != nil {
+		return nil, err
+	}
+	rawValue, ok := rawByLabel[label]
+	if !ok {
+		return nil, fmt.Errorf("metadata label %d not found", label)
+	}
+	return append([]byte(nil), rawValue...), nil
 }
 
 // EntriesFromCBOR returns all metadata labels from encoded transaction
@@ -115,18 +137,22 @@ func extractFromCbor(
 	for _, label := range labels {
 		rawValue := rawByLabel[label]
 		jsonValue, err := metadatumRawToJSON(rawValue)
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrJSONUnavailable) {
 			return nil, fmt.Errorf(
 				"decode metadata label %d JSON: %w",
 				label,
 				err,
 			)
 		}
-		ret = append(ret, Entry{
+		entry := Entry{
 			Label:     label,
 			CborValue: append([]byte(nil), rawValue...),
 			JsonValue: jsonValue,
-		})
+		}
+		if err != nil {
+			entry.JSONError = err
+		}
+		ret = append(ret, entry)
 	}
 	return ret, nil
 }
@@ -138,6 +164,8 @@ func decodeMetadataLabelMap(
 	var asUint64 map[uint64]cbor.RawMessage
 	if _, err := cbor.Decode(metadataCbor, &asUint64); err == nil {
 		return asUint64, nil
+	} else if cbor.IsDuplicateMapKeyError(err) {
+		return nil, fmt.Errorf("duplicate metadata label: %w", err)
 	}
 	var asInt64 map[int64]cbor.RawMessage
 	if _, err := cbor.Decode(metadataCbor, &asInt64); err == nil {
@@ -149,6 +177,8 @@ func decodeMetadataLabelMap(
 			ret[uint64(k)] = v
 		}
 		return ret, nil
+	} else if cbor.IsDuplicateMapKeyError(err) {
+		return nil, fmt.Errorf("duplicate metadata label: %w", err)
 	}
 	return nil, errors.New("metadata is not an integer-keyed map")
 }
@@ -188,6 +218,7 @@ func extractFromMetadatum(
 		return nil, errors.New("metadata is not an integer-keyed map")
 	}
 	ret := make([]Entry, 0, len(tmpMap.Pairs))
+	seenLabels := make(map[uint64]struct{}, len(tmpMap.Pairs))
 	for _, pair := range tmpMap.Pairs {
 		keyInt, ok := pair.Key.(lcommon.MetaInt)
 		if !ok {
@@ -202,6 +233,11 @@ func extractFromMetadatum(
 				keyInt.Value.String(),
 			)
 		}
+		label := keyInt.Value.Uint64()
+		if _, exists := seenLabels[label]; exists {
+			return nil, fmt.Errorf("duplicate metadata label: %d", label)
+		}
+		seenLabels[label] = struct{}{}
 		cborValue, err := metadatumCbor(pair.Value)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -211,26 +247,30 @@ func extractFromMetadatum(
 			)
 		}
 		jsonValueAny, err := metadatumToJSONValue(pair.Value)
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrJSONUnavailable) {
 			return nil, fmt.Errorf(
 				"decode metadata label %s JSON: %w",
 				keyInt.Value.String(),
 				err,
 			)
 		}
-		jsonBytes, err := json.Marshal(jsonValueAny)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"encode metadata label %s JSON: %w",
-				keyInt.Value.String(),
-				err,
-			)
+		jsonValue := ""
+		if err == nil {
+			jsonBytes, marshalErr := json.Marshal(jsonValueAny)
+			if marshalErr != nil {
+				return nil, fmt.Errorf("encode metadata label %s JSON: %w", keyInt.Value.String(), marshalErr)
+			}
+			jsonValue = string(jsonBytes)
 		}
-		ret = append(ret, Entry{
-			Label:     keyInt.Value.Uint64(),
+		entry := Entry{
+			Label:     label,
 			CborValue: cborValue,
-			JsonValue: string(jsonBytes),
-		})
+			JsonValue: jsonValue,
+		}
+		if err != nil {
+			entry.JSONError = err
+		}
+		ret = append(ret, entry)
 	}
 	sort.Slice(ret, func(i, j int) bool { return ret[i].Label < ret[j].Label })
 	return ret, nil
@@ -267,6 +307,13 @@ func metadatumToJSONValue(md lcommon.TransactionMetadatum) (any, error) {
 			key, err := metadatumMapKeyToString(pair.Key)
 			if err != nil {
 				return nil, err
+			}
+			if _, exists := ret[key]; exists {
+				return nil, fmt.Errorf(
+					"%w: metadata map keys %q collide",
+					ErrJSONUnavailable,
+					key,
+				)
 			}
 			tmp, err := metadatumToJSONValue(pair.Value)
 			if err != nil {

--- a/database/plugin/metadata/labelcodec/labelcodec_fuzz_test.go
+++ b/database/plugin/metadata/labelcodec/labelcodec_fuzz_test.go
@@ -16,6 +16,7 @@ package labelcodec
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -77,7 +78,7 @@ func FuzzExtractFromCborRawValues(f *testing.F) {
 			}
 
 			jsonValue, cborValue, err := RawValues(metadataCbor, entry.Label)
-			if err != nil {
+			if err != nil && !errors.Is(err, ErrJSONUnavailable) {
 				t.Fatalf("RawValues(label=%d): %v", entry.Label, err)
 			}
 			if string(jsonValue) != entry.JsonValue {

--- a/database/plugin/metadata/labelcodec/labelcodec_test.go
+++ b/database/plugin/metadata/labelcodec/labelcodec_test.go
@@ -15,7 +15,10 @@
 package labelcodec
 
 import (
+	"encoding/hex"
+	"errors"
 	"math/big"
+	"strings"
 	"testing"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -66,5 +69,136 @@ func TestExtractFromMetadatumAcceptsValidIntegerKey(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Label != 721 {
 		t.Fatalf("unexpected entries: %#v", entries)
+	}
+}
+
+func TestMetadatumToJSONValueRejectsCollidingMapKeys(t *testing.T) {
+	md := lcommon.MetaMap{
+		Pairs: []lcommon.MetaPair{
+			{
+				Key:   lcommon.MetaInt{Value: big.NewInt(1)},
+				Value: lcommon.MetaText{Value: "integer key"},
+			},
+			{
+				Key:   lcommon.MetaText{Value: "1"},
+				Value: lcommon.MetaText{Value: "text key"},
+			},
+		},
+	}
+
+	_, err := metadatumToJSONValue(md)
+	if err == nil {
+		t.Fatal("expected colliding metadata keys to be rejected")
+	}
+	if !errors.Is(err, ErrJSONUnavailable) || err.Error() != `metadata JSON representation unavailable: metadata map keys "1" collide` {
+		t.Fatalf("unexpected collision error: %v", err)
+	}
+}
+
+func TestMetadatumToJSONValueRejectsAllKeyStringCollisions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  lcommon.TransactionMetadatum
+		text string
+	}{
+		{name: "bytes", key: lcommon.MetaBytes{Value: []byte{0xab}}, text: "ab"},
+		{name: "list", key: lcommon.MetaList{Items: []lcommon.TransactionMetadatum{lcommon.MetaInt{Value: big.NewInt(1)}}}, text: "[1]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, pairs := range [][]lcommon.MetaPair{
+				{{Key: tc.key, Value: lcommon.MetaText{Value: "a"}}, {Key: lcommon.MetaText{Value: tc.text}, Value: lcommon.MetaText{Value: "b"}}},
+				{{Key: lcommon.MetaText{Value: tc.text}, Value: lcommon.MetaText{Value: "b"}}, {Key: tc.key, Value: lcommon.MetaText{Value: "a"}}},
+			} {
+				_, err := metadatumToJSONValue(lcommon.MetaMap{Pairs: pairs})
+				if !errors.Is(err, ErrJSONUnavailable) {
+					t.Fatalf("expected unavailable JSON, got %v", err)
+				}
+			}
+		})
+	}
+	value := lcommon.MetaList{Items: []lcommon.TransactionMetadatum{lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+		{Key: lcommon.MetaInt{Value: big.NewInt(1)}, Value: lcommon.MetaText{Value: "a"}},
+		{Key: lcommon.MetaText{Value: "1"}, Value: lcommon.MetaText{Value: "b"}},
+	}}}}
+	_, err := metadatumToJSONValue(value)
+	if !errors.Is(err, ErrJSONUnavailable) {
+		t.Fatalf("expected nested collision to propagate, got %v", err)
+	}
+}
+
+func TestEntriesFromCBORRejectsEncodedKeyCollisions(t *testing.T) {
+	for _, encoded := range []string{
+		"a11902d1a20163696e7461316474657874",
+		"a11902d1a2613164746578740163696e74",
+	} {
+		metadataCbor, err := hex.DecodeString(encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := EntriesFromCBOR(metadataCbor)
+		if err != nil || len(entries) != 1 {
+			t.Fatalf("expected encoded key collision to remain indexed: %s: %v", encoded, err)
+		}
+		if !errors.Is(entries[0].JSONError, ErrJSONUnavailable) || len(entries[0].CborValue) == 0 || entries[0].JsonValue != "" {
+			t.Fatalf("expected unavailable JSON with raw CBOR: %#v", entries[0])
+		}
+		rawValue, err := RawValue(metadataCbor, 721)
+		if err != nil || string(rawValue) != string(entries[0].CborValue) {
+			t.Fatalf("expected raw label retrieval, got %x (%v)", rawValue, err)
+		}
+	}
+}
+
+func TestEncodeAndExtractKeepsAmbiguousLabelAndCBOR(t *testing.T) {
+	md := lcommon.MetaMap{Pairs: []lcommon.MetaPair{{
+		Key: lcommon.MetaInt{Value: big.NewInt(721)},
+		Value: lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+			{Key: lcommon.MetaInt{Value: big.NewInt(1)}, Value: lcommon.MetaText{Value: "integer"}},
+			{Key: lcommon.MetaText{Value: "1"}, Value: lcommon.MetaText{Value: "text"}},
+		}},
+	}}}
+	metadataCbor, entries, err := EncodeAndExtract(md)
+	if err != nil || len(metadataCbor) == 0 || len(entries) != 1 {
+		t.Fatalf("expected metadata to remain indexable: cbor=%x entries=%#v err=%v", metadataCbor, entries, err)
+	}
+	if entries[0].Label != 721 || entries[0].JsonValue != "" || len(entries[0].CborValue) == 0 || !errors.Is(entries[0].JSONError, ErrJSONUnavailable) {
+		t.Fatalf("unexpected ambiguous entry: %#v", entries[0])
+	}
+}
+
+func TestDuplicateMetadataLabelRejectedInBothExtractionPaths(t *testing.T) {
+	metadataCbor, err := hex.DecodeString("a2016161016162")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EntriesFromCBOR(metadataCbor); err == nil || !strings.Contains(err.Error(), "duplicate metadata label") {
+		t.Fatalf("expected duplicate encoded label rejection, got %v", err)
+	}
+	md := lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+		{Key: lcommon.MetaInt{Value: big.NewInt(1)}, Value: lcommon.MetaText{Value: "a"}},
+		{Key: lcommon.MetaInt{Value: big.NewInt(1)}, Value: lcommon.MetaText{Value: "b"}},
+	}}
+	if _, err := extractFromMetadatum(md); err == nil || !strings.Contains(err.Error(), "duplicate metadata label") {
+		t.Fatalf("expected duplicate fallback label rejection, got %v", err)
+	}
+	if _, _, err := EncodeAndExtract(md); err == nil {
+		t.Fatal("expected encoded duplicate label rejection")
+	}
+}
+
+func TestDuplicateNestedEncodedKeyIsUnavailableInJSON(t *testing.T) {
+	metadataCbor, err := hex.DecodeString("a11902d1a2016161016162")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := EntriesFromCBOR(metadataCbor)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected duplicate nested key to remain indexed: %v", err)
+	}
+	if !errors.Is(entries[0].JSONError, ErrJSONUnavailable) || len(entries[0].CborValue) == 0 {
+		t.Fatalf("expected unavailable JSON with raw CBOR: %#v", entries[0])
 	}
 }

--- a/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
+++ b/database/plugin/metadata/sqlite/shared_sqlstore_transaction_write_parity_test.go
@@ -11,11 +11,13 @@ package sqlite
 import (
 	"bytes"
 	"database/sql"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/plugin/metadata"
+	"github.com/blinklabs-io/dingo/database/plugin/metadata/sqlstore"
 	"github.com/blinklabs-io/dingo/database/types"
 	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -103,6 +105,41 @@ func TestSharedSQLStoreTransactionWriteParity(t *testing.T) {
 		return deltas, witnesses
 	}
 	_ = exerciseTransactionWriteStore(t, store, false, counts)
+}
+
+func TestSharedSQLStoreTransactionMetadataCollisionIsNullable(t *testing.T) {
+	t.Parallel()
+	store, raw := func() (*sqlstore.Store, *sql.DB) {
+		store, writeDB, _, err := openSQLStore(
+			Config{DataDir: t.TempDir()},
+			metadata.ProviderDependencies{StorageMode: types.StorageModeAPI},
+		)
+		require.NoError(t, err)
+		require.NoError(t, store.Start(t.Context()))
+		t.Cleanup(func() { require.NoError(t, store.Close()) })
+		return store, writeDB
+	}()
+	txHash := lcommon.Blake2b256{0xe7}
+	metadataValue := lcommon.MetaMap{Pairs: []lcommon.MetaPair{{
+		Key: lcommon.MetaInt{Value: big.NewInt(721)},
+		Value: lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+			{Key: lcommon.MetaInt{Value: big.NewInt(1)}, Value: lcommon.MetaText{Value: "integer"}},
+			{Key: lcommon.MetaText{Value: "1"}, Value: lcommon.MetaText{Value: "text"}},
+		}},
+	}}}
+	require.NoError(t, store.SetTransaction(
+		&mockTransaction{hash: txHash, metadata: metadataValue},
+		ocommon.Point{Slot: 7, Hash: bytes.Repeat([]byte{0xe8}, 32)}, 0, nil, false, nil,
+	))
+	var jsonValue sql.NullString
+	var cborValue []byte
+	require.NoError(t, raw.QueryRow(`
+SELECT l.json_value, l.cbor_value
+FROM transaction_metadata_label AS l
+JOIN "transaction" AS tx ON tx.id = l.transaction_id
+WHERE tx.hash = ? AND l.label = ?`, txHash.Bytes(), "721").Scan(&jsonValue, &cborValue))
+	require.False(t, jsonValue.Valid)
+	require.Equal(t, "a20167696e746567657261316474657874", hex.EncodeToString(cborValue))
 }
 
 // TestSharedSQLStoreWithdrawalWitnessGate covers issue #2919: the

--- a/database/plugin/metadata/sqlstore/transaction_api.go
+++ b/database/plugin/metadata/sqlstore/transaction_api.go
@@ -39,6 +39,10 @@ func (s *Store) applyTransactionMetadataLabels(
 		return nil
 	}
 	for _, label := range labels {
+		var jsonValue any
+		if label.JSONError == nil {
+			jsonValue = label.JsonValue
+		}
 		if _, err := db.ExecContext(ctx, `
 INSERT INTO transaction_metadata_label (
     transaction_id, label, slot, cbor_value, json_value
@@ -51,7 +55,7 @@ ON CONFLICT (transaction_id, label) DO UPDATE SET
 			decimalUint64(types.Uint64(label.Label)),
 			slot,
 			label.CborValue,
-			label.JsonValue,
+			jsonValue,
 		); err != nil {
 			return fmt.Errorf(
 				"create transaction metadata label %d: %w",


### PR DESCRIPTION
Detect metadata map-key collisions before JSON conversion while preserving raw CBOR and label indexing. Unrepresentable JSON is returned as null per record; duplicate top-level labels remain rejected.

Related to #3674.