### PR TITLE
fix(database): detach the blob stop from restore's canceled ctx

### DIFF
--- a/database/lifecycle/restore.go
+++ b/database/lifecycle/restore.go
@@ -659,6 +659,30 @@ func (r *RestoreRecovery) Rollback(ctx context.Context) error {
 	return nil
 }
 
+// stopBlobCapabilityUncancelable stops the blob capability using a context
+// that cannot be cut short by ctx's own cancellation. BlobStoreBadger.
+// CloseContext (the real on-disk "badger" provider's StopFunc) races ctx
+// against its own background close and returns as soon as ctx is Done,
+// before the underlying badger.DB.Close call -- which releases the OS-level
+// directory lock -- has actually run; see CloseContext's and Closed's doc
+// comments in database/plugin/blob/badger/database.go. Every blob
+// StopCapability call in this file that precedes a later in-process reopen
+// of the same directory (prepareRestore's preflight resolve,
+// restoreBlobStore's post-Restore stop, and the automatic rollback's own
+// reopen) used ctx directly, so a restore whose context was canceled mid-
+// Restore -- the ordinary case when a caller's own context is what just
+// failed Restore -- could leave that store's close still running in the
+// background while a subsequent resolve (the automatic rollback, or a
+// caller retrying against the same host) reopened the same path and lost
+// the race for the lock. Detaching cancellation here does not change
+// whether the restore itself is cancelable: only this cleanup step, which
+// must run to completion regardless of why it is running, is affected.
+func stopBlobCapabilityUncancelable(ctx context.Context, host *plugin.Host) error {
+	return host.StopCapability(
+		context.WithoutCancel(ctx), plugin.CapabilityStorageBlob,
+	)
+}
+
 // prepareRestore validates both incoming archives before either live store is
 // reset. When the live-node call path explicitly permits replacement of a
 // populated remote target, it also captures both original stores first. This
