### PR TITLE
test: repair tests broken by concurrent merges on main

### DIFF
--- a/database/plugin/metadata/sqlstore/committee_prune_test.go
+++ b/database/plugin/metadata/sqlstore/committee_prune_test.go
@@ -180,6 +180,7 @@ func applyAuthCertificate(
 		ocommon.Point{Slot: slot, Hash: credentialHash(0x99)},
 		0,
 		nil,
+		requireKnownDeposits,
 	)
 	require.NoError(t, err)
 }
@@ -244,7 +245,7 @@ func TestAuthCommitteeHotTransactionDrainsMultipleBatches(t *testing.T) {
 		newDialectQueryer(store.writeDB, store.dialect.Name()),
 		1, certificates,
 		ocommon.Point{Slot: preprodTipSlot, Hash: credentialHash(0x99)},
-		0, nil,
+		0, nil, requireKnownDeposits,
 	)
 	require.NoError(t, err)
 	// Two certificate calls remove two bounded batches and retain the newest

--- a/ledger/leios_header_announcement_test.go
+++ b/ledger/leios_header_announcement_test.go
@@ -108,9 +108,9 @@ func announcingHeader(
 // half of the crypto gate on the header stream.
 //
 // chainsyncHeaderCryptoPolicy admits a roll-forward header without verifying
-// its VRF/KES on three paths: live validation not yet enabled, a slot covered
-// by an imported Mithril snapshot, and no cached epoch nonce for the slot
-// (verification deferred to blockfetch). All three reach
+// its VRF/KES on two paths: a slot covered by an imported Mithril snapshot and
+// no cached epoch nonce for the slot (verification deferred to blockfetch).
+// Both reach
 // chain.AddBlockHeader, not AddVerifiedBlockHeader. Announcing such a header
 // would let a chainsync peer make this node sign and publish a BLS vote for a
 // ranking block it never authenticated, taking the (slot, voterId) pair the
@@ -124,16 +124,16 @@ func TestChainsyncHeaderAdmissionAnnouncesOnlyWhenCryptoVerified(
 	)
 	point := ocommon.NewPoint(header.slot, header.hash.Bytes())
 
-	// The fixture's ledger has validation not yet enabled, so the policy
-	// returns trustedWithoutVerification and the handler takes the
-	// AddBlockHeader branch -- the real end-to-end unverified admission.
+	// The fixture has no cached epoch nonce, so the policy defers verification
+	// and the handler takes the AddBlockHeader branch -- the real end-to-end
+	// unverified admission.
 	t.Run("unverified admission is queued, not announced", func(t *testing.T) {
 		fixture := newHeaderStreamLedger(t)
 		verifyNow, trusted := fixture.ls.chainsyncHeaderCryptoPolicy(
 			header.slot,
 		)
 		require.False(t, verifyNow, "fixture must exercise the unverified path")
-		require.True(t, trusted)
+		require.False(t, trusted)
 
 		require.NoError(
 			t,


### PR DESCRIPTION
Main `go-test` is red on all four jobs from two independent breaks. Both are tests written against a base that moved before merge. Test-only; no production file changes.

## ledger: `TestChainsyncHeaderAdmissionAnnouncesOnlyWhenCryptoVerified` (red since 99e61331, #3963)

#4101 (47884fd1) removed the "validation not yet enabled" trusted branch from `chainsyncHeaderCryptoPolicy`. #3963 asserted `trusted == true` for that branch. The fixture now reaches the missing-epoch-nonce path, `(false, false)`, which still admits through `AddBlockHeader`, so the subtest keeps exercising unverified admission. Comment and assertion updated to the current policy.

## sqlstore: package test build failure (red since 440d01ab, #3950)

#3855 (4fe6b79e) added `policy depositPolicy` to `applyTransactionCertificates`. #3950's two call sites in `committee_prune_test.go` pass seven arguments. Pass `requireKnownDeposits`, the live block-apply value. Committee authorization certificates are not deposit-bearing, so the policy does not change what the tests exercise.

## Overlap

- #4206 (draft) carries the identical sqlstore hunk; it cannot go green alone because of the ledger red.
- #4103 and #4108 carry the identical ledger hunk bundled with unrelated changes.

The resulting file contents match those PRs byte-for-byte, so they merge cleanly after this lands.

## Validation (440d01ab plus this change)

- Before: `go vet ./database/plugin/metadata/sqlstore/` fails with both call-site errors; the ledger test fails at `leios_header_announcement_test.go:136`.
- `go build ./...` ok
- `go vet ./ledger/ ./database/plugin/metadata/sqlstore/` ok
- `golangci-lint run ./ledger/ ./database/plugin/metadata/sqlstore/` 0 issues
- `go test ./ledger/ -run TestChainsyncHeaderAdmissionAnnouncesOnlyWhenCryptoVerified -v` both subtests PASS
- `go test ./database/plugin/metadata/sqlstore/` ok
- `go test ./... -count=1` (macOS, no race): all packages ok except `bin` entrypoint readiness tests under full-suite load; `go test ./bin/` alone passes, `bin` is untouched here, and CI `bin` was green on all four jobs at 440d01ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183saqpiBDNNMk4Er6wy6g7


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two test breaks that made `go-test` red on all four `main` jobs, without changing any production files.

- Ledger: the announcement test now expects `trusted == false` because the fixture reaches the missing-epoch-nonce path -- `chainsyncHeaderCryptoPolicy` no longer has the validation-not-enabled branch. The subtest still exercises unverified admission through `AddBlockHeader`.
- SQL store: `committee_prune_test.go` now passes `requireKnownDeposits` to `applyTransactionCertificates` at both call sites. Committee authorization certificates are not deposit-bearing, so their behavior is unchanged.
- The resulting files match the same hunks in the overlapping open PRs byte-for-byte, so those merge cleanly after this lands.
- Validated with `go vet` and `golangci-lint` on both packages. Full `go test ./... -count=1` passes except the `bin` readiness tests under full-suite load, which pass standalone and are untouched.

<sup>Written for commit d39ac06af7de6b9ee7e26cf8c9f5e39d40a56753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated certificate-processing test scenarios to specify whether known deposits are required.
  - Revised header admission test expectations for cases without a cached epoch nonce.
  - Removed coverage for the previously described “live validation not yet enabled” path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->