### PR TITLE
perf(sqlstore/migrations): share one baseline across replay subtests

### DIFF
--- a/database/plugin/metadata/sqlstore/migrations/runner_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/runner_test.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -616,21 +617,33 @@ func TestRunnerDoesNotSkipNonAddColumnFailure(t *testing.T) {
 // interrupted upgrade. Replaying expand also replays backfill and contract, so
 // this covers every phase of every shipped version against a database that
 // already has the version's full effect applied.
+//
+// Every subtest's first Run() call was byte-for-byte identical work -- same
+// fresh database, same full registry, same stateless NewProcessLocker -- so it
+// is built once here and shared as a byte copy instead of being replayed by
+// every subtest. That first replay is ~400 individually autocommitted
+// DDL/state writes (13 migrations, each a separate fsync'd transaction under
+// SQLite's default synchronous=FULL/journal_mode=DELETE); redoing it in every
+// one of the ~13 parallel subtests is what pushes this package toward the
+// per-package -timeout bound on a CI runner where fsync is expensive
+// (dingo#4171). The per-migration replay under test -- resetting one version
+// to PhaseExpand and calling Run() again -- still runs against each subtest's
+// own independent copy, so the coverage this test exists for is unchanged.
 func TestRunnerReplaysEveryShippedVersionFromExpand(t *testing.T) {
 	t.Parallel()
 	registry, err := SQLiteRegistry()
 	require.NoError(t, err)
+	baseline := fullyMigratedBaseline(t, registry)
 	for _, migration := range registry {
 		t.Run(migration.Name, func(t *testing.T) {
 			t.Parallel()
-			db := openTestDB(t)
+			db := openTestDBFromBaseline(t, baseline)
 			runner := &Runner{
 				DB:       db,
 				Dialect:  "sqlite",
 				Registry: registry,
 				Locker:   NewProcessLocker(),
 			}
-			require.NoError(t, runner.Run(context.Background()))
 
 			_, err := db.Exec(`
 UPDATE schema_migrations
@@ -657,4 +670,47 @@ SELECT phase, dirty, completed_at FROM schema_migrations WHERE version = ?`,
 			require.True(t, completed.Valid)
 		})
 	}
+}
+
+// fullyMigratedBaseline runs the full registry once against a fresh database
+// and returns its file bytes. Run() leaves no journal file behind under the
+// default journal_mode=DELETE (the rollback journal is removed on commit), so
+// the closed file alone is a complete, valid database each subtest can copy.
+func fullyMigratedBaseline(t *testing.T, registry []Migration) []byte {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "baseline.sqlite")
+	db, err := sql.Open(
+		"sqlite",
+		"file:"+path+"?_pragma=foreign_keys(1)",
+	)
+	require.NoError(t, err)
+	runner := &Runner{
+		DB:       db,
+		Dialect:  "sqlite",
+		Registry: registry,
+		Locker:   NewProcessLocker(),
+	}
+	require.NoError(t, runner.Run(context.Background()))
+	require.NoError(t, db.Close())
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+// openTestDBFromBaseline seeds a subtest's own database file from a byte copy
+// of an already fully-migrated database, replacing a second full 13-migration
+// replay with one file write.
+func openTestDBFromBaseline(t *testing.T, baseline []byte) *sql.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "metadata.sqlite")
+	require.NoError(t, os.WriteFile(path, baseline, 0o600))
+	db, err := sql.Open(
+		"sqlite",
+		"file:"+path+"?_pragma=foreign_keys(1)",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db
 }


### PR DESCRIPTION
`database/plugin/metadata/sqlstore/migrations` has exceeded the 30-minute
per-package bound on Windows CI 5 times, always this package, always on
branches that do not touch it (#4171). A goroutine dump from the fifth
occurrence shows nothing stuck: 16 of 28 goroutines are parked in
`testing.(*testState).waitParallel`, only 4 running, longest 2m58s. The
package is ~20 multi-minute subtests draining through a handful of parallel
slots.

`TestRunnerReplaysEveryShippedVersionFromExpand` ran a full, fresh
13-migration replay inside every `t.Parallel()` subtest, and that first
`Runner.Run()` call was byte-for-byte identical work every time (same
registry, same empty database, stateless `NewProcessLocker()`). Each replay
is ~419 individually autocommitted, fsync'd write-transactions (340 DDL + 78
state-bookkeeping + 1 state-table create), because `execDDL` and the state
helpers run on a bare `*sql.Conn` with no wrapping transaction, and the test
database opens at SQLite's default `journal_mode=DELETE` /
`synchronous=FULL`.

This builds the migrated baseline once per test function and gives each
subtest a byte copy of the file. `journal_mode=DELETE` leaves no journal file
after a clean `Close()`, so the closed file alone is a complete database; and
`NewProcessLocker()` is a fresh in-memory channel token per call, so a copy
carries no lock state. `t.Parallel()` is preserved and each subtest still
resets and replays its own migration version against its own copy, so
per-version replay coverage is unchanged.

Local (darwin/arm64): write-transactions for the test function drop from
~5,538 to ~510 (91%); wall time from 3.0-3.8s to 0.38-0.41s (88-90%). The
Windows per-transaction cost and the projected per-subtest speedup are not
measured — they are inferred from the issue's single Windows data point,
where fsync and antivirus interception on journal-file create/delete are
expected to be far more expensive than on macOS.

If this holds on Windows CI, it removes the dominant contributor to this
package's 30-minute timeout, which is currently why `go-test (Windows)`
cannot become a required check (#3746).

Addresses #4171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qvo7XX3fd5xaSiRb6VVjP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares one fully-migrated baseline across all subtests in `TestRunnerReplaysEveryShippedVersionFromExpand`, replacing a full 13-migration replay in every parallel subtest with a byte copy of the same result. Cuts the test’s local wall time from ~3.5s to ~0.4s and should bring the package under the 30-minute Windows CI timeout observed in #4171.

**Refactors**
- Builds the baseline once per test function by running the full registry against a fresh database.
- Each subtest seeds its own database from a copy of that baseline file, then runs its per-version replay assertion unchanged.
- The baseline is a valid closed database because `journal_mode=DELETE` leaves no journal file, and `NewProcessLocker()` is stateless.

<sup>Written for commit c40ed405a1be5805b92c0964b471cbb6c6e1fdfa. Summary will update on new commits.</sup>

Closes #4171
