### PR TITLE
perf(ledger): memoize UTxO reads per LedgerView

### DIFF
--- a/ledger/state.go
+++ b/ledger/state.go
@@ -920,13 +920,17 @@ type LedgerState struct {
 	// LocalStateQuery caller asking "what are the current protocol
 	// parameters" should see only what the chain has actually committed to,
 	// matching what a real cardano-node reports during the same window.
-	syntheticV2CostModel        bool
-	transitionInfo              hardfork.TransitionInfo // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
-	hfiEvalDoneEpoch            uint64                  // currentEpoch.EpochId for which the HFI tally has been kicked off (held under ls.RWMutex)
-	hfiEvalGeneration           atomic.Uint64           // bumped on rollback to invalidate any in-flight HFI tally
-	hfiStabilityEvalInFlight    atomic.Bool             // guard against overlapping async HFI tallies
-	rewardInputGeneration       atomic.Uint64           // bracketed around rollback to invalidate in-flight reward calculations
-	rewardInputRollbackActive   atomic.Int64            // non-zero while rollback can mutate reward calculation inputs
+	syntheticV2CostModel      bool
+	transitionInfo            hardfork.TransitionInfo // upcoming era boundary state (mirrors Haskell HFC TransitionInfo)
+	hfiEvalDoneEpoch          uint64                  // currentEpoch.EpochId for which the HFI tally has been kicked off (held under ls.RWMutex)
+	hfiEvalGeneration         atomic.Uint64           // bumped on rollback to invalidate any in-flight HFI tally
+	hfiStabilityEvalInFlight  atomic.Bool             // guard against overlapping async HFI tallies
+	rewardInputGeneration     atomic.Uint64           // bracketed around rollback to invalidate in-flight reward calculations
+	rewardInputRollbackActive atomic.Int64            // non-zero while rollback can mutate reward calculation inputs
+	// utxoByRefReads counts database.UtxoByRef reads made by
+	// LedgerView.UtxoById across every view of this LedgerState. Tests use
+	// it to assert the per-view UTxO memo; production code does not read it.
+	utxoByRefReads              atomic.Uint64
 	mempool                     MempoolProvider
 	timerCleanupConsumedUtxos   *time.Timer
 	cleanupConsumedUtxosRunning atomic.Bool

--- a/ledger/utxo_memo_bench_test.go
+++ b/ledger/utxo_memo_bench_test.go
@@ -1,0 +1,369 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	dbtest "github.com/blinklabs-io/dingo/internal/test/dbtest"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	gledger "github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// This file benchmarks (*LedgerState).ValidateTx and LedgerView.UtxoById
+// using real Preprod chain bytes for blinklabs-io/dingo#4226 (the per-view
+// UTxO memo): the same fixtures
+// ledger/eras/conway_plutus_preprod_fixture_test.go uses to pin execution
+// units against producer-declared budgets. That test documents the
+// fixture's provenance: a producer-accepted Preprod block and the funding
+// transactions for one Plutus transaction inside it, fetched over NtN
+// blockfetch.
+//
+// The existing BenchmarkTransactionValidation (ledger/benchmark_test.go)
+// validates against an unfunded ledger and discards the error, so it times
+// the missing-input failure path rather than real validation and cannot show
+// this issue's DB-read cost or its removal (see the issue's "Relationship to
+// other issues" section). This file adds a DB-backed benchmark on a funded
+// fixture instead of changing that one.
+
+const utxoMemoBenchFixtureDir = "eras/testdata"
+
+// preprod slot/time conversion constants, duplicated from
+// ledger/eras/conway_plutus_preprod_fixture_test.go (unexported there). The
+// Conway V3 script context encodes the tx validity range as POSIX
+// milliseconds, so an approximate conversion would change the bytes the
+// Plutus script branches on and desync the benchmark from the real,
+// producer-accepted execution path.
+const (
+	utxoMemoBenchSystemStart   = 1_654_041_600
+	utxoMemoBenchByronSlots    = 86_400
+	utxoMemoBenchByronSlotSecs = 20
+)
+
+func utxoMemoBenchSlotToTime(slot uint64) (time.Time, error) {
+	if slot < utxoMemoBenchByronSlots {
+		return time.Unix(
+			utxoMemoBenchSystemStart+int64(slot)*utxoMemoBenchByronSlotSecs,
+			0,
+		).UTC(), nil
+	}
+	byronEnd := int64(utxoMemoBenchSystemStart) +
+		int64(utxoMemoBenchByronSlots)*utxoMemoBenchByronSlotSecs
+	return time.Unix(byronEnd+int64(slot-utxoMemoBenchByronSlots), 0).UTC(), nil
+}
+
+func utxoMemoBenchTimeToSlot(t time.Time) (uint64, error) {
+	byronEnd := int64(utxoMemoBenchSystemStart) +
+		int64(utxoMemoBenchByronSlots)*utxoMemoBenchByronSlotSecs
+	if t.Unix() < byronEnd {
+		return uint64(
+			(t.Unix() - utxoMemoBenchSystemStart) / utxoMemoBenchByronSlotSecs,
+		), nil
+	}
+	return utxoMemoBenchByronSlots + uint64(t.Unix()-byronEnd), nil
+}
+
+func readUtxoMemoBenchFixture(tb testing.TB, name string) []byte {
+	tb.Helper()
+	raw, err := os.ReadFile(filepath.Join(utxoMemoBenchFixtureDir, name))
+	require.NoError(tb, err)
+	return raw
+}
+
+// utxoMemoBenchProtocolParams builds Conway protocol parameters for the
+// benchmark fixture. The base is ouroboros-mock's NewMockConwayProtocolParams
+// (representative mainnet-scale MinFeeA/B, size limits, deposits); CostModels,
+// ProtocolVersion and MaxTxExUnits are overridden from the real Preprod
+// epoch 309/310 fixture so Plutus cost accounting matches chain-observed
+// values exactly.
+func utxoMemoBenchProtocolParams(
+	tb testing.TB,
+) *conway.ConwayProtocolParameters {
+	tb.Helper()
+	var costModels struct {
+		PlutusV3 []int64 `json:"PlutusV3"`
+	}
+	require.NoError(tb, json.Unmarshal(
+		readUtxoMemoBenchFixture(tb, "preprod-costmodels-plutusv3-pv11.json"),
+		&costModels,
+	))
+	require.NotEmpty(tb, costModels.PlutusV3)
+
+	pp := mockledger.NewMockConwayProtocolParams()
+	pp.ProtocolVersion = lcommon.ProtocolParametersProtocolVersion{
+		Major: 11,
+		Minor: 0,
+	}
+	pp.CostModels = map[uint][]int64{2: costModels.PlutusV3}
+	pp.MaxTxExUnits = lcommon.ExUnits{
+		Memory: 17_500_000,
+		Steps:  10_000_000_000,
+	}
+	return &pp
+}
+
+// utxoMemoBenchFundingUtxo is one funding output resolved from a
+// preprod-conway-inputs-* fixture: the real chain bytes of the transaction
+// that funded a benchmark target transaction's inputs.
+type utxoMemoBenchFundingUtxo struct {
+	txIdBytes []byte
+	idx       int
+	output    lcommon.TransactionOutput
+}
+
+// loadUtxoMemoBenchFundingUtxos decodes a preprod-conway-inputs-*.cbor
+// fixture (a CBOR array of raw funding-transaction bytes) into resolvable
+// UTxOs, matching the decode in TestEvaluateTxConwayPreprodFixtures.
+func loadUtxoMemoBenchFundingUtxos(
+	tb testing.TB,
+	inputsFile string,
+) []utxoMemoBenchFundingUtxo {
+	tb.Helper()
+	var inputTxBytes [][]byte
+	_, err := cbor.Decode(
+		readUtxoMemoBenchFixture(tb, inputsFile),
+		&inputTxBytes,
+	)
+	require.NoError(tb, err)
+	var out []utxoMemoBenchFundingUtxo
+	for _, raw := range inputTxBytes {
+		inputTx, err := conway.NewConwayTransactionFromCbor(raw)
+		require.NoError(tb, err)
+		txIdBytes := inputTx.Hash().Bytes()
+		for idx, output := range inputTx.Outputs() {
+			out = append(out, utxoMemoBenchFundingUtxo{
+				txIdBytes: txIdBytes,
+				idx:       idx,
+				output:    output,
+			})
+		}
+	}
+	return out
+}
+
+// utxoMemoPreprodFixture wires the Hydra Head V2 increment fixture
+// (preprod-conway-block-132228934.cbor, tx
+// d81392f4def652323c5648067ffbe6d45812e415a53d867336aa5026db9ea2eb) into a
+// real, seeded, in-memory dingo LedgerState/database for
+// (*LedgerState).ValidateTx and UTxO input resolution through the
+// production database.UtxoByRef path.
+//
+// Only this one transaction's 3 inputs are funded by the fixture (verified
+// by decoding preprod-conway-inputs-132228934.cbor): the block's other two
+// transactions have no funding data available.
+type utxoMemoPreprodFixture struct {
+	block     gledger.Block
+	blockSlot uint64
+	tx        lcommon.Transaction
+	db        *database.Database
+	dingoLS   *LedgerState
+}
+
+func loadUtxoMemoPreprodFixture(tb testing.TB) *utxoMemoPreprodFixture {
+	tb.Helper()
+	const (
+		blockFile  = "preprod-conway-block-132228934.cbor"
+		inputsFile = "preprod-conway-inputs-132228934.cbor"
+		txId       = "d81392f4def652323c5648067ffbe6d45812e415a53d867336aa5026db9ea2eb"
+	)
+	blockRaw := readUtxoMemoBenchFixture(tb, blockFile)
+	block, err := gledger.NewBlockFromCbor(gledger.BlockTypeConway, blockRaw)
+	require.NoError(tb, err)
+	var tx lcommon.Transaction
+	for _, candidate := range block.Transactions() {
+		if candidate.Hash().String() == txId {
+			tx = candidate
+		}
+	}
+	require.NotNil(tb, tx, "fixture block must contain %s", txId)
+
+	pp := utxoMemoBenchProtocolParams(tb)
+	funding := loadUtxoMemoBenchFundingUtxos(tb, inputsFile)
+
+	db, err := dbtest.NewDatabase(tb, &database.Config{DataDir: ""})
+	require.NoError(tb, err)
+	require.NoError(tb, db.Transaction(true).Do(func(txn *database.Txn) error {
+		for _, fu := range funding {
+			if err := db.CreateUtxo(txn, &models.Utxo{
+				TxId:      fu.txIdBytes,
+				OutputIdx: uint32(fu.idx), // #nosec G115 -- small fixture index
+				AddedSlot: 0,
+			}); err != nil {
+				return err
+			}
+			encoded, err := cbor.Encode(fu.output)
+			if err != nil {
+				return err
+			}
+			if err := db.Blob().SetUtxo(
+				txn.Blob(),
+				fu.txIdBytes,
+				uint32(fu.idx), // #nosec G115 -- small fixture index
+				encoded,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	era := eras.ConwayEraDesc
+	nodeConfig := newTestShelleyGenesisCfg(tb)
+	nodeConfig.ShelleyGenesis().NetworkId = "Testnet"
+	// The production (*LedgerState).SlotToTime path (ledger/slot.go) has no
+	// Byron-era segment here: it extrapolates the single flat-rate epoch
+	// below (1000ms/slot from slot 0) using only ShelleyGenesis().SystemStart.
+	// Real Preprod mixes 86400 Byron slots at 20s with 1s Shelley+ slots
+	// (utxoMemoBenchSlotToTime above), so SystemStart is back-dated by the
+	// Byron/Shelley slot-length difference so that a flat 1s/slot walk from
+	// slot 0 lands on the same wall-clock instant at the fixture's real slot
+	// that the real mixed schedule does.
+	nodeConfig.ShelleyGenesis().SystemStart = time.Unix(
+		utxoMemoBenchSystemStart+
+			utxoMemoBenchByronSlots*utxoMemoBenchByronSlotSecs-
+			utxoMemoBenchByronSlots,
+		0,
+	).UTC()
+	// A single wide epoch covering the fixture's real slot: script-context
+	// construction looks up the current epoch via the hardfork summary built
+	// from activeEras+epochCache, and an empty cache fails closed.
+	benchEpoch := models.Epoch{
+		EpochId:       0,
+		StartSlot:     0,
+		EraId:         era.Id,
+		SlotLength:    1000,
+		LengthInSlots: 200_000_000,
+	}
+	dingoLS := &LedgerState{
+		db:             db,
+		activeEras:     []eras.EraDesc{era},
+		currentEra:     era,
+		currentPParams: pp,
+		currentEpoch:   benchEpoch,
+		epochCache:     []models.Epoch{benchEpoch},
+		config: LedgerStateConfig{
+			Logger:            testLogger(),
+			CardanoNodeConfig: nodeConfig,
+		},
+	}
+	dingoLS.metrics.init(prometheus.NewRegistry())
+	dingoLS.publishSnapshotsLocked()
+
+	return &utxoMemoPreprodFixture{
+		block:     block,
+		blockSlot: block.SlotNumber(),
+		tx:        tx,
+		db:        db,
+		dingoLS:   dingoLS,
+	}
+}
+
+// BenchmarkLedgerStateValidateTxUtxoMemo measures the DB-backed
+// (*LedgerState).ValidateTx path and the LedgerView.UtxoById resolution it
+// repeats per input, before/after blinklabs-io/dingo#4226's per-view memo.
+func BenchmarkLedgerStateValidateTxUtxoMemo(b *testing.B) {
+	fx := loadUtxoMemoPreprodFixture(b)
+
+	b.Run("UtxoInputResolution", func(b *testing.B) {
+		// Real dingo database.UtxoByRef path (LedgerView.UtxoById ->
+		// ls.db.UtxoByRef -> blob fetch + CBOR decode), one open read
+		// transaction and one LedgerView reused across iterations. After
+		// the first iteration, every further call hits the per-view memo
+		// added by #4226 instead of the database.
+		b.ReportAllocs()
+		txn := fx.db.Transaction(false)
+		defer txn.Release()
+		view := fx.dingoLS.NewView(txn)
+		input := fx.tx.Inputs()[0]
+		if _, err := view.UtxoById(input); err != nil {
+			b.Fatal(err)
+		}
+		for b.Loop() {
+			if _, err := view.UtxoById(input); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("FullLedgerStateValidateTx", func(b *testing.B) {
+		// (*LedgerState).ValidateTx against a real, seeded, in-memory dingo
+		// database: a fresh LedgerView (and so a fresh memo) per call, the
+		// same as production's per-transaction validation.
+		b.ReportAllocs()
+		if err := fx.dingoLS.ValidateTx(fx.tx); err != nil {
+			b.Fatal(err)
+		}
+		for b.Loop() {
+			if err := fx.dingoLS.ValidateTx(fx.tx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// TestUtxoMemoBenchmarkNegativeControls proves both benchmarks above time the
+// full check rather than an early-exit/error path.
+func TestUtxoMemoBenchmarkNegativeControls(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+
+	t.Run("UtxoInputResolution_MissingInput", func(t *testing.T) {
+		t.Parallel()
+		txn := fx.db.Transaction(false)
+		defer txn.Release()
+		view := fx.dingoLS.NewView(txn)
+		missing := shelley.NewShelleyTransactionInput(
+			"0000000000000000000000000000000000000000000000000000000000000000",
+			0,
+		)
+		_, err := view.UtxoById(missing)
+		require.Error(t, err)
+	})
+
+	t.Run("FullLedgerStateValidateTx_TamperedFee", func(t *testing.T) {
+		t.Parallel()
+		tamperedPP := *fx.dingoLS.currentPParams.(*conway.ConwayProtocolParameters)
+		tamperedPP.MinFeeA = 1_000_000_000
+		tamperedLS := &LedgerState{
+			db:             fx.db,
+			activeEras:     []eras.EraDesc{eras.ConwayEraDesc},
+			currentEra:     eras.ConwayEraDesc,
+			currentPParams: &tamperedPP,
+			currentEpoch:   fx.dingoLS.currentEpoch,
+			epochCache:     fx.dingoLS.epochCache,
+			config:         fx.dingoLS.config,
+		}
+		tamperedLS.metrics.init(prometheus.NewRegistry())
+		tamperedLS.publishSnapshotsLocked()
+
+		require.Error(t, tamperedLS.ValidateTx(fx.tx))
+	})
+}

--- a/ledger/utxo_memo_test.go
+++ b/ledger/utxo_memo_test.go
@@ -1,0 +1,546 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/database/models"
+	"github.com/blinklabs-io/dingo/ledger/eras"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	gdijkstra "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	omockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// utxoRefKey mirrors the "<hex txid>:<index>" overlay key UtxoById builds
+// for consumedUtxos/intraBlockUtxos (ledger/view.go), so tests can populate
+// those maps exactly like production does.
+func utxoRefKey(in lcommon.TransactionInput) string {
+	return fmt.Sprintf("%s:%d", in.Id().String(), in.Index())
+}
+
+// distinctUtxoRefs returns the number of distinct (txId, index) refs a
+// transaction's spend, collateral, and reference inputs name together --
+// the number of database reads a single validation of tx should need with
+// the per-view memo, however many times a rule resolves the same ref.
+func distinctUtxoRefs(tx lcommon.Transaction) int {
+	seen := map[string]struct{}{}
+	for _, in := range tx.Inputs() {
+		seen[utxoRefKey(in)] = struct{}{}
+	}
+	for _, in := range tx.Collateral() {
+		seen[utxoRefKey(in)] = struct{}{}
+	}
+	for _, in := range tx.ReferenceInputs() {
+		seen[utxoRefKey(in)] = struct{}{}
+	}
+	return len(seen)
+}
+
+// TestUtxoByIdMemoReducesDbReads_ValidateTx checks issue #4226: validating
+// the Preprod fixture transaction through (*LedgerState).ValidateTx does one
+// database.UtxoByRef read per distinct input ref, not one per UtxoById call.
+// Without the memo in LedgerView.UtxoById it reads 60 times for 4 refs.
+func TestUtxoByIdMemoReducesDbReads_ValidateTx(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+
+	wantReads := distinctUtxoRefs(fx.tx)
+	require.Equal(
+		t,
+		4,
+		wantReads,
+		"fixture drifted: expected the documented 4 distinct refs (3 spend incl. 1 shared with collateral, 1 reference)",
+	)
+
+	before := fx.dingoLS.utxoByRefReads.Load()
+	require.NoError(t, fx.dingoLS.ValidateTx(fx.tx))
+	reads := fx.dingoLS.utxoByRefReads.Load() - before
+
+	require.Equal(
+		t,
+		uint64(
+			wantReads,
+		), //nolint:gosec // wantReads is a small, non-negative distinct-ref count
+		reads,
+		"ValidateTx must read each distinct UTxO ref from the database at most once",
+	)
+}
+
+// TestUtxoByIdMemoReducesDbReads_LedgerProcessBlock repeats the same proof
+// through the block-apply path ((*LedgerState).ledgerProcessBlock), which
+// builds its own per-tx LedgerView with an intraBlockUtxos overlay --
+// a different LedgerView construction site than ValidateTx, exercising the
+// same UtxoById memo.
+func TestUtxoByIdMemoReducesDbReads_LedgerProcessBlock(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+	wantReads := distinctUtxoRefs(fx.tx)
+
+	block := &validityOutcomeTestBlock{
+		header: fx.block.Header(),
+		txs:    []lcommon.Transaction{fx.tx},
+		era:    conway.EraConway,
+	}
+
+	offsets := &database.BlockIngestionResult{
+		TxOffsets:   map[[32]byte]database.CborOffset{},
+		UtxoOffsets: map[database.UtxoRef]database.CborOffset{},
+	}
+	blockSlot := fx.blockSlot
+	var txHash [32]byte
+	copy(txHash[:], fx.tx.Hash().Bytes())
+	offsets.TxOffsets[txHash] = database.CborOffset{
+		BlockSlot: blockSlot, ByteLength: 1,
+	}
+	for _, utxo := range fx.tx.Produced() {
+		var producedHash [32]byte
+		copy(producedHash[:], utxo.Id.Id().Bytes())
+		offsets.UtxoOffsets[database.UtxoRef{
+			TxId:      producedHash,
+			OutputIdx: uint32(utxo.Id.Index()), //nolint:gosec // small fixture index
+		}] = database.CborOffset{BlockSlot: blockSlot, ByteLength: 1}
+	}
+
+	point := ocommon.NewPoint(blockSlot, block.Hash().Bytes())
+
+	before := fx.dingoLS.utxoByRefReads.Load()
+	err := fx.db.Transaction(true).Do(func(txn *database.Txn) error {
+		_, err := fx.dingoLS.ledgerProcessBlock(
+			txn,
+			point,
+			block,
+			true,  // shouldValidate
+			false, // reachesTip
+			false, // skipPhase2Validation
+			nil,   // expectedPrevHash
+			envelopeParent{origin: true},
+			offsets,
+			eras.ConwayEraDesc,
+			fx.dingoLS.currentPParams,
+			nil, // prevEraPParams
+			0,   // committeeEpoch
+			false,
+		)
+		return err
+	})
+	require.NoError(t, err)
+	reads := fx.dingoLS.utxoByRefReads.Load() - before
+
+	require.Equal(
+		t,
+		uint64(
+			wantReads,
+		), //nolint:gosec // wantReads is a small, non-negative distinct-ref count
+		reads,
+		"ledgerProcessBlock must read each distinct UTxO ref from the database at most once",
+	)
+}
+
+// TestLedgerViewUtxoByIdMemoNotSharedAcrossViews checks that the memo is
+// scoped to one LedgerView: two views built from the same LedgerState and
+// txn each pay their own database read for the same ref.
+func TestLedgerViewUtxoByIdMemoNotSharedAcrossViews(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+	fxInputs := fx.tx.Inputs()
+	require.NotEmpty(t, fxInputs)
+	input := fxInputs[0]
+
+	txn := fx.db.Transaction(false)
+	defer txn.Release()
+
+	before := fx.dingoLS.utxoByRefReads.Load()
+
+	view1 := fx.dingoLS.NewView(txn)
+	_, err := view1.UtxoById(input)
+	require.NoError(t, err)
+	afterView1 := fx.dingoLS.utxoByRefReads.Load()
+	require.Equal(
+		t,
+		before+1,
+		afterView1,
+		"view1's first lookup must read the database",
+	)
+
+	// A repeat lookup on view1 hits its own memo: no further DB read.
+	_, err = view1.UtxoById(input)
+	require.NoError(t, err)
+	require.Equal(t, afterView1, fx.dingoLS.utxoByRefReads.Load())
+
+	// A fresh view for the *same* ref must not see view1's memo.
+	view2 := fx.dingoLS.NewView(txn)
+	_, err = view2.UtxoById(input)
+	require.NoError(t, err)
+	require.Equal(
+		t, afterView1+1, fx.dingoLS.utxoByRefReads.Load(),
+		"a new LedgerView must not inherit another view's memo",
+	)
+}
+
+// TestLedgerViewUtxoByIdChecksOverlaysBeforeMemo checks that consumedUtxos
+// still wins over a memo entry populated by an earlier successful call on
+// the same view. The overlay maps are shared by reference and
+// validateForgedTxs extends them between transactions, so a view reused
+// across that boundary must not answer from the memo. Consulting the memo
+// before the overlays returns the cached success instead of
+// ErrUtxoAlreadyConsumed.
+func TestLedgerViewUtxoByIdChecksOverlaysBeforeMemo(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+	fxInputs := fx.tx.Inputs()
+	require.NotEmpty(t, fxInputs)
+	input := fxInputs[0]
+
+	txn := fx.db.Transaction(false)
+	defer txn.Release()
+	lv := &LedgerView{
+		txn:           txn,
+		ls:            fx.dingoLS,
+		consumedUtxos: map[string]struct{}{},
+	}
+
+	// First call: nothing consumed yet, resolves from the database and
+	// populates the memo.
+	_, err := lv.UtxoById(input)
+	require.NoError(t, err)
+
+	// Simulate a caller marking the same ref consumed on this view between
+	// calls.
+	lv.consumedUtxos[utxoRefKey(input)] = struct{}{}
+
+	_, err = lv.UtxoById(input)
+	require.ErrorIs(
+		t, err, ErrUtxoAlreadyConsumed,
+		"consumedUtxos must be checked before the memo on every call",
+	)
+}
+
+// TestLedgerViewUtxoByIdDoesNotMemoizeNotFound checks that a miss is not
+// cached: a ref that becomes resolvable after a failed lookup resolves on a
+// later call within the same view.
+func TestLedgerViewUtxoByIdDoesNotMemoizeNotFound(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ls := &LedgerState{db: db, config: LedgerStateConfig{Logger: testLogger()}}
+
+	txId := bytes.Repeat([]byte{0x77}, 32)
+	input, err := omockledger.NewSimpleTransactionInput(txId, 0)
+	require.NoError(t, err)
+
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x78}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Transaction(true).Do(func(txn *database.Txn) error {
+		lv := &LedgerView{txn: txn, ls: ls}
+
+		_, err := lv.UtxoById(input)
+		require.Error(t, err, "ref must not exist yet")
+
+		require.NoError(t, db.CreateUtxo(txn, &models.Utxo{
+			TxId:      txId,
+			OutputIdx: 0,
+			AddedSlot: 1,
+		}))
+		encoded, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+			OutputAddress: address,
+			OutputAmount:  5_000_000,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.Blob().SetUtxo(txn.Blob(), txId, 0, encoded))
+
+		utxo, err := lv.UtxoById(input)
+		require.NoError(
+			t,
+			err,
+			"a not-found result must not be memoized: the ref is now resolvable",
+		)
+		require.NotNil(t, utxo.Output)
+		require.Equal(t, uint64(5_000_000), utxo.Output.Amount().Uint64())
+		return nil
+	}))
+}
+
+// intraBlockDoubleSpendFixture is a block whose two transactions spend the
+// same funded input. Its era's ValidateTxFunc resolves every declared input
+// through the LedgerView it is given, as script.ResolveTxInputs does, and
+// records each transaction that resolved all of its inputs.
+type intraBlockDoubleSpendFixture struct {
+	db        *database.Database
+	ls        *LedgerState
+	era       eras.EraDesc
+	pparams   lcommon.ProtocolParameters
+	block     *validityOutcomeTestBlock
+	offsets   *database.BlockIngestionResult
+	tx1       lcommon.Transaction
+	validated *[]string
+}
+
+func newIntraBlockDoubleSpendFixture(
+	t *testing.T,
+) *intraBlockDoubleSpendFixture {
+	t.Helper()
+
+	db := newTestDB(t)
+	fundingTxId := bytes.Repeat([]byte{0x91}, 32)
+	fundingInput, err := omockledger.NewSimpleTransactionInput(fundingTxId, 0)
+	require.NoError(t, err)
+
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0x92}, lcommon.AddressHashSize),
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, db.CreateUtxo(nil, &models.Utxo{
+		TxId: fundingTxId, OutputIdx: 0, AddedSlot: 1,
+	}))
+	fundingOutputCbor, err := cbor.Encode(&shelley.ShelleyTransactionOutput{
+		OutputAddress: address,
+		OutputAmount:  10_000_000,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.BlobTxn(true).Do(func(txn *database.Txn) error {
+		return db.Blob().SetUtxo(txn.Blob(), fundingTxId, 0, fundingOutputCbor)
+	}))
+
+	output1, err := omockledger.NewSimpleTransactionOutput(
+		address.String(),
+		4_000_000,
+	)
+	require.NoError(t, err)
+	output2, err := omockledger.NewSimpleTransactionOutput(
+		address.String(),
+		4_000_000,
+	)
+	require.NoError(t, err)
+
+	tx1 := omockledger.NewTransactionBuilder()
+	tx1.WithId(bytes.Repeat([]byte{0x93}, 32))
+	tx1.WithType(gdijkstra.TxTypeDijkstra)
+	tx1.WithInputs(fundingInput)
+	tx1.WithOutputs(output1)
+	tx1.WithValid(true)
+
+	tx2 := omockledger.NewTransactionBuilder()
+	tx2.WithId(bytes.Repeat([]byte{0x94}, 32))
+	tx2.WithType(gdijkstra.TxTypeDijkstra)
+	tx2.WithInputs(
+		fundingInput,
+	) // same input as tx1: the intra-block double spend
+	tx2.WithOutputs(output2)
+	tx2.WithValid(true)
+
+	var tx1Hash, tx2Hash [32]byte
+	copy(tx1Hash[:], tx1.Hash().Bytes())
+	copy(tx2Hash[:], tx2.Hash().Bytes())
+	offsets := &database.BlockIngestionResult{
+		TxOffsets: map[[32]byte]database.CborOffset{
+			tx1Hash: {BlockSlot: 10, ByteLength: 1},
+			tx2Hash: {BlockSlot: 10, ByteLength: 1},
+		},
+		UtxoOffsets: map[database.UtxoRef]database.CborOffset{
+			{TxId: tx1Hash, OutputIdx: 0}: {BlockSlot: 10, ByteLength: 1},
+			{TxId: tx2Hash, OutputIdx: 0}: {BlockSlot: 10, ByteLength: 1},
+		},
+	}
+
+	initialTip := ochainsync.Tip{
+		Point: ocommon.Point{Slot: 1, Hash: []byte("unchanged-tip")},
+	}
+	require.NoError(t, db.SetTip(initialTip, nil))
+
+	validated := []string{}
+	testEra := eras.DijkstraEraDesc
+	testEra.ValidateTxFunc = func(
+		gotTx lcommon.Transaction,
+		_ uint64,
+		lv lcommon.LedgerState,
+		_ lcommon.ProtocolParameters,
+	) error {
+		for _, in := range gotTx.Inputs() {
+			if _, err := lv.UtxoById(in); err != nil {
+				return fmt.Errorf("resolve input %s: %w", in.String(), err)
+			}
+		}
+		validated = append(validated, gotTx.Hash().String())
+		return nil
+	}
+
+	pparams := &gdijkstra.DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: lcommon.ProtocolParametersProtocolVersion{
+				Major: gdijkstra.MinProtocolVersionDijkstra,
+			},
+			MaxBlockBodySize:   100_000,
+			MaxBlockHeaderSize: 100_000,
+		},
+	}
+	nodeConfig := newTestShelleyGenesisCfg(t)
+	nodeConfig.ShelleyGenesis().NetworkId = "Testnet"
+	ls := &LedgerState{
+		db:             db,
+		activeEras:     []eras.EraDesc{testEra},
+		currentEra:     testEra,
+		currentPParams: pparams,
+		config: LedgerStateConfig{
+			CardanoNodeConfig: nodeConfig,
+			Logger:            testLogger(),
+		},
+	}
+	ls.metrics.init(prometheus.NewRegistry())
+	ls.publishSnapshotsLocked()
+	block := &validityOutcomeTestBlock{
+		header: &gdijkstra.DijkstraBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockNumber: 1,
+					Slot:        10,
+					ProtoVersion: babbage.BabbageProtoVersion{
+						Major: gdijkstra.MinProtocolVersionDijkstra,
+					},
+				},
+			},
+		},
+		txs: []lcommon.Transaction{tx1, tx2},
+		era: gdijkstra.EraDijkstra,
+	}
+	return &intraBlockDoubleSpendFixture{
+		db:        db,
+		ls:        ls,
+		era:       testEra,
+		pparams:   pparams,
+		block:     block,
+		offsets:   offsets,
+		tx1:       tx1,
+		validated: &validated,
+	}
+}
+
+// TestLedgerProcessBlockRejectsIntraBlockDoubleSpend checks the block-apply
+// path: tx1's delta removes the shared input from the database transaction
+// before tx2's view is built, so tx2 must fail to resolve it. A memo shared
+// across the per-transaction views would answer tx2 from tx1's resolution.
+func TestLedgerProcessBlockRejectsIntraBlockDoubleSpend(t *testing.T) {
+	t.Parallel()
+	fx := newIntraBlockDoubleSpendFixture(t)
+
+	processErr := fx.db.Transaction(true).Do(func(txn *database.Txn) error {
+		_, err := fx.ls.ledgerProcessBlock(
+			txn,
+			ocommon.NewPoint(10, fx.block.Hash().Bytes()),
+			fx.block,
+			true,
+			false,
+			false,
+			nil,
+			envelopeParent{origin: true},
+			fx.offsets,
+			fx.era,
+			fx.pparams,
+			nil,
+			0,
+			false,
+		)
+		return err
+	})
+
+	require.ErrorIs(
+		t,
+		processErr,
+		database.ErrUtxoNotFound,
+		"tx2 must be rejected: it spends an input tx1 already consumed in this block",
+	)
+	require.Equal(
+		t, []string{fx.tx1.Hash().String()}, *fx.validated,
+		"tx1 must validate successfully before tx2 is attempted and rejected",
+	)
+}
+
+// TestValidateForgedTxsRejectsIntraBlockDoubleSpend checks the forged-block
+// path, which writes nothing to the database between transactions and
+// relies on the consumedUtxos overlay instead: tx2 must fail with
+// ErrUtxoAlreadyConsumed. A memo shared across views and consulted before
+// the overlays would answer tx2 from tx1's resolution.
+func TestValidateForgedTxsRejectsIntraBlockDoubleSpend(t *testing.T) {
+	t.Parallel()
+	fx := newIntraBlockDoubleSpendFixture(t)
+
+	err := fx.ls.validateForgedTxs(fx.block)
+
+	require.ErrorIs(
+		t,
+		err,
+		ErrUtxoAlreadyConsumed,
+		"tx2 must be rejected: it spends an input tx1 already consumed in this block",
+	)
+	require.Equal(
+		t, []string{fx.tx1.Hash().String()}, *fx.validated,
+		"tx1 must validate successfully before tx2 is attempted and rejected",
+	)
+}
+
+// TestLedgerViewMemoizedUtxosUnchangedByValidation checks the memo's sharing
+// contract: every UtxoById caller on a view receives the same decoded
+// Output, where each call used to decode its own. After full Conway
+// validation of the Preprod fixture, including Plutus evaluation, each
+// memoized output must still equal a fresh decode of its stored bytes.
+func TestLedgerViewMemoizedUtxosUnchangedByValidation(t *testing.T) {
+	t.Parallel()
+	fx := loadUtxoMemoPreprodFixture(t)
+
+	var lv *LedgerView
+	require.NoError(t, fx.dingoLS.validateTxCore(
+		fx.tx,
+		func(txn *database.Txn) *LedgerView {
+			lv = &LedgerView{txn: txn, ls: fx.dingoLS}
+			return lv
+		},
+	))
+	require.NotNil(t, lv)
+	require.Len(t, lv.utxoMemo, distinctUtxoRefs(fx.tx))
+
+	for key, cached := range lv.utxoMemo {
+		stored, err := fx.db.UtxoByRef(key.txId.Bytes(), key.index, nil)
+		require.NoError(t, err)
+		fresh, err := stored.Decode()
+		require.NoError(t, err)
+		require.Equal(
+			t, fresh, cached.Output,
+			"memoized output %s#%d was mutated during validation",
+			key.txId.String(), key.index,
+		)
+	}
+}

--- a/ledger/view.go
+++ b/ledger/view.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"math"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/dingo/database"
@@ -59,6 +60,15 @@ var ErrNotImplemented = errors.New("not implemented")
 // whatever verdict the rule produced from the false negative.
 var ErrLedgerViewStorageFault = errors.New("ledger view storage fault")
 
+// utxoMemoKey identifies a resolved UTxO by its fixed-size components
+// (transaction hash + output index) for LedgerView.utxoMemo. Using the raw
+// hash avoids both the fmt.Sprintf allocation and the hex-encoding
+// UtxoById's consumedUtxos/intraBlockUtxos overlay key already pays for.
+type utxoMemoKey struct {
+	txId  lcommon.Blake2b256
+	index uint32
+}
+
 type LedgerView struct {
 	ls  *LedgerState
 	txn *database.Txn
@@ -73,6 +83,20 @@ type LedgerView struct {
 	// consumedUtxos tracks inputs consumed by pending mempool transactions.
 	// Key format: hex(txId) + ":" + outputIdx
 	consumedUtxos map[string]struct{}
+	// utxoMemoMu guards utxoMemo. Production views are built per transaction
+	// or query and used from one goroutine; the lock keeps a future shared
+	// view safe at negligible cost next to the database read it saves.
+	utxoMemoMu sync.Mutex
+	// utxoMemo caches successful UtxoById database resolutions for the
+	// lifetime of this view. Era rules resolve the same input from several
+	// independent call sites while validating one transaction (60 reads for
+	// 4 distinct refs on a Preprod fixture, issue #4226). Misses, decode
+	// errors and ErrNilDecodedOutput are never cached, and the memo is
+	// consulted only after consumedUtxos and intraBlockUtxos, so an overlay
+	// entry added between calls still takes precedence. Every caller shares
+	// the cached Output and must not mutate it. Lazily allocated; never
+	// shared across views.
+	utxoMemo map[utxoMemoKey]lcommon.Utxo
 	// skipPhase2Validation is set for accepted block replay, where
 	// the producer's isValid flag is authoritative for Phase-2 results.
 	// Currently unreachable from production: ledgerProcessBlock's sole
@@ -264,12 +288,26 @@ func (lv *LedgerView) UtxoById(
 			return utxo, nil
 		}
 	}
+	// Consult the memo only after both overlays, so an overlay entry added
+	// between calls on this view still takes precedence.
+	memoKey := utxoMemoKey{txId: utxoId.Id(), index: utxoId.Index()}
+	lv.utxoMemoMu.Lock()
+	if lv.utxoMemo != nil {
+		if utxo, ok := lv.utxoMemo[memoKey]; ok {
+			lv.utxoMemoMu.Unlock()
+			return utxo, nil
+		}
+	}
+	lv.utxoMemoMu.Unlock()
+
+	lv.ls.utxoByRefReads.Add(1)
 	utxo, err := lv.ls.db.UtxoByRef(
 		utxoId.Id().Bytes(),
 		utxoId.Index(),
 		lv.txn,
 	)
 	if err != nil {
+		// Not memoized: a ref that is missing now may resolve later.
 		return lcommon.Utxo{}, err
 	}
 	tmpOutput, err := utxo.Decode()
@@ -284,10 +322,17 @@ func (lv *LedgerView) UtxoById(
 			ErrNilDecodedOutput,
 		)
 	}
-	return lcommon.Utxo{
+	result := lcommon.Utxo{
 		Id:     utxoId,
 		Output: tmpOutput,
-	}, nil
+	}
+	lv.utxoMemoMu.Lock()
+	if lv.utxoMemo == nil {
+		lv.utxoMemo = make(map[utxoMemoKey]lcommon.Utxo, 4)
+	}
+	lv.utxoMemo[memoKey] = result
+	lv.utxoMemoMu.Unlock()
+	return result, nil
 }
 
 func (lv *LedgerView) PoolRegistration(


### PR DESCRIPTION
Fixes #4226.

`LedgerView.UtxoById` ran a full `database.UtxoByRef` (metadata query, blob load, CBOR decode) on every call. Era rules resolve the same inputs from many independent call sites, so validating one transaction read each input 12-18 times.

## Change

- `LedgerView` caches successful database resolutions in a lazily allocated per-view map keyed by transaction hash and output index.
- The memo is consulted only after `consumedUtxos` and `intraBlockUtxos`, so overlay entries still take precedence.
- Misses, decode errors and `ErrNilDecodedOutput` are not cached.
- Every production view covers one transaction or query, so the memo never spans transactions. Block apply builds each transaction's view after the previous delta is applied; forged-block and mempool validation reject reuse through `consumedUtxos`.
- Callers on one view now share the cached `Output`. No validation code in gouroboros v0.204.3 or dingo mutates a resolved output: `Amount()` returns a fresh `big.Int`, and the only `MultiAsset` mutator reached from rules (`Add`) is called on fresh accumulators.
- `LedgerState.utxoByRefReads` counts database reads so tests can assert the memo's effect.

## Tests

Each test fails when the production code is changed in place as listed:

| test | fails when |
|---|---|
| `TestUtxoByIdMemoReducesDbReads_ValidateTx`, `TestUtxoByIdMemoReducesDbReads_LedgerProcessBlock` | memo removed (60 reads, want 4) |
| `TestLedgerViewUtxoByIdMemoNotSharedAcrossViews` | memo removed, or shared across views |
| `TestLedgerViewUtxoByIdChecksOverlaysBeforeMemo` | memo consulted before the overlays |
| `TestLedgerViewUtxoByIdDoesNotMemoizeNotFound` | misses cached |
| `TestLedgerProcessBlockRejectsIntraBlockDoubleSpend` | memo shared across views |
| `TestValidateForgedTxsRejectsIntraBlockDoubleSpend` | memo shared across views and consulted before the overlays |
| `TestLedgerViewMemoizedUtxosUnchangedByValidation` | a memoized output is mutated in place |

`BenchmarkLedgerStateValidateTxUtxoMemo` validates the funded Preprod fixture tx `d81392f4…` (3 spend, 1 collateral shared with a spend, 1 reference: 4 distinct refs) against a seeded database, `-count=10`:

| metric | before | after | delta |
|---|---:|---:|---:|
| DB reads per tx | 60 | 4 | -93% |
| `FullLedgerStateValidateTx` time/op | 2.777 ms | 1.218 ms | -56.1% |
| `FullLedgerStateValidateTx` B/op | 6.475 MiB | 3.842 MiB | -40.7% |
| `FullLedgerStateValidateTx` allocs/op | 13,220 | 6,107 | -53.8% |
| `UtxoInputResolution` (repeat lookup, same view) time/op | 25,439 ns | 89.78 ns | -99.65% |
| `UtxoInputResolution` allocs/op | 132 | 4 | -97% |

Related: #4203 batches a block's distinct inputs into one query; this change removes repeated reads of the same ref and sits in front of that path.

Not exercised against a live devnet or chain replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqM3UbnngtDFS5eiFUNhFa
