### PR TITLE
test(lifecycle): allow Windows snapshot interruption setup

### DIFF
--- a/database/lifecycle/snapshot_durability_internal_test.go
+++ b/database/lifecycle/snapshot_durability_internal_test.go
@@ -120,7 +120,11 @@ func TestSnapshotInterruptedBeforeManifest(t *testing.T) {
 		t.Run(stage, func(t *testing.T) {
 			base := t.TempDir()
 			dir := filepath.Join(base, "interrupted")
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			// The child creates a fully migrated test database before it
+			// reaches the injected interruption point. That setup can exceed
+			// 30 seconds on Windows, so keep a bounded but sufficiently large
+			// deadline for the subprocess.
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSnapshotInterruptedBeforeManifest$")
 			cmd.Env = append(os.Environ(), "TMPDIR="+base, "TMP="+base, "TEMP="+base, "DINGO_SNAPSHOT_INTERRUPT_STAGE="+stage, "DINGO_SNAPSHOT_INTERRUPT_DIR="+dir)


### PR DESCRIPTION
## Summary

Increase the subprocess deadline in `TestSnapshotInterruptedBeforeManifest` from 30 seconds to 2 minutes.

The child creates and migrates a complete test database before reaching the injected interruption point. On the failed v0.70.9 publish run, the Windows `metadata.sqlite` case exceeded 30 seconds and was terminated with exit code 1 instead of reaching the intentional exit code 23.

This changes test timing only; the deadline remains bounded.

Related to #3746.

## Validation

- `go test ./database/lifecycle -run '^TestSnapshotInterruptedBeforeManifest$' -count=1`
- `golangci-lint run ./database/lifecycle`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the subprocess deadline in `TestSnapshotInterruptedBeforeManifest` from 30 seconds to 2 minutes so the Windows CI run no longer kills the child before it reaches the injected interruption point. The deadline remains bounded, so the test still fails on true hangs.

Relates to #3746, which tracked the v0.70.9 publish failure where the Windows `metadata.sqlite` setup exceeded the old timeout.

<sup>Written for commit 86c3f115c777ff4331d458baaa5e69ebefee2060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the subprocess deadline for snapshot interruption testing to accommodate slower database setup on some platforms.
  * Added context explaining the longer test duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->