### PR TITLE
build(deps): gouroboros 0.204.3

### DIFF
--- a/database/plugin/metadata/sqlstore/committee_prune_test.go
+++ b/database/plugin/metadata/sqlstore/committee_prune_test.go
@@ -180,6 +180,7 @@ func applyAuthCertificate(
 		ocommon.Point{Slot: slot, Hash: credentialHash(0x99)},
 		0,
 		nil,
+		allowUnknownDeposits,
 	)
 	require.NoError(t, err)
 }
@@ -245,6 +246,7 @@ func TestAuthCommitteeHotTransactionDrainsMultipleBatches(t *testing.T) {
 		1, certificates,
 		ocommon.Point{Slot: preprodTipSlot, Hash: credentialHash(0x99)},
 		0, nil,
+		allowUnknownDeposits,
 	)
 	require.NoError(t, err)
 	// Two certificate calls remove two bounded batches and retain the newest

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/smithy-go v1.28.1
 	github.com/blinklabs-io/bark v0.1.0
 	github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609
-	github.com/blinklabs-io/gouroboros v0.204.1-0.20260910232415-23f3504977ff
+	github.com/blinklabs-io/gouroboros v0.204.3
 	github.com/blinklabs-io/ouroboros-mock v0.19.0
 	github.com/blinklabs-io/plutigo v0.6.1
 	github.com/blockfrost/blockfrost-go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -127,12 +127,8 @@ github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609 h1:mRg3/s1Yd
 github.com/blinklabs-io/bursa v0.16.1-0.20260817233527-1eb8b64db609/go.mod h1:/SKC0QJhEV39p5K3RmUr8NAEHxmY3SGJi8ycXtXlNWQ=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.204.0 h1:z3N2A+4UqERe5A8Okw5m650GKNOQkrZjzAYmUZIFyvQ=
-github.com/blinklabs-io/gouroboros v0.204.0/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
-github.com/blinklabs-io/gouroboros v0.204.1-0.20260910133009-c22de7276492 h1:QOtsaEGa1G17BClH/6erLmOve8PFqEUBugWJaSMZVu4=
-github.com/blinklabs-io/gouroboros v0.204.1-0.20260910133009-c22de7276492/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
-github.com/blinklabs-io/gouroboros v0.204.1-0.20260910232415-23f3504977ff h1:6DaZ0LSjkb1yjqR+EXPxXNA+kg2Jf+BrAjDWyrJX6tg=
-github.com/blinklabs-io/gouroboros v0.204.1-0.20260910232415-23f3504977ff/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
+github.com/blinklabs-io/gouroboros v0.204.3 h1:DrXfkwmZEPRFOnFSlQ1NpZT40RmktdFhiy3/GdQldyQ=
+github.com/blinklabs-io/gouroboros v0.204.3/go.mod h1:QUrXbiy0I3EIYj2T7w+P3RUSbp3GwW7Yh5bhfaA286o=
 github.com/blinklabs-io/ouroboros-mock v0.19.0 h1:f4ej1znSUxCNWfPW6asOd/+mjxBwtMzYAw8nmHHuvtw=
 github.com/blinklabs-io/ouroboros-mock v0.19.0/go.mod h1:CrsKaqRA5cBXYEoMZR+erL2pEp/rbdkvnzNv1wWEeA4=
 github.com/blinklabs-io/plutigo v0.6.1 h1:gmwiv7k76ysM4jrSCrPaBW8W0AUCsIGM1nnKk9Cl6Jc=

