### PR TITLE
test(ledger): update reference-script admission arguments

### DIFF
--- a/ledger/block_reference_script_test.go
+++ b/ledger/block_reference_script_test.go
@@ -142,13 +142,13 @@ func TestBlockReferenceScriptLimitAdmission(t *testing.T) {
 					}
 					currentParams.ProtocolVersion.Major = dijkstra.MinProtocolVersionDijkstra
 					return db.Transaction(true).Do(func(txn *database.Txn) error {
-						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, eras.DijkstraEraDesc, currentParams, pp, 0)
+						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, eras.DijkstraEraDesc, currentParams, pp, 0, false)
 						return err
 					})
 				},
 				"imported": func() error {
 					return db.Transaction(true).Do(func(txn *database.Txn) error {
-						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0)
+						_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0, false)
 						return err
 					})
 				},

--- a/ledger/block_reference_scripts_additional_test.go
+++ b/ledger/block_reference_scripts_additional_test.go
@@ -109,7 +109,7 @@ func additionalReferenceAdmission(
 	for path, run := range map[string]func() error{
 		"imported": func() error {
 			return db.Transaction(true).Do(func(txn *database.Txn) error {
-				_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0)
+				_, err := ls.ledgerProcessBlock(txn, ocommon.NewPoint(1, block.Hash().Bytes()), block, true, false, false, nil, envelopeParent{origin: true}, nil, era, pp, nil, 0, false)
 				return err
 			})
 		},


### PR DESCRIPTION
Pass the explicit non-synthetic cost-model state to the three reference-script admission fixtures, matching the current `ledgerProcessBlock` signature and restoring ledger test compilation.

Related to #4095.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the reference-script admission test fixtures to pass the explicit non-synthetic cost-model state to `ledgerProcessBlock`, matching its current signature and restoring ledger test compilation. Related to #4095.

<sup>Written for commit f0dedaabffbbbcbfb2a131560258a51bd62e399c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

