### PR TITLE
fix(ledger/snapshot): retain reward_account_output for koios-parity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7080,6 +7080,25 @@ second sync:
   permanent Dingo subsystem — SQLite (or whichever metadata backend the node
   itself runs) remains the only backend involved, since `DatabaseSource`
   reads the live node's own store rather than opening a second connection.
+  - **Reward-state retention (dingo #4188).** `Run()` and
+    `reinitializeBackgroundManagers` both call
+    `n.snapshotMgr.SetRewardAccountOutputRetentionUnbounded(
+    n.config.koiosParity.Enabled)` immediately after configuring the
+    snapshot manager's other options, before `CaptureGenesisSnapshot`/`Start`.
+    This is necessary because the observer only validates a closed epoch
+    after fetching and comparing against Koios over the network — work that
+    can fall arbitrarily far behind chain progression during a from-genesis
+    or catch-up sync — while `ledger/snapshot.cleanupOldSnapshots` otherwise
+    prunes `reward_account_output` to a fixed 4-epoch window on every epoch
+    transition (see DATABASE.md, Snapshot and Reward-State Retention).
+    Without this, an epoch's reward rows are routinely gone by the time the
+    observer's backlog reaches that epoch, and every koios-parity account
+    check for it fails permanently with a row that genuinely no longer
+    exists rather than one Koios and Dingo actually disagree on. The setter
+    mirrors API storage mode's pre-existing unbounded retention (#1875) and
+    is not consensus-affecting (it only widens local historical retention),
+    so unlike `SetDelegatorInactivity` it carries no `configurationLocked`
+    gate.
   - **Live database Restore/Truncate.** `node_lifecycle.go`'s
     `quiesceForLiveLifecycleOp` stops the `Observer` (blocking until its
     background goroutine has exited, same as `shutdown()`) and unsubscribes

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1063,18 +1063,32 @@ leader-threshold rejection.
 Every epoch transition runs `cleanupOldSnapshots`, which prunes to the four
 epochs the Shelley rotation and delayed reward model need: current, current-1,
 current-2 for Go, and current-3 so reward calculation can be replayed after a
-rollback across the boundary where those rewards were applied. Retention is not
-operator-configurable, and it only ever deletes rows below that window (but see
-the deferred-header retention pin below, which can hold `pool_stake_snapshot`
-rows longer).
+rollback across the boundary where those rewards were applied. It only ever
+deletes rows below that window (but see the deferred-header retention pin
+below, which can hold `pool_stake_snapshot` rows longer).
+
+`reward_account_output` is the one exception to "not operator/config
+configurable": it is retained WITHOUT BOUND, instead of pruned to the window
+below, whenever the database is in API storage mode (`types.StorageModeAPI`,
+issue #1875, so the Blockfrost account reward-history endpoint can serve an
+account's full history) or the in-process Koios parity observer is enabled
+(`Manager.SetRewardAccountOutputRetentionUnbounded`, wired from
+`KoiosParityConfig.Enabled` in `node.go`/`node_lifecycle.go`, issue #4188). The
+observer validates a closed epoch only after fetching and comparing against
+Koios over the network, which can fall arbitrarily far behind chain
+progression during a from-genesis or catch-up sync — well past the fixed
+4-epoch window — so without this a checked epoch's `reward_account_output`
+rows are routinely gone before the observer ever reads them.
+`reward_stake_input` is pruned to the window in every case, including both of
+the above.
 
 Pruned at `epoch < current-3`:
 
 | Table | Scales with | Pruned by |
 |---|---|---|
 | `pool_stake_snapshot` | pools per epoch | `DeletePoolStakeSnapshotsBeforeEpoch` |
-| `reward_stake_input` | delegators per epoch | `DeleteRewardStateBeforeEpoch` |
-| `reward_account_output` | delegators per epoch | `DeleteRewardStateBeforeEpoch` |
+| `reward_stake_input` | delegators per epoch | `DeleteRewardStateBeforeEpoch` / `DeleteRewardStakeInputBeforeEpoch` |
+| `reward_account_output` | delegators per epoch | `DeleteRewardStateBeforeEpoch` (CORE mode, observer disabled only) |
 
 Retained for the life of the database: `epoch`, `epoch_summary`,
 `reward_ada_pots`, `reward_snapshot`, `reward_seed_failure`,

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1067,8 +1067,8 @@ rollback across the boundary where those rewards were applied. It only ever
 deletes rows below that window (but see the deferred-header retention pin
 below, which can hold `pool_stake_snapshot` rows longer).
 
-`reward_account_output` is the one exception to "not operator/config
-configurable": it is retained WITHOUT BOUND, instead of pruned to the window
+`reward_account_output` is the one table whose retention depends on node
+configuration: it is retained WITHOUT BOUND, instead of pruned to the window
 below, whenever the database is in API storage mode (`types.StorageModeAPI`,
 issue #1875, so the Blockfrost account reward-history endpoint can serve an
 account's full history) or the in-process Koios parity observer is enabled

--- a/internal/koiosparity/dingo_db.go
+++ b/internal/koiosparity/dingo_db.go
@@ -846,8 +846,9 @@ func (d *DingoDB) GetPoolEpochDataMap(
 // Presence is epoch-level. A pool with no spendable member row legitimately
 // earned nothing, but only if the table holds the epoch at all —
 // cleanupOldSnapshots retains reward_account_output without bound in api
-// storage mode and prunes it in core, so an empty read must not be reported as
-// a pool-wide zero.
+// storage mode and, since dingo #4188, in core mode too when the node's
+// koios-parity observer is enabled; it prunes the table to a 4-epoch window
+// otherwise, so an empty read must not be reported as a pool-wide zero.
 func (d *DingoDB) addSpendableMemberRewards(
 	ctx context.Context,
 	m map[string]*DingoPoolEpochData,

--- a/internal/koiosparity/source.go
+++ b/internal/koiosparity/source.go
@@ -161,22 +161,24 @@ var (
 // populate at every epoch boundary. It opens no second database connection,
 // requires no export step, and adds no new table.
 //
-// Core-mode pruning: ledger/snapshot/rotation.go's cleanupOldSnapshots keeps
-// reward_pool_input/reward_pool_output/reward_account_output for the current
-// epoch and the three that precede it (a rolling 4-epoch window; API storage
-// mode retains reward_account_output without bound instead). DatabaseSource
+// Retention: ledger/snapshot/rotation.go's cleanupOldSnapshots prunes
+// reward_account_output to the current epoch and the three that precede it
+// (a rolling 4-epoch window) only in core storage mode with the in-process
+// observer disabled. It is retained without bound in API storage mode
+// (dingo #1875) and whenever the observer is enabled (dingo #4188), because
+// the observer validates a closed epoch only after fetching and comparing
+// against Koios over the network and can fall arbitrarily far behind chain
+// progression during a from-genesis or catch-up sync — process-level timing
+// alone does not keep its reads inside the window. reward_pool_input,
+// reward_pool_output, epoch_summary and reward_ada_pots are retained for the
+// life of the database in every mode; pool_stake_snapshot and
+// reward_stake_input are pruned to the window in every mode. DatabaseSource
 // does not race that pruning in any special way — it just reads whatever is
 // currently committed, the same as DingoDB would against a separately synced
-// copy. What actually satisfies "available before cleanup runs" is
-// process-level timing: the in-process observer (observer.go) processes a
-// newly closed epoch promptly after its own event.EpochTransitionEvent
-// fires, which is many epochs (hours to days on preview/preprod) before that
-// epoch's rows would fall out of the retention window. A GetEpochData or
-// GetPoolEpochDataMap call made long after an epoch's data has aged out of
-// that window reads back as absent (nil / *Present == false) — the same
-// signal DingoDB already reports for "not yet computed" — not as an error;
-// it is the caller's responsibility (the observer, or an operator invoking
-// this source directly) to read promptly.
+// copy. A GetEpochData or GetPoolEpochDataMap call made after an epoch's data
+// has aged out of the window reads back as absent (nil / *Present == false) —
+// the same signal DingoDB already reports for "not yet computed" — not as an
+// error.
 type DatabaseSource struct {
 	db *database.Database
 }

--- a/ledger/snapshot/manager.go
+++ b/ledger/snapshot/manager.go
@@ -50,6 +50,17 @@ type Manager struct {
 	delegatorInactivityPeriod  uint64
 	configurationLocked        bool
 
+	// rewardAccountOutputRetentionUnbounded mirrors whether the in-process
+	// Koios parity observer (dingo #3098) is enabled, from node/load
+	// construction. When true, cleanupOldSnapshots retains reward_account_output
+	// without bound in CORE storage mode too, exactly as it already does
+	// unconditionally in API storage mode (dingo #1875) — see
+	// cleanupOldSnapshots's doc comment. Not consensus-affecting: it only
+	// widens local historical retention, so it carries no configurationLocked
+	// gate and may be changed at any time. Default false preserves CORE mode's
+	// existing pruning behavior when the observer is disabled (dingo #4188).
+	rewardAccountOutputRetentionUnbounded bool
+
 	mu             sync.RWMutex
 	running        bool
 	stopping       bool
@@ -264,6 +275,38 @@ func (m *Manager) inactivityPeriod() uint64 {
 		return 0
 	}
 	return m.delegatorInactivityPeriod
+}
+
+// SetRewardAccountOutputRetentionUnbounded mirrors whether the in-process
+// Koios parity observer (dingo #3098) is enabled into the snapshot manager's
+// cleanup path. When enabled is true, cleanupOldSnapshots retains
+// reward_account_output without bound in CORE storage mode, matching API
+// storage mode's existing unbounded retention (dingo #1875).
+//
+// The Koios parity observer validates each closed epoch against Koios only
+// after fetching and comparing over the network, which can fall arbitrarily
+// far behind chain progression during a from-genesis or catch-up sync —
+// unlike the fixed, small rotation/reward-replay window CORE mode's
+// cleanupOldSnapshots otherwise prunes to. Without this, reward_account_output
+// for an epoch is routinely pruned before the observer ever reads it, and the
+// koios-parity check for that epoch fails permanently with a
+// reward_account_output row that genuinely no longer exists (dingo #4188).
+//
+// Not consensus-affecting — it only widens local historical retention — so
+// unlike SetDelegatorInactivity this is not gated by configurationLocked and
+// may be called or changed at any time, including after Start.
+func (m *Manager) SetRewardAccountOutputRetentionUnbounded(enabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rewardAccountOutputRetentionUnbounded = enabled
+}
+
+// RewardAccountOutputRetentionUnbounded reports the current value set by
+// SetRewardAccountOutputRetentionUnbounded, for tests and diagnostics.
+func (m *Manager) RewardAccountOutputRetentionUnbounded() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.rewardAccountOutputRetentionUnbounded
 }
 
 // SetPromRegistry enables snapshot manager metrics.

--- a/ledger/snapshot/rotation.go
+++ b/ledger/snapshot/rotation.go
@@ -1066,10 +1066,16 @@ const poolSnapshotRetentionMaxDepth uint64 = 24
 // reward-history endpoint (GET /accounts/{stake_address}/rewards, dingo #1875)
 // can serve an account's full reward history instead of only the trailing few
 // epochs — the same "silently look empty past the window" failure mode #2987
-// already identified for epoch_summary. See
-// rewardstate.DeleteStateBeforeEpoch (core, prunes both tables) and
-// rewardstate.DeleteStakeInputBeforeEpoch (API, prunes only
-// reward_stake_input) for the implementation and full rationale.
+// already identified for epoch_summary. reward_account_output is likewise
+// retained without bound whenever SetRewardAccountOutputRetentionUnbounded(true)
+// has been called (node.go wires this from the koios-parity observer's Enabled
+// config): that observer only validates a closed epoch after fetching and
+// comparing over the network, which can fall arbitrarily far behind chain
+// progression during a from-genesis or catch-up sync, so the fixed 4-epoch
+// window otherwise prunes an epoch's rows before the observer ever reads them
+// (dingo #4188). See rewardstate.DeleteStateBeforeEpoch (core, prunes both
+// tables) and rewardstate.DeleteStakeInputBeforeEpoch (API/koios-parity, prunes
+// only reward_stake_input) for the implementation and full rationale.
 //
 // epoch_summary is deliberately NOT pruned. It is a single small row per epoch
 // (aggregate stake/pool/delegator totals plus the epoch nonce and boundary
@@ -1160,8 +1166,10 @@ func (m *Manager) cleanupOldSnapshots(
 	meta := m.db.Metadata()
 	metaTxn := txn.Metadata()
 
-	if m.db.StorageMode() == types.StorageModeAPI {
-		// API storage mode: retain reward_account_output without bound (see
+	if m.db.StorageMode() == types.StorageModeAPI ||
+		m.RewardAccountOutputRetentionUnbounded() {
+		// API storage mode, or the in-process Koios parity observer enabled
+		// (dingo #4188): retain reward_account_output without bound (see
 		// doc comment above) and prune only reward_stake_input.
 		if err := meta.DeleteRewardStakeInputBeforeEpoch(
 			deleteBeforeEpoch,

--- a/ledger/snapshot/rotation_reward_retention_mode_test.go
+++ b/ledger/snapshot/rotation_reward_retention_mode_test.go
@@ -161,6 +161,74 @@ func TestCleanupOldSnapshotsAPIModeRetainsRewardAccountOutput(t *testing.T) {
 	}
 }
 
+// TestCleanupOldSnapshotsKoiosParityRetentionUnbounded is the dingo #4188
+// regression test: enabling SetRewardAccountOutputRetentionUnbounded on a
+// CORE-mode database (the koios-parity observer's node.go wiring) must retain
+// reward_account_output without bound, exactly like API storage mode, instead
+// of pruning it to the 4-epoch rotation/reward-replay window. Without this,
+// the observer's own network-bound epoch validation routinely falls behind
+// chain progression during a catch-up sync and reads an epoch's
+// reward_account_output rows only after cleanupOldSnapshots has already
+// deleted them, making every koios-parity account check fail permanently with
+// a row that genuinely no longer exists.
+func TestCleanupOldSnapshotsKoiosParityRetentionUnbounded(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDBWithStorageMode(t, types.StorageModeCore)
+	require.Equal(t, types.StorageModeCore, db.StorageMode())
+	mgr := NewManager(db, event.NewEventBus(nil, nil), nil)
+	mgr.SetRewardAccountOutputRetentionUnbounded(true)
+	require.True(t, mgr.RewardAccountOutputRetentionUnbounded())
+	meta := db.Metadata()
+
+	const currentEpoch = uint64(10)
+	const firstRetainedEpoch = currentEpoch - 3
+	poolKeyHash := bytes.Repeat([]byte{0x44}, 28)
+
+	seedRetentionRows(t, db, poolKeyHash, currentEpoch)
+	require.NoError(
+		t,
+		mgr.cleanupOldSnapshots(context.Background(), currentEpoch),
+	)
+
+	// reward_account_output survives for every epoch, including those
+	// outside the rotation/reward-replay window, exactly like API mode.
+	for epoch := uint64(0); epoch <= currentEpoch; epoch++ {
+		accountOutputs, err := meta.GetRewardAccountOutputs(epoch, nil)
+		require.NoError(t, err, "get reward account outputs %d", epoch)
+		require.Len(
+			t,
+			accountOutputs,
+			1,
+			"koios-parity retention must retain reward_account_output for epoch %d",
+			epoch,
+		)
+	}
+
+	// reward_stake_input is still pruned to the same window as core mode.
+	for epoch := range firstRetainedEpoch {
+		stakeInputs, err := meta.GetRewardStakeInputs(epoch, nil)
+		require.NoError(t, err, "get reward stake inputs %d", epoch)
+		require.Empty(
+			t,
+			stakeInputs,
+			"koios-parity retention must still prune reward_stake_input for epoch %d",
+			epoch,
+		)
+	}
+	for epoch := firstRetainedEpoch; epoch <= currentEpoch; epoch++ {
+		stakeInputs, err := meta.GetRewardStakeInputs(epoch, nil)
+		require.NoError(t, err, "get reward stake inputs %d", epoch)
+		require.Len(
+			t,
+			stakeInputs,
+			1,
+			"reward_stake_input for epoch %d is inside the retained window",
+			epoch,
+		)
+	}
+}
+
 // TestDeleteRewardStateAfterSlotUnaffectedByAPIModeRetention is the rollback
 // correctness check for dingo #1875: retaining reward_account_output without
 // bound in API storage mode must not stop a rollback from removing rows

--- a/node.go
+++ b/node.go
@@ -863,6 +863,17 @@ func (n *Node) Run(ctx context.Context) (runErr error) {
 		return fmt.Errorf("configuring snapshot manager: %w", err)
 	}
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
+	// When the Koios parity observer is enabled, retain reward_account_output
+	// without bound in CORE storage mode too (dingo #4188): the observer only
+	// validates a closed epoch after fetching and comparing against Koios over
+	// the network, which can fall arbitrarily far behind chain progression
+	// during a from-genesis or catch-up sync, well past the fixed 4-epoch
+	// window cleanupOldSnapshots otherwise prunes reward_account_output to.
+	// Set before CaptureGenesisSnapshot/Start below, matching every other
+	// snapshot-manager configuration call in this sequence.
+	n.snapshotMgr.SetRewardAccountOutputRetentionUnbounded(
+		n.config.koiosParity.Enabled,
+	)
 	// Prune pool snapshots through the deferred-header retention guard, so a
 	// snapshot a queued/deferred header still needs for leader validation is
 	// never pruned out from under it and misread as pool absence, and the

--- a/node_lifecycle.go
+++ b/node_lifecycle.go
@@ -747,6 +747,13 @@ func (n *Node) reinitializeBackgroundManagers(ctx context.Context) error {
 		return fmt.Errorf("configuring snapshot manager: %w", err)
 	}
 	n.snapshotMgr.SetPromRegistry(n.config.promRegistry)
+	// Mirror the Koios parity observer's enablement into the rebuilt snapshot
+	// manager too (see Run()'s identical call in node.go, dingo #4188), or a
+	// live restore/truncate would silently drop back to CORE mode's 4-epoch
+	// reward_account_output retention even though the observer is enabled.
+	n.snapshotMgr.SetRewardAccountOutputRetentionUnbounded(
+		n.config.koiosParity.Enabled,
+	)
 	// Prune pool snapshots through the deferred-header retention guard, so a
 	// snapshot a queued/deferred header still needs for leader validation is
 	// never pruned out from under it and misread as pool absence, and the

--- a/node_snapshot_config_wiring_test.go
+++ b/node_snapshot_config_wiring_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dingo
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// snapshotMgrSetterCall matches a snapshot-manager configuration call on the
+// node, capturing the setter name.
+var snapshotMgrSetterCall = regexp.MustCompile(
+	`n\.snapshotMgr\.(Set[A-Za-z0-9_]+)\(`,
+)
+
+// koiosParityRetentionWiring matches the retention setter called with the
+// operator's own koios-parity enablement. It binds the argument, not just the
+// setter name: a call wired from any other field would leave the operator's
+// setting ignored exactly as silently as no call at all.
+var koiosParityRetentionWiring = regexp.MustCompile(
+	`n\.snapshotMgr\.SetRewardAccountOutputRetentionUnbounded\(\s*` +
+		`n\.config\.koiosParity\.Enabled,?\s*\)`,
+)
+
+// nodeFuncBodyForSnapshotWiring returns the source of the named function, from
+// its declaration to the next top-level declaration.
+func nodeFuncBodyForSnapshotWiring(
+	t *testing.T,
+	path string,
+	decl string,
+) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	s := string(b)
+	start := strings.Index(s, decl)
+	if start < 0 {
+		t.Fatalf("%s not found in %s", decl, path)
+	}
+	body := s[start+len(decl):]
+	if end := strings.Index(body, "\nfunc "); end >= 0 {
+		body = body[:end]
+	}
+	return body
+}
+
+// TestReinitializeBackgroundManagersMirrorsRunSnapshotConfig pins that a live
+// Restore/Truncate rebuilds the snapshot manager with every option Run()
+// configures. reinitializeBackgroundManagers constructs a second
+// snapshot.Manager by hand, so an option added to Run() alone is silently
+// dropped after a live lifecycle operation and the node keeps running with
+// package defaults instead of the operator's configuration -- which is
+// exactly what happened to SetDelegatorInactivity (see
+// TestLiveTruncateReinitializationPreservesSnapshotManagerDelegatorInactivityConfig)
+// and is the same gap dingo #4188's retention setter would leave.
+func TestReinitializeBackgroundManagersMirrorsRunSnapshotConfig(t *testing.T) {
+	t.Parallel()
+
+	runBody := nodeFuncBodyForSnapshotWiring(
+		t,
+		"node.go",
+		"func (n *Node) Run(ctx context.Context) (runErr error) {",
+	)
+	reinitBody := nodeFuncBodyForSnapshotWiring(
+		t,
+		"node_lifecycle.go",
+		"func (n *Node) reinitializeBackgroundManagers(",
+	)
+
+	runSetters := snapshotMgrSetterCall.FindAllStringSubmatch(runBody, -1)
+	if len(runSetters) == 0 {
+		t.Fatal("no n.snapshotMgr setter calls found in Run")
+	}
+	reinitSetters := map[string]struct{}{}
+	for _, m := range snapshotMgrSetterCall.FindAllStringSubmatch(
+		reinitBody,
+		-1,
+	) {
+		reinitSetters[m[1]] = struct{}{}
+	}
+	for _, m := range runSetters {
+		if _, ok := reinitSetters[m[1]]; !ok {
+			t.Errorf(
+				"Run configures the snapshot manager with %s but "+
+					"reinitializeBackgroundManagers does not; a live "+
+					"restore/truncate would silently drop that setting",
+				m[1],
+			)
+		}
+	}
+}
+
+// TestKoiosParityRetentionWiredFromConfigInBothStartupPaths pins dingo #4188's
+// wiring itself: both node startup paths must widen reward_account_output
+// retention from the operator's koios-parity enablement. Without the call the
+// node keeps CORE mode's 4-epoch window, and the observer -- whose network
+// -bound epoch validation routinely runs many epochs behind chain progression
+// during a catch-up sync -- reads an epoch's rows only after
+// cleanupOldSnapshots has already deleted them.
+func TestKoiosParityRetentionWiredFromConfigInBothStartupPaths(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		path string
+		decl string
+	}{
+		{
+			path: "node.go",
+			decl: "func (n *Node) Run(ctx context.Context) (runErr error) {",
+		},
+		{
+			path: "node_lifecycle.go",
+			decl: "func (n *Node) reinitializeBackgroundManagers(",
+		},
+	} {
+		body := nodeFuncBodyForSnapshotWiring(t, tc.path, tc.decl)
+		if !koiosParityRetentionWiring.MatchString(body) {
+			t.Errorf(
+				"%s does not call "+
+					"n.snapshotMgr.SetRewardAccountOutputRetentionUnbounded("+
+					"n.config.koiosParity.Enabled); reward_account_output "+
+					"would be pruned to the 4-epoch window with the "+
+					"koios-parity observer enabled",
+				tc.decl,
+			)
+		}
+	}
+}


### PR DESCRIPTION
`cleanupOldSnapshots` prunes `reward_account_output` to a fixed
`current-3..current` window at every epoch transition in CORE storage mode. The
in-process koios-parity observer validates a closed epoch only after fetching
and comparing against Koios over the network, so on a from-genesis or catch-up
sync it reaches an epoch well after chain progression has evicted that epoch's
rows. Every per-account check for it then fails as `acct_only_koios` against a
row that genuinely no longer exists (#4188).

- `Manager.SetRewardAccountOutputRetentionUnbounded`, wired from
  `KoiosParityConfig.Enabled` in `node.go` (`Run`) and `node_lifecycle.go`
  (`reinitializeBackgroundManagers`), makes `cleanupOldSnapshots` retain
  `reward_account_output` without bound. It reuses the branch API storage mode
  already takes for the Blockfrost reward-history endpoint (#1875).
  `reward_stake_input` and `pool_stake_snapshot` stay pruned to the window in
  every mode.
- Retention is not consensus-affecting, so unlike `SetDelegatorInactivity` the
  setter carries no `configurationLocked` gate and applies after `Start`.
- A koios-parity-enabled CORE node therefore keeps `reward_account_output` for
  its whole history, the same growth profile API mode already accepts. No
  backfill: epochs already pruned before the upgrade stay absent.
- `DATABASE.md` and `ARCHITECTURE.md` record the new retention exception;
  `internal/koiosparity`'s source comments described the pre-fix rule and the
  disproved "observer timing keeps reads inside the window" model.

`TestCleanupOldSnapshotsKoiosParityRetentionUnbounded` fails (epoch 0 rows
deleted) with the new disjunct removed from `cleanupOldSnapshots`. Two
source-level guards in `node_snapshot_config_wiring_test.go` fail with either
`SetRewardAccountOutputRetentionUnbounded` call site deleted; the first also
covers any future `n.snapshotMgr` setter added to `Run` alone.

Fixes #4188. Related to #3857 (absent reward rows misreported during replay),
which this does not close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes koios-parity account checks permanently failing on closed epochs: `cleanupOldSnapshots` prunes `reward_account_output` to a 4-epoch window at every epoch transition, and the observer only validates an epoch after a network comparison with Koios that can fall far behind during catch-up syncs. When koios-parity is enabled, the table is now retained without bound, matching API storage mode.

- Adds `Manager.SetRewardAccountOutputRetentionUnbounded`, wired from `KoiosParityConfig.Enabled` in both `Run` and `reinitializeBackgroundManagers`.
- `reward_stake_input` and `pool_stake_snapshot` are still pruned to the window; retention is not consensus-affecting, so no `configurationLocked` gate.
- No backfill: epochs already pruned before the upgrade stay absent.
- Adds a regression test and source-level guards that both startup paths keep the same snapshot-manager configuration.

Fixes #4188.

<sup>Written for commit 782caf6f1497f6348ea3f33169d9a5c8ebb3ec3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Koios parity observer mode now retains reward-account outputs without a fixed four-epoch limit, including during catch-up synchronization and lifecycle restores.
  - Reward-stake inputs continue to follow the existing pruning window.

- **Documentation**
  - Updated architecture, database, and developer documentation to clarify reward-state retention behavior across storage modes and observer configurations.

- **Tests**
  - Added coverage confirming retention behavior and consistent configuration across startup and restoration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->