@@ -772,7 +796,7 @@ func prepareRestore(
 		))
 	}
 	if _, ok := blobStore.(blob.Restorer); !ok {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return cleanupOnError(fmt.Errorf(
 			"blob plugin %q does not support restore", manifest.BlobPlugin,
 		))
@@ -780,7 +804,7 @@ func prepareRestore(
 	blobBackupPath := filepath.Join(snapshotDir, BlobBackupFileName)
 	blobBackupFile, err := os.Open(blobBackupPath)
 	if err != nil {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return cleanupOnError(fmt.Errorf("open %q: %w", blobBackupPath, err))
 	}
 	if validator, ok := blobStore.(blob.BackupValidator); ok {
@@ -788,13 +812,13 @@ func prepareRestore(
 	}
 	closeErr := blobBackupFile.Close()
 	if err != nil {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return cleanupOnError(fmt.Errorf(
 			"validate blob backup %q: %w", blobBackupPath, err,
 		))
 	}
 	if closeErr != nil {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return cleanupOnError(fmt.Errorf(
 			"close blob backup %q after validation: %w",
 			blobBackupPath,
@@ -805,7 +829,7 @@ func prepareRestore(
 		metadata.ResetOfPopulatedTargetAllowed(ctx) {
 		backuper, ok := blobStore.(blob.Backuper)
 		if !ok {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return cleanupOnError(fmt.Errorf(
 				"blob plugin %q cannot retain a rollback backup",
 				manifest.BlobPlugin,
@@ -816,7 +840,7 @@ func prepareRestore(
 			rollback.blobPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600,
 		)
 		if openErr != nil {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return cleanupOnError(fmt.Errorf(
 				"create original blob rollback backup: %w", openErr,
 			))
@@ -827,19 +851,19 @@ func prepareRestore(
 		}
 		backupCloseErr := rollbackFile.Close()
 		if backupErr != nil {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return cleanupOnError(fmt.Errorf(
 				"backup original blob store before restore: %w", backupErr,
 			))
 		}
 		if backupCloseErr != nil {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return cleanupOnError(fmt.Errorf(
 				"close original blob rollback backup: %w", backupCloseErr,
 			))
 		}
 	}
-	if err := host.StopCapability(ctx, plugin.CapabilityStorageBlob); err != nil {
+	if err := stopBlobCapabilityUncancelable(ctx, host); err != nil {
 		return cleanupOnError(fmt.Errorf(
 			"stop blob plugin after restore preflight: %w", err,
 		))
@@ -856,7 +880,7 @@ func (r *restoreRollback) restore(
 ) error {
 	var errs []error
 	if r.blobMutated && r.blobPath != "" {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		if err := restoreBlobStore(
 			ctx,
 			host,
@@ -1014,7 +1038,7 @@ func restoreBlobStore(
 	}
 	restorer, ok := store.(blob.Restorer)
 	if !ok {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return fmt.Errorf(
 			"blob plugin %q does not support restore",
 			manifest.BlobPlugin,
@@ -1023,14 +1047,14 @@ func restoreBlobStore(
 	if replacePopulated {
 		resettable, ok := store.(blob.Resettable)
 		if !ok {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return fmt.Errorf(
 				"blob plugin %q does not support replacing a populated store",
 				manifest.BlobPlugin,
 			)
 		}
 		if err := resettable.Reset(ctx); err != nil {
-			_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+			_ = stopBlobCapabilityUncancelable(ctx, host)
 			return fmt.Errorf(
 				"reset blob plugin %q before restore: %w",
 				manifest.BlobPlugin, err,
@@ -1039,12 +1063,12 @@ func restoreBlobStore(
 	}
 	backupFile, err := os.Open(backupPath)
 	if err != nil {
-		_ = host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+		_ = stopBlobCapabilityUncancelable(ctx, host)
 		return fmt.Errorf("open %q: %w", backupPath, err)
 	}
 	restoreErr := restorer.Restore(ctx, backupFile)
 	closeErr := backupFile.Close()
-	stopErr := host.StopCapability(ctx, plugin.CapabilityStorageBlob)
+	stopErr := stopBlobCapabilityUncancelable(ctx, host)
 	if restoreErr != nil {
 		return fmt.Errorf("restore blob store: %w", restoreErr)
 	}

--- a/database/lifecycle/restore_blob_stop_race_internal_test.go
+++ b/database/lifecycle/restore_blob_stop_race_internal_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/plugin/blob/badger"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/dingo/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+const cancelOnRestoreBlobProviderName = "cancel-on-restore-blob"
+
+// cancelOnRestoreBlobStore embeds an unopened Badger blob store purely to
+// satisfy the full blob.BlobStore method set plugin.Resolve's type
+// assertion requires -- restoreBlobStore itself never calls any of those
+// promoted methods, only Restore (overridden below) and the Restorer/
+// Resettable type assertions.
+//
+// Its own stop method reproduces BlobStoreBadger.CloseContext's exact
+// documented contract (see database/plugin/blob/badger/database.go):
+// returning is not the completion signal, because a caller-supplied ctx
+// can race the real close and return first. Reproducing that contract
+// here, rather than depending on Badger's own on-disk directory lock
+// timing, isolates what this test proves -- restoreBlobStore's own
+// context handling -- from Badger's OS-level lock behavior, which
+// database/plugin/blob/badger's own tests (provider_test.go's
+// TestProviderStopDeadlineDuringValueLogGC) already cover.
+type cancelOnRestoreBlobStore struct {
+	*badger.BlobStoreBadger
+	cancelRestore context.CancelFunc
+	stopEntered   chan struct{}
+	release       chan struct{}
+	stopFinished  atomic.Bool
+}
+
+func (s *cancelOnRestoreBlobStore) Restore(
+	ctx context.Context,
+	_ io.Reader,
+) error {
+	s.cancelRestore()
+	return ctx.Err()
+}
+
+// stop races ctx against a completion signal gated on s.release, exactly
+// as CloseContext races ctx against its own closeDone channel.
+func (s *cancelOnRestoreBlobStore) stop(ctx context.Context) error {
+	close(s.stopEntered)
+	done := make(chan struct{})
+	go func() {
+		<-s.release
+		s.stopFinished.Store(true)
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func newCancelOnRestoreTestHost(
+	t *testing.T,
+	store *cancelOnRestoreBlobStore,
+) *plugin.Host {
+	t.Helper()
+	host := plugin.NewHost()
+	require.NoError(t, plugin.Register[blob.BlobStore](
+		host,
+		plugin.Descriptor{
+			Capability: plugin.CapabilityStorageBlob,
+			Name:       cancelOnRestoreBlobProviderName,
+		},
+		func() struct{} { return struct{}{} },
+		func(
+			_ context.Context,
+			_ struct{},
+			_ blob.ProviderDependencies,
+		) (blob.BlobStore, plugin.Instance, error) {
+			return store, plugin.Lifecycle{
+				StartFunc: func(context.Context) error { return nil },
+				StopFunc:  store.stop,
+			}, nil
+		},
+	))
+	t.Cleanup(func() { _ = host.Stop(context.Background()) })
+	return host
+}
+
+// TestRestoreBlobStoreStopWaitsForProviderAfterCanceledRestore is a
+// regression test for the restore-rollback lock race in dingo#4179's
+// class: restoreBlobStore's own StopCapability call must not surface as
+// "the provider is stopped" before the provider's Stop has genuinely
+// finished, even when Restore failed because the operation's own context
+// was just canceled -- the ordinary case, since Restore and the cleanup
+// Stop that follows it share the same ctx.
+//
+// If StopCapability races that canceled ctx instead of waiting for the
+// real completion, an automatic rollback (restoreRollback.restore) or a
+// caller retrying the same restore against the same host can reopen
+// targetDataDir while the prior store's close is still in flight and
+// lose the race for its directory lock -- restore_remote_test.go's
+// TestRestoreFailureRollsBackPopulatedRemoteStoresExactly/
+// cancellation_after_reset is the user-visible "automatic restore
+// rollback failed ... Cannot acquire directory lock" symptom this
+// produces for a provider whose Stop propagates ctx like the real
+// on-disk "badger" plugin does (badger.RegisterProvider wires
+// StopFunc: store.CloseContext directly, unlike that test's own
+// remoteTestBlobStore, whose Stop always uses context.Background and so
+// cannot observe this race).
+func TestRestoreBlobStoreStopWaitsForProviderAfterCanceledRestore(t *testing.T) {
+	backupPath := filepath.Join(t.TempDir(), "blob.backup")
+	require.NoError(t, os.WriteFile(backupPath, nil, 0o600))
+	targetDir := t.TempDir()
+
+	embedded, err := badger.New(badger.WithDeferOpen())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancelOnRestoreBlobStore{
+		BlobStoreBadger: embedded,
+		cancelRestore:   cancel,
+		stopEntered:     make(chan struct{}),
+		release:         make(chan struct{}),
+	}
+	host := newCancelOnRestoreTestHost(t, store)
+	manifest := Manifest{BlobPlugin: cancelOnRestoreBlobProviderName}
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- restoreBlobStore(
+			ctx, host, manifest, backupPath, targetDir, nil, false,
+		)
+	}()
+
+	testutil.RequireReceive(
+		t, store.stopEntered, 5*time.Second,
+		"restoreBlobStore never reached the post-Restore StopCapability call",
+	)
+
+	// restoreBlobStore must not return yet: its StopCapability call is
+	// required to wait for the provider's own Stop to actually finish,
+	// not race the operation's already-canceled context. 200ms only
+	// needs to distinguish "returned without waiting at all" (the bug,
+	// which resolves near-instantly since ctx.Done() is already ready)
+	// from "genuinely still blocked" -- it is not a narrow race window.
+	testutil.RequireNoReceive(
+		t, resultCh, 200*time.Millisecond,
+		"restoreBlobStore returned before the blob provider finished "+
+			"stopping -- a subsequent reopen of the same directory can "+
+			"race the still-in-flight close and hit "+
+			"\"Cannot acquire directory lock\"",
+	)
+	require.False(t, store.stopFinished.Load())
+
+	close(store.release)
+	err = testutil.RequireReceive(
+		t, resultCh, 5*time.Second,
+		"restoreBlobStore did not return after the provider finished stopping",
+	)
+	require.True(
+		t, store.stopFinished.Load(),
+		"blob provider must be fully stopped by the time restoreBlobStore returns",
+	)
+	require.ErrorContains(t, err, "context canceled")
+}

--- a/database/lifecycle/restore_blob_stop_race_internal_test.go
+++ b/database/lifecycle/restore_blob_stop_race_internal_test.go
@@ -131,6 +131,8 @@ func newCancelOnRestoreTestHost(
 // remoteTestBlobStore, whose Stop always uses context.Background and so
 // cannot observe this race).
 func TestRestoreBlobStoreStopWaitsForProviderAfterCanceledRestore(t *testing.T) {
+	t.Parallel()
+
 	backupPath := filepath.Join(t.TempDir(), "blob.backup")
 	require.NoError(t, os.WriteFile(backupPath, nil, 0o600))
 	targetDir := t.TempDir()


### PR DESCRIPTION
`restoreBlobStore`, `prepareRestore` and `restoreRollback.restore` stopped the
blob capability using the restore operation's own context.
`BlobStoreBadger.CloseContext` — the on-disk `badger` provider's `StopFunc` —
races that context against its own background close and returns as soon as it
is Done, before `badger.DB.Close`, which releases the OS-level directory lock,
has run. Restore's context is usually what just failed the restore, so the stop
immediately following it inherited an already-cancelled context and could
return early. The automatic rollback, or a caller retrying against the same
`plugin.Host`, then reopened the same directory against a still-closing store
and could fail with `Cannot acquire directory lock`.

`stopBlobCapabilityUncancelable` performs the stop under `context.WithoutCancel`,
and every blob `StopCapability` call in `database/lifecycle/restore.go` now
routes through it; `validateRestoredDatabase` already did this. `Restore` and
`Backup` themselves are unchanged and remain cancellable — only the cleanup
stop is detached.

`TestRestoreBlobStoreStopWaitsForProviderAfterCanceledRestore` drives
`restoreBlobStore` with a provider whose `StopFunc` honours the passed context,
as the real badger provider's does, and asserts the call does not return until
the provider's stop has actually finished. It fails with the production change
reverted in place. The existing remote-store fixture cannot observe this defect:
its `StopFunc` discards the passed context and calls `Close()`.

Audited beyond the edited lines:

- The `aws` and `gcs` blob providers discard the context in their `StopFunc`,
  so `badger` is the only blob provider that can return before its close
  completes.
- The `sqlite`, `postgres` and `mysql` metadata providers all wire `StopFunc`
  to `sqlstore.Store.CloseContext`, whose cancelled branch still calls
  `closePools()` synchronously, so no metadata stop leaves a close in flight.
- `node_lifecycle.go`'s `closeStorageForLiveLifecycleOp` keeps its bounded
  context deliberately: it escalates a cancelled or timed-out storage stop to
  `errStorageDrainUnconfirmed`, which forces a supervised restart rather than
  an in-process reopen.

Fixes #4184.

**#4185 is deliberately left open.** It tracks the CI failure that prompted
this work, and this change is *not* established as its cause — that failure has
not been reproduced in 63 runs. See the negative-result writeup on #4185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qvo7XX3fd5xaSiRb6VVjP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detaches the blob cleanup stop from the restore operation's canceled context, so the on-disk `badger` store finishes closing before a rollback or caller retry reopens the same directory. This prevents the "Cannot acquire directory lock" failure that occurred when the stop returned before the OS-level lock was released.

**Details**
- The stop now uses `context.WithoutCancel`; `Restore` and `Backup` calls remain cancellable.
- Adds `TestRestoreBlobStoreStopWaitsForProviderAfterCanceledRestore`, which runs in parallel and fails without the fix.
- `aws` and `gcs` ignore the stop context, and `sqlite`, `postgres`, and `mysql` close synchronously, so `badger` is the only affected provider.
- Fixes #4184.

<sup>Written for commit e20f3e365624292093527ffcfc323c1e9c3fd322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore, rollback, and recovery reliability by ensuring blob storage shutdown completes before database reopening.
  * Shutdown errors during restore are now surfaced more consistently.

* **Tests**
  * Added regression coverage for a race condition that could allow restore operations to finish before blob storage was fully stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
