### PR TITLE
build(deps): bump plutigo to v0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
 	github.com/blinklabs-io/gouroboros v0.204.0
 	github.com/blinklabs-io/ouroboros-mock v0.19.0
-	github.com/blinklabs-io/plutigo v0.6.0
+	github.com/blinklabs-io/plutigo v0.6.1
 	github.com/blockfrost/blockfrost-go v0.5.0
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/consensys/gnark-crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/blinklabs-io/gouroboros v0.204.0 h1:z3N2A+4UqERe5A8Okw5m650GKNOQkrZjz
 github.com/blinklabs-io/gouroboros v0.204.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
 github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
-github.com/blinklabs-io/plutigo v0.6.0 h1:kfIMM+SKcRO8tMj96IAN8EOvjrCnGZ1hsm0+qn8xLL0=
-github.com/blinklabs-io/plutigo v0.6.0/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
+github.com/blinklabs-io/plutigo v0.6.1 h1:gmwiv7k76ysM4jrSCrPaBW8W0AUCsIGM1nnKk9Cl6Jc=
+github.com/blinklabs-io/plutigo v0.6.1/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
 github.com/blockfrost/blockfrost-go v0.5.0 h1:I+qEQw5Re9UHolKZGJE0FtuQL3a7L0WqEYkEO4GisIw=
 github.com/blockfrost/blockfrost-go v0.5.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/internal/test/antithesis/go.mod
+++ b/internal/test/antithesis/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.7
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
 	github.com/blinklabs-io/gouroboros v0.202.10
-	github.com/blinklabs-io/plutigo v0.6.0
+	github.com/blinklabs-io/plutigo v0.6.1
 	github.com/stretchr/testify v1.12.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/test/antithesis/go.sum
+++ b/internal/test/antithesis/go.sum
@@ -8,8 +8,8 @@ github.com/blinklabs-io/gouroboros v0.202.10 h1:pWfOUTxTGys58s8vbZ5yW1qVbgYbipuv
 github.com/blinklabs-io/gouroboros v0.202.10/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
 github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
-github.com/blinklabs-io/plutigo v0.6.0 h1:kfIMM+SKcRO8tMj96IAN8EOvjrCnGZ1hsm0+qn8xLL0=
-github.com/blinklabs-io/plutigo v0.6.0/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
+github.com/blinklabs-io/plutigo v0.6.1 h1:gmwiv7k76ysM4jrSCrPaBW8W0AUCsIGM1nnKk9Cl6Jc=
+github.com/blinklabs-io/plutigo v0.6.1/go.mod h1:KJ06q5t/1iHBpEHsMi8zWA9b6sB0kfEvxB52roHnnso=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0/go.mod h1:+K/MYXcLBtHEQjRbjHuJChuybk4LCgjdjgRwil+e+Kk=
 github.com/btcsuite/btcd/btcutil v1.2.0 h1:p3+S2g3Q+7G5NOh4Ji+2UrBOrg5Z0Q4ykzShWG1Dhgs=


### PR DESCRIPTION
## Problem

Plutigo `v0.6.0` (Dingo's current pin) validates BLS multi-scalar-mul
scalar bounds only over the truncated `min(len(scalars), len(points))`
prefix, inside the pairing loop. The Plutus reference implementation
validates the bound over the *entire* scalar list before truncation.
A script calling `bls12_381_G1_multiScalarMul` (builtin tag 92) or
`G2_multiScalarMul` (tag 93) with more scalars than points, with an
out-of-range scalar past the truncation point, is **accepted by Dingo
and rejected by cardano-node**.

Fixed upstream in blinklabs-io/plutigo#400 (closing #399): both G1 and
G2 now validate the whole scalar list before pairing.

## Scope

These builtins are PlutusV4-era, not reachable under PlutusV3 scripts
today, so this closes a divergence that isn't yet live rather than one
under active exploitation. `v0.6.1` contains exactly one commit over
`v0.6.0` (`fccef9a8`, the BLS fix) — verified via the GitHub compare
view, no other changes.

## Validation

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make docs-parity`, `go test ./ledger/...` (all subpackages) and
`go test ./internal/test/conformance/...` (118.8s) all pass.
