### PR TITLE
fix(ledgerstate): bound CBOR map allocation by remaining input

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5808,7 +5808,12 @@ that. That cap does NOT extend to manual header-reading APIs
 read a raw count/byte off the wire with no built-in bound from the decoder
 itself, so every such call site enforces its own explicit check.
 `ledgerstate`'s hand-rolled map/array walkers (`decodeMapEntries`) retain the
-generic 10,000,000-entry cap. The streaming UTxO decoder instead has an
+generic 10,000,000-entry cap. Before reserving a definite map's entry slice,
+the decoder also checks that the remaining input contains at least two bytes
+per declared entry (the minimum one-byte key and one-byte value). Truncated
+maps cannot reserve capacity solely from their declared count. Indefinite
+maps grow their entry slice only as key/value pairs are parsed.
+The streaming UTxO decoder instead has an
 explicit 100,000,000-entry cap because a valid chain UTxO set can exceed the
 generic map limit; the larger bound still limits work on malformed or
 adversarial input. The definite-length UTxO map's

--- a/ledgerstate/cbor_decode.go
+++ b/ledgerstate/cbor_decode.go
@@ -48,6 +48,9 @@ import (
 //     used for non-comparable Cardano credential keys): capped at
 //     maxMapEntries (10,000,000 entries, matching gouroboros's map
 //     limit above) for both definite- and indefinite-length maps.
+//     Definite maps also require at least two remaining bytes per
+//     declared entry before allocating capacity: each key and value
+//     needs at least one byte. Indefinite maps grow only as parsed.
 //   - parseUTxOsStreamingWithProgress (UTxO map streaming decode):
 //     UTxO maps have their own maxUTxOMapEntries (100,000,000) cap
 //     because valid chain state can exceed the generic 10,000,000-map
@@ -264,10 +267,21 @@ func decodeMapEntriesLimit(data []byte, limit int) ([]MapEntry, error) {
 			count, limit,
 		)
 	}
-	entries := make([]MapEntry, 0, count)
+	// #nosec G115 -- count is bounded by the non-negative int limit above.
+	countInt := int(count)
+	// Every map entry contains at least one byte for its key and one byte
+	// for its value. Reject a truncated payload before using the untrusted
+	// count as a slice capacity.
+	remaining := len(data) - headerLen
+	if countInt > remaining/2 {
+		return nil, fmt.Errorf(
+			"definite-length map claims %d entries, but only %d bytes remain",
+			count, remaining,
+		)
+	}
+	entries := make([]MapEntry, 0, countInt)
 	pos := headerLen
-	// #nosec G115
-	for i := 0; i < int(count); i++ {
+	for i := 0; i < countInt; i++ {
 		// Key
 		keySize, err := cborItemSize(data[pos:])
 		if err != nil {

--- a/ledgerstate/cbor_decode_test.go
+++ b/ledgerstate/cbor_decode_test.go
@@ -17,6 +17,7 @@ package ledgerstate
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"runtime"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -119,6 +120,71 @@ func TestDecodeMapEntriesLimit_DefiniteLength_OverLimitRejected(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds max")
+}
+
+func TestDecodeMapEntriesLimit_DefiniteLength_TruncatedPayloadDoesNotAllocate(
+	t *testing.T,
+) {
+	// Not t.Parallel: TotalAlloc measures allocations across the process.
+	const count = 100_000
+	data := cborTypeHeader(cborMajorMap, count)
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	var errorsSeen int
+	var firstErr error
+	for range 3 {
+		_, err := decodeMapEntriesLimit(data, count)
+		if err != nil {
+			errorsSeen++
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	runtime.ReadMemStats(&after)
+
+	require.Equal(t, 3, errorsSeen)
+	require.Error(t, firstErr)
+	require.Less(
+		t,
+		after.TotalAlloc-before.TotalAlloc,
+		uint64(1<<20),
+		"truncated declared map count must not allocate its slice capacity",
+	)
+	require.Contains(t, firstErr.Error(), "but only")
+}
+
+func TestDecodeMapEntriesLimit_DefiniteLength_RemainingByteBoundaries(
+	t *testing.T,
+) {
+	tests := []struct {
+		name string
+		data []byte
+		err  bool
+	}{
+		{name: "empty", data: []byte{0xa0}},
+		{name: "smallest valid pair", data: []byte{0xa1, 0x00, 0x00}},
+		{name: "one byte short", data: []byte{0xa2, 0x00, 0x00}, err: true},
+		{name: "truncated key", data: []byte{0xa1}, err: true},
+		{name: "truncated value", data: []byte{0xa1, 0x00}, err: true},
+		// Tags and indefinite nested values remain valid CBOR items.
+		{name: "tagged value", data: []byte{0xa1, 0x00, 0xc0, 0x00}},
+		{name: "indefinite nested value", data: []byte{0xa1, 0x00, 0x9f, 0x00, 0xff}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeMapEntriesLimit(tc.data, 5)
+			if tc.err {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "but only")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestDecodeMapEntriesLimit_IndefiniteLength_AtLimitAccepted(t *testing.T) {

--- a/ledgerstate/cbor_decode_test.go
+++ b/ledgerstate/cbor_decode_test.go
@@ -159,6 +159,8 @@ func TestDecodeMapEntriesLimit_DefiniteLength_TruncatedPayloadDoesNotAllocate(
 func TestDecodeMapEntriesLimit_DefiniteLength_RemainingByteBoundaries(
 	t *testing.T,
 ) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		data []byte


### PR DESCRIPTION
Reject definite-map entry counts exceeding half the remaining input bytes before allocating the entry slice. Each entry requires at least one key byte and one value byte. The existing entry-count ceiling remains unchanged; indefinite maps continue to grow as pairs are parsed.

Adds allocation and byte-boundary regressions, including compact tagged and nested values, and documents the bound.

Fixes #3413.

## Summary by cubic

Bounds definite-length CBOR map entry counts by remaining input bytes so truncated payloads cannot trigger disproportionate slice allocations.

- Checks the minimum bytes per declared entry before reserving capacity.
- Leaves indefinite-map allocation behavior unchanged.
- Adds allocation and boundary tests and updates `ARCHITECTURE.md`.
