### PR TITLE
fix(database): read the pinned blob store, not the live one

### DIFF
--- a/database/blob_store_pin_test.go
+++ b/database/blob_store_pin_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/database/plugin/blob"
+	"github.com/blinklabs-io/dingo/database/types"
+	"github.com/stretchr/testify/require"
+)
+
+// errPinnedStoreBypassed is returned by poisonBlobStore's Get so a call that
+// reached it, instead of the transaction's pinned store, is unambiguous.
+var errPinnedStoreBypassed = errors.New(
+	"poisonBlobStore: pinned store was bypassed",
+)
+
+// poisonBlobStore wraps a real store but makes every read observably wrong:
+// NewIterator returns nil and Get returns errPinnedStoreBypassed. Installing
+// it via Database.SetBlobStore after a transaction has opened simulates a
+// concurrent blob-store replacement; a caller that reads db.Blob() again
+// instead of using the transaction's pinned Txn.BlobStore() hits this store
+// and observably fails.
+type poisonBlobStore struct {
+	blob.BlobStore
+}
+
+func (poisonBlobStore) Get(types.Txn, []byte) ([]byte, error) {
+	return nil, errPinnedStoreBypassed
+}
+
+func (poisonBlobStore) NewIterator(
+	types.Txn,
+	types.BlobIteratorOptions,
+) types.BlobIterator {
+	return nil
+}
+
+// TestBlockNumberBoundTxnUsesPinnedStore is the regression test for
+// ResolveBlockNumberBoundTxn, blockIndexEntryAtOrAfterTxn and
+// blockMetadataByKey re-reading Database.Blob (the currently installed
+// store) instead of the transaction's pinned Txn.BlobStore(). A store
+// replacement between the transaction's construction and these calls must
+// not change which store they read.
+func TestBlockNumberBoundTxnUsesPinnedStore(t *testing.T) {
+	t.Parallel()
+
+	db, err := newTestDatabase(t, &Config{DataDir: t.TempDir()})
+	require.NoError(t, err)
+	base := db.Blob()
+	require.NotNil(t, base)
+	t.Cleanup(func() { db.SetBlobStore(base) })
+
+	txn := db.Transaction(false)
+	t.Cleanup(txn.Release)
+
+	// Replace the installed store after the transaction opened. The
+	// transaction's pin must still resolve to base, not this poison store.
+	db.SetBlobStore(poisonBlobStore{BlobStore: base})
+
+	_, err = ResolveBlockNumberBoundTxn(txn)
+	require.NoError(t, err)
+
+	_, err = blockIndexEntryAtOrAfterTxn(txn, 0)
+	require.True(
+		t,
+		err == nil || errors.Is(err, models.ErrBlockNotFound),
+		"blockIndexEntryAtOrAfterTxn used the live store instead of the pin: %v",
+		err,
+	)
+
+	_, err = blockMetadataByKey(txn, []byte("nonexistent-block-key"))
+	require.False(
+		t,
+		errors.Is(err, errPinnedStoreBypassed),
+		"blockMetadataByKey used the live store instead of the pin: %v",
+		err,
+	)
+}

--- a/database/block.go
+++ b/database/block.go
@@ -390,7 +390,7 @@ func ResolveBlockNumberBoundTxn(txn *Txn) (BlockNumberBound, error) {
 	if blobTxn == nil {
 		return BlockNumberBound{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return BlockNumberBound{}, types.ErrBlobStoreUnavailable
 	}
@@ -592,7 +592,7 @@ func blockIndexEntryAtOrAfterTxn(
 	if blobTxn == nil {
 		return blockIndexEntry{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return blockIndexEntry{}, types.ErrBlobStoreUnavailable
 	}
@@ -667,7 +667,7 @@ func blockMetadataByKey(
 	if blobTxn == nil {
 		return types.BlockMetadata{}, types.ErrNilTxn
 	}
-	blob := txn.DB().Blob()
+	blob := txn.BlobStore()
 	if blob == nil {
 		return types.BlockMetadata{}, types.ErrBlobStoreUnavailable
 	}


### PR DESCRIPTION
## Problem

Three call sites in `database/block.go` — `ResolveBlockNumberBoundTxn`,
`blockIndexEntryAtOrAfterTxn`, and `blockMetadataByKey` — read
`txn.DB().Blob()`, which returns the database's currently installed
blob store, instead of `txn.BlobStore()`, the store pinned to that
transaction at construction time (`pinBlobStoreForTxn`). The doc
comment on `BlobStore()` states the invariant directly: "re-reading
Database.Blob later could hand back a different store than the one
blobTxn belongs to." Roughly twenty other blob-reading call sites in
the same file already use the pinned accessor; these three were
stragglers, present identically on `main`.

A blob-store replacement between a transaction's construction and one
of these calls — a live restore, a hot swap — hands the call a
different store than the one its `blobTxn` handle actually belongs to.

## Fix

Read `txn.BlobStore()` at all three sites, matching the rest of the
file.

## Tests

`TestBlockNumberBoundTxnUsesPinnedStore` installs a `poisonBlobStore`
(nil iterators, a sentinel error on `Get`) via `SetBlobStore` after a
transaction has already opened, then calls all three functions through
that transaction. Reverting the fix reproduces the defect: the test
fails with `blob iterator is nil`, coming from the un-pinned call
reading the swapped-in poison store.

`go build ./...`, `go vet ./database/...`, `golangci-lint run
--build-tags dingo_extra_plugins ./database/...` (0 issues) all pass.
`go test -race -tags dingo_extra_plugins -count=1 ./database/...`
passes across all subpackages (341.5s for the `database` package
itself).

ARCHITECTURE.md and DATABASE.md already document the pin invariant
this restores; neither needed a change.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three functions in `database/block.go` that read the database's currently installed blob store instead of the store pinned to the transaction, so a blob-store replacement mid-transaction no longer hands them a different store than the one their `blobTxn` handle belongs to.

- Switches `ResolveBlockNumberBoundTxn`, `blockIndexEntryAtOrAfterTxn`, and `blockMetadataByKey` from `txn.DB().Blob()` to `txn.BlobStore()`.
- Adds `database/blob_store_pin_test.go` with a regression test that installs a poison blob store after a transaction opens and verifies all three functions still read the pinned store.

<sup>Written for commit aa0a6536727fad13c582bc8eb95840b6d05a2263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
