### PR TITLE
perf(sqlstore/migrations): relax durability on throwaway test databases

### DIFF
--- a/database/plugin/metadata/sqlstore/migrations/account_baseline_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/account_baseline_test.go
@@ -94,7 +94,7 @@ func baselineBackfillDB(
 	t.Helper()
 	ctx := context.Background()
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	registry, err := migrations.SQLiteRegistry()

--- a/database/plugin/metadata/sqlstore/migrations/committee_credentials_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/committee_credentials_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCommitteeCredentialMigrationPreservesExistingRows(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	registry, err := migrations.SQLiteRegistry()
@@ -145,7 +145,7 @@ func TestCommitteeCredentialMigrationPreservesExistingRows(t *testing.T) {
 
 func TestCommitteeTermStartBackfillResumesAfterInterruption(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	registry, err := migrations.SQLiteRegistry()

--- a/database/plugin/metadata/sqlstore/migrations/committee_term_backfill_rebind_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/committee_term_backfill_rebind_test.go
@@ -30,7 +30,7 @@ import (
 // see its own placeholders, which is why Batch carries the rebinder.
 func TestCommitteeTermStartBackfillUsesDialectPlaceholders(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 
@@ -70,7 +70,7 @@ func TestCommitteeTermStartBackfillUsesDialectPlaceholders(t *testing.T) {
 // Batch.Rebind is never nil, so a backfill can call it unconditionally.
 func TestBackfillBatchRebindDefaultsToIdentity(t *testing.T) {
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 

--- a/database/plugin/metadata/sqlstore/migrations/dsn_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/dsn_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations_test
+
+// testDBPragmas relaxes durability for throwaway per-test SQLite databases:
+// each one is created, migrated, asserted against, and deleted inside a
+// single test, so an fsync'd rollback journal buys nothing and is expensive
+// on a contended CI runner (dingo#4171). No test in this package kills a
+// connection mid-transaction, simulates crash recovery, or inspects a
+// journal/WAL file, so relaxing durability does not change what any
+// assertion observes. This is a twin of the identical constant in package
+// migrations (runner_test.go); Go test files in the internal and external
+// test packages for one directory compile separately and cannot share it.
+const testDBPragmas = "_pragma=journal_mode(MEMORY)&_pragma=synchronous(OFF)"

--- a/database/plugin/metadata/sqlstore/migrations/pool_deposit_held_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/pool_deposit_held_test.go
@@ -34,7 +34,7 @@ func depositHeldBackfillDB(
 	t.Helper()
 	ctx := context.Background()
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	registry, err := migrations.SQLiteRegistry()

--- a/database/plugin/metadata/sqlstore/migrations/runner_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/runner_test.go
@@ -36,12 +36,23 @@ var addColumnPattern = regexp.MustCompile(
 		"ADD\\s+COLUMN\\s+[`\"]?([a-zA-Z0-9_]+)[`\"]?(?:\\s+(.*))?$",
 )
 
+// testDBPragmas relaxes durability for throwaway per-test SQLite databases:
+// each one is created, migrated, asserted against, and deleted inside a
+// single test, so an fsync'd rollback journal buys nothing and is expensive
+// on a contended CI runner (dingo#4171). No test in this package kills a
+// connection mid-transaction, simulates crash recovery, or inspects a
+// journal/WAL file -- "interruption" tests resume from a schema_migrations
+// row an in-process UPDATE or a returned error puts into the dirty state, not
+// from an actual process crash -- so relaxing durability does not change what
+// any assertion observes.
+const testDBPragmas = "_pragma=journal_mode(MEMORY)&_pragma=synchronous(OFF)"
+
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open(
 		"sqlite",
 		"file:"+filepath.Join(t.TempDir(), "metadata.sqlite")+
-			"?_pragma=foreign_keys(1)",
+			"?_pragma=foreign_keys(1)&"+testDBPragmas,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -622,13 +633,13 @@ func TestRunnerDoesNotSkipNonAddColumnFailure(t *testing.T) {
 // fresh database, same full registry, same stateless NewProcessLocker -- so it
 // is built once here and shared as a byte copy instead of being replayed by
 // every subtest. That first replay is ~400 individually autocommitted
-// DDL/state writes (13 migrations, each a separate fsync'd transaction under
-// SQLite's default synchronous=FULL/journal_mode=DELETE); redoing it in every
-// one of the ~13 parallel subtests is what pushes this package toward the
-// per-package -timeout bound on a CI runner where fsync is expensive
-// (dingo#4171). The per-migration replay under test -- resetting one version
-// to PhaseExpand and calling Run() again -- still runs against each subtest's
-// own independent copy, so the coverage this test exists for is unchanged.
+// DDL/state writes (13 migrations, each a separate transaction); sharing it
+// avoids redoing that work in every one of the ~13 parallel subtests, and
+// testDBPragmas removes the per-write fsync from both the shared baseline and
+// each subtest's own per-version replay (dingo#4171). The per-migration
+// replay under test -- resetting one version to PhaseExpand and calling
+// Run() again -- still runs against each subtest's own independent copy, so
+// the coverage this test exists for is unchanged.
 func TestRunnerReplaysEveryShippedVersionFromExpand(t *testing.T) {
 	t.Parallel()
 	registry, err := SQLiteRegistry()
@@ -673,15 +684,15 @@ SELECT phase, dirty, completed_at FROM schema_migrations WHERE version = ?`,
 }
 
 // fullyMigratedBaseline runs the full registry once against a fresh database
-// and returns its file bytes. Run() leaves no journal file behind under the
-// default journal_mode=DELETE (the rollback journal is removed on commit), so
-// the closed file alone is a complete, valid database each subtest can copy.
+// and returns its file bytes. journal_mode=MEMORY never materializes a
+// rollback journal file at all, so the closed database file alone is a
+// complete, valid database each subtest can copy.
 func fullyMigratedBaseline(t *testing.T, registry []Migration) []byte {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "baseline.sqlite")
 	db, err := sql.Open(
 		"sqlite",
-		"file:"+path+"?_pragma=foreign_keys(1)",
+		"file:"+path+"?_pragma=foreign_keys(1)&"+testDBPragmas,
 	)
 	require.NoError(t, err)
 	runner := &Runner{
@@ -706,7 +717,7 @@ func openTestDBFromBaseline(t *testing.T, baseline []byte) *sql.DB {
 	require.NoError(t, os.WriteFile(path, baseline, 0o600))
 	db, err := sql.Open(
 		"sqlite",
-		"file:"+path+"?_pragma=foreign_keys(1)",
+		"file:"+path+"?_pragma=foreign_keys(1)&"+testDBPragmas,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/database/plugin/metadata/sqlstore/migrations/schema_parity_test.go
+++ b/database/plugin/metadata/sqlstore/migrations/schema_parity_test.go
@@ -45,7 +45,7 @@ func TestSQLiteVersionOneSchemaIsDeterministic(t *testing.T) {
 func migratedSQLiteV1(t *testing.T) (*sql.DB, error) {
 	t.Helper()
 	databasePath := filepath.Join(t.TempDir(), "metadata.sqlite")
-	db, err := sql.Open("sqlite", "file:"+databasePath)
+	db, err := sql.Open("sqlite", "file:"+databasePath+"?"+testDBPragmas)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`database/plugin/metadata/sqlstore/migrations` still exceeds the 30-minute
Windows CI bound with #4174's fix present (measured: 1800.936s). That fix
optimized one test function and moved Windows runtime by ~2s on a ~1060s
package (1060.731s with it, 1062.743s without) — not the dominant cost.

The package has ~50 top-level test functions across 11 files. All of them
still open a real SQLite file at SQLite's defaults
(`synchronous=FULL`, `journal_mode=DELETE`), paying an fsync per
autocommitted DDL/state write. This adds `journal_mode=MEMORY` +
`synchronous=OFF` at all 10 `sql.Open` call sites for throwaway per-test
databases, so the change reaches every test function instead of one.

Durability is irrelevant here: each database is created, migrated, asserted
against, and discarded inside a single test process. No test in this package
kills a connection mid-transaction, simulates crash recovery, or inspects a
journal/WAL file — both "interruption" tests resume from a
`schema_migrations` row that an in-process `UPDATE` or a returned error puts
into the dirty state, not from an actual process crash.

## Mechanism evidence

Counting the top-level SQL statements SQLite traces (`SQLITE_TRACE_STMT`)
during one full 13-migration registry replay: 447 statements with the
default pragmas, 449 with the two added pragmas. The two extra statements
are the added `PRAGMA journal_mode(MEMORY)` / `PRAGMA synchronous(OFF)`
connection-setup calls themselves (each `_pragma` DSN parameter is applied
as its own statement) — the migration work executed is identical.

Polling for the on-disk rollback-journal sidecar file (`<db>-journal`)
during a single open transaction: observed present under the default
pragmas, never observed under the added pragmas. `journal_mode=MEMORY`
holds the journal in memory instead of writing it to disk, so there is
nothing for `synchronous=FULL`'s fsync to flush.

## Timings

Local (darwin/arm64), same-window before/after pairs, collected under
ongoing contention from other test activity on the same machine:

- `-parallel=1`: 99.2s before vs 24.1/28.7/9.0s after (~4-11x)
- `-parallel=4`: 6.4/7.0s before vs 0.89/0.78s after (~8x)
- default parallelism: 46.0/7.5/5.1s before vs 2.6/1.9/1.2s after (~4-10x)

The spread within each condition reflects that contention, not this change;
the before/after pairing controls for it since both sides of each pair ran
in the same window.

## Windows effect is not measured

The Windows multiplier is extrapolated, not measured — this environment
cannot run Windows CI. `FlushFileBuffers` is a real device flush there, and
Defender inspects rollback-journal create/delete on every one of the ~419
autocommitted writes per full replay, so removing both is expected to help
at least as much as on macOS, where `fsync` is nearly free without
`F_FULLFSYNC`. #4174's equivalent projection did not hold, so the same
standard applies here: **if this package still approaches the 30-minute
bound on Windows CI with this change present, this fix is wrong too.**

Closes #4171.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxes SQLite durability on throwaway test databases in the migrations package. The default synchronous=FULL and journal_mode=DELETE cause an fsync per write; these databases are only used for a single test run, so durability isn't needed. Now all test database connections use journal_mode=MEMORY and synchronous=OFF, which speeds up the suite without changing any assertions.

<sup>Written for commit cb567b8d4cb52b9b1756e8603fbf59d069e92e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