--- a/ouroboros/blockfetch_test.go
+++ b/ouroboros/blockfetch_test.go
@@ -27,6 +27,7 @@ import (
 
 	ouroboros_conn "github.com/blinklabs-io/gouroboros/connection"
 	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -191,8 +192,8 @@ func TestBlockfetchServerRequestRange_StartAfterEnd(t *testing.T) {
 	// we never reach GetChainFromPoint and avoid a nil dereference on
 	// LedgerState.
 
-	start := ocommon.NewPoint(100, []byte{0x01})
-	end := ocommon.NewPoint(50, []byte{0x02})
+	start := ocommon.NewPoint(100, make([]byte, lcommon.Blake2b256Size))
+	end := ocommon.NewPoint(50, make([]byte, lcommon.Blake2b256Size))
 	ctx := blockfetch.CallbackContext{
 		ConnectionId: testConnId(),
 		// Server is nil, so NoBlocks() will panic after the log.
@@ -834,8 +835,8 @@ func TestBlockfetchServerRequestRange_RepeatedInvertedRangeReachesCloseThreshold
 	})
 	peer := newBlockfetchServerPeer(t, o)
 
-	start := ocommon.NewPoint(100, []byte{0x01})
-	end := ocommon.NewPoint(50, []byte{0x02})
+	start := ocommon.NewPoint(100, make([]byte, lcommon.Blake2b256Size))
+	end := ocommon.NewPoint(50, make([]byte, lcommon.Blake2b256Size))
 
 	for i := 1; i <= blockfetchMaxConsecutiveNoBlocks; i++ {
 		logBuf.Reset()
@@ -900,8 +901,8 @@ func TestBlockfetchServerRequestRange_ValidRangeNotRejected(
 		Logger:   logger,
 		EventBus: event.NewEventBus(nil, logger),
 	})
-	start := ocommon.NewPoint(100, []byte{0x01})
-	end := ocommon.NewPoint(150, []byte{0x02})
+	start := ocommon.NewPoint(100, make([]byte, lcommon.Blake2b256Size))
+	end := ocommon.NewPoint(150, make([]byte, lcommon.Blake2b256Size))
 	ctx := blockfetch.CallbackContext{ConnectionId: testConnId()}
 
 	assert.Panics(t, func() {

--- a/ouroboros/chainsync_test.go
+++ b/ouroboros/chainsync_test.go
@@ -2312,9 +2312,12 @@ func newFindIntersectTestOuroboros(t *testing.T) *Ouroboros {
 func makeFindIntersectPoints(n int) []ocommon.Point {
 	points := make([]ocommon.Point, n)
 	for i := range points {
+		hash := make([]byte, 32)
+		hash[0] = byte(i)
+		hash[1] = byte(i >> 8)
 		points[i] = ocommon.NewPoint(
 			uint64(i+1),
-			[]byte{byte(i), byte(i >> 8)},
+			hash,
 		)
 	}
 	return points

--- a/ouroboros/leios_range_responder_test.go
+++ b/ouroboros/leios_range_responder_test.go
@@ -60,8 +60,8 @@ func TestLeiosFetchBlockRangeRequestIsDeclined(t *testing.T) {
 	peer := newLeiosFetchServerPeer(t, o)
 
 	peer.send(t, oleiosfetch.ProtocolId, oleiosfetch.NewMsgBlockRangeRequest(
-		ocommon.NewPoint(3623, []byte{0x01, 0x02}),
-		ocommon.NewPoint(3700, []byte{0x03, 0x04}),
+		ocommon.NewPoint(3623, make([]byte, lcommon.Blake2b256Size)),
+		ocommon.NewPoint(3700, make([]byte, lcommon.Blake2b256Size)),
 	))
 
 	select {


### PR DESCRIPTION
Update the root module from the Gouroboros pseudo-version to v0.204.3 and refresh its checksums. Nested modules retain their own dependency selections.

Use 32-byte Point hashes in protocol fixtures so requests reach the intended point-count, request-budget, inverted-range, and Leios range-response assertions. The released decoder and those assertions remain unchanged.

The corrected fixtures pass the [Linux, Linux race, Windows, and macOS test jobs](https://github.com/blinklabs-io/dingo/actions/runs/34729711130) without relaxing decoder validation.

## Summary by cubic

Updates `github.com/blinklabs-io/gouroboros` from a pre-release pseudo-version to the tagged `v0.204.3` release, and updates `go.sum` to match the new dependency checksums.

