### PR TITLE
feat(dmq): add CIP-0137 message mempool (phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ make govulncheck  # reachable Go vulnerabilities; needs network
 | `chainselection.chain_switch` | active peer changed |
 | `epoch.transition` | epoch boundary — triggers stake snapshot |
 | `mempool.add_tx` / `mempool.remove_tx` | tx lifecycle |
+| `dmq.add_message` / `dmq.remove_message` | CIP-0137 DMQ message pool lifecycle |
 | `connmanager.conn_closed` | connection closed |
 | `peergov.peer_churn` | peer rotation |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4900,9 +4900,10 @@ context, so a caller composing it into a larger shutdown adds its own
 component name and deadline.
 
 `dmq.add_message` / `dmq.remove_message` events publish outside the pool's
-lock, matching the mempool package's event-publication rule. `EventBus` is
-optional (nil-safe) so the package is usable standalone ahead of node
-composition.
+lock, matching the mempool package's event-publication rule. Their payloads
+are `AddMessageEvent` and `RemoveMessageEvent`, each carrying a 32-byte
+`MessageID` field. `EventBus` is optional (nil-safe) so the package is usable
+standalone ahead of node composition.
 
 ## Block Production
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -179,6 +179,7 @@ Dingo is a high-performance Cardano blockchain node implementation in Go. This d
 - [Network and Protocol Handling](#network-and-protocol-handling)
 - [Peer Governance](#peer-governance)
 - [Transaction Mempool](#transaction-mempool)
+- [DMQ Message Pool](#dmq-message-pool)
 - [Block Production](#block-production)
 - [Mithril Bootstrap](#mithril-bootstrap)
 - [External Interfaces](#external-interfaces)
@@ -4841,6 +4842,67 @@ through the backend-neutral `RemoveTxsByHash` adapter. The chain-update rebuild 
 responsible for transactions confirmed by peer blocks. This local fast path
 prevents confirmed transactions from accumulating when sustained admissions
 make a long rebuild repeatedly lose its pinned ledger generation.
+
+## DMQ Message Pool
+
+`dmq.MessageMempool` is phase 1 of CIP-0137's Decentralized Message Queue
+(issue #1948 of 7; primary use case: Mithril signature diffusion). It is a
+standalone package, not yet wired into `node.go`, the plugin host, or any
+network protocol client/server -- that composition, a feature flag, and peer
+manager are later phases (issue #1953).
+
+The wire types are not redefined here. `Message`, `MessagePayload`, and
+`OperationalCertificate` from CIP-0137's CDDL, along with their CBOR
+encode/decode and Blake2b-256 message-ID computation, already exist upstream
+as `github.com/blinklabs-io/gouroboros/protocol/common`'s `DmqMessage`,
+`DmqMessagePayload`, and `OperationalCertificate`. `dmq` imports them directly.
+
+```
+                     MessageMempool
+    -------------------------------------------------
+    | Message Log                                    |
+    |   Dedup by 32-byte message ID                  |
+    |   Arrival-ordered, sequence-tagged entries     |
+    |   Capacity limits (bytes and/or count)         |
+    |   Reject-on-full backpressure (ErrFull)        |
+    |   TTL expiry via CIP-0137 expiresAt            |
+    |                                                 |
+    | Per-Peer Diffusion Cursor                      |
+    |   FIFO cursor over the arrival-ordered log      |
+    |   New peer starts from the retained backlog    |
+    -------------------------------------------------
+```
+
+`Add` de-duplicates by the message's 32-byte ID (computing one from the
+payload via `ComputeDmqMessageID` when the caller left it unset), rejects an
+already-expired message with `ErrExpired`, and rejects one that would exceed
+`Config.Capacity` or `Config.MaxMessages` with `ErrFull`. A duplicate ID
+returns `(false, nil)` rather than an error -- distinct from an outright
+rejection, since later phases translate each case into a different CIP-0137
+`RejectReason`. `Add` computes the CBOR-encoded size and admits under a single
+write-locked check to avoid a race between a concurrent capacity check and
+insert.
+
+`NextForPeer` gives each peer identifier its own FIFO cursor (a last-seen
+sequence number, not a slice index, so TTL compaction never invalidates it)
+over the arrival-ordered log, mirroring CIP-0137's per-peer outstanding
+message-ids queue for the node-to-node message-submission mini-protocol
+(protocol 18) without implementing that protocol's blocking/non-blocking
+request state machine itself -- that is phase 3 (issue #1950). A peer new to
+the pool sees the full retained backlog before anything arriving after it
+connects; `RemovePeer` releases a disconnected peer's cursor.
+
+A background goroutine (`Start`/`Stop`) sweeps expired messages on
+`Config.CleanupInterval` (default 30s), compacting the retained log and
+removing them from the dedup index. `Stop` follows this codebase's lifecycle
+convention: it returns an unprefixed error and bounds its wait on the caller's
+context, so a caller composing it into a larger shutdown adds its own
+component name and deadline.
+
+`dmq.add_message` / `dmq.remove_message` events publish outside the pool's
+lock, matching the mempool package's event-publication rule. `EventBus` is
+optional (nil-safe) so the package is usable standalone ahead of node
+composition.
 
 ## Block Production
 

--- a/dmq/doc.go
+++ b/dmq/doc.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dmq implements phase 1 of CIP-0137's Decentralized Message Queue:
+// the generic message pool shared by every DMQ topic instance. It holds no
+// opinion about authentication, KES/opcert validation, network wiring, or
+// peer selection -- those belong to later CIP-0137 phases (issues #1949-#1954).
+//
+// The wire types -- Message, MessagePayload, and OperationalCertificate, along
+// with their CBOR encode/decode and message-ID computation -- already exist
+// upstream as github.com/blinklabs-io/gouroboros/protocol/common's
+// DmqMessage, DmqMessagePayload, and OperationalCertificate. This package
+// reuses them rather than redefining CIP-0137's CDDL a second time.
+//
+// # MessageMempool
+//
+// MessageMempool de-duplicates messages by their 32-byte message ID, retains
+// admitted messages in arrival order behind a size bound, and expires them
+// once their CIP-0137 expiresAt timestamp passes. A background goroutine
+// sweeps expired messages on a fixed interval; Start launches it and Stop
+// tears it down.
+//
+// # Per-peer diffusion cursor
+//
+// Each connected peer gets its own FIFO cursor over the arrival-ordered
+// message log, obtained by calling NextForPeer with that peer's identifier.
+// A peer new to the pool starts at the beginning of the retained log; each
+// call advances that peer's cursor past the message it returns. This mirrors
+// CIP-0137's per-peer outstanding-message-ids queue for the node-to-node
+// message-submission mini-protocol (protocol 18), without implementing the
+// protocol's blocking/non-blocking request state machine itself -- that is
+// phase 3's job (issue #1950).
+//
+// # Size limits and backpressure
+//
+// Config.Capacity and Config.MaxMessages bound the pool's total CBOR-encoded
+// size and message count. Add rejects a message that would exceed either
+// bound with ErrFull, and rejects an already-expired message with ErrExpired,
+// so callers can apply their own backpressure or reply with a CIP-0137 reject
+// reason without the pool growing unbounded between TTL sweeps.
+package dmq

--- a/dmq/mempool.go
+++ b/dmq/mempool.go
@@ -1,0 +1,374 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dmq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Event types published by MessageMempool. See AGENTS.md's "Key events"
+// table.
+const (
+	AddMessageEventType    event.EventType = "dmq.add_message"
+	RemoveMessageEventType event.EventType = "dmq.remove_message"
+)
+
+// AddMessageEvent is published whenever a new DMQ message is admitted.
+type AddMessageEvent struct {
+	MessageID []byte
+}
+
+// RemoveMessageEvent is published whenever a DMQ message leaves the pool,
+// whether by TTL expiry or explicit removal.
+type RemoveMessageEvent struct {
+	MessageID []byte
+}
+
+// Sentinel errors returned by MessageMempool.Add.
+var (
+	// ErrInvalidMessageID is returned when a message's ID (explicit or
+	// computed) is not exactly 32 bytes.
+	ErrInvalidMessageID = errors.New(
+		"dmq: message id must be exactly 32 bytes",
+	)
+	// ErrExpired is returned when a submitted message's expiresAt has
+	// already passed.
+	ErrExpired = errors.New("dmq: message is already expired")
+	// ErrFull is returned when admitting a message would exceed
+	// Config.Capacity or Config.MaxMessages.
+	ErrFull = errors.New("dmq: message mempool is full")
+)
+
+// DefaultCleanupInterval is used when Config.CleanupInterval is zero.
+const DefaultCleanupInterval = 30 * time.Second
+
+// Config configures a MessageMempool.
+type Config struct {
+	// Capacity is the maximum total size, in CBOR-encoded bytes, of all
+	// messages held at once. Zero means unlimited.
+	Capacity int64
+	// MaxMessages is the maximum message count held at once. Zero means
+	// unlimited.
+	MaxMessages int
+	// CleanupInterval controls how often the background goroutine sweeps
+	// for expired messages. Zero uses DefaultCleanupInterval.
+	CleanupInterval time.Duration
+	// EventBus, when non-nil, receives AddMessageEventType and
+	// RemoveMessageEventType notifications.
+	EventBus *event.EventBus
+	// Now, when non-nil, replaces time.Now for expiry checks. Tests use
+	// this for deterministic TTL behavior.
+	Now func() time.Time
+}
+
+// entry is one message held in the pool, tagged with its arrival sequence.
+type entry struct {
+	seq  uint64
+	id   [32]byte
+	msg  ocommon.DmqMessage
+	size int64
+}
+
+// peerCursor tracks how far one peer has been fed the arrival-ordered
+// message log.
+type peerCursor struct {
+	mu      sync.Mutex
+	lastSeq uint64
+}
+
+// MessageMempool is a CIP-0137 DMQ message pool. See the package doc comment
+// for its scope.
+type MessageMempool struct {
+	mu       sync.RWMutex // guards byID, order, nextSeq, curBytes
+	byID     map[[32]byte]*entry
+	order    []*entry // ascending by seq; append-only except compaction
+	nextSeq  uint64
+	curBytes int64
+
+	peersMu sync.Mutex // guards peers
+	peers   map[string]*peerCursor
+
+	capacity        int64
+	maxMessages     int
+	cleanupInterval time.Duration
+	eventBus        *event.EventBus
+	now             func() time.Time
+
+	done      chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+}
+
+// NewMessageMempool constructs a MessageMempool. Call Start to begin the
+// background TTL sweep.
+func NewMessageMempool(cfg Config) *MessageMempool {
+	interval := cfg.CleanupInterval
+	if interval <= 0 {
+		interval = DefaultCleanupInterval
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &MessageMempool{
+		byID:            make(map[[32]byte]*entry),
+		peers:           make(map[string]*peerCursor),
+		capacity:        cfg.Capacity,
+		maxMessages:     cfg.MaxMessages,
+		cleanupInterval: interval,
+		eventBus:        cfg.EventBus,
+		now:             now,
+		done:            make(chan struct{}),
+	}
+}
+
+// Start launches the background TTL-expiry goroutine. Calling Start more
+// than once is a no-op.
+func (p *MessageMempool) Start() {
+	p.startOnce.Do(func() {
+		p.wg.Add(1)
+		go p.expireLoop()
+	})
+}
+
+// Stop halts the background goroutine, waiting up to ctx's deadline for it
+// to exit. Stop is idempotent. It returns an unprefixed error; a caller
+// composing it into a larger shutdown should add its own component name
+// (e.g. "dmq mempool shutdown: %w"), matching every other component's Stop
+// in this codebase.
+func (p *MessageMempool) Stop(ctx context.Context) error {
+	p.stopOnce.Do(func() { close(p.done) })
+
+	waitDone := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *MessageMempool) expireLoop() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(p.cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.removeExpired()
+		case <-p.done:
+			return
+		}
+	}
+}
+
+// Add inserts msg into the pool. It returns (true, nil) when the message is
+// newly admitted, (false, nil) when a message with the same ID is already
+// present, and (false, err) when the message is rejected outright: an
+// unset/malformed ID (ErrInvalidMessageID), an already-expired message
+// (ErrExpired), or a full pool (ErrFull).
+//
+// A message with no MessageID set has one computed and attached before any
+// other check, matching gouroboros' own MarshalCBOR/ID behavior.
+func (p *MessageMempool) Add(msg ocommon.DmqMessage) (bool, error) {
+	id := msg.ID()
+	if len(id) == 0 {
+		computed, err := ocommon.ComputeDmqMessageID(msg.Payload)
+		if err != nil {
+			return false, fmt.Errorf("dmq: compute message id: %w", err)
+		}
+		msg.SetMessageID(computed)
+		id = computed
+	}
+	if len(id) != 32 {
+		return false, ErrInvalidMessageID
+	}
+	var key [32]byte
+	copy(key[:], id)
+
+	// Cheap early duplicate check before paying for a CBOR encode below;
+	// re-checked under the write lock since this read is not atomic with
+	// the insert.
+	p.mu.RLock()
+	_, exists := p.byID[key]
+	p.mu.RUnlock()
+	if exists {
+		return false, nil
+	}
+
+	if !msg.IsValidAt(p.now()) {
+		return false, ErrExpired
+	}
+
+	encoded, err := msg.MarshalCBOR()
+	if err != nil {
+		return false, fmt.Errorf("dmq: encode message: %w", err)
+	}
+	size := int64(len(encoded))
+
+	p.mu.Lock()
+	if _, exists := p.byID[key]; exists {
+		p.mu.Unlock()
+		return false, nil
+	}
+	if p.capacity > 0 && p.curBytes+size > p.capacity {
+		p.mu.Unlock()
+		return false, ErrFull
+	}
+	if p.maxMessages > 0 && len(p.byID) >= p.maxMessages {
+		p.mu.Unlock()
+		return false, ErrFull
+	}
+	p.nextSeq++
+	e := &entry{seq: p.nextSeq, id: key, msg: msg, size: size}
+	p.byID[key] = e
+	p.order = append(p.order, e)
+	p.curBytes += size
+	p.mu.Unlock()
+
+	if p.eventBus != nil {
+		p.eventBus.Publish(
+			AddMessageEventType,
+			event.NewEvent(AddMessageEventType, AddMessageEvent{MessageID: id}),
+		)
+	}
+	return true, nil
+}
+
+// Get returns the pooled message with the given ID, if present.
+func (p *MessageMempool) Get(id []byte) (ocommon.DmqMessage, bool) {
+	if len(id) != 32 {
+		return ocommon.DmqMessage{}, false
+	}
+	var key [32]byte
+	copy(key[:], id)
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	e, ok := p.byID[key]
+	if !ok {
+		return ocommon.DmqMessage{}, false
+	}
+	return e.msg, true
+}
+
+// NextForPeer returns the next message peerID has not yet seen, in arrival
+// order, and advances that peer's cursor past it. It returns the zero
+// message and false once the peer has caught up to the current log. An
+// unknown peerID is registered on first call, starting from the beginning
+// of the currently retained log -- a newly connected peer sees the pool's
+// full backlog before anything arriving after it connected.
+func (p *MessageMempool) NextForPeer(peerID string) (ocommon.DmqMessage, bool) {
+	cursor := p.cursorFor(peerID)
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	cursor.mu.Lock()
+	defer cursor.mu.Unlock()
+
+	idx := sort.Search(len(p.order), func(i int) bool {
+		return p.order[i].seq > cursor.lastSeq
+	})
+	if idx >= len(p.order) {
+		return ocommon.DmqMessage{}, false
+	}
+	e := p.order[idx]
+	cursor.lastSeq = e.seq
+	return e.msg, true
+}
+
+// RemovePeer releases the FIFO cursor tracked for peerID. Callers should
+// invoke it when a peer connection closes so its cursor does not linger.
+func (p *MessageMempool) RemovePeer(peerID string) {
+	p.peersMu.Lock()
+	delete(p.peers, peerID)
+	p.peersMu.Unlock()
+}
+
+func (p *MessageMempool) cursorFor(peerID string) *peerCursor {
+	p.peersMu.Lock()
+	defer p.peersMu.Unlock()
+	c, ok := p.peers[peerID]
+	if !ok {
+		c = &peerCursor{}
+		p.peers[peerID] = c
+	}
+	return c
+}
+
+// Len returns the number of messages currently held in the pool.
+func (p *MessageMempool) Len() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.byID)
+}
+
+// SizeBytes returns the total CBOR-encoded size, in bytes, of every message
+// currently held in the pool.
+func (p *MessageMempool) SizeBytes() int64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.curBytes
+}
+
+// removeExpired sweeps the pool for messages whose CIP-0137 expiresAt has
+// passed, removing them and compacting the retained order. Event
+// publication happens after the lock is released.
+func (p *MessageMempool) removeExpired() {
+	now := p.now()
+
+	p.mu.Lock()
+	var removedIDs [][32]byte
+	kept := make([]*entry, 0, len(p.order))
+	for _, e := range p.order {
+		if e.msg.IsValidAt(now) {
+			kept = append(kept, e)
+			continue
+		}
+		delete(p.byID, e.id)
+		p.curBytes -= e.size
+		removedIDs = append(removedIDs, e.id)
+	}
+	p.order = kept
+	p.mu.Unlock()
+
+	if p.eventBus == nil {
+		return
+	}
+	for _, id := range removedIDs {
+		p.eventBus.Publish(
+			RemoveMessageEventType,
+			event.NewEvent(
+				RemoveMessageEventType,
+				RemoveMessageEvent{MessageID: id[:]},
+			),
+		)
+	}
+}

--- a/dmq/mempool.go
+++ b/dmq/mempool.go
@@ -15,6 +15,7 @@
 package dmq
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -46,10 +47,12 @@ type RemoveMessageEvent struct {
 
 // Sentinel errors returned by MessageMempool.Add.
 var (
-	// ErrInvalidMessageID is returned when a message's ID (explicit or
-	// computed) is not exactly 32 bytes.
+	// ErrInvalidMessageID is returned when a message's explicitly supplied
+	// ID is not exactly 32 bytes, or does not equal the Blake2b-256 hash of
+	// its own payload (ComputeDmqMessageID) -- a caller cannot pick an
+	// arbitrary ID for a payload and bypass dedup by content.
 	ErrInvalidMessageID = errors.New(
-		"dmq: message id must be exactly 32 bytes",
+		"dmq: message id must be the 32-byte hash of its payload",
 	)
 	// ErrExpired is returned when a submitted message's expiresAt has
 	// already passed.
@@ -118,6 +121,14 @@ type MessageMempool struct {
 	startOnce sync.Once
 	stopOnce  sync.Once
 	wg        sync.WaitGroup
+
+	// testBeforeLock, when non-nil, runs in Add immediately before the
+	// write-lock section that performs the final admission checks and
+	// insert. It exists only so tests can deterministically simulate a
+	// message expiring (or being concurrently admitted) in the window
+	// between Add's early checks and the write lock -- a race otherwise
+	// too narrow to hit reliably.
+	testBeforeLock func()
 }
 
 // NewMessageMempool constructs a MessageMempool. Call Start to begin the
@@ -191,26 +202,37 @@ func (p *MessageMempool) expireLoop() {
 // Add inserts msg into the pool. It returns (true, nil) when the message is
 // newly admitted, (false, nil) when a message with the same ID is already
 // present, and (false, err) when the message is rejected outright: an
-// unset/malformed ID (ErrInvalidMessageID), an already-expired message
-// (ErrExpired), or a full pool (ErrFull).
+// unset/malformed/mismatched ID (ErrInvalidMessageID), an already-expired
+// message (ErrExpired), or a full pool (ErrFull).
 //
-// A message with no MessageID set has one computed and attached before any
-// other check, matching gouroboros' own MarshalCBOR/ID behavior.
+// A message's ID is always verified against ComputeDmqMessageID(msg.Payload):
+// one left unset has the computed ID attached, matching gouroboros' own
+// MarshalCBOR/ID behavior, and one explicitly supplied must equal that hash
+// or the message is rejected -- a caller cannot submit identical payloads
+// under different IDs to bypass dedup and consume separate capacity.
+//
+// Expiry is checked before dedup, so a message whose expiresAt has passed is
+// always rejected with ErrExpired even if an expired copy of it is still
+// present awaiting the next TTL sweep; dedup applies only to resubmissions
+// that are still valid.
 func (p *MessageMempool) Add(msg ocommon.DmqMessage) (bool, error) {
-	id := msg.ID()
-	if len(id) == 0 {
-		computed, err := ocommon.ComputeDmqMessageID(msg.Payload)
-		if err != nil {
-			return false, fmt.Errorf("dmq: compute message id: %w", err)
+	computedID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	if err != nil {
+		return false, fmt.Errorf("dmq: compute message id: %w", err)
+	}
+	if suppliedID := msg.ID(); len(suppliedID) != 0 {
+		if len(suppliedID) != 32 || !bytes.Equal(suppliedID, computedID) {
+			return false, ErrInvalidMessageID
 		}
-		msg.SetMessageID(computed)
-		id = computed
 	}
-	if len(id) != 32 {
-		return false, ErrInvalidMessageID
-	}
+	msg.SetMessageID(computedID)
+
 	var key [32]byte
-	copy(key[:], id)
+	copy(key[:], computedID)
+
+	if !msg.IsValidAt(p.now()) {
+		return false, ErrExpired
+	}
 
 	// Cheap early duplicate check before paying for a CBOR encode below;
 	// re-checked under the write lock since this read is not atomic with
@@ -222,17 +244,25 @@ func (p *MessageMempool) Add(msg ocommon.DmqMessage) (bool, error) {
 		return false, nil
 	}
 
-	if !msg.IsValidAt(p.now()) {
-		return false, ErrExpired
-	}
-
 	encoded, err := msg.MarshalCBOR()
 	if err != nil {
 		return false, fmt.Errorf("dmq: encode message: %w", err)
 	}
 	size := int64(len(encoded))
+	stored := cloneDmqMessage(msg)
+
+	if p.testBeforeLock != nil {
+		p.testBeforeLock()
+	}
 
 	p.mu.Lock()
+	// Re-check expiry: enough time may have passed since the check above
+	// (CBOR encode, lock contention) for the message to have expired in the
+	// interim.
+	if !stored.IsValidAt(p.now()) {
+		p.mu.Unlock()
+		return false, ErrExpired
+	}
 	if _, exists := p.byID[key]; exists {
 		p.mu.Unlock()
 		return false, nil
@@ -246,7 +276,7 @@ func (p *MessageMempool) Add(msg ocommon.DmqMessage) (bool, error) {
 		return false, ErrFull
 	}
 	p.nextSeq++
-	e := &entry{seq: p.nextSeq, id: key, msg: msg, size: size}
+	e := &entry{seq: p.nextSeq, id: key, msg: stored, size: size}
 	p.byID[key] = e
 	p.order = append(p.order, e)
 	p.curBytes += size
@@ -255,13 +285,18 @@ func (p *MessageMempool) Add(msg ocommon.DmqMessage) (bool, error) {
 	if p.eventBus != nil {
 		p.eventBus.Publish(
 			AddMessageEventType,
-			event.NewEvent(AddMessageEventType, AddMessageEvent{MessageID: id}),
+			event.NewEvent(
+				AddMessageEventType,
+				AddMessageEvent{MessageID: computedID},
+			),
 		)
 	}
 	return true, nil
 }
 
-// Get returns the pooled message with the given ID, if present.
+// Get returns the pooled message with the given ID, if present. The returned
+// message is an independent copy: mutating it cannot affect the pool's
+// retained data.
 func (p *MessageMempool) Get(id []byte) (ocommon.DmqMessage, bool) {
 	if len(id) != 32 {
 		return ocommon.DmqMessage{}, false
@@ -275,7 +310,7 @@ func (p *MessageMempool) Get(id []byte) (ocommon.DmqMessage, bool) {
 	if !ok {
 		return ocommon.DmqMessage{}, false
 	}
-	return e.msg, true
+	return cloneDmqMessage(e.msg), true
 }
 
 // NextForPeer returns the next message peerID has not yet seen, in arrival
@@ -283,7 +318,9 @@ func (p *MessageMempool) Get(id []byte) (ocommon.DmqMessage, bool) {
 // message and false once the peer has caught up to the current log. An
 // unknown peerID is registered on first call, starting from the beginning
 // of the currently retained log -- a newly connected peer sees the pool's
-// full backlog before anything arriving after it connected.
+// full backlog before anything arriving after it connected. The returned
+// message is an independent copy: mutating it cannot affect the pool's
+// retained data.
 func (p *MessageMempool) NextForPeer(peerID string) (ocommon.DmqMessage, bool) {
 	cursor := p.cursorFor(peerID)
 
@@ -301,7 +338,7 @@ func (p *MessageMempool) NextForPeer(peerID string) (ocommon.DmqMessage, bool) {
 	}
 	e := p.order[idx]
 	cursor.lastSeq = e.seq
-	return e.msg, true
+	return cloneDmqMessage(e.msg), true
 }
 
 // RemovePeer releases the FIFO cursor tracked for peerID. Callers should
@@ -371,4 +408,33 @@ func (p *MessageMempool) removeExpired() {
 			),
 		)
 	}
+}
+
+// cloneDmqMessage returns msg with every byte-slice field backed by a fresh
+// array, so neither the pool nor a caller can mutate data the other still
+// holds a reference to. DmqMessage's scalar fields (KESPeriod, ExpiresAt,
+// IssueNumber) copy by value already.
+func cloneDmqMessage(msg ocommon.DmqMessage) ocommon.DmqMessage {
+	msg.MessageID = cloneBytes(msg.MessageID)
+	msg.Payload.MessageID = cloneBytes(msg.Payload.MessageID)
+	msg.Payload.MessageBody = cloneBytes(msg.Payload.MessageBody)
+	msg.KESSignature = cloneBytes(msg.KESSignature)
+	msg.OperationalCertificate.KESVerificationKey = cloneBytes(
+		msg.OperationalCertificate.KESVerificationKey,
+	)
+	msg.OperationalCertificate.ColdSignature = cloneBytes(
+		msg.OperationalCertificate.ColdSignature,
+	)
+	msg.ColdVerificationKey = cloneBytes(msg.ColdVerificationKey)
+	return msg
+}
+
+// cloneBytes returns an independent copy of src, or nil if src is nil.
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
 }

--- a/dmq/mempool_test.go
+++ b/dmq/mempool_test.go
@@ -89,6 +89,51 @@ func TestMessageMempool_AddComputesIDAndRoundTrips(t *testing.T) {
 	require.Equal(t, msg.Payload.MessageBody, decoded.Payload.MessageBody)
 }
 
+func TestMessageMempool_AddClonesStoredMessage(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	body := []byte("original")
+	msg := newTestMessage(body, futureExpiry(t))
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	// Mutate the caller's own backing array after Add returns. The pool
+	// must own an independent copy, not an alias into it.
+	body[0] = 'X'
+
+	got, ok := mp.Get(wantID)
+	require.True(t, ok)
+	require.Equal(t, []byte("original"), got.Payload.MessageBody)
+}
+
+func TestMessageMempool_GetReturnsIndependentCopy(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	msg := newTestMessage([]byte("original"), futureExpiry(t))
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	got, ok := mp.Get(wantID)
+	require.True(t, ok)
+	got.Payload.MessageBody[0] = 'X'
+
+	// A second, independent Get must not observe the mutation above: Get
+	// must return a copy the caller cannot use to corrupt retained data.
+	got2, ok := mp.Get(wantID)
+	require.True(t, ok)
+	require.Equal(t, []byte("original"), got2.Payload.MessageBody)
+}
+
 func TestMessageMempool_AddDedup(t *testing.T) {
 	t.Parallel()
 
@@ -119,6 +164,21 @@ func TestMessageMempool_AddInvalidMessageID(t *testing.T) {
 	require.Equal(t, 0, mp.Len())
 }
 
+func TestMessageMempool_AddRejectsMismatchedMessageID(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	msg := newTestMessage([]byte("mismatched"), futureExpiry(t))
+	wrongID := make([]byte, 32)
+	wrongID[0] = 0xAB
+	msg.SetMessageID(wrongID)
+
+	added, err := mp.Add(msg)
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrInvalidMessageID)
+	require.Equal(t, 0, mp.Len())
+}
+
 func TestMessageMempool_AddExpired(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +191,39 @@ func TestMessageMempool_AddExpired(t *testing.T) {
 		[]byte("expired"),
 		uint32(fixedNow.Add(-time.Minute).Unix()),
 	)
+
+	added, err := mp.Add(msg)
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrExpired)
+	require.Equal(t, 0, mp.Len())
+}
+
+func TestMessageMempool_AddRechecksExpiryUnderLock(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	now := time.Unix(2_000_000_000, 0)
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	mp := NewMessageMempool(Config{Now: nowFn})
+	// Simulate the message's expiresAt passing in the window between Add's
+	// early (unlocked) expiry check and the write lock that actually admits
+	// it -- a race otherwise too narrow to hit deterministically.
+	mp.testBeforeLock = func() {
+		mu.Lock()
+		now = now.Add(2 * time.Minute)
+		mu.Unlock()
+	}
+
+	mu.Lock()
+	// #nosec G115 -- fixed test timestamp
+	expiresAt := uint32(now.Add(time.Minute).Unix())
+	mu.Unlock()
+	msg := newTestMessage([]byte("race"), expiresAt)
 
 	added, err := mp.Add(msg)
 	require.False(t, added)
@@ -173,6 +266,7 @@ func TestMessageMempool_AddPublishesEvent(t *testing.T) {
 	t.Parallel()
 
 	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
 	mp := NewMessageMempool(Config{EventBus: bus})
 	_, addCh := bus.Subscribe(AddMessageEventType)
 
@@ -204,6 +298,7 @@ func TestMessageMempool_TTLExpirySweepsAndPublishes(t *testing.T) {
 	}
 
 	bus := event.NewEventBus(nil, nil)
+	t.Cleanup(bus.Close)
 	mp := NewMessageMempool(Config{
 		Now:             nowFn,
 		CleanupInterval: 10 * time.Millisecond,

--- a/dmq/mempool_test.go
+++ b/dmq/mempool_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dmq
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/event"
+	"github.com/blinklabs-io/dingo/internal/test/testutil"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMessage builds a well-formed DmqMessage with no message ID set, so
+// Add computes one from the payload, matching real submissions.
+func newTestMessage(body []byte, expiresAt uint32) ocommon.DmqMessage {
+	return ocommon.DmqMessage{
+		Payload: ocommon.DmqMessagePayload{
+			MessageBody: body,
+			KESPeriod:   1,
+			ExpiresAt:   expiresAt,
+		},
+		KESSignature: make([]byte, 448),
+		OperationalCertificate: ocommon.OperationalCertificate{
+			KESVerificationKey: make([]byte, 32),
+			IssueNumber:        1,
+			KESPeriod:          1,
+			ColdSignature:      make([]byte, 64),
+		},
+		ColdVerificationKey: make([]byte, 32),
+	}
+}
+
+func futureExpiry(t *testing.T) uint32 {
+	t.Helper()
+	// #nosec G115 -- test fixture timestamp, far from the uint32 rollover
+	return uint32(time.Now().Add(time.Hour).Unix())
+}
+
+func TestMessageMempool_AddComputesIDAndRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	msg := newTestMessage([]byte("hello dmq"), futureExpiry(t))
+
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+	require.Len(t, wantID, 32)
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	got, ok := mp.Get(wantID)
+	require.True(t, ok)
+	require.Equal(t, wantID, got.ID())
+	require.Equal(t, msg.Payload.MessageBody, got.Payload.MessageBody)
+
+	// Round-trip: what the pool holds must encode identically to the same
+	// fields marshaled directly, and decoding those bytes must reproduce
+	// the same payload and ID.
+	msg.SetMessageID(wantID)
+	wantEncoded, err := msg.MarshalCBOR()
+	require.NoError(t, err)
+	gotEncoded, err := got.MarshalCBOR()
+	require.NoError(t, err)
+	require.Equal(t, wantEncoded, gotEncoded)
+
+	var decoded ocommon.DmqMessage
+	_, err = cbor.Decode(gotEncoded, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, wantID, decoded.ID())
+	require.Equal(t, msg.Payload.MessageBody, decoded.Payload.MessageBody)
+}
+
+func TestMessageMempool_AddDedup(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	msg := newTestMessage([]byte("dup"), futureExpiry(t))
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	added, err = mp.Add(msg)
+	require.NoError(t, err)
+	require.False(t, added)
+
+	require.Equal(t, 1, mp.Len())
+}
+
+func TestMessageMempool_AddInvalidMessageID(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	msg := newTestMessage([]byte("bad id"), futureExpiry(t))
+	msg.SetMessageID([]byte{1, 2, 3})
+
+	added, err := mp.Add(msg)
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrInvalidMessageID)
+	require.Equal(t, 0, mp.Len())
+}
+
+func TestMessageMempool_AddExpired(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Unix(2_000_000_000, 0)
+	mp := NewMessageMempool(Config{
+		Now: func() time.Time { return fixedNow },
+	})
+	// #nosec G115 -- fixed test timestamp
+	msg := newTestMessage(
+		[]byte("expired"),
+		uint32(fixedNow.Add(-time.Minute).Unix()),
+	)
+
+	added, err := mp.Add(msg)
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrExpired)
+	require.Equal(t, 0, mp.Len())
+}
+
+func TestMessageMempool_AddFullByMaxMessages(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{MaxMessages: 1})
+	expiry := futureExpiry(t)
+
+	added, err := mp.Add(newTestMessage([]byte("one"), expiry))
+	require.NoError(t, err)
+	require.True(t, added)
+
+	added, err = mp.Add(newTestMessage([]byte("two"), expiry))
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrFull)
+	require.Equal(t, 1, mp.Len())
+}
+
+func TestMessageMempool_AddFullByCapacity(t *testing.T) {
+	t.Parallel()
+
+	msg := newTestMessage([]byte("size probe"), futureExpiry(t))
+	encoded, err := msg.MarshalCBOR()
+	require.NoError(t, err)
+
+	mp := NewMessageMempool(Config{Capacity: int64(len(encoded)) - 1})
+
+	added, err := mp.Add(msg)
+	require.False(t, added)
+	require.ErrorIs(t, err, ErrFull)
+	require.Equal(t, int64(0), mp.SizeBytes())
+}
+
+func TestMessageMempool_AddPublishesEvent(t *testing.T) {
+	t.Parallel()
+
+	bus := event.NewEventBus(nil, nil)
+	mp := NewMessageMempool(Config{EventBus: bus})
+	_, addCh := bus.Subscribe(AddMessageEventType)
+
+	msg := newTestMessage([]byte("event"), futureExpiry(t))
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	evt := testutil.RequireReceive(
+		t, addCh, time.Second, "add event for new message",
+	)
+	data, ok := evt.Data.(AddMessageEvent)
+	require.True(t, ok)
+	require.Equal(t, wantID, data.MessageID)
+}
+
+func TestMessageMempool_TTLExpirySweepsAndPublishes(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	now := time.Unix(2_000_000_000, 0)
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+
+	bus := event.NewEventBus(nil, nil)
+	mp := NewMessageMempool(Config{
+		Now:             nowFn,
+		CleanupInterval: 10 * time.Millisecond,
+		EventBus:        bus,
+	})
+	_, removeCh := bus.Subscribe(RemoveMessageEventType)
+
+	mp.Start()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, mp.Stop(ctx))
+	})
+
+	mu.Lock()
+	// #nosec G115 -- fixed test timestamp
+	expiresAt := uint32(now.Add(time.Minute).Unix())
+	mu.Unlock()
+	msg := newTestMessage([]byte("ttl"), expiresAt)
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+	require.Equal(t, 1, mp.Len())
+
+	mu.Lock()
+	now = now.Add(2 * time.Minute)
+	mu.Unlock()
+
+	testutil.WaitForCondition(t, func() bool {
+		return mp.Len() == 0
+	}, time.Second, "expired message must be swept from the pool")
+	require.Equal(t, int64(0), mp.SizeBytes())
+
+	evt := testutil.RequireReceive(
+		t, removeCh, time.Second, "remove event for expired message",
+	)
+	data, ok := evt.Data.(RemoveMessageEvent)
+	require.True(t, ok)
+	require.Equal(t, wantID, data.MessageID)
+}
+
+func TestMessageMempool_NextForPeerFIFOCursorAdvancement(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	expiry := futureExpiry(t)
+
+	bodies := [][]byte{[]byte("first"), []byte("second"), []byte("third")}
+	ids := make([][]byte, len(bodies))
+	for i, body := range bodies {
+		msg := newTestMessage(body, expiry)
+		id, err := ocommon.ComputeDmqMessageID(msg.Payload)
+		require.NoError(t, err)
+		ids[i] = id
+
+		added, err := mp.Add(msg)
+		require.NoError(t, err)
+		require.True(t, added)
+	}
+
+	// A fresh peer walks the log in arrival order.
+	for i, wantID := range ids {
+		got, ok := mp.NextForPeer("peer-a")
+		require.Truef(t, ok, "message %d", i)
+		require.Equal(t, wantID, got.ID())
+	}
+	// The peer has caught up: no more messages until something new arrives.
+	_, ok := mp.NextForPeer("peer-a")
+	require.False(t, ok)
+
+	// A second peer's cursor is independent and starts from the beginning.
+	first, ok := mp.NextForPeer("peer-b")
+	require.True(t, ok)
+	require.Equal(t, ids[0], first.ID())
+
+	// New arrivals appear only after messages peer-a already consumed.
+	msg := newTestMessage([]byte("fourth"), expiry)
+	fourthID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	got, ok := mp.NextForPeer("peer-a")
+	require.True(t, ok)
+	require.Equal(t, fourthID, got.ID())
+
+	_, ok = mp.NextForPeer("peer-a")
+	require.False(t, ok)
+}
+
+func TestMessageMempool_RemovePeerResetsCursor(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{})
+	expiry := futureExpiry(t)
+
+	msg := newTestMessage([]byte("only"), expiry)
+	wantID, err := ocommon.ComputeDmqMessageID(msg.Payload)
+	require.NoError(t, err)
+	added, err := mp.Add(msg)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	got, ok := mp.NextForPeer("peer-a")
+	require.True(t, ok)
+	require.Equal(t, wantID, got.ID())
+	_, ok = mp.NextForPeer("peer-a")
+	require.False(t, ok)
+
+	mp.RemovePeer("peer-a")
+
+	got, ok = mp.NextForPeer("peer-a")
+	require.True(t, ok)
+	require.Equal(t, wantID, got.ID())
+}
+
+func TestMessageMempool_StopIsIdempotentAndBounded(t *testing.T) {
+	t.Parallel()
+
+	mp := NewMessageMempool(Config{CleanupInterval: 5 * time.Millisecond})
+	mp.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, mp.Stop(ctx))
+	require.NoError(t, mp.Stop(ctx))
+}

--- a/internal/architecture/import_boundary_test.go
+++ b/internal/architecture/import_boundary_test.go
@@ -53,6 +53,7 @@ var importBoundaryRules = []importBoundaryRule{
 			".",
 			"ledger",
 			"mempool",
+			"dmq",
 			"connmanager",
 			"peergov",
 			"ouroboros",
@@ -62,7 +63,7 @@ var importBoundaryRules = []importBoundaryRule{
 			"api",
 		},
 		reason: "database and storage plugins sit below ledger, mempool, " +
-			"networking, node composition, and API packages",
+			"dmq, networking, node composition, and API packages",
 	},
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of CIP-0137's Decentralized Message Queue (7 phases total; primary
use case: Mithril signature diffusion): a standalone `dmq` package with a
`MessageMempool`.

- Dedups messages by their 32-byte ID
- Retains admitted messages in arrival order behind a size bound
  (`Config.Capacity` bytes and/or `Config.MaxMessages`), rejecting on full
  with `ErrFull`
- Expires messages past their CIP-0137 `expiresAt` via a background sweep
  (`Start`/`Stop`)
- Gives each peer identifier (`NextForPeer`) its own FIFO cursor over the
  arrival-ordered log for diffusion, independent of TTL compaction
- Publishes `dmq.add_message` / `dmq.remove_message` on an optional
  `event.EventBus`

## Design note

CIP-0137's wire types are not redefined here. `Message`, `MessagePayload`,
and `OperationalCertificate`, their CBOR encode/decode, and Blake2b-256
message-ID computation already exist upstream as
`github.com/blinklabs-io/gouroboros/protocol/common`'s `DmqMessage`,
`DmqMessagePayload`, and `OperationalCertificate` (present since gouroboros
v0.146.0, unchanged through the currently pinned v0.204.0). This package
imports them directly rather than duplicating CIP-0137's CDDL a second time.

Not wired into `node.go`, the plugin host, or any network protocol
client/server -- that composition, a feature flag, and peer manager are a
later phase (#1953).

## Checks

- `go build`, `go vet` (both with `-tags dingo_extra_plugins`): clean
- `go test -race -count=1 ./dmq/...`: 11/11 pass; every test calls
  `t.Parallel()`
- Each new invariant (dedup, expiry-at-admission, capacity/count limits,
  cursor advancement, `RemovePeer`, TTL sweep, event publication) verified by
  reverting it in isolation and confirming the corresponding test fails with
  a message naming the defect, then restoring
- `golangci-lint run` (including `GOOS=windows`), `nilaway`, `modernize`,
  `golines`: clean
- `make import-boundaries`, `make docs-parity`: pass
- `AGENTS.md` (Key events table) and `ARCHITECTURE.md` (new "DMQ Message
  Pool" section) updated; `DATABASE.md` checked, not affected (no
  schema/storage-plugin change)

## Skipped

- Full `make test` / devnet / conformance: not run. This change does not
  touch consensus, ledger, mempool, networking, or node composition -- it
  adds one new, unwired package -- so the narrower scope above is the
  affected contract.
- `make govulncheck`: not run (needs network access unavailable here).

Closes #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phase 1 of CIP-0137's Decentralized Message Queue (issue #1948): a standalone `dmq` package with a `MessageMempool` that dedups messages, bounds retention, and expires them by TTL. It is not wired into the node yet — later phases add node composition, a feature flag, and peer management.

- Dedups by 32-byte message ID; a duplicate returns `(false, nil)` so later phases can map it to a distinct CIP-0137 reject reason. A caller-supplied ID must equal the Blake2b-256 hash of its payload, or `Add` rejects with `ErrInvalidMessageID`.
- Enforces `Config.Capacity` (CBOR bytes) and `Config.MaxMessages`, rejecting with `ErrFull`; `ErrExpired` for messages already past their `expiresAt`. Expiry is rechecked under the write lock immediately before insertion to close a TOCTOU window.
- Retained messages are deep-cloned on admit and on read, so neither callers nor the pool can mutate data the other still holds.
- A background `Start`/`Stop` sweep removes expired messages; `Stop` is idempotent and bounded by the caller's context.
- `NextForPeer` keeps a per-peer FIFO cursor over the arrival-ordered log; `RemovePeer` releases it on disconnect.
- Publishes `dmq.add_message` and `dmq.remove_message` on an optional, nil-safe `EventBus`.
- Reuses `gouroboros`'s `DmqMessage`, `DmqMessagePayload`, and `OperationalCertificate` types instead of redefining CIP-0137's CDDL.

<sup>Written for commit 8df73c1c16558dc36fedccad6e8937410d1ea33e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a decentralized message queue pool for retaining and distributing messages in arrival order.
  * Added duplicate detection using message IDs, message count and size limits, and expiration handling.
  * Added per-peer FIFO message delivery with independent cursors.
  * Added lifecycle controls for starting and stopping automatic cleanup.
  * Added optional events for message addition and expiration-based removal.

* **Documentation**
  * Documented the message queue pool, supported behaviors, limits, and lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->