### PR TITLE
fix(ouroboros): accept reordered transaction replies

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4694,8 +4694,11 @@ for acknowledging only the fetched prefix would permit batched requests.
 TxSubmission checks reply counts and aggregate body bytes against the
 outstanding request before decoding any transaction. Replies exceeding the
 advertised byte budget are classified and counted as size mismatches. Replies
-within that budget still require ordered hash/era matching and an exact body
-or wrapped-wire size match for each transaction before any mempool admission.
+within that budget still require matching requested hashes and eras and an
+exact body or wrapped-wire size match before any mempool admission. A peer may
+omit requested bodies or return them in a different order. Duplicate returned
+bodies are rejected; validated bodies are restored to request order before
+admission so reply ordering cannot reorder the mempool's dependencies.
 
 The selected pool manages pending transactions:
 

--- a/ouroboros/txsubmission.go
+++ b/ouroboros/txsubmission.go
@@ -15,7 +15,6 @@
 package ouroboros
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -122,8 +121,13 @@ func validateTxsubmissionReply(
 		)
 	}
 	var requestedBytes uint64
-	for _, requestedTx := range requested {
+	requestedIndex := make(map[[32]byte]int, len(requested))
+	for index, requestedTx := range requested {
 		requestedBytes += uint64(requestedTx.Size)
+		// Preserve the first announcement if an ID appears more than once.
+		if _, exists := requestedIndex[requestedTx.TxId.TxId]; !exists {
+			requestedIndex[requestedTx.TxId.TxId] = index
+		}
 	}
 	remainingBytes := requestedBytes
 	for index, txBody := range returned {
@@ -142,8 +146,7 @@ func validateTxsubmissionReply(
 		}
 		remainingBytes -= bodySize
 	}
-	ret := make([]validatedTxsubmissionBody, 0, len(returned))
-	nextRequested := 0
+	validatedByIndex := make(map[int]validatedTxsubmissionBody, len(returned))
 	for i, txBody := range returned {
 		tx, err := ledger.NewTransactionFromCbor(
 			uint(txBody.EraId),
@@ -157,18 +160,19 @@ func validateTxsubmissionReply(
 			)
 		}
 		txHash := tx.Hash()
-		matched := -1
-		for requestedIdx := nextRequested; requestedIdx < len(requested); requestedIdx++ {
-			if bytes.Equal(txHash[:], requested[requestedIdx].TxId.TxId[:]) {
-				matched = requestedIdx
-				break
-			}
-		}
-		if matched < 0 {
+		matched, found := requestedIndex[[32]byte(txHash)]
+		if !found {
 			return nil, fmt.Errorf(
-				"txsubmission reply hash or order mismatch at index %d: received %x",
+				"txsubmission reply hash mismatch at index %d: received %x",
 				i,
-				txHash,
+				txHash.Bytes(),
+			)
+		}
+		if _, duplicate := validatedByIndex[matched]; duplicate {
+			return nil, fmt.Errorf(
+				"txsubmission reply duplicate transaction at index %d: received %x",
+				i,
+				txHash.Bytes(),
 			)
 		}
 		want := requested[matched]
@@ -201,12 +205,19 @@ func validateTxsubmissionReply(
 				txBody.EraId,
 			)
 		}
-		nextRequested = matched + 1
-		ret = append(ret, validatedTxsubmissionBody{
+		validatedByIndex[matched] = validatedTxsubmissionBody{
 			body:               txBody,
 			tx:                 tx,
 			wireSizeAdvertised: wireSizeAdvertised,
-		})
+		}
+	}
+	// Reply order is not an admission-order contract. Preserve the requested
+	// order so an earlier transaction can be admitted before its dependents.
+	ret := make([]validatedTxsubmissionBody, 0, len(returned))
+	for requestedIdx := range requested {
+		if validated, ok := validatedByIndex[requestedIdx]; ok {
+			ret = append(ret, validated)
+		}
 	}
 	return ret, nil
 }

--- a/ouroboros/txsubmission_test.go
+++ b/ouroboros/txsubmission_test.go
@@ -728,6 +728,15 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 		require.Len(t, validated, 1)
 		require.Equal(t, returned[1], validated[0].body)
 	})
+	t.Run("reordered reply preserves admission order", func(t *testing.T) {
+		got := []txsubmission.TxBody{returned[1], returned[0]}
+		validated, err := validateTxsubmissionReply(requested, got)
+		require.NoError(t, err)
+		require.Len(t, validated, 2)
+		require.Equal(t, returned[0], validated[0].body)
+		require.Equal(t, returned[1], validated[1].body)
+		require.Equal(t, returned[1], got[0], "do not mutate the reply")
+	})
 
 	tests := []struct {
 		name   string
@@ -739,11 +748,15 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 			match: "count exceeds request",
 		},
 		{
-			name: "order",
+			name: "duplicate body",
 			mutate: func(_ []txsubmission.TxIdAndSize, got []txsubmission.TxBody) {
-				got[0], got[1] = got[1], got[0]
+				if len(got[0].TxBody) <= len(got[1].TxBody) {
+					got[1] = got[0]
+				} else {
+					got[0] = got[1]
+				}
 			},
-			match: "hash or order mismatch",
+			match: "duplicate transaction",
 		},
 		{
 			name: "era",
@@ -765,7 +778,7 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 			mutate: func(want []txsubmission.TxIdAndSize, _ []txsubmission.TxBody) {
 				want[0].TxId.TxId[0] ^= 0xff
 			},
-			match: "hash or order mismatch",
+			match: "hash mismatch",
 		},
 	}
 	for _, tt := range tests {
@@ -781,6 +794,9 @@ func TestValidateTxsubmissionReply(t *testing.T) {
 			validated, err := validateTxsubmissionReply(want, got)
 			require.ErrorContains(t, err, tt.match)
 			require.Nil(t, validated)
+			if tt.name == "hash" {
+				require.Contains(t, err.Error(), "received "+fixtures[0].hash)
+			}
 		})
 	}
 }
