### PR TITLE
fix(ouroboros): reuse parent deadline cancellation

### DIFF
--- a/ouroboros/leios_backfill.go
+++ b/ouroboros/leios_backfill.go
@@ -54,6 +54,16 @@ func leiosFetchRequestContext(
 		parent = context.Background()
 	}
 	if !deadline.IsZero() {
+		// WithDeadline creates an independent timer when the requested deadline
+		// is equal to the parent's deadline (it uses a strict Before check).
+		// That timer can win while parent.Err is still nil, making a caller
+		// deadline look like a peer timeout. Reuse the parent's cancellation
+		// whenever it is no later than the requested attempt deadline; only
+		// create a child timer when the attempt is genuinely earlier.
+		if parentDeadline, ok := parent.Deadline(); ok &&
+			!parentDeadline.After(deadline) {
+			return context.WithCancel(parent)
+		}
 		return context.WithDeadline(parent, deadline)
 	}
 	return context.WithTimeout(

--- a/ouroboros/leios_fetch_resilience_test.go
+++ b/ouroboros/leios_fetch_resilience_test.go
@@ -15,11 +15,80 @@
 package ouroboros
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+type manualDeadlineContext struct {
+	context.Context
+	deadline time.Time
+	done     chan struct{}
+	canceled atomic.Bool
+	err      error
+}
+
+func (c *manualDeadlineContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func (c *manualDeadlineContext) Done() <-chan struct{} { return c.done }
+
+func (c *manualDeadlineContext) Err() error {
+	if c.canceled.Load() {
+		return c.err
+	}
+	return nil
+}
+
+func TestLeiosFetchRequestContextReusesEqualParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	deadline := time.Now().Add(-time.Second)
+	parent := &manualDeadlineContext{
+		Context:  context.Background(),
+		deadline: deadline,
+		done:     make(chan struct{}),
+	}
+	child, cancel := leiosFetchRequestContext(parent, deadline)
+	defer cancel()
+
+	// WithDeadline's strict parent-before-child check used to create an
+	// independently expired timer here, even though the parent timer has not
+	// delivered cancellation yet. The child must remain live until the parent
+	// is cancelled.
+	select {
+	case <-child.Done():
+		t.Fatal("child deadline fired before parent cancellation")
+	default:
+	}
+	parent.err = context.DeadlineExceeded
+	parent.canceled.Store(true)
+	close(parent.done)
+	select {
+	case <-child.Done():
+		require.ErrorIs(t, child.Err(), context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("child did not follow parent cancellation")
+	}
+}
+
+func TestLeiosFetchRequestContextKeepsEarlierAttemptDeadline(t *testing.T) {
+	t.Parallel()
+
+	parent := &manualDeadlineContext{
+		Context:  context.Background(),
+		deadline: time.Now().Add(time.Hour),
+		done:     make(chan struct{}),
+	}
+	child, cancel := leiosFetchRequestContext(parent, time.Now().Add(-time.Second))
+	defer cancel()
+	require.ErrorIs(t, child.Err(), context.DeadlineExceeded)
+	require.NoError(t, parent.Err())
+}
 
 // assertCooldownWindow asserts the guard is in cooldown right up to, but not at,
 // now+want.


### PR DESCRIPTION
Reuse parent cancellation when the caller deadline is equal to or earlier
than the Leios fetch attempt deadline. Equal deadlines must not create an
independent child timer that can expire before the parent reports cancellation.
Earlier attempt deadlines retain their independent timeout.

Add deterministic equal-deadline and earlier-attempt regression coverage.

Related to #4154. The observed CI failure's exact interleaving remains unconfirmed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Leios fetch request context so an equal parent deadline no longer creates an independent timer that can expire before the parent reports cancellation, which could mislabel a caller deadline as a peer timeout. When the parent deadline is equal to or earlier than the attempt deadline, the child now reuses parent cancellation; earlier attempt deadlines keep their independent timeout.

Adds deterministic regression tests for both equal-deadline and earlier-attempt cases in `ouroboros`. Related to #4154; the exact CI failure interleaving remains unconfirmed.

<sup>Written for commit 797cb2b409ada420f5817dab3336c46f2ac06700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout handling so parent cancellation and attempt-specific deadlines are distinguished correctly.
  - Prevented equal deadlines from being reported prematurely as peer timeouts.
  - Preserved independent expiration for earlier attempt deadlines.

- **Tests**
  - Added coverage for cancellation behavior with equal and earlier deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->