### PR TITLE
fix(koiosparity): synthetic PlutusV2 cost model is informational

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6527,6 +6527,26 @@ cmd/koios-parity/          # thin Cobra CLI wrapper
   "this era does not define it", so one-sided absence is a disagreement about
   the shape of the ledger state, which is what an era-gating bug looks like.
 
+  One cost-model divergence is exempt from that rule. Between the Babbage
+  transition and the first real PlutusV2 update, Dingo carries
+  `HardForkBabbage`'s fabricated PlutusV2 cost model (`synthetic_v2_cost_model`,
+  dingo #3825) while Koios correctly reports no PlutusV2 model at all — both
+  sides agree no real model exists yet and disagree only about reporting a
+  placeholder, so failing those epochs was a false divergence (dingo #4127).
+  `GetProtocolParams` (both `RewardParitySource` implementations) resolves
+  `DingoProtocolParams.SyntheticV2CostModel` from the durable
+  `synthetic_v2_cost_model_cleared_epoch` marker, mirroring
+  `ledger.queryShelleyCurrentProtocolParams`'s historical-epoch resolution:
+  the marker is authoritative for epochs at or after the epoch it records,
+  and an absent marker falls back to comparing the stored model against
+  `eras.DefaultPlutusV2CostModel`. `compareCostModels` then reports
+  `cost_model_synthetic` (informational) instead of `value_mismatch` for
+  exactly that shape. The exemption is narrow by construction: it applies
+  only to PlutusV2 and only to a Koios-side absence, so a one-sided PlutusV1
+  or PlutusV3 model in the same epoch, a length or entry difference on a
+  model both sides price, and any PlutusV2 divergence once the flag is false
+  all stay `value_mismatch`/FAIL.
+
   **Epoch alignment.** Koios reports everything for a reporting epoch K, but
   Dingo's `epoch_summary`/`reward_pool_input`/`reward_pool_output` rows do not
   all use K for the same ledger period, so `checkEpoch` (`check.go`) never
@@ -6832,9 +6852,12 @@ reward_type) row within one side — a data-integrity problem, not a value
 disagreement), `acct_zero_reward_row` (informational: a reward row worth zero
 lovelace present on one side only — nothing was credited either way, so the
 two sides agree about every lovelace and the one-sided row is a
-representational difference, not a divergence), and `acct_coverage_incomplete`
+representational difference, not a divergence), `acct_coverage_incomplete`
 (the per-account Koios fetch for this epoch never completed across every chunk
-— see "Per-account exact parity (#3097)" below). Results are stored in
+— see "Per-account exact parity (#3097)" below), and `cost_model_synthetic`
+(informational: Dingo prices PlutusV2 only because `HardForkBabbage`
+fabricated the model before the chain enacted a real one — see "Protocol
+parameter resolution" above). Results are stored in
 `check_mismatches` and summarised in `check_epoch_status`.
 
 Epochs 0-1 predate a valid Shelley "go" stake snapshot (mark→set→go takes 3

--- a/internal/koiosparity/compare.go
+++ b/internal/koiosparity/compare.go
@@ -94,6 +94,20 @@ const (
 	// stake epoch's reward_account_output universe but absent from this
 	// epoch's.
 	CategoryAcctDeregistered = "acct_deregistered"
+
+	// CategoryCostModelSynthetic marks a PlutusV2-only-on-Dingo cost-model
+	// divergence where DingoProtocolParams.SyntheticV2CostModel says the
+	// only reason the two sides differ is that Dingo still carries
+	// HardForkBabbage's fabricated PlutusV2 default (dingo #3825) for an
+	// epoch before the chain enacted a real one. Koios correctly reports no
+	// PlutusV2 model over that window, so both sides in fact agree on the
+	// true state (no real model exists yet) and disagree only about whether
+	// to report a placeholder — the same shape as the account lifecycle
+	// categories above. Purely informational and must never fail the epoch
+	// (dingo #4127); once the real update lands, SyntheticV2CostModel goes
+	// false and any remaining divergence reports as a genuine
+	// value_mismatch again.
+	CategoryCostModelSynthetic = "cost_model_synthetic"
 )
 
 // AllCategories is every mismatch category above, in one place.
@@ -120,6 +134,7 @@ var AllCategories = []string{
 	CategoryAcctZeroRewardRow,
 	CategoryAcctNewlyRegistered,
 	CategoryAcctDeregistered,
+	CategoryCostModelSynthetic,
 }
 
 // Epoch check status values.
@@ -534,6 +549,7 @@ func CompareEpochProtocolParams(
 	return append(out, compareCostModels(
 		dingoParams.CostModels,
 		koios.CostModels,
+		dingoParams.SyntheticV2CostModel,
 		mismatch,
 	)...)
 }
@@ -560,9 +576,18 @@ func CompareEpochProtocolParams(
 // Koios priced no scripts. Text that will not parse is reported rather than
 // skipped, so a corrupt cached row can never turn the whole cost-model
 // comparison into a silent pass.
+//
+// synthetic is DingoProtocolParams.SyntheticV2CostModel: when true and the
+// only divergence is that Dingo prices PlutusV2 and Koios does not, the
+// finding is CategoryCostModelSynthetic (informational) rather than
+// CategoryValueMismatch (dingo #4127) — see that category's doc comment.
+// This never suppresses any other cost-model finding: a length or entry
+// mismatch on a model both sides price, or a real value_mismatch once
+// synthetic goes false, is reported exactly as before.
 func compareCostModels(
 	dingoModels map[string][]int64,
 	koiosJSON string,
+	synthetic bool,
 	mismatch func(field, dingoValue, koiosValue, category string) CheckMismatch,
 ) []CheckMismatch {
 	var koiosModels map[string][]int64
@@ -600,12 +625,20 @@ func compareCostModels(
 		switch {
 		case !inKoios:
 			// Dingo prices a language Koios does not, or vice versa below —
-			// a disagreement about which scripts can run at all.
+			// a disagreement about which scripts can run at all. Downgraded
+			// to informational for exactly the synthetic-PlutusV2 case: see
+			// CategoryCostModelSynthetic's doc comment (dingo #4127). Any
+			// other language, or a genuinely real PlutusV2 model Koios
+			// hasn't enacted, stays a real divergence.
+			cat := CategoryValueMismatch
+			if language == "PlutusV2" && synthetic {
+				cat = CategoryCostModelSynthetic
+			}
 			out = append(out, mismatch(
 				field,
 				entryCount(dingoModel),
 				"",
-				CategoryValueMismatch,
+				cat,
 			))
 		case !inDingo:
 			out = append(out, mismatch(
@@ -1385,7 +1418,8 @@ func severityOf(category string) mismatchSeverity {
 		CategoryAcctZeroRewardRow,
 		CategoryAcctNewlyRegistered,
 		CategoryAcctDeregistered,
-		CategoryPoolDeparted:
+		CategoryPoolDeparted,
+		CategoryCostModelSynthetic:
 		// Purely informational — see these categories' doc comments.
 		return severityInformational
 	default:

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -469,11 +469,54 @@ func (d *DingoDB) GetProtocolParams(
 		}
 		return nil, fmt.Errorf("pparams epoch %d: %w", epoch, err)
 	}
+
+	// See isSyntheticV2CostModel's doc comment and
+	// syntheticV2CostModelClearedEpochSyncKey for why this is read here
+	// rather than skipped: without it, a PlutusV2 model Dingo still holds
+	// only because HardForkBabbage fabricated it (dingo #3825) reads as a
+	// real value and compareCostModels has no way to tell it apart from an
+	// actual divergence (dingo #4127).
+	var clearedEpochVal sql.NullString
+	if err := queryRow(
+		`SELECT value FROM sync_state WHERE sync_key = ?`,
+		syntheticV2CostModelClearedEpochSyncKey,
+	).Scan(&clearedEpochVal); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf(
+			"synthetic v2 cost model cleared epoch: %w", err,
+		)
+	}
+	var clearedEpoch uint64
+	cleared := clearedEpochVal.Valid && clearedEpochVal.String != ""
+	if cleared {
+		clearedEpoch, err = strconv.ParseUint(clearedEpochVal.String, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse synthetic v2 cost model cleared epoch %q: %w",
+				clearedEpochVal.String,
+				err,
+			)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit protocol params read: %w", err)
 	}
-	return decodeProtocolParams(cborBytes, eraID, sourceEpoch)
+	out, err := decodeProtocolParams(cborBytes, eraID, sourceEpoch)
+	if err != nil {
+		return nil, err
+	}
+	v2, hasV2 := out.CostModels["PlutusV2"]
+	out.SyntheticV2CostModel = isSyntheticV2CostModel(
+		v2, hasV2, epoch, clearedEpoch, cleared,
+	)
+	return out, nil
 }
+
+// syntheticV2CostModelClearedEpochSyncKey mirrors
+// database.SyntheticV2CostModelClearedEpochSyncKey (dingo #3825), duplicated
+// for the same reason mithrilLedgerSlotSyncKey above is: DingoDB reads a
+// separate raw SQL connection with no dependency on the database package.
+const syntheticV2CostModelClearedEpochSyncKey = "synthetic_v2_cost_model_cleared_epoch"
 
 // GetPoolEpochDataMap returns per-pool reward data assembled for Koios
 // reporting epoch K, keyed by pool-key-hash hex. Dingo's reward_pool_input/

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -512,11 +513,15 @@ func (d *DingoDB) GetProtocolParams(
 	return out, nil
 }
 
-// syntheticV2CostModelClearedEpochSyncKey mirrors
-// database.SyntheticV2CostModelClearedEpochSyncKey (dingo #3825), duplicated
-// for the same reason mithrilLedgerSlotSyncKey above is: DingoDB reads a
-// separate raw SQL connection with no dependency on the database package.
-const syntheticV2CostModelClearedEpochSyncKey = "synthetic_v2_cost_model_cleared_epoch"
+// syntheticV2CostModelClearedEpochSyncKey is the sync-state key DingoDB reads
+// over its own raw SQL connection (dingo #3825). Unlike mithrilLedgerSlotSyncKey
+// above it is bound to the owning package's constant rather than re-typed as a
+// literal: this package already depends on database (DatabaseSource reads the
+// same marker through database.SyntheticV2CostModelClearedEpoch), so a
+// duplicated literal buys no decoupling and would let the two
+// RewardParitySource implementations read different keys if the owning
+// constant ever changed.
+const syntheticV2CostModelClearedEpochSyncKey = database.SyntheticV2CostModelClearedEpochSyncKey
 
 // GetPoolEpochDataMap returns per-pool reward data assembled for Koios
 // reporting epoch K, keyed by pool-key-hash hex. Dingo's reward_pool_input/

--- a/internal/koiosparity/pparams.go
+++ b/internal/koiosparity/pparams.go
@@ -16,6 +16,7 @@ package koiosparity
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/blinklabs-io/dingo/ledger/eras"
@@ -89,6 +90,55 @@ type DingoProtocolParams struct {
 	// than Dingo's stored numeric keys, so the two sides are directly
 	// comparable. nil in Shelley/Allegra/Mary, where no scripts are priced.
 	CostModels map[string][]int64
+
+	// SyntheticV2CostModel reports whether CostModels["PlutusV2"], if
+	// present, is still HardForkBabbage's fabricated default (dingo #3825)
+	// for this epoch rather than real governance/protocol-update data --
+	// i.e. whether Dingo has a PlutusV2 model in force before the chain
+	// actually enacted one. Callers (GetProtocolParams's own
+	// implementations) populate this from the durable
+	// synthetic_v2_cost_model_cleared_epoch marker the ledger package
+	// maintains, mirroring ledger.queryShelleyCurrentProtocolParams's
+	// historical-epoch resolution exactly (see isSyntheticV2CostModel).
+	// compareCostModels reads it to classify a PlutusV2-only-on-Dingo
+	// divergence as informational rather than a real mismatch when this is
+	// true (dingo #4127) -- Koios's absence and Dingo's placeholder both
+	// correctly describe "no real PlutusV2 model exists on chain yet".
+	// Always false when CostModels has no "PlutusV2" entry.
+	SyntheticV2CostModel bool
+}
+
+// isSyntheticV2CostModel reports whether v2 (targetEpoch's decoded PlutusV2
+// cost model, if hasV2) should be treated as HardForkBabbage's fabricated
+// default rather than real data, mirroring
+// ledger.queryShelleyCurrentProtocolParams's historical-epoch resolution
+// (dingo #4127, following #3825's design):
+//
+//   - No PlutusV2 model at all: not synthetic (there is nothing to fabricate
+//     a divergence from).
+//   - The durable cleared-epoch marker is authoritative when present:
+//     targetEpoch at or after clearedEpoch means real PlutusV2 data was
+//     already confirmed on chain by then, whatever the value itself
+//     compares equal to (a real update can legitimately re-affirm the exact
+//     default array).
+//   - Otherwise (no confirmation recorded yet, e.g. a database that
+//     predates the marker, or the real update has not landed) fall back to
+//     the value-based heuristic: synthetic exactly when v2 is byte-for-byte
+//     eras.DefaultPlutusV2CostModel.
+func isSyntheticV2CostModel(
+	v2 []int64,
+	hasV2 bool,
+	targetEpoch uint64,
+	clearedEpoch uint64,
+	cleared bool,
+) bool {
+	if !hasV2 {
+		return false
+	}
+	if cleared && targetEpoch >= clearedEpoch {
+		return false
+	}
+	return slices.Equal(v2, eras.DefaultPlutusV2CostModel)
 }
 
 // decodeProtocolParams decodes one stored `pparams` CBOR blob as the given

--- a/internal/koiosparity/pparams_test.go
+++ b/internal/koiosparity/pparams_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/blinklabs-io/dingo/database/models"
 	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/blinklabs-io/dingo/ledger/eras"
 	"github.com/stretchr/testify/require"
 )
 
@@ -642,6 +643,47 @@ func TestDatabaseSourceGetProtocolParams(t *testing.T) {
 	require.Nil(t, got)
 }
 
+// TestDatabaseSourceGetProtocolParamsMarksSyntheticV2CostModel is
+// DatabaseSource's half of TestDingoDBGetProtocolParamsMarksSyntheticV2CostModel
+// (dingo #4127): both RewardParitySource implementations must classify the
+// same fabricated-default row the same way, since checkEpoch's comparison
+// logic is shared between them.
+func TestDatabaseSourceGetProtocolParamsMarksSyntheticV2CostModel(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDatabaseSourceDB(t)
+	sqlDB := sourceSQLDB(t, db)
+	source, err := NewDatabaseSource(db)
+	require.NoError(t, err)
+
+	seedEpochEra(t, sqlDB, 3, 5)
+	seedPParams(t, sqlDB, 1, 259_200, 3, 5,
+		loadPParamsFixture(t, "pparams_preview_epoch2_babbage.hex"))
+
+	got, err := source.GetProtocolParams(context.Background(), 3)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.SyntheticV2CostModel)
+
+	require.NoError(t, sqlDB.Exec(
+		`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)`,
+		syntheticV2CostModelClearedEpochSyncKey, "9",
+	).Error)
+
+	got, err = source.GetProtocolParams(context.Background(), 3)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.SyntheticV2CostModel,
+		"epoch 3 predates the epoch-9 confirmation and must stay synthetic")
+
+	seedEpochEra(t, sqlDB, 9, 5)
+	got, err = source.GetProtocolParams(context.Background(), 9)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.False(t, got.SyntheticV2CostModel,
+		"epoch 9 is at the confirming epoch and must no longer read as synthetic")
+}
+
 // seedProtocolParamsCheckFixture builds the smallest Dingo+cache pair that
 // Check reports a clean PASS for at koiosEpoch, so a test can then perturb
 // exactly one protocol-parameter input and attribute the result to it.
@@ -1054,4 +1096,214 @@ func TestDingoDBGetProtocolParamsDecodesCostModels(t *testing.T) {
 	// Entry-for-entry equality with what Koios publishes for the same epoch
 	// is the property the comparison depends on.
 	require.Equal(t, costModelFixture(t), got.CostModels)
+}
+
+// TestIsSyntheticV2CostModel pins isSyntheticV2CostModel's classification
+// (dingo #4127): the durable cleared-epoch marker is authoritative when
+// present, and the value-based comparison against
+// eras.DefaultPlutusV2CostModel is only a fallback for when it is absent.
+func TestIsSyntheticV2CostModel(t *testing.T) {
+	t.Parallel()
+
+	realModel := append([]int64{}, eras.DefaultPlutusV2CostModel...)
+	realModel[0]++ // any value that is provably not the fabricated default
+
+	cases := []struct {
+		name         string
+		v2           []int64
+		hasV2        bool
+		targetEpoch  uint64
+		clearedEpoch uint64
+		cleared      bool
+		want         bool
+	}{
+		{
+			name:  "no V2 model at all is never synthetic",
+			hasV2: false,
+			v2:    eras.DefaultPlutusV2CostModel,
+			want:  false,
+		},
+		{
+			name:         "cleared and at the confirming epoch overrides a default-looking value",
+			hasV2:        true,
+			v2:           eras.DefaultPlutusV2CostModel,
+			targetEpoch:  9,
+			clearedEpoch: 9,
+			cleared:      true,
+			want:         false,
+		},
+		{
+			name:         "cleared and past the confirming epoch",
+			hasV2:        true,
+			v2:           eras.DefaultPlutusV2CostModel,
+			targetEpoch:  12,
+			clearedEpoch: 9,
+			cleared:      true,
+			want:         false,
+		},
+		{
+			name:         "cleared but the target epoch predates confirmation, value is the default",
+			hasV2:        true,
+			v2:           eras.DefaultPlutusV2CostModel,
+			targetEpoch:  5,
+			clearedEpoch: 9,
+			cleared:      true,
+			want:         true,
+		},
+		{
+			name:         "cleared but the target epoch predates confirmation, value is real",
+			hasV2:        true,
+			v2:           realModel,
+			targetEpoch:  5,
+			clearedEpoch: 9,
+			cleared:      true,
+			want:         false,
+		},
+		{
+			name:        "no cleared-epoch marker, value matches the fabricated default",
+			hasV2:       true,
+			v2:          eras.DefaultPlutusV2CostModel,
+			targetEpoch: 5,
+			cleared:     false,
+			want:        true,
+		},
+		{
+			name:        "no cleared-epoch marker, value is real",
+			hasV2:       true,
+			v2:          realModel,
+			targetEpoch: 5,
+			cleared:     false,
+			want:        false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isSyntheticV2CostModel(
+				tc.v2, tc.hasV2, tc.targetEpoch, tc.clearedEpoch, tc.cleared,
+			)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCompareEpochProtocolParamsSyntheticV2CostModelIsInformational is the
+// regression for dingo #4127: a from-genesis Preview replay reported
+// pparams_cost_model_plutus_v2 as a FAIL for epochs 3-8, where Dingo holds
+// HardForkBabbage's fabricated PlutusV2 default (dingo #3825) and Koios
+// correctly has no PlutusV2 model at all -- both sides agree no real model
+// exists yet, so this must classify as informational, not a divergence.
+//
+// Discriminates: with SyntheticV2CostModel left false (or the classification
+// removed), this reports CategoryValueMismatch and DetermineStatus is FAIL.
+func TestCompareEpochProtocolParamsSyntheticV2CostModelIsInformational(t *testing.T) {
+	t.Parallel()
+
+	models := costModelFixture(t)
+	dingo := dingoPParamsPreview380()
+	dingo.CostModels = map[string][]int64{
+		"PlutusV1": models["PlutusV1"],
+		"PlutusV2": eras.DefaultPlutusV2CostModel,
+	}
+	dingo.SyntheticV2CostModel = true
+	koios := koiosPParamsPreview380()
+	koios.CostModels = koiosCostModelsJSON(
+		t, map[string][]int64{"PlutusV1": models["PlutusV1"]},
+	)
+
+	got := CompareEpochProtocolParams(
+		"preview", 5, koios, dingo, nil, time.Now(), 0, time.Time{},
+	)
+	require.Len(t, got, 1)
+	require.Equal(t, "pparams_cost_model_plutus_v2", got[0].Field)
+	require.Equal(t, CategoryCostModelSynthetic, got[0].Category)
+	require.Equal(t, StatusPass, DetermineStatus(got))
+	require.Equal(t, 0, CountSignificant(got))
+}
+
+// TestCompareEpochProtocolParamsRealV2CostModelAheadOfKoiosStillFails is the
+// negative case for #4127's fix: when Dingo's PlutusV2 model is NOT flagged
+// synthetic, a Koios-side absence stays a real, wedge-class divergence
+// (FAIL) exactly as before. SyntheticV2CostModel is the only thing that may
+// downgrade this classification.
+func TestCompareEpochProtocolParamsRealV2CostModelAheadOfKoiosStillFails(t *testing.T) {
+	t.Parallel()
+
+	models := costModelFixture(t)
+	dingo := dingoPParamsPreview380()
+	dingo.CostModels = map[string][]int64{
+		"PlutusV1": models["PlutusV1"],
+		"PlutusV2": models["PlutusV2"],
+	}
+	dingo.SyntheticV2CostModel = false
+	koios := koiosPParamsPreview380()
+	koios.CostModels = koiosCostModelsJSON(
+		t, map[string][]int64{"PlutusV1": models["PlutusV1"]},
+	)
+
+	got := CompareEpochProtocolParams(
+		"preview", 5, koios, dingo, nil, time.Now(), 0, time.Time{},
+	)
+	require.Len(t, got, 1)
+	require.Equal(t, "pparams_cost_model_plutus_v2", got[0].Field)
+	require.Equal(t, CategoryValueMismatch, got[0].Category)
+	require.Equal(t, StatusFail, DetermineStatus(got))
+	require.Equal(t, 1, CountSignificant(got))
+}
+
+// TestDingoDBGetProtocolParamsMarksSyntheticV2CostModel is the DB-layer half
+// of #4127's regression, using the exact shape the issue reported: a real
+// preview Babbage pparams row (pparams_preview_epoch2_babbage.hex) whose
+// PlutusV2 cost model is byte-for-byte HardForkBabbage's fabricated default,
+// resolved for epochs before and after the durable cleared-epoch marker
+// records the real update landing.
+func TestDingoDBGetProtocolParamsMarksSyntheticV2CostModel(t *testing.T) {
+	t.Parallel()
+
+	dingo, gdb := openTestDingoDB(t)
+	defer dingo.Close() //nolint:errcheck
+
+	seedEpochEra(t, gdb, 3, 5)
+	seedPParams(t, gdb, 1, 259_200, 3, 5,
+		loadPParamsFixture(t, "pparams_preview_epoch2_babbage.hex"))
+
+	// No cleared-epoch marker recorded yet: falls back to the value-based
+	// heuristic, and this fixture's PlutusV2 model is exactly the default.
+	got, err := dingo.GetProtocolParams(context.Background(), 3)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.SyntheticV2CostModel)
+
+	// Record that real PlutusV2 data was confirmed at epoch 9 (the boundary
+	// the issue reported).
+	require.NoError(t, gdb.Exec(
+		`INSERT INTO sync_state (sync_key, value) VALUES (?, ?)`,
+		syntheticV2CostModelClearedEpochSyncKey, "9",
+	).Error)
+
+	// Epoch 5 still resolves to the epoch-3 fabricated row and still
+	// predates the confirming epoch: still synthetic.
+	seedEpochEra(t, gdb, 5, 5)
+	got, err = dingo.GetProtocolParams(context.Background(), 5)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.SyntheticV2CostModel)
+
+	// Epoch 9 itself is at the confirming epoch: no longer synthetic, even
+	// though no new pparams row has landed yet and the value is unchanged.
+	seedEpochEra(t, gdb, 9, 5)
+	got, err = dingo.GetProtocolParams(context.Background(), 9)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.False(t, got.SyntheticV2CostModel)
+
+	// A real update landing at epoch 9 also resolves as not synthetic
+	// through the normal value path, matching the marker.
+	seedPParams(t, gdb, 2, 2_000_000, 9, 5,
+		loadPParamsFixture(t, "pparams_preview_epoch22_babbage.hex"))
+	got, err = dingo.GetProtocolParams(context.Background(), 9)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(9), got.SourceEpoch)
+	require.False(t, got.SyntheticV2CostModel)
 }

--- a/internal/koiosparity/pparams_test.go
+++ b/internal/koiosparity/pparams_test.go
@@ -1251,6 +1251,110 @@ func TestCompareEpochProtocolParamsRealV2CostModelAheadOfKoiosStillFails(t *test
 	require.Equal(t, 1, CountSignificant(got))
 }
 
+// TestCompareEpochProtocolParamsSyntheticDowngradeIsNarrow pins the two
+// bounds on #4127's downgrade, which are what keep it from widening into a
+// suppression of real divergences while SyntheticV2CostModel is true:
+//
+//   - It applies to PlutusV2 only. During the synthetic window Dingo also
+//     prices PlutusV1, so a language guard that classified by the flag alone
+//     would downgrade a genuine one-sided PlutusV1 (or a future PlutusV3)
+//     model in the same epoch, and a wedge-class divergence would stop
+//     failing the epoch.
+//   - It applies to a Koios-side absence only. When Koios prices PlutusV2
+//     too, the two sides disagree about a model both hold, which the flag
+//     says nothing about — the length and entry branches stay
+//     value_mismatch/FAIL.
+//
+// Discriminates: dropping the `language == "PlutusV2"` condition, or moving
+// the classification out of the `!inKoios` branch, turns a FAIL here into a
+// PASS.
+func TestCompareEpochProtocolParamsSyntheticDowngradeIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	models := costModelFixture(t)
+	realV2 := append([]int64{}, eras.DefaultPlutusV2CostModel...)
+	realV2[0]++ // provably not the fabricated default
+
+	t.Run("only PlutusV2 is downgraded", func(t *testing.T) {
+		t.Parallel()
+
+		dingo := dingoPParamsPreview380()
+		dingo.CostModels = map[string][]int64{
+			"PlutusV1": models["PlutusV1"],
+			"PlutusV2": eras.DefaultPlutusV2CostModel,
+			"PlutusV3": models["PlutusV2"],
+		}
+		dingo.SyntheticV2CostModel = true
+		koios := koiosPParamsPreview380()
+		koios.CostModels = ""
+
+		got := CompareEpochProtocolParams(
+			"preview", 5, koios, dingo, nil, time.Now(), 0, time.Time{},
+		)
+		require.Len(t, got, 3)
+		byField := map[string]string{}
+		for _, m := range got {
+			byField[m.Field] = m.Category
+		}
+		require.Equal(t, map[string]string{
+			"pparams_cost_model_plutus_v1": CategoryValueMismatch,
+			"pparams_cost_model_plutus_v2": CategoryCostModelSynthetic,
+			"pparams_cost_model_plutus_v3": CategoryValueMismatch,
+		}, byField)
+		require.Equal(t, StatusFail, DetermineStatus(got))
+		require.Equal(t, 2, CountSignificant(got))
+	})
+
+	t.Run("a PlutusV2 entry difference still fails", func(t *testing.T) {
+		t.Parallel()
+
+		dingo := dingoPParamsPreview380()
+		dingo.CostModels = map[string][]int64{
+			"PlutusV2": eras.DefaultPlutusV2CostModel,
+		}
+		dingo.SyntheticV2CostModel = true
+		koios := koiosPParamsPreview380()
+		koios.CostModels = koiosCostModelsJSON(
+			t, map[string][]int64{"PlutusV2": realV2},
+		)
+
+		got := CompareEpochProtocolParams(
+			"preview", 5, koios, dingo, nil, time.Now(), 0, time.Time{},
+		)
+		require.Len(t, got, 1)
+		require.Equal(t, "pparams_cost_model_plutus_v2", got[0].Field)
+		require.Equal(t, CategoryValueMismatch, got[0].Category)
+		require.Equal(t, StatusFail, DetermineStatus(got))
+		require.Equal(t, 1, CountSignificant(got))
+	})
+
+	t.Run("a PlutusV2 length difference still fails", func(t *testing.T) {
+		t.Parallel()
+
+		dingo := dingoPParamsPreview380()
+		dingo.CostModels = map[string][]int64{
+			"PlutusV2": eras.DefaultPlutusV2CostModel,
+		}
+		dingo.SyntheticV2CostModel = true
+		koios := koiosPParamsPreview380()
+		koios.CostModels = koiosCostModelsJSON(
+			t,
+			map[string][]int64{
+				"PlutusV2": eras.DefaultPlutusV2CostModel[:10],
+			},
+		)
+
+		got := CompareEpochProtocolParams(
+			"preview", 5, koios, dingo, nil, time.Now(), 0, time.Time{},
+		)
+		require.Len(t, got, 1)
+		require.Equal(t, "pparams_cost_model_plutus_v2", got[0].Field)
+		require.Equal(t, CategoryValueMismatch, got[0].Category)
+		require.Equal(t, StatusFail, DetermineStatus(got))
+		require.Equal(t, 1, CountSignificant(got))
+	})
+}
+
 // TestDingoDBGetProtocolParamsMarksSyntheticV2CostModel is the DB-layer half
 // of #4127's regression, using the exact shape the issue reported: a real
 // preview Babbage pparams row (pparams_preview_epoch2_babbage.hex) whose

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -588,11 +588,33 @@ func (s *DatabaseSource) GetProtocolParams(
 	if len(rows) == 0 {
 		return nil, nil
 	}
-	return decodeProtocolParams(
+	out, err := decodeProtocolParams(
 		rows[0].Cbor,
 		epochRow.EraId,
 		rows[0].Epoch,
 	)
+	if err != nil {
+		return nil, err
+	}
+	// See isSyntheticV2CostModel's doc comment (dingo #4127, following
+	// #3825's design): the durable cleared-epoch marker is the same one
+	// ledger.queryShelleyCurrentProtocolParams reads for its own historical
+	// path, read here directly via the database package rather than
+	// DingoDB's duplicated raw-SQL copy since this source already holds a
+	// live *database.Database.
+	clearedEpoch, cleared, err := database.SyntheticV2CostModelClearedEpoch(
+		s.db, txn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"synthetic v2 cost model cleared epoch: %w", err,
+		)
+	}
+	v2, hasV2 := out.CostModels["PlutusV2"]
+	out.SyntheticV2CostModel = isSyntheticV2CostModel(
+		v2, hasV2, epoch, clearedEpoch, cleared,
+	)
+	return out, nil
 }
 
 // GetRewardAccountOutputs returns every per-account reward calculation


### PR DESCRIPTION
`HardForkBabbage` fabricates a PlutusV2 cost-model default at the Babbage
transition (#3825) before the chain enacts a real one. `compareCostModels`
never consulted that marker, so it reported the fabricated model as a
`value_mismatch` against Koios's correct absence and failed every epoch
between the era transition and the real enactment.

- `GetProtocolParams` on both `RewardParitySource` implementations resolves
  `DingoProtocolParams.SyntheticV2CostModel` from the durable
  `synthetic_v2_cost_model_cleared_epoch` marker, mirroring
  `ledger.queryShelleyCurrentProtocolParams`'s historical-epoch resolution:
  the marker is authoritative for epochs at or after the one it records, and
  an absent marker falls back to comparing the stored model against
  `eras.DefaultPlutusV2CostModel`.
- `compareCostModels` classifies that shape as the new informational
  `cost_model_synthetic` category instead of `value_mismatch`, so it can
  never fail the epoch.
- The exemption is narrow by construction: PlutusV2 only, and a Koios-side
  absence only. A one-sided PlutusV1 or PlutusV3 model in the same epoch, a
  length or entry difference on a model both sides price, and any PlutusV2
  divergence once the flag is false all stay `value_mismatch`/FAIL.

`ARCHITECTURE.md` records the new category, how `SyntheticV2CostModel`
resolves, and those two bounds.

Fixes #4127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
