### PR TITLE
fix(storage): expose Badger's async close completion signal

### DIFF
--- a/database/plugin/blob/badger/database.go
+++ b/database/plugin/blob/badger/database.go
@@ -499,6 +499,18 @@ func (d *BlobStoreBadger) CloseContext(ctx context.Context) error {
 	}
 }
 
+// Closed returns a channel that is closed once CloseContext's background
+// cleanup has actually finished -- GC has drained and the underlying
+// badger.DB.Close() call, which releases the on-disk directory lock, has
+// returned. CloseContext itself may return earlier, when its context's
+// deadline expires before that cleanup completes (see its doc comment); a
+// caller that needs to know the close is actually done, for example before
+// reopening the same data directory, must wait on this channel rather than
+// on CloseContext returning.
+func (d *BlobStoreBadger) Closed() <-chan struct{} {
+	return d.closeDone
+}
+
 // DB returns the database handle
 func (d *BlobStoreBadger) DB() *badger.DB {
 	return d.db

--- a/node_lifecycle_test.go
+++ b/node_lifecycle_test.go
@@ -37,6 +37,7 @@ import (
 	internalplugins "github.com/blinklabs-io/dingo/internal/plugins"
 	"github.com/blinklabs-io/dingo/internal/test/dbtest"
 	testfixtures "github.com/blinklabs-io/dingo/internal/test/fixtures"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
 	"github.com/blinklabs-io/dingo/ledger"
 	"github.com/blinklabs-io/dingo/ledger/leios"
 	"github.com/blinklabs-io/dingo/mempool"
@@ -881,6 +882,20 @@ func TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed(
 	// close continues asynchronously.
 	n.deferredIndexMaintenanceDone = make(chan struct{})
 
+	// Capture the blob store's own completion signal before Truncate closes
+	// n.db out from under it: BlobStoreBadger.Closed() closes only once its
+	// background CloseContext cleanup (GC drain, then badger.DB.Close(),
+	// which releases the on-disk directory lock) has actually finished, so
+	// waiting on it -- instead of polling by repeatedly reopening the data
+	// directory -- proves drain completion directly rather than guessing at
+	// a bound. See BlobStoreBadger.Closed's doc comment for why CloseContext
+	// returning is not itself that signal.
+	blobCloser, ok := n.db.Blob().(interface{ Closed() <-chan struct{} })
+	require.True(
+		t, ok,
+		"test harness blob store does not expose a completion signal",
+	)
+
 	shortCtx, cancel := context.WithTimeout(
 		context.Background(),
 		20*time.Millisecond,
@@ -898,23 +913,27 @@ func TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed(
 	require.Error(t, n.ctx.Err())
 	require.Nil(t, n.db, "storage must not be reopened before provider drain")
 
-	// Wait for the provider-owned background close before TempDir cleanup. A
-	// scratch runtime can acquire the same path only after the old Badger lock
-	// is released; the cancelled Node itself remains stopped and never reopens.
-	require.Eventually(t, func() bool {
-		deps := n.storageDependencies(n.config.dataDir)
-		deps.PromRegistry = n.config.promRegistry
-		runtime, openErr := internalplugins.OpenDatabase(
-			context.Background(),
-			n.databaseConfig(),
-			n.storageSelections(),
-			deps,
-		)
-		if openErr != nil {
-			return false
-		}
-		return runtime.Close(context.Background()) == nil
-	}, 5*time.Second, 10*time.Millisecond)
+	// Wait for the provider-owned background close before TempDir cleanup,
+	// via its own completion signal rather than a fixed bound: the cancelled
+	// Node itself remains stopped and never reopens.
+	testutil.RequireReceive(
+		t, blobCloser.Closed(), 30*time.Second,
+		"storage provider background close never confirmed drain",
+	)
+
+	// Once drain is confirmed, a scratch runtime opening the same data
+	// directory must succeed deterministically -- the old Badger lock is
+	// guaranteed released, so this is a single attempt, not a poll.
+	deps := n.storageDependencies(n.config.dataDir)
+	deps.PromRegistry = n.config.promRegistry
+	runtime, openErr := internalplugins.OpenDatabase(
+		context.Background(),
+		n.databaseConfig(),
+		n.storageSelections(),
+		deps,
+	)
+	require.NoError(t, openErr)
+	require.NoError(t, runtime.Close(context.Background()))
 }
 
 // TestLiveTruncateResumesAfterCompletedStorageStopFailure proves that an


### PR DESCRIPTION
## Symptom

`TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed` flaked on Windows CI (`Condition never satisfied` at `node_lifecycle_test.go:904`), reproduced on two unrelated PRs' CI runs. Linux, Linux-race, and macOS always pass.

## Root cause

The test polled by repeatedly reopening the data directory inside `require.Eventually(..., 5*time.Second, ...)`. That races a fixed guess against `BlobStoreBadger.CloseContext`'s background cleanup: `CloseContext` returns as soon as its context expires, while `db.Close()` — which releases the on-disk Badger directory lock — keeps running in a goroutine. `BlobStoreBadger` already tracked that goroutine's completion internally via `closeDone`, but nothing outside the struct could observe it.

## Fix

Add `BlobStoreBadger.Closed() <-chan struct{}`, returning the existing `closeDone` channel, documented to make explicit that `CloseContext` returning is not the completion signal. The test now captures the blob store's `Closed()` channel before `Truncate` runs, waits on it instead of polling, then performs a single deterministic reopen once drain is confirmed.

This is an additive change to `BlobStoreBadger`'s public surface; no other blob or metadata provider has this gap (sqlstore's `CloseContext` closes its pools synchronously even when its context expires first; the AWS/GCS blob stores close synchronously with no background goroutine). No current caller consumes `Closed()` outside this test — on an unconfirmed drain, the live node's only response is a full supervised process exit, and OS process termination releases the lock regardless.

## Validation

Injecting a 6s delay before `db.Close()` in `CloseContext` reproduces the CI failure against the old polling test (same assertion, same message). With the fix and the same injected delay, the test passes; with the delay reverted, it passes repeatedly, including under constrained `GOMAXPROCS` with CPU load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qvo7XX3fd5xaSiRb6VVjP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `TestLiveTruncateCancelsWhenStorageProviderDrainIsUnconfirmed` test on Windows CI by exposing Badger's async close completion signal.

- Adds `BlobStoreBadger.Closed()`, which returns a channel that closes when the background cleanup from `CloseContext` (including Badger's `db.Close()` that releases the directory lock) actually finishes, not when the context expires.
- The test now waits on that channel before reopening the data directory, replacing the old polling loop that raced a fixed timeout against the async close.

<sup>Written for commit 347f2d0061ece30b7d17027b2a26cdd8e4e91c27. Summary will update on new commits.</sup>
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way for applications to determine when blob storage shutdown has fully completed.

* **Tests**
  * Improved lifecycle testing to reliably verify storage cleanup before reopening the same data directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #4179
