### PR TITLE
test(database): pass the deposit policy at the committee-prune call sites

### DIFF
--- a/database/plugin/metadata/sqlstore/committee_prune_test.go
+++ b/database/plugin/metadata/sqlstore/committee_prune_test.go
@@ -180,6 +180,7 @@ func applyAuthCertificate(
 		ocommon.Point{Slot: slot, Hash: credentialHash(0x99)},
 		0,
 		nil,
+		requireKnownDeposits,
 	)
 	require.NoError(t, err)
 }
@@ -244,7 +245,7 @@ func TestAuthCommitteeHotTransactionDrainsMultipleBatches(t *testing.T) {
 		newDialectQueryer(store.writeDB, store.dialect.Name()),
 		1, certificates,
 		ocommon.Point{Slot: preprodTipSlot, Hash: credentialHash(0x99)},
-		0, nil,
+		0, nil, requireKnownDeposits,
 	)
 	require.NoError(t, err)
 	// Two certificate calls remove two bounded batches and retain the newest


### PR DESCRIPTION
Superseded by #4222: main now passes `requireKnownDeposits` at both committee-pruning test call sites. This draft's two-call repair is already included there.

The change restores the `applyTransactionCertificates` signature in `committee_prune_test.go`; it does not change production behavior. Related: #3950 and #3855.

## Summary by cubic

- Passes `requireKnownDeposits`, matching the live block-apply path these tests cover.
- The policy restores the signature without changing committee-authorization test behavior.
- Test-only change; no production files are touched.

## Summary by CodeRabbit

- Updates committee-pruning test calls for the required deposit-policy parameter while preserving existing behavior.