@@ -921,6 +937,9 @@ type txSubmissionRelayHarnessOpts struct {
 	omitOfferHash    string
 	corruptAllOffers bool
 	batchRequestsA   bool
+	// transformReplyB runs after the real callback consumes requested cache
+	// entries, so a wire-order change cannot alter cache lookup semantics.
+	transformReplyB func([]txsubmission.TxBody)
 	// promRegistryA installs protocol metrics on node A, whose
 	// txsubmission server runs the relay pull loop under test.
 	promRegistryA prometheus.Registerer
@@ -1009,6 +1028,24 @@ func newTxSubmissionRelayHarnessWithOpts(
 		}
 	}
 	nodeB.mempool = nodeBMempool
+	nodeBClientOpts := nodeB.txsubmissionClientConnOpts()
+	if opts.transformReplyB != nil {
+		nodeBClientOpts = append(
+			nodeBClientOpts,
+			txsubmission.WithRequestTxsFunc(
+				nodeB.instrumentTxsubmissionRequestTxs(func(
+					ctx txsubmission.CallbackContext,
+					ids []txsubmission.TxId,
+				) ([]txsubmission.TxBody, error) {
+					bodies, err := nodeB.txsubmissionClientRequestTxs(ctx, ids)
+					if err == nil {
+						opts.transformReplyB(bodies)
+					}
+					return bodies, err
+				}),
+			),
+		)
+	}
 
 	serverPipe, clientPipe := net.Pipe()
 
@@ -1047,7 +1084,7 @@ func newTxSubmissionRelayHarnessWithOpts(
 		ouroboros.WithTxSubmissionConfig(
 			txsubmission.NewConfig(
 				slices.Concat(
-					nodeB.txsubmissionClientConnOpts(),
+					nodeBClientOpts,
 					nodeB.txsubmissionServerConnOpts(),
 				)...,
 			),
@@ -1528,4 +1565,50 @@ func TestTxSubmissionServerInitAcceptsOrderedSubset(t *testing.T) {
 	)
 	_, admitted := h.mA.GetTransaction(omitted.hash)
 	require.False(t, admitted)
+}
+
+// Observe the real FIFO after a peer reverses the two returned bodies.
+// These existing fixtures are not claimed to be a parent/child transaction
+// pair; the invariant is preservation of announcement order at admission.
+func TestTxSubmissionServerInitRestoresOrderForReorderedReply(t *testing.T) {
+	t.Parallel()
+	fixtures := txsubmissionTestFixtures(t)[:2]
+	replies := make(chan []txsubmission.TxBody, 1)
+	logBuf := &lockedBuffer{}
+	h := newTxSubmissionRelayHarnessWithOpts(t, txSubmissionRelayHarnessOpts{
+		logger: slog.New(slog.NewJSONHandler(
+			logBuf, &slog.HandlerOptions{Level: slog.LevelDebug},
+		)),
+		batchRequestsA: true,
+		transformReplyB: func(bodies []txsubmission.TxBody) {
+			slices.Reverse(bodies)
+			if len(bodies) == 2 {
+				select {
+				case replies <- slices.Clone(bodies):
+				default:
+				}
+			}
+		},
+	})
+	defer h.close(t)
+	addTxSubmissionTestFixtures(t, h.mB, fixtures...)
+	require.NoError(t, h.nodeB.txsubmissionClientStart(h.connB.Id()))
+	select {
+	case reply := <-replies:
+		require.Equal(t, fixtures[1].body, reply[0].TxBody)
+		require.Equal(t, fixtures[0].body, reply[1].TxBody)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no reversed two-body reply: %s", logBuf.String())
+	}
+	require.Eventually(t, func() bool {
+		return len(h.mA.Transactions()) == 2 || strings.Contains(
+			logBuf.String(), "rejected mismatched txsubmission reply",
+		)
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NotContains(t, logBuf.String(),
+		"rejected mismatched txsubmission reply")
+	admitted := h.mA.Transactions()
+	require.Len(t, admitted, 2)
+	require.Equal(t, fixtures[0].body, admitted[0].Cbor)
+	require.Equal(t, fixtures[1].body, admitted[1].Cbor)
 }


### PR DESCRIPTION
Match returned transactions by requested ID rather than reply position, then restore request order before mempool admission. Preserve whole-batch validation, count, era and size checks, and reject duplicate returned bodies.

Use indexed matching and cover reordered replies through the real relay callback and mempool FIFO. Format mismatch diagnostics from raw hash bytes.

Related to #3505 and blinklabs-io/gouroboros#2076. Advertised-size validation is unchanged.

## Summary by cubic

Fixes txsubmission reply validation to accept replies in any order, matching returned transactions by requested ID and restoring request order before mempool admission.

- Replies are now matched by requested transaction ID instead of reply position, so reordered replies no longer fail validation.
- Validated bodies are restored to request order before mempool admission, preserving dependency order.
- Duplicate returned bodies are rejected; whole-batch validation, count, era, and size checks are unchanged.
- Adds a relay-level test with reversed reply order and updates the architecture doc to describe the new behavior.
