### PR TITLE
fix(ouroboros): validate LocalStateQuery Acquire's point at Acquire time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3454,6 +3454,17 @@ protocol constraint rather than a preference. The LocalStateQuery server
 propagates a handler error as a protocol error, so returning one does not fail
 a single query — the node drops the client's connection and `cardano-cli`
 reports only a closed bearer, which is the failure mode #2997 was filed for.
+This is why `localstatequeryServerAcquire` validates an `AcquireSpecificPoint`
+target synchronously, at Acquire time, rather than leaving it to the first
+`Query` (#4156): an Acquire-time rejection has a graceful wire-level
+`AcquireFailure` reply, so a point ahead of the tip or naming the wrong fork
+is now rejected without this failure mode applying at all. A point that
+passes Acquire (on-chain at that instant) but whose historical data a later
+Query can no longer serve — e.g. a rollback or retention-floor pruning
+between Acquire and Query — still hits this same connection-teardown
+behavior; closing that residual gap needs either a gouroboros protocol
+change or cross-cutting historical-state retention, and is tracked
+separately as #4234 rather than attempted here.
 `GetPoolDistr2` therefore logs and omits a pool that holds snapshot stake but
 has no registration to supply a VRF key hash (the unfiltered form covers every
 pool on the chain, so aborting would take `leadership-schedule` down for every

--- a/ledger/queries.go
+++ b/ledger/queries.go
@@ -181,6 +181,37 @@ func (ls *LedgerState) verifyPointOnChain(
 	return nil
 }
 
+// VerifyPointOnChain validates at against this node's current chain, the
+// same way Query does for a pinned point, but callable at Acquire time
+// (blinklabs-io/dingo#4156) rather than deferred to the first Query. An
+// unpinned at (the live/no-pin zero value) always succeeds -- there is
+// nothing to validate.
+//
+// Ordinary LocalStateQuery clients (a real cardano-node included) validate
+// a specific-point Acquire synchronously, replying with a graceful
+// AcquireFailure over the wire when the point is not (yet, or no longer) on
+// the chain. Deferring this check to the first Query instead, as this
+// node's Acquire handling used to, hits a real gap in that later stage:
+// there is no equivalent graceful-failure path once Acquire has already
+// signaled success, so a query-time rejection propagates as a fatal
+// protocol error and the whole LocalStateQuery connection is torn down --
+// observed live at close to 100% of the time for any client whose Acquire
+// races dingo's own block application (extremely common at real block
+// cadence, since dingo and the client's own reference node sync
+// independently and rarely advance in lockstep). Callers should map the
+// returned error's sentinel (ErrPointNotOnChain / ErrHistoricalStateUnavailable)
+// to gouroboros's own olocalstatequery.ErrAcquireFailurePointNotOnChain /
+// ErrAcquireFailurePointTooOld so the server replies gracefully instead of
+// closing the connection.
+func (ls *LedgerState) VerifyPointOnChain(at QueryPoint) error {
+	if !at.pinned() {
+		return nil
+	}
+	txn := ls.db.Transaction(false)
+	defer txn.Release()
+	return ls.verifyPointOnChain(txn, at)
+}
+
 // resolveAsOfEpoch resolves at to the epoch that governed it -- unpinned
 // (at.pinned() false) means live, resolving the live tip's own epoch
 // instead. Shared by every query handler that reconstructs epoch-keyed

--- a/ouroboros/localstatequery.go
+++ b/ouroboros/localstatequery.go
@@ -15,6 +15,8 @@
 package ouroboros
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/blinklabs-io/dingo/ledger"
@@ -96,16 +98,46 @@ func (o *Ouroboros) localstatequeryServerAcquire(
 	acquireTarget olocalstatequery.AcquireTarget,
 	reAcquire bool,
 ) error {
-	o.localstatequeryAcquireMutex.Lock()
-	defer o.localstatequeryAcquireMutex.Unlock()
 	if specific, ok := acquireTarget.(olocalstatequery.AcquireSpecificPoint); ok {
-		o.localstatequeryAcquiredPoints[ctx.ConnectionId] = ledger.QueryPoint{
+		point := ledger.QueryPoint{
 			Slot: specific.Point.Slot,
 			Hash: specific.Point.Hash,
 		}
-	} else {
-		delete(o.localstatequeryAcquiredPoints, ctx.ConnectionId)
+		// Validate synchronously, at Acquire time, rather than deferring to
+		// the first Query: a rejection here has a graceful wire-level
+		// AcquireFailure reply (gouroboros' handleAcquire/handleReAcquire
+		// both translate ErrAcquireFailurePointNotOnChain into one), but a
+		// rejection surfacing later, from the Query callback, has no such
+		// path and tears down the whole connection instead
+		// (blinklabs-io/dingo#4156). This point is deliberately not yet
+		// recorded in localstatequiredPoints when validation fails, so a
+		// client that ignores the failure and queries anyway keeps
+		// whatever point (or lack of one) it had before this call.
+		if err := o.ledgerState.VerifyPointOnChain(point); err != nil {
+			if errors.Is(err, ledger.ErrPointNotOnChain) {
+				return fmt.Errorf(
+					"%w: %w",
+					olocalstatequery.ErrAcquireFailurePointNotOnChain,
+					err,
+				)
+			}
+			if errors.Is(err, ledger.ErrHistoricalStateUnavailable) {
+				return fmt.Errorf(
+					"%w: %w",
+					olocalstatequery.ErrAcquireFailurePointTooOld,
+					err,
+				)
+			}
+			return err
+		}
+		o.localstatequeryAcquireMutex.Lock()
+		o.localstatequeryAcquiredPoints[ctx.ConnectionId] = point
+		o.localstatequeryAcquireMutex.Unlock()
+		return nil
 	}
+	o.localstatequeryAcquireMutex.Lock()
+	delete(o.localstatequeryAcquiredPoints, ctx.ConnectionId)
+	o.localstatequeryAcquireMutex.Unlock()
 	return nil
 }
 

--- a/ouroboros/localstatequery.go
+++ b/ouroboros/localstatequery.go
@@ -110,9 +110,9 @@ func (o *Ouroboros) localstatequeryServerAcquire(
 		// rejection surfacing later, from the Query callback, has no such
 		// path and tears down the whole connection instead
 		// (blinklabs-io/dingo#4156). This point is deliberately not yet
-		// recorded in localstatequiredPoints when validation fails, so a
-		// client that ignores the failure and queries anyway keeps
-		// whatever point (or lack of one) it had before this call.
+		// recorded in localstatequeryAcquiredPoints when validation
+		// fails, so a client that ignores the failure and queries anyway
+		// keeps whatever point (or lack of one) it had before this call.
 		if err := o.ledgerState.VerifyPointOnChain(point); err != nil {
 			if errors.Is(err, ledger.ErrPointNotOnChain) {
 				return fmt.Errorf(
@@ -121,6 +121,16 @@ func (o *Ouroboros) localstatequeryServerAcquire(
 					err,
 				)
 			}
+			// Not currently reachable: VerifyPointOnChain only calls the
+			// private verifyPointOnChain helper, which can only return
+			// ErrPointNotOnChain above. ErrHistoricalStateUnavailable is
+			// raised deep inside specific Query handlers instead (e.g.
+			// circulating-supply reconstruction and GetUTxOByTxIn's
+			// retention-floor check), which this Acquire-time check does
+			// not run. Kept here (rather than removed) so this mapping is
+			// already in place if VerifyPointOnChain's scope ever grows
+			// to cover pruned-but-on-chain points too
+			// (blinklabs-io/dingo#4232 review).
 			if errors.Is(err, ledger.ErrHistoricalStateUnavailable) {
 				return fmt.Errorf(
 					"%w: %w",

--- a/ouroboros/localstatequery_test.go
+++ b/ouroboros/localstatequery_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/ledger"
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	ochainsync "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	olocalstatequery "github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLocalstatequeryServerAcquire_PointAheadOfTip_GracefulFailure is the
+// blinklabs-io/dingo#4156 regression. Before this fix, localstatequeryServerAcquire
+// unconditionally accepted any AcquireSpecificPoint, deferring the actual
+// tip-validity check to the first Query -- and a rejection surfacing there
+// has no graceful wire-level reply (unlike a rejection at Acquire time), so
+// it propagated as a fatal protocol error and gouroboros tore the whole
+// LocalStateQuery connection down instead of just failing one Acquire.
+//
+// Acquiring a point ahead of this node's own current tip is not a client
+// bug: it is the ordinary result of two independently-syncing nodes (this
+// node and whatever reference the caller derived the point from) not
+// advancing in perfect lockstep, which happens on close to every block at
+// real cadence. It must fail gracefully -- an error errors.Is-matching
+// gouroboros' own olocalstatequery.ErrAcquireFailurePointNotOnChain, which
+// its server (handleAcquire/handleReAcquire) translates into a wire-level
+// AcquireFailure reply -- not with an arbitrary error gouroboros has no
+// graceful handling for.
+func TestLocalstatequeryServerAcquire_PointAheadOfTip_GracefulFailure(t *testing.T) {
+	o := &Ouroboros{
+		localstatequeryAcquiredPoints: make(
+			map[ouroboros.ConnectionId]ledger.QueryPoint,
+		),
+	}
+	ls, db := newTestLedgerStateWithChain(t, 2)
+	o.ledgerState = ls
+
+	tipHash := bytes.Repeat([]byte{1}, 32)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(1, tipHash),
+	}, nil))
+
+	aheadHash := bytes.Repeat([]byte{2}, 32)
+	connID := ouroboros.ConnectionId{}
+	err := o.localstatequeryServerAcquire(
+		olocalstatequery.CallbackContext{ConnectionId: connID},
+		olocalstatequery.AcquireSpecificPoint{
+			Point: ocommon.NewPoint(2, aheadHash),
+		},
+		false,
+	)
+	require.Error(t, err)
+	require.True(
+		t,
+		errors.Is(err, olocalstatequery.ErrAcquireFailurePointNotOnChain),
+		"expected a gracefully-mapped AcquireFailurePointNotOnChain, got: %v",
+		err,
+	)
+
+	o.localstatequeryAcquireMutex.Lock()
+	_, recorded := o.localstatequeryAcquiredPoints[connID]
+	o.localstatequeryAcquireMutex.Unlock()
+	require.False(
+		t, recorded,
+		"a rejected Acquire must not record the unvalidated point",
+	)
+}
+
+// TestLocalstatequeryServerAcquire_PointOnChain_Succeeds is the companion
+// positive case: a specific point genuinely matching this node's chain at
+// that slot must still be accepted and recorded, unchanged from before the
+// #4156 fix.
+func TestLocalstatequeryServerAcquire_PointOnChain_Succeeds(t *testing.T) {
+	o := &Ouroboros{
+		localstatequeryAcquiredPoints: make(
+			map[ouroboros.ConnectionId]ledger.QueryPoint,
+		),
+	}
+	ls, db := newTestLedgerStateWithChain(t, 2)
+	o.ledgerState = ls
+
+	tipHash := bytes.Repeat([]byte{2}, 32)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(2, tipHash),
+	}, nil))
+
+	connID := ouroboros.ConnectionId{}
+	err := o.localstatequeryServerAcquire(
+		olocalstatequery.CallbackContext{ConnectionId: connID},
+		olocalstatequery.AcquireSpecificPoint{
+			Point: ocommon.NewPoint(2, tipHash),
+		},
+		false,
+	)
+	require.NoError(t, err)
+
+	o.localstatequeryAcquireMutex.Lock()
+	recorded, ok := o.localstatequeryAcquiredPoints[connID]
+	o.localstatequeryAcquireMutex.Unlock()
+	require.True(t, ok)
+	require.Equal(t, uint64(2), recorded.Slot)
+}
+
+// TestLocalstatequeryServerAcquire_VolatileTip_ClearsPoint covers the
+// AcquireVolatileTip branch, unchanged by the #4156 fix: it must clear any
+// previously-recorded pinned point rather than being validated as a
+// specific point.
+func TestLocalstatequeryServerAcquire_VolatileTip_ClearsPoint(t *testing.T) {
+	o := &Ouroboros{
+		localstatequeryAcquiredPoints: make(
+			map[ouroboros.ConnectionId]ledger.QueryPoint,
+		),
+	}
+	ls, _ := newTestLedgerStateWithChain(t, 1)
+	o.ledgerState = ls
+
+	connID := ouroboros.ConnectionId{}
+	o.localstatequeryAcquiredPoints[connID] = ledger.QueryPoint{Slot: 1}
+
+	err := o.localstatequeryServerAcquire(
+		olocalstatequery.CallbackContext{ConnectionId: connID},
+		olocalstatequery.AcquireVolatileTip{},
+		false,
+	)
+	require.NoError(t, err)
+
+	o.localstatequeryAcquireMutex.Lock()
+	_, recorded := o.localstatequeryAcquiredPoints[connID]
+	o.localstatequeryAcquireMutex.Unlock()
+	require.False(t, recorded)
+}

--- a/ouroboros/localstatequery_test.go
+++ b/ouroboros/localstatequery_test.go
@@ -17,7 +17,9 @@ package ouroboros
 import (
 	"bytes"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo/ledger"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -146,4 +148,111 @@ func TestLocalstatequeryServerAcquire_VolatileTip_ClearsPoint(t *testing.T) {
 	_, recorded := o.localstatequeryAcquiredPoints[connID]
 	o.localstatequeryAcquireMutex.Unlock()
 	require.False(t, recorded)
+}
+
+// TestLocalstatequeryProtocol_PointAheadOfTip_ConnectionSurvivesAndStaysUsable
+// is the blinklabs-io/dingo#4156 regression at the actual protocol level a
+// bot reviewer asked for: the three tests above drive
+// localstatequeryServerAcquire's callback directly, which proves the
+// callback's return value is right, but not that gouroboros' server
+// actually turns that into a graceful wire reply rather than tearing the
+// connection down -- that translation lives entirely in gouroboros'
+// server.go, outside this callback. This test wires a real dingo
+// *Ouroboros server (the same localstatequeryServerConnOpts production
+// code every real NtC connection uses) to a real gouroboros client over an
+// actual connection (net.Pipe -- an in-memory net.Conn pair, no sockets
+// needed), the same way connmanager/listener.go wires a live NtC listener.
+//
+// It Acquires a point ahead of this node's tip (reproducing the exact race
+// blinklabs-io/dingo#4156 was filed for) and asserts two things a direct
+// callback test cannot: the client's Acquire call itself returns
+// ErrAcquireFailurePointNotOnChain (not a connection-closed/EOF error), and
+// -- the part that actually matters, since #4156's bug was the whole
+// connection dying -- a second, valid Acquire on the very same connection
+// immediately afterward still succeeds.
+func TestLocalstatequeryProtocol_PointAheadOfTip_ConnectionSurvivesAndStaysUsable(
+	t *testing.T,
+) {
+	o := &Ouroboros{
+		localstatequeryAcquiredPoints: make(
+			map[ouroboros.ConnectionId]ledger.QueryPoint,
+		),
+	}
+	ls, db := newTestLedgerStateWithChain(t, 2)
+	o.ledgerState = ls
+
+	tipHash := bytes.Repeat([]byte{1}, 32)
+	require.NoError(t, db.SetTip(ochainsync.Tip{
+		Point: ocommon.NewPoint(1, tipHash),
+	}, nil))
+
+	rawServer, rawClient := net.Pipe()
+
+	type serverResult struct {
+		conn *ouroboros.Connection
+		err  error
+	}
+	serverDone := make(chan serverResult, 1)
+	go func() {
+		conn, err := ouroboros.New(
+			ouroboros.WithConnection(rawServer),
+			ouroboros.WithNetworkMagic(42),
+			ouroboros.WithNodeToNode(false),
+			ouroboros.WithServer(true),
+			ouroboros.WithLocalStateQueryConfig(
+				olocalstatequery.NewConfig(
+					o.localstatequeryServerConnOpts()...,
+				),
+			),
+		)
+		serverDone <- serverResult{conn: conn, err: err}
+	}()
+
+	cliConn, err := ouroboros.New(
+		ouroboros.WithConnection(rawClient),
+		ouroboros.WithNetworkMagic(42),
+		ouroboros.WithNodeToNode(false),
+	)
+	require.NoError(t, err)
+	defer cliConn.Close() //nolint:errcheck
+
+	var srvRes serverResult
+	select {
+	case srvRes = <-serverDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("server side of ouroboros.New never completed the handshake")
+	}
+	require.NoError(t, srvRes.err)
+	defer srvRes.conn.Close() //nolint:errcheck
+
+	client := cliConn.LocalStateQuery().Client
+	require.NotNil(t, client)
+
+	aheadHash := bytes.Repeat([]byte{2}, 32)
+	aheadPoint := ocommon.NewPoint(2, aheadHash)
+	acquireErr := client.Acquire(&aheadPoint)
+	require.Error(
+		t,
+		acquireErr,
+		"an ahead-of-tip Acquire must fail",
+	)
+	require.True(
+		t,
+		errors.Is(acquireErr, olocalstatequery.ErrAcquireFailurePointNotOnChain),
+		"expected a graceful AcquireFailurePointNotOnChain reply over the "+
+			"wire, got: %v",
+		acquireErr,
+	)
+
+	// The actual #4156 bug: before the fix, the ahead-of-tip Acquire above
+	// didn't just fail -- it took the whole connection down with it, so any
+	// subsequent call would see a connection-closed error instead of a
+	// normal protocol response. Prove the connection is still alive and
+	// usable by Acquiring a genuinely valid point right after.
+	require.NoError(
+		t,
+		client.AcquireVolatileTip(),
+		"the connection must remain usable after a graceful AcquireFailure",
+	)
+	require.NoError(t, client.Release())
 }


### PR DESCRIPTION
## Summary

Fixes #4156. `localstatequeryServerAcquire` unconditionally accepted any `AcquireSpecificPoint`, deferring the actual tip-validity check to the first `Query`. A rejection at Acquire time has a graceful wire-level `AcquireFailure` reply (gouroboros' `handleAcquire`/`handleReAcquire` both translate `ErrAcquireFailurePointNotOnChain`/`ErrAcquireFailurePointTooOld` into one), but a rejection surfacing later, from the `Query` callback, has no such path — it propagates as a fatal protocol error and tears down the whole LocalStateQuery connection instead of just failing one Acquire.

Acquiring a point momentarily ahead of this node's own tip is not a client bug: it's the ordinary result of two independently-syncing nodes not advancing in lockstep, and it happens on close to every block at real cadence.

## Root cause (confirmed live, not just theorized)

Reproduced continuously against a real, fully-synced Preview `cardano-node` and `dingo` pair, using this repo's own `internal/nodeparity`/`cmd/node-parity` tool in incremental mode. Added temporary debug logging at the two places gouroboros' `Connection` tears itself down on any mini-protocol error, and confirmed, with 100% correlation across dozens of occurrences, that every single "protocol is shutting down" disconnect traced back to exactly this: `Acquire` succeeding for a point the ledger hadn't reached yet, then the first query's `verifyPointOnChain` rejection tearing the connection down.

## Fix

- `ledger/queries.go`: add `LedgerState.VerifyPointOnChain`, an exported wrapper around the existing pinned-point validation `Query` already does, callable before a point is recorded as acquired.
- `ouroboros/localstatequery.go`: `localstatequeryServerAcquire` now validates an `AcquireSpecificPoint` via `VerifyPointOnChain` before recording it, mapping `ErrPointNotOnChain`/`ErrHistoricalStateUnavailable` to gouroboros' own `ErrAcquireFailurePointNotOnChain`/`ErrAcquireFailurePointTooOld` so the server replies gracefully instead of closing the connection.

## Tests

- `TestLocalstatequeryServerAcquire_PointAheadOfTip_GracefulFailure`: the regression test. Verified it fails against the prior behavior (a stash/apply round-trip showed the point-ahead-of-tip Acquire silently succeeding) and passes with this change.
- `TestLocalstatequeryServerAcquire_PointOnChain_Succeeds` / `TestLocalstatequeryServerAcquire_VolatileTip_ClearsPoint`: companion cases confirming unchanged behavior for the on-chain and volatile-tip paths.

## Validation

- `go build ./...`, `go vet ./...`: clean.
- `go test ./...`: all green except `bin.TestEntrypointForwardsSignalsDuringMithrilBootstrap`, a pre-existing flaky subprocess-timing test — confirmed by re-running it in isolation (passes) and confirmed unrelated to this change.
- `make lint` (golangci-lint, nilaway, modernize, import-boundaries): nilaway reports 25 pre-existing findings, none in any file this PR touches — confirmed identical count/content on a clean `origin/main` checkout with no changes at all, so this is baseline noise, not something introduced here.
- Live re-test: rebuilt `dingo` + `cmd/node-parity` with this fix, ran a fresh Mithril bootstrap and a live incremental `node-parity watch` session against the real Preview `cardano-node` for an extended period. Zero "protocol is shutting down" / "peer closed the connection" disconnects observed afterward — the failure mode this PR targets is gone. (A residual, much more benign "acquire failure: point not on chain" now surfaces as a normal Go error causing `node-parity`'s own incremental session to restart cleanly — a client-side design choice in this repo's own tool, not a dingo bug, and out of scope for this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates a LocalStateQuery `AcquireSpecificPoint` at Acquire time against the current chain instead of deferring the check to the first Query, fixing #4156. A rejection at Acquire time maps to a graceful wire-level `AcquireFailure` reply, while a query-time rejection previously propagated as a fatal protocol error that tore down the whole LocalStateQuery connection.

This failure was common: a point momentarily ahead of this node's tip is normal when two independently-syncing nodes are not perfectly in lockstep.

**Bug Fixes**
- Adds `LedgerState.VerifyPointOnChain`, an exported wrapper around the pinned-point validation `Query` already performs.
- `localstatequeryServerAcquire` maps `ErrPointNotOnChain` and `ErrHistoricalStateUnavailable` to `ErrAcquireFailurePointNotOnChain` and `ErrAcquireFailurePointTooOld` so the server replies gracefully instead of closing the connection.
- A rejected Acquire leaves the connection's previously recorded point (or lack of one) untouched.
- Adds a callback-level regression test for the point-ahead-of-tip case plus companion tests for unchanged on-chain and volatile-tip behavior.
- Adds a protocol-level regression test over a real connection proving the client receives `ErrAcquireFailurePointNotOnChain` and the connection stays usable afterward.
- Documents the new behavior and the remaining teardown gap for points that pass Acquire but whose historical data a later Query can no longer serve (#4234).

<sup>Written for commit 3ae208a2f98c02baa905f7be8fc1c725bb7bd454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dingo/pull/4232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Specific chain points are now validated immediately when acquired.
  - Invalid or unavailable points return clear acquisition errors instead of failing later during queries.
  - Failed acquisitions no longer record invalid pinned points.
  - Switching to the volatile tip clears any previously pinned point.

- **Tests**
  - Added coverage for valid points, points ahead of the chain, and clearing pinned points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->